### PR TITLE
Refactoring - added method Stack.asList

### DIFF
--- a/src/VASSAL/build/module/map/CounterDetailViewer.java
+++ b/src/VASSAL/build/module/map/CounterDetailViewer.java
@@ -623,9 +623,7 @@ public class CounterDetailViewer extends AbstractConfigurable implements Drawabl
       boolean addContents = foundPieceAt == null ?
         super.visitStack(s) != null : foundPieceAt.equals(s.getPosition());
       if (addContents) {
-        for (Iterator<GamePiece> i = s.getPiecesIterator(); i.hasNext();) {
-          apply(i.next());
-        }
+        s.getPiecesAsList().forEach(this::apply);
       }
       return null;
     }

--- a/src/VASSAL/build/module/map/CounterDetailViewer.java
+++ b/src/VASSAL/build/module/map/CounterDetailViewer.java
@@ -40,7 +40,6 @@ import java.awt.event.MouseEvent;
 import java.awt.event.MouseListener;
 import java.awt.event.MouseMotionListener;
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
 
 import javax.swing.JComponent;
@@ -623,7 +622,7 @@ public class CounterDetailViewer extends AbstractConfigurable implements Drawabl
       boolean addContents = foundPieceAt == null ?
         super.visitStack(s) != null : foundPieceAt.equals(s.getPosition());
       if (addContents) {
-        s.getPiecesAsList().forEach(this::apply);
+        s.asList().forEach(this::apply);
       }
       return null;
     }

--- a/src/VASSAL/build/module/map/DrawPile.java
+++ b/src/VASSAL/build/module/map/DrawPile.java
@@ -23,7 +23,6 @@ import java.awt.Dimension;
 import java.awt.Point;
 import java.awt.Rectangle;
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
 
 import javax.swing.JPopupMenu;
@@ -766,7 +765,7 @@ public class DrawPile extends SetupStack implements PropertySource, PropertyName
     Stack s = super.initializeContents();
     myDeck = new Deck(getDeckType());
     myDeck.setPropertySource(source);
-    s.getPiecesAsList().forEach(gamePiece -> myDeck.add(gamePiece));
+    s.asList().forEach(gamePiece -> myDeck.add(gamePiece));
     myDeck.setFaceDown(!Deck.NEVER.equals(dummy.getFaceDownOption()));
     return myDeck;
   }

--- a/src/VASSAL/build/module/map/DrawPile.java
+++ b/src/VASSAL/build/module/map/DrawPile.java
@@ -766,9 +766,7 @@ public class DrawPile extends SetupStack implements PropertySource, PropertyName
     Stack s = super.initializeContents();
     myDeck = new Deck(getDeckType());
     myDeck.setPropertySource(source);
-    for (Iterator<GamePiece> i = s.getPiecesIterator(); i.hasNext();) {
-      myDeck.add(i.next());
-    }
+    s.getPiecesAsList().forEach(gamePiece -> myDeck.add(gamePiece));
     myDeck.setFaceDown(!Deck.NEVER.equals(dummy.getFaceDownOption()));
     return myDeck;
   }

--- a/src/VASSAL/build/module/map/MovementReporter.java
+++ b/src/VASSAL/build/module/map/MovementReporter.java
@@ -22,6 +22,7 @@ import java.awt.Point;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.function.Predicate;
 
 import VASSAL.build.GameModule;
 import VASSAL.build.module.Chatter;
