### PR TITLE
Bug 12576 Resolution

### DIFF
--- a/src/VASSAL/build/module/map/BoardPicker.java
+++ b/src/VASSAL/build/module/map/BoardPicker.java
@@ -36,6 +36,7 @@ import java.util.Enumeration;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Vector;
+import java.util.stream.Collectors;
 
 import javax.swing.Box;
 import javax.swing.BoxLayout;
@@ -411,6 +412,13 @@ public class BoardPicker extends AbstractBuildable implements ActionListener, Ga
     else {
       return Collections.unmodifiableCollection(currentBoards);
     }
+  }
+
+  /**
+   * @return a List of the names of all boards from which have been selected either by the user via the dialog or from reading a savefile
+   */
+  public List<String> getSelectedBoardNames() {
+    return currentBoards.stream().map(Board::getName).collect(Collectors.toList());
   }
 
   /**

--- a/src/VASSAL/build/module/map/SetupStack.java
+++ b/src/VASSAL/build/module/map/SetupStack.java
@@ -60,6 +60,7 @@ import java.awt.image.BufferedImage;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
+import java.util.List;
 
 import javax.swing.Box;
 import javax.swing.ImageIcon;
@@ -322,7 +323,13 @@ public class SetupStack extends AbstractConfigurable implements GameComponent, U
     }
     else if (OWNING_BOARD.equals(key)) {
       if (OwningBoardPrompt.ANY.equals(value)) {
-        owningBoardName = null;
+        if (map != null) {
+          List<String> selectedBoardNames = map.getBoardPicker().getSelectedBoardNames();
+          owningBoardName = (!selectedBoardNames.isEmpty()) ? selectedBoardNames.get(0) : null;
+        }
+        else {
+          owningBoardName = null;
+        }
       }
       else {
         owningBoardName = (String) value;


### PR DESCRIPTION
Bug 12576 - if At-Start stack has owningBoard "Any", default to first selected board, not first allowable board. If no selected board is available, old default remains.

Recreated from previously closed pull request because I messed up and created it against my local master.