### PR TITLE
Bug 12952 - Evalute $..$ strings in Property Match expressions on source pce

### DIFF
--- a/src/VASSAL/counters/Labeler.java
+++ b/src/VASSAL/counters/Labeler.java
@@ -154,7 +154,7 @@ public class Labeler extends Decorator implements TranslatablePiece, Loopable {
    */
   protected String clean(String s) {
     // Cannot use $PieceName$ in a label format, must use $pieceName$
-    return s.replaceAll("$"+BAD_PIECE_NAME+"$", "$"+PIECE_NAME+"$");
+    return s.replace("$"+BAD_PIECE_NAME+"$", "$"+PIECE_NAME+"$");
   }
 
   @Override


### PR DESCRIPTION
Turned out the $..$ variables just wheren't being evalated at all on either the source or the targets. So this can't possibly be working in any module.