@@ -119,9 +120,8 @@ public class MovementReporter {
     Command c = null;
     if (p instanceof Stack) {
       c = new NullCommand();
-      for (Iterator<GamePiece> i = ((Stack) p).getPiecesIterator();
-           i.hasNext();) {
-        c.append(markMoved(i.next()));
+      for (GamePiece gp : ((Stack)p).getPiecesAsList()) {
+        c.append(markMoved(gp));
       }
     }
     else if (p.getProperty(Properties.MOVED) != null) {
@@ -262,14 +262,10 @@ public class MovementReporter {
         return false;
       }
       if (target instanceof Stack) {
-        for (Iterator<GamePiece> i = ((Stack) target).getPiecesIterator(); i.hasNext() ;) {
-          GamePiece piece = i.next();
-          if (Boolean.TRUE.equals(piece.getProperty(Properties.INVISIBLE_TO_ME))
-              || Boolean.TRUE.equals(piece.getProperty(Properties.INVISIBLE_TO_OTHERS))) {
-            return true;
-          }
-        }
-        return false;
+        final Predicate<GamePiece> gamePiecePredicate =
+          piece -> Boolean.TRUE.equals(piece.getProperty(Properties.INVISIBLE_TO_ME))
+            || Boolean.TRUE.equals(piece.getProperty(Properties.INVISIBLE_TO_OTHERS));
+        return ((Stack) target).getPiecesAsList().stream().anyMatch(gamePiecePredicate);
       }
       else {
         return Boolean.TRUE.equals(target.getProperty(Properties.INVISIBLE_TO_ME))
@@ -389,8 +385,7 @@ public class MovementReporter {
       boolean first = true;
       for (GamePiece piece : pieces) {
         if (piece instanceof Stack) {
-          for (Iterator<GamePiece> j = ((Stack) piece).getPiecesIterator(); j.hasNext(); ) {
-            GamePiece p = j.next();
+          for (GamePiece p : ((Stack) piece).getPiecesAsList()) {
             if (isInvisible(p)) {
               if (!first) {
                 names.append(", ");

--- a/src/VASSAL/build/module/map/MovementReporter.java
+++ b/src/VASSAL/build/module/map/MovementReporter.java
@@ -120,7 +120,7 @@ public class MovementReporter {
     Command c = null;
     if (p instanceof Stack) {
       c = new NullCommand();
-      for (GamePiece gp : ((Stack)p).getPiecesAsList()) {
+      for (GamePiece gp : ((Stack)p).asList()) {
         c.append(markMoved(gp));
       }
     }
@@ -265,7 +265,7 @@ public class MovementReporter {
         final Predicate<GamePiece> gamePiecePredicate =
           piece -> Boolean.TRUE.equals(piece.getProperty(Properties.INVISIBLE_TO_ME))
             || Boolean.TRUE.equals(piece.getProperty(Properties.INVISIBLE_TO_OTHERS));
-        return ((Stack) target).getPiecesAsList().stream().anyMatch(gamePiecePredicate);
+        return ((Stack) target).asList().stream().anyMatch(gamePiecePredicate);
       }
       else {
         return Boolean.TRUE.equals(target.getProperty(Properties.INVISIBLE_TO_ME))
@@ -385,7 +385,7 @@ public class MovementReporter {
       boolean first = true;
       for (GamePiece piece : pieces) {
         if (piece instanceof Stack) {
-          for (GamePiece p : ((Stack) piece).getPiecesAsList()) {
+          for (GamePiece p : ((Stack) piece).asList()) {
             if (isInvisible(p)) {
               if (!first) {
                 names.append(", ");

--- a/src/VASSAL/build/module/map/PieceMover.java
+++ b/src/VASSAL/build/module/map/PieceMover.java
@@ -484,7 +484,7 @@ public class PieceMover extends AbstractBuildable
     Command c = new NullCommand();
     if (!hasMoved || shouldMarkMoved()) {
       if (p instanceof Stack) {
-        for (GamePiece gamePiece : ((Stack) p).getPiecesAsList()) {
+        for (GamePiece gamePiece : ((Stack) p).asList()) {
           c = c.append(markMoved(gamePiece, hasMoved));
         }
       }

--- a/src/VASSAL/build/module/map/PieceMover.java
+++ b/src/VASSAL/build/module/map/PieceMover.java
@@ -484,9 +484,8 @@ public class PieceMover extends AbstractBuildable
     Command c = new NullCommand();
     if (!hasMoved || shouldMarkMoved()) {
       if (p instanceof Stack) {
-        for (Iterator<GamePiece> i = ((Stack) p).getPiecesIterator();
-             i.hasNext();) {
-          c = c.append(markMoved(i.next(), hasMoved));
+        for (GamePiece gamePiece : ((Stack) p).getPiecesAsList()) {
+          c = c.append(markMoved(gamePiece, hasMoved));
         }
       }
       else if (p.getProperty(Properties.MOVED) != null) {

--- a/src/VASSAL/build/module/map/StackMetrics.java
+++ b/src/VASSAL/build/module/map/StackMetrics.java
@@ -27,7 +27,6 @@ import java.awt.Rectangle;
 import java.awt.Shape;
 import java.awt.event.KeyEvent;
 import java.awt.geom.AffineTransform;
-import java.util.Iterator;
 
 import javax.swing.KeyStroke;
 
@@ -289,7 +288,7 @@ public class StackMetrics extends AbstractConfigurable {
       }
     }
 
-    stack.getPiecesAsList().stream()
+    stack.asList().stream()
          .filter(gamePiece -> selectedVisible.accept(gamePiece))
          .forEach(gamePiece -> {
            int index = stack.indexOf(gamePiece);
@@ -338,7 +337,7 @@ public class StackMetrics extends AbstractConfigurable {
       }
     }
 
-    stack.getPiecesAsList().stream()
+    stack.asList().stream()
          .filter(gamePiece -> selectedVisible.accept(gamePiece))
          .forEach(gamePiece -> {
            int index = stack.indexOf(gamePiece);
@@ -670,7 +669,7 @@ public class StackMetrics extends AbstractConfigurable {
         }
 
         if (moving instanceof Stack) {
-          for (GamePiece p : ((Stack) moving).getPiecesAsList()) {
+          for (GamePiece p : ((Stack) moving).asList()) {
             final MoveTracker t = new MoveTracker(p);
             fixedParent.insertChild(p, index++);
             comm = comm.append(t.getMoveCommand());

--- a/src/VASSAL/build/module/map/StackMetrics.java
+++ b/src/VASSAL/build/module/map/StackMetrics.java
@@ -289,17 +289,15 @@ public class StackMetrics extends AbstractConfigurable {
       }
     }
 
-    for (PieceIterator e = new PieceIterator(stack.getPiecesIterator(),
-                                             selectedVisible);
-         e.hasMoreElements();)
-    {
-      GamePiece next = e.nextPiece();
-      int index = stack.indexOf(next);
-      int nextX = x + (int) (zoom * (positions[index].x - x));
-      int nextY = y + (int) (zoom * (positions[index].y - y));
-      next.draw(g, nextX, nextY, obs, zoom);
-      highlighter.draw(next, g, nextX, nextY, obs, zoom);
-    }
+    stack.getPiecesAsList().stream()
+         .filter(gamePiece -> selectedVisible.accept(gamePiece))
+         .forEach(gamePiece -> {
+           int index = stack.indexOf(gamePiece);
+           int nextX = x + (int) (zoom * (positions[index].x - x));
+           int nextY = y + (int) (zoom * (positions[index].y - y));
+           gamePiece.draw(g, nextX, nextY, obs, zoom);
+           highlighter.draw(gamePiece, g, nextX, nextY, obs, zoom);
+         });
   }
 
   /**
@@ -340,18 +338,16 @@ public class StackMetrics extends AbstractConfigurable {
       }
     }
 
-    for (PieceIterator e = new PieceIterator(stack.getPiecesIterator(),
-                                             selectedVisible);
-         e.hasMoreElements();)
-    {
-      GamePiece next = e.nextPiece();
-      int index = stack.indexOf(next);
-      if (bounds == null || isVisible(region, bounds[index])) {
-        Point pt = map.mapToDrawing(positions[index], os_scale);
-        next.draw(g, pt.x, pt.y, view, zoom);
-        highlighter.draw(next, g, pt.x, pt.y, view, zoom);
-      }
-    }
+    stack.getPiecesAsList().stream()
+         .filter(gamePiece -> selectedVisible.accept(gamePiece))
+         .forEach(gamePiece -> {
+           int index = stack.indexOf(gamePiece);
+           if (bounds == null || isVisible(region, bounds[index])) {
+             Point pt = map.mapToDrawing(positions[index], os_scale);
+             gamePiece.draw(g, pt.x, pt.y, view, zoom);
+             highlighter.draw(gamePiece, g, pt.x, pt.y, view, zoom);
+           }
+         });
   }
 
   private boolean isVisible(Rectangle region, Rectangle bounds) {
@@ -674,9 +670,7 @@ public class StackMetrics extends AbstractConfigurable {
         }
 
         if (moving instanceof Stack) {
-          for (Iterator<GamePiece> i = ((Stack) moving).getPiecesIterator();
-               i.hasNext(); ) {
-            final GamePiece p = i.next();
+          for (GamePiece p : ((Stack) moving).getPiecesAsList()) {
             final MoveTracker t = new MoveTracker(p);
             fixedParent.insertChild(p, index++);
             comm = comm.append(t.getMoveCommand());

--- a/src/VASSAL/counters/Deck.java
+++ b/src/VASSAL/counters/Deck.java
@@ -232,9 +232,9 @@ public class Deck extends Stack implements PlayerRoster.SideChangeListener {
       expressionProperties.get(index).setPropertyValue("0"); //$NON-NLS-1$
     }
     //Increase all of the pieces with expressions specified in this deck
-    getPiecesAsList().stream()
-                     .filter(Objects::nonNull)
-                     .forEach(p -> updateCounts(p, true));
+    asList().stream()
+            .filter(Objects::nonNull)
+            .forEach(p -> updateCounts(p, true));
   }
 
   /**
@@ -859,7 +859,7 @@ public class Deck extends Stack implements PlayerRoster.SideChangeListener {
     se.append(getMap() == null ? "null" : getMap().getIdentifier()).append(getPosition().x).append(getPosition().y); //$NON-NLS-1$
     se.append(faceDown);
     final SequenceEncoder se2 = new SequenceEncoder(',');
-    getPiecesAsList().forEach(gamePiece -> se2.append(gamePiece.getId()));
+    asList().forEach(gamePiece -> se2.append(gamePiece.getId()));
     if (se2.getValue() != null) {
       se.append(se2.getValue());
     }
@@ -1389,7 +1389,7 @@ public class Deck extends Stack implements PlayerRoster.SideChangeListener {
 
   public void saveDeck(File f) throws IOException {
     Command comm = new LoadDeckCommand(null);
-    for (GamePiece p : getPiecesAsList()) {
+    for (GamePiece p : asList()) {
       p.setMap(null);
       comm = comm.append(new AddPiece(p));
     }

--- a/src/VASSAL/counters/Deck.java
+++ b/src/VASSAL/counters/Deck.java
@@ -41,6 +41,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Objects;
 import java.util.Random;
 
 import javax.swing.Action;
@@ -231,12 +232,9 @@ public class Deck extends Stack implements PlayerRoster.SideChangeListener {
       expressionProperties.get(index).setPropertyValue("0"); //$NON-NLS-1$
     }
     //Increase all of the pieces with expressions specified in this deck
-    for (Iterator<GamePiece> i = getPiecesIterator(); i.hasNext();) {
-      final GamePiece p = i.next();
-      if (p != null) {
-        updateCounts(p,true);
-      }
-    }
+    getPiecesAsList().stream()
+                     .filter(Objects::nonNull)
+                     .forEach(p -> updateCounts(p, true));
   }
 
   /**
@@ -861,9 +859,7 @@ public class Deck extends Stack implements PlayerRoster.SideChangeListener {
     se.append(getMap() == null ? "null" : getMap().getIdentifier()).append(getPosition().x).append(getPosition().y); //$NON-NLS-1$
     se.append(faceDown);
     final SequenceEncoder se2 = new SequenceEncoder(',');
-    for (Iterator<GamePiece> i = getPiecesIterator(); i.hasNext();) {
-      se2.append(i.next().getId());
-    }
+    getPiecesAsList().forEach(gamePiece -> se2.append(gamePiece.getId()));
     if (se2.getValue() != null) {
       se.append(se2.getValue());
     }
@@ -1393,8 +1389,7 @@ public class Deck extends Stack implements PlayerRoster.SideChangeListener {
 
   public void saveDeck(File f) throws IOException {
     Command comm = new LoadDeckCommand(null);
-    for (Iterator<GamePiece> i = getPiecesIterator(); i.hasNext();) {
-      final GamePiece p = i.next();
+    for (GamePiece p : getPiecesAsList()) {
       p.setMap(null);
       comm = comm.append(new AddPiece(p));
     }

--- a/src/VASSAL/counters/DragBuffer.java
+++ b/src/VASSAL/counters/DragBuffer.java
@@ -53,7 +53,7 @@ public class DragBuffer {
         !pieces.contains(p) &&
         !Boolean.TRUE.equals(p.getProperty(Properties.RESTRICTED_MOVEMENT))) {
       if (p instanceof Stack) {
-        for (GamePiece gamePiece : ((Stack) p).getPiecesAsList()) {
+        for (GamePiece gamePiece : ((Stack) p).asList()) {
           if (Boolean.TRUE.equals(
                 gamePiece.getProperty(Properties.RESTRICTED_MOVEMENT))) {
             return;

--- a/src/VASSAL/counters/DragBuffer.java
+++ b/src/VASSAL/counters/DragBuffer.java
@@ -53,10 +53,9 @@ public class DragBuffer {
         !pieces.contains(p) &&
         !Boolean.TRUE.equals(p.getProperty(Properties.RESTRICTED_MOVEMENT))) {
       if (p instanceof Stack) {
-        for (Iterator<GamePiece> i = ((Stack) p).getPiecesIterator();
-             i.hasNext();) {
+        for (GamePiece gamePiece : ((Stack) p).getPiecesAsList()) {
           if (Boolean.TRUE.equals(
-                i.next().getProperty(Properties.RESTRICTED_MOVEMENT))) {
+                gamePiece.getProperty(Properties.RESTRICTED_MOVEMENT))) {
             return;
           }
         }

--- a/src/VASSAL/counters/GlobalCommand.java
+++ b/src/VASSAL/counters/GlobalCommand.java
@@ -18,8 +18,6 @@
  */
 package VASSAL.counters;
 
-import java.util.Iterator;
-
 import javax.swing.KeyStroke;
 
 import VASSAL.build.GameModule;
@@ -169,7 +167,7 @@ public class GlobalCommand {
 
     @Override
     public Object visitStack(Stack s) {
-      s.getPiecesAsList().forEach(this::apply);
+      s.asList().forEach(this::apply);
       return null;
     }
 

--- a/src/VASSAL/counters/GlobalCommand.java
+++ b/src/VASSAL/counters/GlobalCommand.java
@@ -169,9 +169,7 @@ public class GlobalCommand {
 
     @Override
     public Object visitStack(Stack s) {
-      for (Iterator<GamePiece> i = s.getPiecesIterator(); i.hasNext();) {
-        apply(i.next());
-      }
+      s.getPiecesAsList().forEach(this::apply);
       return null;
     }
 

--- a/src/VASSAL/counters/KeyBuffer.java
+++ b/src/VASSAL/counters/KeyBuffer.java
@@ -77,7 +77,7 @@ public class KeyBuffer {
 
   public boolean contains(GamePiece p) {
     if (p instanceof Stack) {
-      return pieces.containsAll(((Stack) p).getPiecesAsList());
+      return pieces.containsAll(((Stack) p).asList());
     }
     else {
       return pieces.contains(p);
@@ -138,6 +138,6 @@ public class KeyBuffer {
    * @return true if a child of the specified Stack is selected
    */
   public boolean containsChild(Stack stack) {
-    return stack.getPiecesAsList().stream().anyMatch(this::contains);
+    return stack.asList().stream().anyMatch(this::contains);
   }
 }

--- a/src/VASSAL/counters/KeyBuffer.java
+++ b/src/VASSAL/counters/KeyBuffer.java
@@ -77,13 +77,7 @@ public class KeyBuffer {
 
   public boolean contains(GamePiece p) {
     if (p instanceof Stack) {
-      for (Iterator<GamePiece> i = ((Stack) p).getPiecesIterator();
-           i.hasNext();) {
-        if (!pieces.contains(i.next())) {
-          return false;
-        }
-      }
-      return true;
+      return pieces.containsAll(((Stack) p).getPiecesAsList());
     }
     else {
       return pieces.contains(p);
@@ -144,11 +138,6 @@ public class KeyBuffer {
    * @return true if a child of the specified Stack is selected
    */
   public boolean containsChild(Stack stack) {
-    for (Iterator<GamePiece> i = stack.getPiecesIterator(); i.hasNext();) {
-      if (contains(i.next())) {
-        return true;
-      }
-    }
-    return false;
+    return stack.getPiecesAsList().stream().anyMatch(this::contains);
   }
 }

--- a/src/VASSAL/counters/PieceIterator.java
+++ b/src/VASSAL/counters/PieceIterator.java
@@ -20,6 +20,7 @@ package VASSAL.counters;
 
 import java.util.Enumeration;
 import java.util.Iterator;
+import java.util.function.Predicate;
 
 /**
  * An iterator for GamePieces.  Takes an optional PieceFilter to
@@ -93,12 +94,14 @@ public class PieceIterator {
     return pi.hasNext();
   }
 
+  public static final Predicate<GamePiece> VISIBLE =
+    gamePiece -> !Boolean.TRUE.equals(gamePiece.getProperty(Properties.INVISIBLE_TO_ME));
+
   public static <T extends GamePiece> PieceIterator visible(Iterator<T> i) {
     return new PieceIterator(i, new PieceFilter() {
       @Override
       public boolean accept(GamePiece piece) {
-        return !Boolean.TRUE.equals(
-          piece.getProperty(Properties.INVISIBLE_TO_ME));
+        return VISIBLE.test(piece);
       }
     });
   }

--- a/src/VASSAL/counters/Restricted.java
+++ b/src/VASSAL/counters/Restricted.java
@@ -30,7 +30,6 @@ import java.awt.Component;
 import java.awt.Graphics;
 import java.awt.Rectangle;
 import java.awt.Shape;
-import java.util.Iterator;
 
 import javax.swing.Box;
 import javax.swing.JComponent;
@@ -297,7 +296,7 @@ public class Restricted extends Decorator implements EditablePiece {
     @Override
     public Object visitStack(Stack s) {
       Command c = new NullCommand();
-      for (GamePiece gamePiece : s.getPiecesAsList()) {
+      for (GamePiece gamePiece : s.asList()) {
         c = c.append((Command)visitDefault(gamePiece));
       }
       return c;

--- a/src/VASSAL/counters/Restricted.java
+++ b/src/VASSAL/counters/Restricted.java
@@ -297,8 +297,8 @@ public class Restricted extends Decorator implements EditablePiece {
     @Override
     public Object visitStack(Stack s) {
       Command c = new NullCommand();
-      for (Iterator<GamePiece> it = s.getPiecesIterator(); it.hasNext();) {
-        c = c.append((Command)visitDefault(it.next()));
+      for (GamePiece gamePiece : s.getPiecesAsList()) {
+        c = c.append((Command)visitDefault(gamePiece));
       }
       return c;
     }

--- a/src/VASSAL/counters/Stack.java
+++ b/src/VASSAL/counters/Stack.java
@@ -90,11 +90,7 @@ public class Stack implements GamePiece, StateMergeable {
    * @return an unmodifiable {@link List} of {@link GamePiece}s contained in this {@link Stack}
    */
   public List<GamePiece> asList() {
-    List<GamePiece> result = new ArrayList<>();
-    for (int i = 0; i < pieceCount; i++) {
-      result.add(contents[i]);
-    }
-    return Collections.unmodifiableList(result);
+    return Collections.unmodifiableList(Arrays.asList(contents).subList(0, pieceCount));
   }
 
   public Iterator<GamePiece> getPiecesReverseIterator() {

--- a/src/VASSAL/counters/Stack.java
+++ b/src/VASSAL/counters/Stack.java
@@ -26,6 +26,7 @@ import java.awt.Shape;
 import java.awt.geom.Area;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Enumeration;
 import java.util.Iterator;
 import java.util.List;
@@ -77,7 +78,7 @@ public class Stack implements GamePiece, StateMergeable {
    * @return an Enumeration of the pieces in the stack, from the bottom up This
    *         is a clone of the contents so add/remove operations during read
    *         won't affect it.
-   * @deprecated use {@link #getPiecesAsList()}
+   * @deprecated use {@link #asList()}
    */
   @Deprecated
   public Enumeration<GamePiece> getPieces() {
@@ -86,14 +87,14 @@ public class Stack implements GamePiece, StateMergeable {
   }
 
   /**
-   * @return a defensive copy of the {@link List} of {@link GamePiece}s contained in this {@link Stack}
+   * @return an unmodifiable {@link List} of {@link GamePiece}s contained in this {@link Stack}
    */
-  public List<GamePiece> getPiecesAsList() {
+  public List<GamePiece> asList() {
     List<GamePiece> result = new ArrayList<>();
     for (int i = 0; i < pieceCount; i++) {
       result.add(contents[i]);
     }
-    return result;
+    return Collections.unmodifiableList(result);
   }
 
   public Iterator<GamePiece> getPiecesReverseIterator() {
@@ -329,9 +330,9 @@ public class Stack implements GamePiece, StateMergeable {
     final Rectangle[] childBounds = new Rectangle[getPieceCount()];
     getMap().getStackMetrics().getContents(this, null, null, childBounds, 0, 0);
 
-    getPiecesAsList().stream()
-                     .filter(PieceIterator.VISIBLE)
-                     .forEach(p -> r.add(childBounds[indexOf(p)]));
+    asList().stream()
+            .filter(PieceIterator.VISIBLE)
+            .forEach(p -> r.add(childBounds[indexOf(p)]));
 
     return r;
   }
@@ -342,9 +343,9 @@ public class Stack implements GamePiece, StateMergeable {
     Shape[] childBounds = new Shape[getPieceCount()];
     StackMetrics metrics = getMap() == null ? getDefaultMetrics() : getMap().getStackMetrics();
     metrics.getContents(this, null, childBounds, null, 0, 0);
-    getPiecesAsList().stream()
-                     .filter(PieceIterator.VISIBLE)
-                     .forEach(p -> a.add(new Area(childBounds[indexOf(p)])));
+    asList().stream()
+            .filter(PieceIterator.VISIBLE)
+            .forEach(p -> a.add(new Area(childBounds[indexOf(p)])));
 
     return a;
   }
@@ -438,9 +439,9 @@ public class Stack implements GamePiece, StateMergeable {
    * @return Number of GamePieces that are visible to me
    */
   protected int nVisible() {
-    return (int) getPiecesAsList().stream()
-                                  .filter(PieceIterator.VISIBLE)
-                                  .count();
+    return (int) asList().stream()
+                         .filter(PieceIterator.VISIBLE)
+                         .count();
   }
 
   @Override
@@ -567,7 +568,7 @@ public class Stack implements GamePiece, StateMergeable {
    * @param val
    */
   public void setPropertyOnContents(Object key, Object val) {
-    getPiecesAsList().forEach(gamePiece -> gamePiece.setProperty(key, val));
+    asList().forEach(gamePiece -> gamePiece.setProperty(key, val));
   }
 
   @Override

--- a/test/VASSAL/counters/StackTest.java
+++ b/test/VASSAL/counters/StackTest.java
@@ -11,6 +11,8 @@ import java.awt.Point;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
+
+import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
@@ -466,7 +468,7 @@ public class StackTest {
   }
 
   @Test
-  public void getPiecesAsListShouldReturnWithCorrectSize() {
+  public void asListShouldReturnWithCorrectSize() {
     // prepare
     final GamePiece gamePiece1 = mock(GamePiece.class);
     final GamePiece gamePiece2 = mock(GamePiece.class);
@@ -477,14 +479,14 @@ public class StackTest {
     s.add(gamePiece1);
     s.add(gamePiece2);
     s.add(gamePiece3);
-    final List<GamePiece> pieces = s.getPiecesAsList();
+    final List<GamePiece> pieces = s.asList();
 
     // assert
     assertEquals(3, pieces.size());
   }
 
   @Test
-  public void getPiecesAsListShouldGetAllPiecesInOrder() {
+  public void asListShouldGetAllPiecesInOrder() {
     // prepare
     final GamePiece gamePiece0 = mock(GamePiece.class);
     final GamePiece gamePiece1 = mock(GamePiece.class);
@@ -495,7 +497,7 @@ public class StackTest {
     s.add(gamePiece0);
     s.add(gamePiece1);
     s.add(gamePiece2);
-    final List<GamePiece> pieces = s.getPiecesAsList();
+    final List<GamePiece> pieces = s.asList();
 
     // assert
     assertEquals(gamePiece0, pieces.get(0));
@@ -504,7 +506,7 @@ public class StackTest {
   }
 
   @Test
-  public void getPiecesAsListShouldReturnDefensiveCopy() {
+  public void asListShouldReturnDefensiveCopy() {
     // prepare
     final GamePiece gamePiece0 = mock(GamePiece.class);
     final GamePiece gamePiece1 = mock(GamePiece.class);
@@ -515,18 +517,32 @@ public class StackTest {
     s.add(gamePiece0);
     s.add(gamePiece1);
     s.add(gamePiece2);
-    final List<GamePiece> pieces = s.getPiecesAsList();
+    final List<GamePiece> pieces = s.asList();
 
     pieces.remove(0);
     pieces.remove(0);
 
     // assert
     assertEquals(3, s.getPieceCount());
-    final List<GamePiece> anotherPiecesList = s.getPiecesAsList();
+    final List<GamePiece> anotherPiecesList = s.asList();
     assertEquals(3, anotherPiecesList.size());
     assertEquals(gamePiece0, anotherPiecesList.get(0));
     assertEquals(gamePiece1, anotherPiecesList.get(1));
     assertEquals(gamePiece2, anotherPiecesList.get(2));
   }
 
+  @Test(expected = UnsupportedOperationException.class)
+  public void asListShouldReturnUnmodifiableList() {
+    // prepare
+    final GamePiece gamePiece0 = mock(GamePiece.class);
+    Stack s = new Stack();
+    s.add(gamePiece0);
+    final List<GamePiece> pieces = s.asList();
+
+    // run - trying to modify the list should throw
+    pieces.add(gamePiece0);
+
+    // assert - should not get here
+    Assert.fail();
+  }
 }

--- a/test/VASSAL/counters/StackTest.java
+++ b/test/VASSAL/counters/StackTest.java
@@ -464,4 +464,69 @@ public class StackTest {
     }
 
   }
+
+  @Test
+  public void getPiecesAsListShouldReturnWithCorrectSize() {
+    // prepare
+    final GamePiece gamePiece1 = mock(GamePiece.class);
+    final GamePiece gamePiece2 = mock(GamePiece.class);
+    final GamePiece gamePiece3 = mock(GamePiece.class);
+
+    // run
+    Stack s = new Stack();
+    s.add(gamePiece1);
+    s.add(gamePiece2);
+    s.add(gamePiece3);
+    final List<GamePiece> pieces = s.getPiecesAsList();
+
+    // assert
+    assertEquals(3, pieces.size());
+  }
+
+  @Test
+  public void getPiecesAsListShouldGetAllPiecesInOrder() {
+    // prepare
+    final GamePiece gamePiece0 = mock(GamePiece.class);
+    final GamePiece gamePiece1 = mock(GamePiece.class);
+    final GamePiece gamePiece2 = mock(GamePiece.class);
+
+    // run
+    Stack s = new Stack();
+    s.add(gamePiece0);
+    s.add(gamePiece1);
+    s.add(gamePiece2);
+    final List<GamePiece> pieces = s.getPiecesAsList();
+
+    // assert
+    assertEquals(gamePiece0, pieces.get(0));
+    assertEquals(gamePiece1, pieces.get(1));
+    assertEquals(gamePiece2, pieces.get(2));
+  }
+
+  @Test
+  public void getPiecesAsListShouldReturnDefensiveCopy() {
+    // prepare
+    final GamePiece gamePiece0 = mock(GamePiece.class);
+    final GamePiece gamePiece1 = mock(GamePiece.class);
+    final GamePiece gamePiece2 = mock(GamePiece.class);
+
+    // run
+    Stack s = new Stack();
+    s.add(gamePiece0);
+    s.add(gamePiece1);
+    s.add(gamePiece2);
+    final List<GamePiece> pieces = s.getPiecesAsList();
+
+    pieces.remove(0);
+    pieces.remove(0);
+
+    // assert
+    assertEquals(3, s.getPieceCount());
+    final List<GamePiece> anotherPiecesList = s.getPiecesAsList();
+    assertEquals(3, anotherPiecesList.size());
+    assertEquals(gamePiece0, anotherPiecesList.get(0));
+    assertEquals(gamePiece1, anotherPiecesList.get(1));
+    assertEquals(gamePiece2, anotherPiecesList.get(2));
+  }
+
 }

--- a/test/VASSAL/counters/StackTest.java
+++ b/test/VASSAL/counters/StackTest.java
@@ -505,32 +505,6 @@ public class StackTest {
     assertEquals(gamePiece2, pieces.get(2));
   }
 
-  @Test
-  public void asListShouldReturnDefensiveCopy() {
-    // prepare
-    final GamePiece gamePiece0 = mock(GamePiece.class);
-    final GamePiece gamePiece1 = mock(GamePiece.class);
-    final GamePiece gamePiece2 = mock(GamePiece.class);
-
-    // run
-    Stack s = new Stack();
-    s.add(gamePiece0);
-    s.add(gamePiece1);
-    s.add(gamePiece2);
-    final List<GamePiece> pieces = s.asList();
-
-    pieces.remove(0);
-    pieces.remove(0);
-
-    // assert
-    assertEquals(3, s.getPieceCount());
-    final List<GamePiece> anotherPiecesList = s.asList();
-    assertEquals(3, anotherPiecesList.size());
-    assertEquals(gamePiece0, anotherPiecesList.get(0));
-    assertEquals(gamePiece1, anotherPiecesList.get(1));
-    assertEquals(gamePiece2, anotherPiecesList.get(2));
-  }
-
   @Test(expected = UnsupportedOperationException.class)
   public void asListShouldReturnUnmodifiableList() {
     // prepare


### PR DESCRIPTION
For now this is only for discussion as it will probably clash with PR #5.

I am not too happy with the naming, but the simpler `getPieces()` is already taken by the old enumeration method.

This change would have some nice side effects, most of the clients of `getPiecesIterator()` can be rewritten to use the new method, and the List.stream() allows other interesting code improvements.

The whole `PieceIterator` and `PieceFilter` can probably be removed altogether, in favor of this new method and `Predicate<GamePiece>` from the stream API.