### PR TITLE
Refactoring - use Stack.asList() instead of manual getPieceCount() / getPieceAt() access

### DIFF
--- a/src/VASSAL/build/module/map/KeyBufferer.java
+++ b/src/VASSAL/build/module/map/KeyBufferer.java
@@ -123,9 +123,7 @@ public class KeyBufferer extends MouseAdapter implements Buildable, MouseMotionL
           }
           else {
             Stack s = p.getParent();
-            for (int i = 0; i < s.getPieceCount(); i++) {
-              KeyBuffer.getBuffer().add(s.getPieceAt(i));
-            }
+            s.asList().forEach(gamePiece -> KeyBuffer.getBuffer().add(gamePiece));
           }
         }
         // End RFE 1629255
@@ -138,9 +136,7 @@ public class KeyBufferer extends MouseAdapter implements Buildable, MouseMotionL
             KeyBuffer.getBuffer().remove(p);
           }
           else if (!s.isExpanded()) {
-            for (int i = 0; i < s.getPieceCount(); i++) {
-              KeyBuffer.getBuffer().remove(s.getPieceAt(i));
-            }
+            s.asList().forEach(gamePiece -> KeyBuffer.getBuffer().remove(gamePiece));
           }
         }
         // End RFE 1659481
@@ -235,14 +231,14 @@ public class KeyBufferer extends MouseAdapter implements Buildable, MouseMotionL
           }
         }
         else if (mapsel.contains(s.getPosition())) {
-          for (int i = 0, n = s.getPieceCount(); i < n; ++i) {
+          s.asList().forEach(gamePiece -> {
             if (selecting) {
-              KeyBuffer.getBuffer().add(s.getPieceAt(i));
+              KeyBuffer.getBuffer().add(gamePiece);
             }
             else {
-              KeyBuffer.getBuffer().remove(s.getPieceAt(i));
+              KeyBuffer.getBuffer().remove(gamePiece);
             }
-          }
+          });
         }
       }
       return null;

--- a/src/VASSAL/build/module/map/MapShader.java
+++ b/src/VASSAL/build/module/map/MapShader.java
@@ -234,9 +234,7 @@ public class MapShader extends AbstractConfigurable implements GameComponent, Dr
   protected void checkPiece(Area area, GamePiece piece) {
     if (piece instanceof Stack) {
       Stack s = (Stack) piece;
-      for (int i = 0; i < s.getPieceCount(); i++) {
-        checkPiece(area, s.getPieceAt(i));
-      }
+      s.asList().forEach(gamePiece -> checkPiece(area, gamePiece));
     }
     else {
       ShadedPiece shaded = (ShadedPiece) Decorator.getDecorator(piece,ShadedPiece.class);

--- a/src/VASSAL/build/module/map/PieceMover.java
+++ b/src/VASSAL/build/module/map/PieceMover.java
@@ -461,8 +461,8 @@ public class PieceMover extends AbstractBuildable
   protected Command setOldLocations(GamePiece p) {
     Command comm = new NullCommand();
     if (p instanceof Stack) {
-      for (int i = 0; i < ((Stack) p).getPieceCount(); i++) {
-        comm = comm.append(Decorator.setOldProperties(((Stack) p).getPieceAt(i)));
+      for (GamePiece gamePiece : ((Stack) p).asList()) {
+        comm = comm.append(Decorator.setOldProperties(gamePiece));
       }
     }
     else {
@@ -540,10 +540,7 @@ public class PieceMover extends AbstractBuildable
        */
       final ArrayList<GamePiece> draggedPieces = new ArrayList<>(0);
       if (dragging instanceof Stack) {
-        int size = ((Stack) dragging).getPieceCount();
-        for (int i = 0; i < size; i++) {
-           draggedPieces.add(((Stack) dragging).getPieceAt(i));
-        }
+        draggedPieces.addAll(((Stack) dragging).asList());
       }
       else {
         draggedPieces.add(dragging);

--- a/src/VASSAL/counters/SendToLocation.java
+++ b/src/VASSAL/counters/SendToLocation.java
@@ -253,9 +253,9 @@ public class SendToLocation extends Decorator implements TranslatablePiece {
            GameModule.getGameModule().getGameState().getAllPieces()) {
         if (piece instanceof Stack) {
           Stack s = (Stack) piece;
-          for (int i = 0; i < s.getPieceCount(); i++) {
-            if (propertyFilter.accept(this, s.getPieceAt(i))) {
-              target = s.getPieceAt(i);
+          for (GamePiece gamePiece : s.asList()) {
+            if (propertyFilter.accept(this, gamePiece)) {
+              target = gamePiece;
               if (target != null) break;
             }
           }

--- a/src/VASSAL/script/ExpressionInterpreter.java
+++ b/src/VASSAL/script/ExpressionInterpreter.java
@@ -109,7 +109,7 @@ public class ExpressionInterpreter extends AbstractInterpreter {
    * can only be created by createInterpreter.
    *
    * @param expr Expression
-   * @throws MalformedExpressionException
+   * @throws ExpressionException
    */
   private ExpressionInterpreter(String expr) throws ExpressionException {
     super();
@@ -331,11 +331,10 @@ public class ExpressionInterpreter extends AbstractInterpreter {
     if (ps instanceof GamePiece) {
       Stack s = ((GamePiece) ps).getParent();
       if (s != null) {
-        for (int i = 0; i < s.getPieceCount(); i++) {
-          
+        for (GamePiece gamePiece : s.asList()) {
           try {
             result +=
-              Integer.parseInt(s.getPieceAt(i).getProperty(property).toString());
+              Integer.parseInt(gamePiece.getProperty(property).toString());
           }
           catch (Exception e) {
             // Anything at all goes wrong trying to add the property, just ignore it and treat as 0
@@ -370,9 +369,9 @@ public class ExpressionInterpreter extends AbstractInterpreter {
           if (here.equals(m.locationName(piece.getPosition()))) {
             if (piece instanceof Stack) {
               Stack s = (Stack) piece;
-              for (int j = 0; j < s.getPieceCount(); j++) {
+              for (GamePiece gamePiece : s.asList()) {
                 try {
-                  result += Integer.parseInt(s.getPieceAt(j).getProperty(property).toString());
+                  result += Integer.parseInt(gamePiece.getProperty(property).toString());
                 }
                 catch (NumberFormatException e) {
                   //


### PR DESCRIPTION
Some more places where the new Stack.asList() can be used instead of manual access of its contents. The loops that do not contain assignment to non-final variables use the more modern forEach() / stream() variants, rest uses the "traditional" handwritten foreach.

While I was at it, and my IDE went crazy and marked the whole class bright red because of this, I included a small fix of a reference to a non-existing Exception class in a javadoc.