### PR TITLE
Bug 12951 - Undo of cards back through a Deck results in incorrect

### DIFF
--- a/src/VASSAL/counters/Deck.java
+++ b/src/VASSAL/counters/Deck.java
@@ -815,9 +815,16 @@ public class Deck extends Stack implements PlayerRoster.SideChangeListener {
       @Override
       public GamePiece nextPiece() {
         GamePiece p = super.nextPiece();
-        if (faceDown) {
-          p.setProperty(Properties.OBSCURED_BY, NO_USER);
-        }
+        /*
+         * Bug 12951 results in Cards going back into a Deck via Undo in an inconsistent state.
+         * This statement is the culprit. As far as I can tell, it is not needed as Deck.pieceRemoved()
+         * sets OBSCURED_BY if drawing a facedown card from a face down Deck which is the only case
+         * where this would be needed.
+         * This will need thorough testing in Deck heavy modules.
+         */
+        // if (faceDown) {
+        //  p.setProperty(Properties.OBSCURED_BY, NO_USER);
+        //}
         return p;
       }
     };


### PR DESCRIPTION
This appears to fix Bug 12951 where card ownership is lost when a Return to Deck - Send To Location is Undone through a face down Deck.

Logically, this statement is not required except for face-down draws from a Deck, but Deck.pieceRemoved() is called and handles this case anyway.

Will need thorough testing with Deck heavy modules.