### PR TITLE
Bugs 12970 12972

### DIFF
--- a/src/VASSAL/build/module/map/PieceMover.java
+++ b/src/VASSAL/build/module/map/PieceMover.java
@@ -441,25 +441,26 @@ public class PieceMover extends AbstractBuildable
 
   /** Invoked just before a piece is moved */
   protected Command movedPiece(GamePiece p, Point loc) {
-    setOldLocation(p);
-    Command c = null;
+    Command c = new NullCommand();
+    c = c.append(setOldLocation(p));
     if (!loc.equals(p.getPosition())) {
-      c = markMoved(p, true);
+      c = c.append(markMoved(p, true));
     }
     if (p.getParent() != null) {
       final Command removedCommand = p.getParent().pieceRemoved(p);
-      c = c == null ? removedCommand : c.append(removedCommand);
+      c.append(removedCommand);
     }
     return c;
   }
 
-  protected void setOldLocation(GamePiece p) {
+  protected Command setOldLocation(GamePiece p) {
     if (p instanceof Stack) {
       for (int i = 0; i < ((Stack) p).getPieceCount(); i++) {
-        Decorator.setOldProperties(((Stack) p).getPieceAt(i));
+        return Decorator.setOldProperties(((Stack) p).getPieceAt(i));
       }
+      return null; // A stack of 0 pieces - no old properties
     }
-    else Decorator.setOldProperties(p);
+    else return Decorator.setOldProperties(p);
   }
 
   public Command markMoved(GamePiece p, boolean hasMoved) {
@@ -772,6 +773,7 @@ public class PieceMover extends AbstractBuildable
   }
 
   protected void performDrop(Point p) {
+System.out.println("PieceMover.performDrop(): Dropped at"+p);    
     final Command move = movePieces(map, p);
     GameModule.getGameModule().sendAndLog(move);
     if (move != null) {

--- a/src/VASSAL/build/module/map/PieceMover.java
+++ b/src/VASSAL/build/module/map/PieceMover.java
@@ -773,7 +773,6 @@ public class PieceMover extends AbstractBuildable
   }
 
   protected void performDrop(Point p) {
-System.out.println("PieceMover.performDrop(): Dropped at"+p);    
     final Command move = movePieces(map, p);
     GameModule.getGameModule().sendAndLog(move);
     if (move != null) {

--- a/src/VASSAL/command/SetPersistentPropertyCommand.java
+++ b/src/VASSAL/command/SetPersistentPropertyCommand.java
@@ -1,0 +1,78 @@
+package VASSAL.command;
+
+import VASSAL.build.GameModule;
+import VASSAL.counters.BasicPiece;
+import VASSAL.counters.Decorator;
+import VASSAL.counters.GamePiece;
+
+/**
+ * This Command sets a Persistent Property in a PersistentPropertyContainer.
+ * Currently only BasicPiece and Decorator implement PersistentPropertyContainer.
+ * The Undo Command is a SetPropertyCommand to set the value back to the original value.
+ */
+public class SetPersistentPropertyCommand extends Command {
+  public static final String COMMAND_PREFIX = "SPP\t";
+  protected Object key;
+  protected Object oldValue;  
+  protected Object newValue;
+  protected String id;
+  
+
+  public SetPersistentPropertyCommand(String id, Object key, Object oldValue, Object newValue) {
+    setKey(key);
+    setOldValue (oldValue);
+    setNewValue (newValue);
+    setId (id);
+  }
+
+  protected void executeCommand() {
+    GamePiece target = GameModule.getGameModule().getGameState().getPieceForId(id);
+    if (target != null) {
+      // Ugly, but we REALLY don't want GamePiece to implement PersistentPropertyContainer.
+      // Only BasicPiece and Decorators support Persistent properties
+      if (target instanceof Decorator) {
+         ((Decorator) target).setPersistentProperty(getKey(), getNewValue());
+      }
+      else if (target instanceof BasicPiece) {
+           ((BasicPiece) target).setPersistentProperty(getKey(), getNewValue());
+      }
+    }
+  }
+
+  protected Command myUndoCommand() {
+    return new SetPersistentPropertyCommand (id, key, newValue, oldValue);
+  }
+
+  public Object getKey() {
+    return key;
+  }
+
+  public void setKey(Object key) {
+    this.key = key;
+  }
+
+  public Object getOldValue() {
+    return oldValue;
+  }
+
+  public void setOldValue(Object oldValue) {
+    this.oldValue = oldValue;
+  }
+
+  public Object getNewValue() {
+    return newValue;
+  }
+
+  public void setNewValue(Object newValue) {
+    this.newValue = newValue;
+  }
+
+  public String getId() {
+    return id;
+  }
+
+  public void setId(String id) {
+    this.id = id;
+  }
+
+}

--- a/src/VASSAL/counters/Decorator.java
+++ b/src/VASSAL/counters/Decorator.java
@@ -34,9 +34,11 @@ import VASSAL.build.module.map.boardPicker.Board;
 import VASSAL.build.module.map.boardPicker.board.mapgrid.Zone;
 import VASSAL.build.module.properties.PropertyNameSource;
 import VASSAL.command.Command;
+import VASSAL.command.NullCommand;
 import VASSAL.i18n.Localization;
 import VASSAL.i18n.PieceI18nData;
 import VASSAL.i18n.TranslatablePiece;
+import VASSAL.property.PersistentPropertyContainer;
 import VASSAL.tools.ArrayUtils;
 import VASSAL.tools.ErrorDialog;
 import VASSAL.tools.SequenceEncoder;
@@ -45,7 +47,7 @@ import VASSAL.tools.SequenceEncoder;
  * The abstract class describing a generic 'trait' of a GamePiece.  Follows the Decorator design pattern
  * of wrapping around another instance of GamePiece (the 'inner' piece) and delegating some of the GamePiece methods to it
  */
-public abstract class Decorator implements GamePiece, StateMergeable, PropertyNameSource {
+public abstract class Decorator implements GamePiece, StateMergeable, PropertyNameSource , PersistentPropertyContainer {
   protected GamePiece piece;
   private Decorator dec;
   private boolean selected = false;
@@ -158,6 +160,25 @@ public abstract class Decorator implements GamePiece, StateMergeable, PropertyNa
     else {
       piece.setProperty(key, val);
     }
+  }
+  
+  @Override
+  public Command setPersistentProperty(Object key, Object val) {
+    // Ugly, but we REALLY don't want GamePiece to implement PersistentPropertyContainer.
+    // Only BasicPiece and Decorators support Persistent properties and piece can only be one of these two types.
+    if (piece instanceof Decorator) {
+      return ((Decorator) piece).setPersistentProperty(key, val);
+    }
+    else if (piece instanceof BasicPiece) {
+      return ((BasicPiece) piece).setPersistentProperty(key, val);
+    }
+    return null;
+  }
+  
+  @Override
+  public Object getPersistentProperty (Object key) {
+    // Standard getProperty also returns persistent properties
+    return piece.getProperty(key);
   }
 
   /*
@@ -432,13 +453,23 @@ public abstract class Decorator implements GamePiece, StateMergeable, PropertyNa
    * Set the Oldxxxx properties related to movement
    * @param p
    */
-  public static void setOldProperties(GamePiece p) {
+  public static Command setOldProperties(GamePiece p) {
+    PersistentPropertyContainer container;
+    // Not nice, but we don't want GamePiece to implement PersistentPropertyContainer
+    if (p instanceof Decorator || p instanceof GamePiece) {
+      container = (PersistentPropertyContainer) p;
+    }
+    else {
+      return null;
+    }
+    
     String mapName = ""; //$NON-NLS-1$
     String boardName = ""; //$NON-NLS-1$
     String zoneName = ""; //$NON-NLS-1$
     String locationName = ""; //$NON-NLS-1$
     final Map m = p.getMap();
     final Point pos = p.getPosition();
+    Command comm = new NullCommand();
 
     if (m != null) {
       mapName = m.getConfigureName();
@@ -453,16 +484,18 @@ public abstract class Decorator implements GamePiece, StateMergeable, PropertyNa
       locationName = m.locationName(pos);
     }
 
-    p.setProperty(BasicPiece.OLD_X, String.valueOf(pos.x));
-    p.setProperty(BasicPiece.OLD_Y, String.valueOf(pos.y));
-    p.setProperty(BasicPiece.OLD_MAP, mapName);
-    p.setProperty(BasicPiece.OLD_BOARD, boardName);
-    p.setProperty(BasicPiece.OLD_ZONE, zoneName);
-    p.setProperty(BasicPiece.OLD_LOCATION_NAME, locationName);
+    comm = comm.append(container.setPersistentProperty(BasicPiece.OLD_X, String.valueOf(pos.x)));
+    comm = comm.append(container.setPersistentProperty(BasicPiece.OLD_Y, String.valueOf(pos.y)));
+    comm = comm.append(container.setPersistentProperty(BasicPiece.OLD_MAP, mapName));
+    comm = comm.append(container.setPersistentProperty(BasicPiece.OLD_BOARD, boardName));
+    comm = comm.append(container.setPersistentProperty(BasicPiece.OLD_ZONE, zoneName));
+    comm = comm.append(container.setPersistentProperty(BasicPiece.OLD_LOCATION_NAME, locationName));
+    
+    return comm;
   }
 
-  public void setOldProperties() {
-    setOldProperties(this);
+  public Command setOldProperties() {
+    return setOldProperties(this);
   }
 
   /**

--- a/src/VASSAL/counters/Pivot.java
+++ b/src/VASSAL/counters/Pivot.java
@@ -140,7 +140,7 @@ public class Pivot extends Decorator implements TranslatablePiece {
         rotator.setAngle(oldAngle - angle);
         double newAngle = rotator.getAngle();
         if (getMap() != null) {
-          setOldProperties();
+          c = setOldProperties();
           Point pos = getPosition();
           pivotPoint(pos, -Math.PI * oldAngle / 180.0, -Math.PI * newAngle / 180.0);
           GamePiece outer = Decorator.getOutermost(this);
@@ -148,7 +148,7 @@ public class Pivot extends Decorator implements TranslatablePiece {
             pos = getMap().snapTo(pos);
           }
           outer.setProperty(Properties.MOVED, Boolean.TRUE);
-          c = t.getChangeCommand();
+          c = c.append(t.getChangeCommand());
           MoveTracker moveTracker = new MoveTracker(outer);
           getMap().placeOrMerge(outer, pos);
           c = c.append(moveTracker.getMoveCommand());

--- a/src/VASSAL/counters/ReturnToDeck.java
+++ b/src/VASSAL/counters/ReturnToDeck.java
@@ -127,7 +127,7 @@ public class ReturnToDeck extends Decorator implements TranslatablePiece {
         return null;
       final Map preMap = getMap();
       final Point prePos = getPosition();
-      setOldProperties();
+      comm = setOldProperties();
       comm = pile.addToContents(Decorator.getOutermost(this));
       // Apply Auto-move key if the piece has moved
       Map m = pile.getMap();

--- a/src/VASSAL/counters/SendToLocation.java
+++ b/src/VASSAL/counters/SendToLocation.java
@@ -362,13 +362,15 @@ public class SendToLocation extends Decorator implements TranslatablePiece {
           // don't do anything if we're already there.
           return null;
         }
+        final ChangeTracker tracker = new ChangeTracker(this);
         setProperty(BACK_MAP, getMap());
         setProperty(BACK_POINT, getPosition());
-        setOldProperties();
+        c = tracker.getChangeCommand();
+        c.append(setOldProperties());
         if (!Boolean.TRUE.equals(outer.getProperty(Properties.IGNORE_GRID))) {
           dest = map.snapTo(dest);
         }
-        c = map.placeOrMerge(outer, dest);
+        c.append(map.placeOrMerge(outer, dest));
         // Apply Auto-move key
         if (map.getMoveKey() != null) {
           c.append(outer.keyEvent(map.getMoveKey()));
@@ -376,27 +378,27 @@ public class SendToLocation extends Decorator implements TranslatablePiece {
         if (parent != null) {
           c.append(parent.pieceRemoved(outer));
         }
-      }
+       
+      }      
     }
     else if (backCommand.matches(stroke)) {
       GamePiece outer = Decorator.getOutermost(this);
       Map backMap = (Map) getProperty(BACK_MAP);
       Point backPoint = (Point) getProperty(BACK_POINT);
+      final ChangeTracker tracker = new ChangeTracker(this);
+      setProperty(BACK_MAP, null);
+      setProperty(BACK_POINT, null);
+      c = tracker.getChangeCommand();
+      
       if (backMap != null && backPoint != null) {
-         setOldProperties();
-         c = backMap.placeOrMerge(outer, backPoint);
-         final ChangeTracker tracker = new ChangeTracker(this);
-         setProperty(BACK_MAP, null);
-         setProperty(BACK_POINT, null);
-         c.append(tracker.getChangeCommand());
+         c = c.append(setOldProperties());
+         c = c.append(backMap.placeOrMerge(outer, backPoint));
 
          // Apply Auto-move key
          if (backMap.getMoveKey() != null) {
            c.append(outer.keyEvent(backMap.getMoveKey()));
          }
       }
-      setProperty(BACK_MAP, null);
-      setProperty(BACK_POINT, null);
     }
     return c;
   }

--- a/src/VASSAL/counters/Translate.java
+++ b/src/VASSAL/counters/Translate.java
@@ -166,7 +166,7 @@ public class Translate extends Decorator implements TranslatablePiece {
     myGetKeyCommands();
     Command c = null;
     if (moveCommand.matches(stroke)) {
-      setOldProperties();
+      c = setOldProperties();
       if (mover == null) {
         mover = new MoveExecuter();
         mover.setKeyEvent(stroke);
@@ -174,10 +174,12 @@ public class Translate extends Decorator implements TranslatablePiece {
       }
       GamePiece target = findTarget(stroke);
       if (target != null) {
-        c = moveTarget(target);
+        c = c.append(moveTarget(target));
       }
       mover.addKeyEventTarget(piece);
       // Return a non-null command to indicate that a change actually happened
+      // FIXME - THIS IS WRONG.... it wipes out the previous commands.
+      //     Probably should be if (c== null) {
       c = new NullCommand() {
         @Override
         public boolean isNull() {

--- a/src/VASSAL/property/PersistentPropertyContainer.java
+++ b/src/VASSAL/property/PersistentPropertyContainer.java
@@ -1,0 +1,31 @@
+/*
+ * $Id$
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License (LGPL) as published by the Free Software Foundation.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public
+ * License along with this library; if not, copies are available
+ * at http://www.opensource.org.
+ */
+
+package VASSAL.property;
+
+import VASSAL.command.Command;
+
+/**
+ * A container holding properties that must be persisted in the GameState
+ *
+ */
+public interface PersistentPropertyContainer {
+
+    public Command setPersistentProperty (Object key, Object val);
+    
+    public Object getPersistentProperty (Object key);
+}


### PR DESCRIPTION
12970 - Changes to Old... variables not being encoded in a Command or sent to other clients or log files, nor are they saved in the gamestate.  Undo will break any automation that depends on these.

Added new PersistentPropertyContainer interface to BasicPiece and Decorator only. Would have been nice to add it to the GamePiece interface, but that would break any Custom class that implements GamePiece. Results in a bit of ugly 'instanceof' checks in a couple of places.


12972 - backPoint and backMap used for the SendToLocation Back command where being saved in the gamestate, but no changes during play where being encoded and sent to other clients or a log file. Undo will break automation depending on these being up to date.