### PR TITLE
Refactoring - replace Collections.sort() with list.sort()

### DIFF
--- a/src/VASSAL/build/module/GameState.java
+++ b/src/VASSAL/build/module/GameState.java
@@ -847,7 +847,7 @@ public class GameState implements CommandEncoder {
   public Command getRestorePiecesCommand() {
     // TODO remove stacks that were empty when the game was loaded and are still empty now
     final List<GamePiece> pieceList = new ArrayList<>(pieces.values());
-    Collections.sort(pieceList, new Comparator<>() {
+    pieceList.sort(new Comparator<>() {
       private final Map<GamePiece, Integer> indices = new HashMap<>();
 
       // Cache indices because indexOf() is linear;

--- a/src/VASSAL/build/module/Inventory.java
+++ b/src/VASSAL/build/module/Inventory.java
@@ -1264,9 +1264,9 @@ public class Inventory extends AbstractConfigurable
       if (sortStrategy.equals(ALPHA))
         Collections.sort(children);
       else if (sortStrategy.equals(LENGTHALPHA))
-        Collections.sort(children, new LengthAlpha());
+        children.sort(new LengthAlpha());
       else if (sortStrategy.equals(NUMERIC))
-        Collections.sort(children, new Numerical());
+        children.sort(new Numerical());
       else
         Collections.sort(children);
     }

--- a/src/VASSAL/counters/DragBuffer.java
+++ b/src/VASSAL/counters/DragBuffer.java
@@ -25,7 +25,6 @@ import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.awt.event.MouseListener;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
@@ -199,7 +198,7 @@ public class DragBuffer {
   }
 
   public void sort(Comparator<GamePiece> comp) {
-    Collections.sort(pieces, comp);
+    pieces.sort(comp);
   }
 
   /**

--- a/src/VASSAL/counters/KeyBuffer.java
+++ b/src/VASSAL/counters/KeyBuffer.java
@@ -135,7 +135,7 @@ public class KeyBuffer {
   }
 
   public void sort(Comparator<GamePiece> comp) {
-    Collections.sort(pieces, comp);
+    pieces.sort(comp);
   }
 
   /**

--- a/src/VASSAL/i18n/LocaleConfigurer.java
+++ b/src/VASSAL/i18n/LocaleConfigurer.java
@@ -22,7 +22,6 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.text.Collator;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
@@ -150,7 +149,7 @@ public class LocaleConfigurer extends Configurer {
         languages.put(lang, s);
         sortedLangs.add(lang);
       }
-      Collections.sort(sortedLangs, Collator.getInstance(Locale.getDefault()));
+      sortedLangs.sort(Collator.getInstance(Locale.getDefault()));
       languageList = sortedLangs.toArray(new String[0]);
     }
     return languageList;
@@ -166,8 +165,7 @@ public class LocaleConfigurer extends Configurer {
         countries.put(country, s);
         sortedCountries.add(country);
       }
-      Collections.sort(sortedCountries,
-                       Collator.getInstance(Locale.getDefault()));
+      sortedCountries.sort(Collator.getInstance(Locale.getDefault()));
       countries.put(ANY_COUNTRY, "");
       sortedCountries.add(0, ANY_COUNTRY);
       countryList = sortedCountries.toArray(new String[0]);

--- a/src/VASSAL/launch/ModuleManagerWindow.java
+++ b/src/VASSAL/launch/ModuleManagerWindow.java
@@ -498,7 +498,7 @@ public class ModuleManagerWindow extends JFrame {
       recentModuleConfig.removeValue(s);
     }
 
-    Collections.sort(moduleList, new Comparator<>() {
+    moduleList.sort(new Comparator<>() {
       @Override
       public int compare(ModuleInfo f1, ModuleInfo f2) {
         return f1.compareTo(f2);


### PR DESCRIPTION
Minor refactoring replacing Collections.sort() with Java 8's list.sort()