### PR TITLE
Bug 12948 move fixed distance undo trigger issues

### DIFF
--- a/.settings/.gitignore
+++ b/.settings/.gitignore
@@ -1,0 +1,1 @@
+/org.eclipse.jdt.core.prefs

--- a/src/VASSAL/build/module/GlobalOptions.java
+++ b/src/VASSAL/build/module/GlobalOptions.java
@@ -78,6 +78,7 @@ public class GlobalOptions extends AbstractConfigurable {
   public static final String MAXIMUM_HEAP = "maximumHeap"; //$NON-NLS-1$
   public static final String INITIAL_HEAP = "initialHeap"; //$NON-NLS-1$
   public static final String BUG_10295 = "bug10295";
+  public static final String CLASSIC_MFD = "classicMfd";
 
   public static final String PLAYER_NAME = "PlayerName"; //$NON-NLS-1$
   public static final String PLAYER_NAME_ALT = "playerName"; //$NON-NLS-1$
@@ -101,6 +102,9 @@ public class GlobalOptions extends AbstractConfigurable {
 
   private static GlobalOptions instance = new GlobalOptions();
   private boolean useSingleWindow;
+  
+  private boolean useClassicMoveFixedDistance = false;
+  private BooleanConfigurer classicMfd;
 
   @Override
   public void addTo(Buildable parent) {
@@ -167,6 +171,16 @@ public class GlobalOptions extends AbstractConfigurable {
 
       prefs.addOption(bug10295Conf);
     }
+    
+    // Move Fixed Distance trait (Translate) has been substantially re-written.
+    // Use new version by default. User may over-ride to use old buggy behaviour.
+    classicMfd = new BooleanConfigurer(
+        CLASSIC_MFD,
+        Resources.getString("GlobalOptions.classic_mfd"),
+        Boolean.FALSE
+      );
+    classicMfd.addPropertyChangeListener( (evt) -> setUseClassicMoveFixedDistance(classicMfd.getValueBoolean()));
+    prefs.addOption(classicMfd);
 
     validator = new SingleChildInstance(gm, getClass());
   }
@@ -177,6 +191,14 @@ public class GlobalOptions extends AbstractConfigurable {
 
   public boolean isUseSingleWindow() {
     return useSingleWindow;
+  }
+
+  public boolean isUseClassicMoveFixedDistance() {
+    return useClassicMoveFixedDistance;
+  }
+
+  public void setUseClassicMoveFixedDistance(boolean b) {
+    useClassicMoveFixedDistance = b;
   }
 
   @Deprecated

--- a/src/VASSAL/counters/Translate.java
+++ b/src/VASSAL/counters/Translate.java
@@ -237,7 +237,7 @@ public class Translate extends Decorator implements TranslatablePiece {
   /*
    * Move a single piece to a destination
    */
-  protected Command movePiece (GamePiece gp, Point dest) {
+  protected Command movePiece(GamePiece gp, Point dest) {
     
     // Is the piece on a map?
     final Map map = gp.getMap();
@@ -278,7 +278,7 @@ public class Translate extends Decorator implements TranslatablePiece {
      if (mover == null) {
        mover = new MoveExecuter();
        mover.setKeyEvent(stroke);
-       mover.setAdditionalCommand (setOldProperties(this));
+       mover.setAdditionalCommand(setOldProperties(this));
        SwingUtilities.invokeLater(mover);
      }
      GamePiece target = findTarget(stroke);

--- a/src/VASSAL/counters/Translate.java
+++ b/src/VASSAL/counters/Translate.java
@@ -184,7 +184,6 @@ public class Translate extends Decorator implements TranslatablePiece {
    * recommended for this reason and now defaults to 'N' and is marked in the Editor as 'Not Recommended'.
    */
   protected Command newTranslate (KeyStroke stroke) {
-    Command c = new NullCommand();
     
     GamePiece target = findTarget(stroke);
     if (target == null) {
@@ -216,6 +215,7 @@ public class Translate extends Decorator implements TranslatablePiece {
     }
     
     // Move the piece(s)
+    Command c = new NullCommand();
     if (target instanceof Stack) {
       
       final Stack s = (Stack) target;

--- a/src/VASSAL/i18n/VASSAL.properties
+++ b/src/VASSAL/i18n/VASSAL.properties
@@ -473,6 +473,7 @@ GlobalOptions.mark_moved=Mark moved pieces?
 GlobalOptions.initial_heap=JVM initial heap (in MB):
 GlobalOptions.maximum_heap=JVM maximum heap (in MB):
 GlobalOptions.bug10295=Drag ghost bug correction?
+GlobalOptions.classic_mfd=Use Classic Move Fixed Distance trait move batching?
 
 # Help Window
 Help.error_log=Show Error Log


### PR DESCRIPTION
This fix is a complete re-organisation of the Move Fixed Distance (MFD) Trait code. 

The 'batching' of moves is replaced by using the same method as SendToLocation to move each piece as required in the correct logical sequence. This now combines correctly with other commands and movements in Trigger Actions.

The original code is retained and can be enabled via a Preference. The default for the preference is OFF. Players who need the old behaviour (unlikely) will need to opt in.

This fix resolves the following issues (Bugs 1874, 1948, 2610, 4212):
 - MFD no longer creates additional NullCommands when used in a Trigger. All Triggers now have a single undo.
 - Multiple MFD commands applied to a unit by a Trigger Action now execute in the correct order and interact with other traits and movement in a logical order.
 - MFD now works with the Can Rotate trait if the Rotate trait is defined above the MFD.
 