### PR TITLE
Refactoring - make the Deck testable

### DIFF
--- a/src/VASSAL/build/GameModule.java
+++ b/src/VASSAL/build/GameModule.java
@@ -1127,4 +1127,21 @@ public abstract class GameModule extends AbstractConfigurable implements Command
     myI18nData.setAttributeTranslatable(MODULE_VERSION, false);
     return myI18nData;
   }
+
+  /**
+   * @return the {@link PlayerRoster} instance, or <code>null</code> if no {@link PlayerRoster} exists
+   * within this {@link GameModule}
+   */
+  public PlayerRoster getPlayerRoster() {
+    return getComponentsOf(PlayerRoster.class).stream()
+                                              .findFirst()
+                                              .orElse(null);
+  }
+
+  public void addSideChangeListenerToPlayerRoster(PlayerRoster.SideChangeListener l) {
+    PlayerRoster r = getPlayerRoster();
+    if (r != null) {
+      r.addSideChangeListenerToInstance(l);
+    }
+  }
 }

--- a/src/VASSAL/build/module/Inventory.java
+++ b/src/VASSAL/build/module/Inventory.java
@@ -219,8 +219,8 @@ public class Inventory extends AbstractConfigurable
 
   @Override
   public void addTo(Buildable b) {
-  // Support for players changing sides
-  PlayerRoster.addSideChangeListener(this);
+    // Support for players changing sides
+    GameModule.getGameModule().addSideChangeListenerToPlayerRoster(this);
     launch.setAlignmentY(0.0F);
     GameModule.getGameModule().getToolBar().add(getComponent());
     GameModule.getGameModule().getGameState().addGameComponent(this);

--- a/src/VASSAL/build/module/Map.java
+++ b/src/VASSAL/build/module/Map.java
@@ -704,7 +704,7 @@ public class Map extends AbstractConfigurable implements GameComponent, MouseLis
       }
     });
 
