### PR TITLE
Revert Stack.asList to return a defensive copy of contained GamePieces

### DIFF
--- a/src/VASSAL/counters/Stack.java
+++ b/src/VASSAL/counters/Stack.java
@@ -86,10 +86,15 @@ public class Stack implements GamePiece, StateMergeable {
   }
 
   /**
-   * @return an unmodifiable {@link List} of {@link GamePiece}s contained in this {@link Stack}
+   * @return an unmodifiable {@link List} which is a defensive copy of {@link GamePiece}s contained in
+   * this {@link Stack}
    */
   public List<GamePiece> asList() {
-    return Collections.unmodifiableList(Arrays.asList(contents).subList(0, pieceCount));
+    List<GamePiece> result = new ArrayList<>();
+    for (int i = 0; i < pieceCount; i++) {
+      result.add(contents[i]);
+    }
+    return Collections.unmodifiableList(result);
   }
 
   public Iterator<GamePiece> getPiecesReverseIterator() {

--- a/test/VASSAL/counters/StackTest.java
+++ b/test/VASSAL/counters/StackTest.java
@@ -519,4 +519,24 @@ public class StackTest {
     // assert - should not get here
     Assert.fail();
   }
+
+  @Test
+  public void asListShouldReturnDefensiveList() {
+    // prepare
+    final GamePiece gamePiece0 = mock(GamePiece.class);
+    final GamePiece gamePiece1 = mock(GamePiece.class);
+    Stack s = new Stack();
+    s.add(gamePiece0);
+    s.add(gamePiece1);
+
+    // run - trying to modify the list should throw
+    final List<GamePiece> pieces = s.asList();
+    s.removePieceAt(0);
+
+    // assert - should not get here
+    assertEquals(2, pieces.size());
+    assertEquals(gamePiece0, pieces.get(0));
+    assertEquals(gamePiece1, pieces.get(1));
+  }
+
 }

--- a/test/VASSAL/counters/StackTest.java
+++ b/test/VASSAL/counters/StackTest.java
@@ -529,11 +529,11 @@ public class StackTest {
     s.add(gamePiece0);
     s.add(gamePiece1);
 
-    // run - trying to modify the list should throw
+    // run
     final List<GamePiece> pieces = s.asList();
     s.removePieceAt(0);
 
-    // assert - should not get here
+    // assert
     assertEquals(2, pieces.size());
     assertEquals(gamePiece0, pieces.get(0));
     assertEquals(gamePiece1, pieces.get(1));


### PR DESCRIPTION
This should fix the bug mentioned in http://www.vassalengine.org/forum/viewtopic.php?f=3&t=11996