-    PlayerRoster.addSideChangeListener(this);
+    GameModule.getGameModule().addSideChangeListenerToPlayerRoster(this);
     g.getPrefs().addOption(
       Resources.getString("Prefs.general_tab"), //$NON-NLS-1$
       new IntConfigurer(

--- a/src/VASSAL/build/module/PlayerRoster.java
+++ b/src/VASSAL/build/module/PlayerRoster.java
@@ -191,15 +191,20 @@ public class PlayerRoster extends AbstractConfigurable implements CommandEncoder
   public void addPropertyChangeListener(PropertyChangeListener l) {
   }
 
+  /**
+   * @deprecated use {@link GameModule#addSideChangeListenerToPlayerRoster(SideChangeListener)}
+   */
+  @Deprecated
   public static void addSideChangeListener(SideChangeListener l) {
-    PlayerRoster r = getInstance();
-    if (r != null) {
-      r.sideChangeListeners.add(l);
-    }
+    GameModule.getGameModule().addSideChangeListenerToPlayerRoster(l);
+  }
+
+  public void addSideChangeListenerToInstance(SideChangeListener l) {
+    sideChangeListeners.add(l);
   }
 
   public static void removeSideChangeListener(SideChangeListener l) {
-    PlayerRoster r = getInstance();
+    PlayerRoster r = GameModule.getGameModule().getPlayerRoster();
     if (r != null) {
       r.sideChangeListeners.remove(l);
     }
@@ -290,15 +295,15 @@ public class PlayerRoster extends AbstractConfigurable implements CommandEncoder
   }
 
   public static boolean isActive() {
-    return getInstance() != null;
+    return GameModule.getGameModule().getPlayerRoster() != null;
   }
 
+  /**
+   * @deprecated use {@link GameModule#getPlayerRoster()}
+   */
+  @Deprecated
   protected static PlayerRoster getInstance() {
-    for (PlayerRoster pr :
-         GameModule.getGameModule().getComponentsOf(PlayerRoster.class)) {
-      return pr;
-    }
-    return null;
+    return GameModule.getGameModule().getPlayerRoster();
   }
 
   public static String getMySide() {
@@ -310,7 +315,7 @@ public class PlayerRoster extends AbstractConfigurable implements CommandEncoder
   }
 
   protected static String getMySide(boolean localized) {
-    final PlayerRoster r = getInstance();
+    final PlayerRoster r = GameModule.getGameModule().getPlayerRoster();
     if (r != null) {
       for (PlayerInfo pi : r.getPlayers()) {
         if (pi.playerId.equals(GameModule.getUserId())) {
@@ -534,7 +539,7 @@ public class PlayerRoster extends AbstractConfigurable implements CommandEncoder
     }
 
     public String getLocalizedSide() {
-      return PlayerRoster.getInstance().translateSide(side);
+      return GameModule.getGameModule().getPlayerRoster().translateSide(side);
     }
   }
 

--- a/src/VASSAL/counters/Deck.java
+++ b/src/VASSAL/counters/Deck.java
@@ -199,7 +199,7 @@ public class Deck extends Stack implements PlayerRoster.SideChangeListener {
   public Deck(GameModule gameModule, String type) {
     this.gameModule = gameModule;
     mySetType(type);
-    PlayerRoster.addSideChangeListener(this);
+    gameModule.addSideChangeListenerToPlayerRoster(this);
   }
 
   public Deck(GameModule gameModule, String type, PropertySource source) {

--- a/src/VASSAL/counters/Restricted.java
+++ b/src/VASSAL/counters/Restricted.java
@@ -67,7 +67,7 @@ public class Restricted extends Decorator implements EditablePiece {
     mySetType(type);
     if (handleRetirement == null) {
       handleRetirement = new RetirementHandler();
-      PlayerRoster.addSideChangeListener(handleRetirement);
+      GameModule.getGameModule().addSideChangeListenerToPlayerRoster(handleRetirement);
     }
   }
 

--- a/test/VASSAL/counters/DeckTest.java
+++ b/test/VASSAL/counters/DeckTest.java
@@ -1,0 +1,26 @@
+package VASSAL.counters;
+
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.*;
+
+import VASSAL.build.GameModule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DeckTest {
+
+  @Test
+  public void defaultConstructorShouldConstruct() {
+    // prepare
+    final GameModule gameModule = mock(GameModule.class);
+
+    // run
+    Deck d = new Deck(gameModule);
+
+    // assert
+    assertNotNull(d);
+  }
+
+}


### PR DESCRIPTION
Another step towards make the `Deck` testable. For now as a draft. The static access to `PlayerRoster` had to be removed, after that the first unit tests can be written.

The static `PlayerRoster.getInstance()` had to be resolved, I decided to make it a method of the `GameModule` as it is the container for a possible `PlayerRoster` instance.

The static `PlayerRoster.addSideChangeListener()` also had to be changed, I decided to make it a method of the `GameModule` as well. It needed access to the PlayerRoster's sideChangeListeners so `PlayerRoster` received a new accessor method for it. And now the `GameModule.addSideChangeListenerToPlayerRoster()` is simply a convenience method, maybe it makes sense to remove it entirely and have the clients do what it does now i.e. get the `PlayerRoster` instance from the `GameModule`, do a null-check on it, and add the listener via the new `PlayerRoster.addSideChangeListenerToInstance()` method.

The naming for `PlayerRoster.addSideChangeListenerToInstance()`, I am not too happy with, but the `addSideChangeListener` is already used for the static method.

Taking this further, the sibling `static PlayerRoster.removeSideChangeListener()` should also change in the same way. Taking this even further, the many static methods of `PlayerRoster` can change into regular methods as well, and the clients can get a possible `PlayerRoster` instance from the `GameModule`, do the null-check themselves and then call these new methods.

I have also added a simple first test for `Deck`.

The change is backwards compatible, I have declared the methods as deprecated and referenced the new methods in their javadoc.

I have thought of two other ways of doing this, this particular way feels the least cumbersome and invasive, and uses the fact that one `GameModule` already is directly related to zero or one `PlayerRoster`s as an advantage. The other ways broke up this structure and either passed both a `GameModule` and a `PlayerRoster` to a new `Deck` via constructor, or passed some new container that contained both a `GameModule` and a `PlayerRoster` via `Deck`s constructor.

This part: `getComponentsOf(PlayerRoster.class).stream().findFirst().orElse(null)` is a replacement for the previous for-loop in `PlayerRoster.getInstance()` that did the same thing, it either returned the first found object, or null. I deduced from this that one `GameModule` is related to (has-a relation) zero or one `PlayerRoster`.

