### PR TITLE
Bug 13137 - Drag Threshold - fixes bug where drag threshold was effectively 1 pixel. Also allows user to adjust w/ preference.

### DIFF
--- a/src/main/java/VASSAL/build/GameModule.java
+++ b/src/main/java/VASSAL/build/GameModule.java
@@ -186,7 +186,7 @@ public abstract class GameModule extends AbstractConfigurable implements Command
   protected GpIdSupport gpidSupport = null;
   protected Long crc = null;
   
-  private static String oldDragThreshold; //BR//13137
+  private static String oldDragThreshold; //
 
   /**
    * @return the top-level frame of the controls window
@@ -882,7 +882,7 @@ public abstract class GameModule extends AbstractConfigurable implements Command
       theModule.checkGpIds();
     }
     
-    //BR//13137 - Save our old drag threshold
+    //Save our old drag threshold
     oldDragThreshold = System.getProperty("awt.dnd.drag.threshold");
     System.setProperty("awt.dnd.drag.threshold", Integer.toString(GlobalOptions.getDragThreshold()));
 

--- a/src/main/java/VASSAL/build/GameModule.java
+++ b/src/main/java/VASSAL/build/GameModule.java
@@ -185,6 +185,8 @@ public abstract class GameModule extends AbstractConfigurable implements Command
    */
   protected GpIdSupport gpidSupport = null;
   protected Long crc = null;
+  
+  private static String oldDragThreshold; //BR//13137
 
   /**
    * @return the top-level frame of the controls window
@@ -871,7 +873,7 @@ public abstract class GameModule extends AbstractConfigurable implements Command
         throw e;
       }
     }
-
+    
     /*
      *  If we are editing, check for duplicate, illegal or missing GamePiece Id's
      *  and update if necessary.
@@ -879,6 +881,10 @@ public abstract class GameModule extends AbstractConfigurable implements Command
     if (theModule.getDataArchive() instanceof ArchiveWriter) {
       theModule.checkGpIds();
     }
+    
+    //BR//13137 - Save our old drag threshold
+    oldDragThreshold = System.getProperty("awt.dnd.drag.threshold");
+    System.setProperty("awt.dnd.drag.threshold", Integer.toString(GlobalOptions.getDragThreshold()));
 
     /*
      * Tell any Plugin components that the build is complete so that they
@@ -893,6 +899,14 @@ public abstract class GameModule extends AbstractConfigurable implements Command
    * Unload the module
    */
   public static void unload() {
+    
+    //BR// Put our old drag threshold back, or if it wasn't set then return it to an unset state.
+    if (oldDragThreshold != null) {
+      System.setProperty("awt.dnd.drag.threshold", oldDragThreshold);      
+    } else {
+      System.setProperty("awt.dnd.drag.threshold", "");            
+    }
+    
     if (theModule != null) {
       if (theModule.shutDown()) {
         theModule = null;

--- a/src/main/java/VASSAL/build/GameModule.java
+++ b/src/main/java/VASSAL/build/GameModule.java
@@ -900,11 +900,11 @@ public abstract class GameModule extends AbstractConfigurable implements Command
    */
   public static void unload() {
     
-    //BR// Put our old drag threshold back, or if it wasn't set then return it to an unset state.
+    // Put our old drag threshold back, or if it wasn't set then return it to an unset state.
     if (oldDragThreshold != null) {
       System.setProperty("awt.dnd.drag.threshold", oldDragThreshold);      
     } else {
-      System.setProperty("awt.dnd.drag.threshold", "");            
+      System.clearProperty("awt.dnd.drag.threshold");            
     }
     
     if (theModule != null) {

--- a/src/main/java/VASSAL/build/GameModule.java
+++ b/src/main/java/VASSAL/build/GameModule.java
@@ -884,7 +884,7 @@ public abstract class GameModule extends AbstractConfigurable implements Command
     
     //Save our old drag threshold
     oldDragThreshold = System.getProperty("awt.dnd.drag.threshold");
-    System.setProperty("awt.dnd.drag.threshold", Integer.toString(GlobalOptions.getDragThreshold()));
+    System.setProperty("awt.dnd.drag.threshold", Integer.toString(GlobalOptions.getInstance().getDragThreshold()));
 
     /*
      * Tell any Plugin components that the build is complete so that they

--- a/src/main/java/VASSAL/build/module/GlobalOptions.java
+++ b/src/main/java/VASSAL/build/module/GlobalOptions.java
@@ -94,7 +94,7 @@ public class GlobalOptions extends AbstractConfigurable {
   private String autoReport = ALWAYS;
   private String markMoved = NEVER;
   
-  private static int dragThreshold = 10;
+  private int dragThreshold = 10;
 
   private Map<String,Object> properties = new HashMap<>();
   private static Map<String,Configurer> optionConfigurers = new LinkedHashMap<>();
@@ -477,10 +477,10 @@ public class GlobalOptions extends AbstractConfigurable {
     return isEnabled(markMoved, MARK_MOVED);
   }
   
-  public static int getDragThreshold() {
+  public int getDragThreshold() {
     return dragThreshold;
   }
-
+  
   public String getPlayerId() {
     playerIdFormat.setProperty(PLAYER_NAME, (String) GameModule.getGameModule().getPrefs().getValue(GameModule.REAL_NAME));
     playerIdFormat.setProperty(PLAYER_SIDE, PlayerRoster.getMyLocalizedSide());

--- a/src/main/java/VASSAL/build/module/GlobalOptions.java
+++ b/src/main/java/VASSAL/build/module/GlobalOptions.java
@@ -76,8 +76,9 @@ public class GlobalOptions extends AbstractConfigurable {
   public static final String SINGLE_WINDOW = "singleWindow"; //$NON-NLS-1$
   public static final String MAXIMUM_HEAP = "maximumHeap"; //$NON-NLS-1$
   public static final String INITIAL_HEAP = "initialHeap"; //$NON-NLS-1$
-  public static final String BUG_10295 = "bug10295";
-  public static final String CLASSIC_MFD = "classicMfd";
+  public static final String BUG_10295 = "bug10295"; //$NON-NLS-1$
+  public static final String CLASSIC_MFD = "classicMfd"; //$NON-NLS-1$
+  public static final String DRAG_THRESHOLD = "dragThreshold"; //$NON-NLS-1$
 
   public static final String PLAYER_NAME = "PlayerName"; //$NON-NLS-1$
   public static final String PLAYER_NAME_ALT = "playerName"; //$NON-NLS-1$
@@ -92,6 +93,8 @@ public class GlobalOptions extends AbstractConfigurable {
   private String centerOnMoves = ALWAYS;
   private String autoReport = ALWAYS;
   private String markMoved = NEVER;
+  
+  private static int dragThreshold = 10;
 
   private Map<String,Object> properties = new HashMap<>();
   private static Map<String,Configurer> optionConfigurers = new LinkedHashMap<>();
@@ -181,6 +184,21 @@ public class GlobalOptions extends AbstractConfigurable {
     classicMfd.addPropertyChangeListener( (evt) -> setUseClassicMoveFixedDistance(classicMfd.getValueBoolean()));
     prefs.addOption(classicMfd);
 
+    //BR// Drag Threshold
+    final IntConfigurer dragThresholdConf = new IntConfigurer(
+      DRAG_THRESHOLD,
+      Resources.getString("Mouse Drag Threshold"),  //$NON-NLS-1$
+      10
+    );
+    dragThresholdConf.addPropertyChangeListener(new PropertyChangeListener() {
+      @Override
+      public void propertyChange(PropertyChangeEvent e) {
+        dragThreshold = dragThresholdConf.getIntValue(10);
+        System.setProperty("awt.dnd.drag.threshold", Integer.toString(dragThreshold));
+      }
+    });
+    prefs.addOption(dragThresholdConf);
+    
     validator = new SingleChildInstance(gm, getClass());
   }
 
@@ -374,6 +392,9 @@ public class GlobalOptions extends AbstractConfigurable {
     else if (PLAYER_ID_FORMAT.equals(key)) {
       return playerIdFormat.getFormat();
     }
+    else if (DRAG_THRESHOLD.equals(key)) {
+      return Integer.toString(dragThreshold);  
+    }
     else if (!optionConfigurers.containsKey(key)) {
       Object val = properties.get(key);
       return val != null ? val.toString() : null;
@@ -454,6 +475,10 @@ public class GlobalOptions extends AbstractConfigurable {
 
   public boolean isMarkMoveEnabled() {
     return isEnabled(markMoved, MARK_MOVED);
+  }
+  
+  public static int getDragThreshold() {
+    return dragThreshold;
   }
 
   public String getPlayerId() {

--- a/src/main/java/VASSAL/build/module/GlobalOptions.java
+++ b/src/main/java/VASSAL/build/module/GlobalOptions.java
@@ -187,7 +187,7 @@ public class GlobalOptions extends AbstractConfigurable {
     //BR// Drag Threshold
     final IntConfigurer dragThresholdConf = new IntConfigurer(
       DRAG_THRESHOLD,
-      Resources.getString("Mouse Drag Threshold"),  //$NON-NLS-1$
+      Resources.getString("GlobalOptions.mouse_drag_threshold"),  //$NON-NLS-1$
       10
     );
     dragThresholdConf.addPropertyChangeListener(new PropertyChangeListener() {

--- a/src/main/java/VASSAL/build/module/Map.java
+++ b/src/main/java/VASSAL/build/module/Map.java
@@ -1221,6 +1221,15 @@ public class Map extends AbstractConfigurable implements GameComponent, MouseLis
   @Override
   public void mouseExited(MouseEvent e) {
   }
+  
+  
+  public MouseEvent translateEvent(MouseEvent e) {
+    //don't write over java's mouse event
+    MouseEvent mapEvent = new MouseEvent(e.getComponent(), e.getID(), e.getWhen(), e.getModifiersEx(), e.getX(), e.getY(), e.getXOnScreen(), e.getYOnScreen(), e.getClickCount(), e.isPopupTrigger(), e.getButton());
+    final Point p = componentToMap(mapEvent.getPoint());
+    mapEvent.translatePoint(p.x - mapEvent.getX(), p.y - mapEvent.getY());
+    return mapEvent;
+  }
 
   /**
    * Mouse events are first translated into map coordinates. Then the event is forwarded to the top MouseListener in the
@@ -1232,17 +1241,11 @@ public class Map extends AbstractConfigurable implements GameComponent, MouseLis
    */
   @Override
   public void mouseClicked(MouseEvent e) {
-    //BR// Bug13137 - don't write over java's mouse event
-    MouseEvent mapEvent = new MouseEvent(e.getComponent(), e.getID(), e.getWhen(), e.getModifiersEx(), e.getX(), e.getY(), e.getXOnScreen(), e.getYOnScreen(), e.getClickCount(), e.isPopupTrigger(), e.getButton());
     if (!mouseListenerStack.isEmpty()) {
-      final Point p = componentToMap(mapEvent.getPoint());
-      mapEvent.translatePoint(p.x - mapEvent.getX(), p.y - mapEvent.getY());
-      mouseListenerStack.get(mouseListenerStack.size()-1).mouseClicked(mapEvent);
+      mouseListenerStack.get(mouseListenerStack.size()-1).mouseClicked(translateEvent(e));
     }
     else if (multicaster != null) {
-      final Point p = componentToMap(mapEvent.getPoint());
-      mapEvent.translatePoint(p.x - mapEvent.getX(), p.y - mapEvent.getY());
-      multicaster.mouseClicked(mapEvent);
+      multicaster.mouseClicked(translateEvent(e));
     }
   }
 
@@ -1285,17 +1288,11 @@ public class Map extends AbstractConfigurable implements GameComponent, MouseLis
     }
     activeMap = this;
 
-    //BR// Bug13137 - don't write over java's mouse event    
-    MouseEvent mapEvent = new MouseEvent(e.getComponent(), e.getID(), e.getWhen(), e.getModifiersEx(), e.getX(), e.getY(), e.getXOnScreen(), e.getYOnScreen(), e.getClickCount(), e.isPopupTrigger(), e.getButton());
     if (!mouseListenerStack.isEmpty()) {
-      final Point p = componentToMap(mapEvent.getPoint());
-      mapEvent.translatePoint(p.x - mapEvent.getX(), p.y - mapEvent.getY());
-      mouseListenerStack.get(mouseListenerStack.size()-1).mousePressed(mapEvent);
+      mouseListenerStack.get(mouseListenerStack.size()-1).mousePressed(translateEvent(e));
     }
     else if (multicaster != null) {
-      final Point p = componentToMap(mapEvent.getPoint());
-      mapEvent.translatePoint(p.x - mapEvent.getX(), p.y - mapEvent.getY());
-      multicaster.mousePressed(mapEvent);
+      multicaster.mousePressed(translateEvent(e));
     }
   }
 
@@ -1310,20 +1307,15 @@ public class Map extends AbstractConfigurable implements GameComponent, MouseLis
    */
   @Override
   public void mouseReleased(MouseEvent e) {
-    //BR// Bug13137 - don't write over java's mouse event
-    MouseEvent mapEvent = new MouseEvent(e.getComponent(), e.getID(), e.getWhen(), e.getModifiersEx(), e.getX(), e.getY(), e.getXOnScreen(), e.getYOnScreen(), e.getClickCount(), e.isPopupTrigger(), e.getButton());
+    // don't write over java's mouse event
     Point p = e.getPoint();
     p.translate(theMap.getX(), theMap.getY());
     if (theMap.getBounds().contains(p)) {
       if (!mouseListenerStack.isEmpty()) {
-        p = componentToMap(mapEvent.getPoint());
-        mapEvent.translatePoint(p.x - mapEvent.getX(), p.y - mapEvent.getY());
-        mouseListenerStack.get(mouseListenerStack.size()-1).mouseReleased(mapEvent);
+        mouseListenerStack.get(mouseListenerStack.size()-1).mouseReleased(translateEvent(e));
       }
       else if (multicaster != null) {
-        p = componentToMap(mapEvent.getPoint());
-        mapEvent.translatePoint(p.x - mapEvent.getX(), p.y - mapEvent.getY());
-        multicaster.mouseReleased(mapEvent);
+        multicaster.mouseReleased(translateEvent(e));
       }
       // Request Focus so that keyboard input will be recognized
       theMap.requestFocus();

--- a/src/main/java/VASSAL/build/module/Map.java
+++ b/src/main/java/VASSAL/build/module/Map.java
@@ -1232,15 +1232,17 @@ public class Map extends AbstractConfigurable implements GameComponent, MouseLis
    */
   @Override
   public void mouseClicked(MouseEvent e) {
+    //BR// Bug13137 - don't write over java's mouse event
+    MouseEvent mapEvent = new MouseEvent(e.getComponent(), e.getID(), e.getWhen(), e.getModifiersEx(), e.getX(), e.getY(), e.getXOnScreen(), e.getYOnScreen(), e.getClickCount(), e.isPopupTrigger(), e.getButton());
     if (!mouseListenerStack.isEmpty()) {
-      final Point p = componentToMap(e.getPoint());
-      e.translatePoint(p.x - e.getX(), p.y - e.getY());
-      mouseListenerStack.get(mouseListenerStack.size()-1).mouseClicked(e);
+      final Point p = componentToMap(mapEvent.getPoint());
+      mapEvent.translatePoint(p.x - mapEvent.getX(), p.y - mapEvent.getY());
+      mouseListenerStack.get(mouseListenerStack.size()-1).mouseClicked(mapEvent);
     }
     else if (multicaster != null) {
-      final Point p = componentToMap(e.getPoint());
-      e.translatePoint(p.x - e.getX(), p.y - e.getY());
-      multicaster.mouseClicked(e);
+      final Point p = componentToMap(mapEvent.getPoint());
+      mapEvent.translatePoint(p.x - mapEvent.getX(), p.y - mapEvent.getY());
+      multicaster.mouseClicked(mapEvent);
     }
   }
 
@@ -1283,15 +1285,17 @@ public class Map extends AbstractConfigurable implements GameComponent, MouseLis
     }
     activeMap = this;
 
+    //BR// Bug13137 - don't write over java's mouse event    
+    MouseEvent mapEvent = new MouseEvent(e.getComponent(), e.getID(), e.getWhen(), e.getModifiersEx(), e.getX(), e.getY(), e.getXOnScreen(), e.getYOnScreen(), e.getClickCount(), e.isPopupTrigger(), e.getButton());
     if (!mouseListenerStack.isEmpty()) {
-      final Point p = componentToMap(e.getPoint());
-      e.translatePoint(p.x - e.getX(), p.y - e.getY());
-      mouseListenerStack.get(mouseListenerStack.size()-1).mousePressed(e);
+      final Point p = componentToMap(mapEvent.getPoint());
+      mapEvent.translatePoint(p.x - mapEvent.getX(), p.y - mapEvent.getY());
+      mouseListenerStack.get(mouseListenerStack.size()-1).mousePressed(mapEvent);
     }
     else if (multicaster != null) {
-      final Point p = componentToMap(e.getPoint());
-      e.translatePoint(p.x - e.getX(), p.y - e.getY());
-      multicaster.mousePressed(e);
+      final Point p = componentToMap(mapEvent.getPoint());
+      mapEvent.translatePoint(p.x - mapEvent.getX(), p.y - mapEvent.getY());
+      multicaster.mousePressed(mapEvent);
     }
   }
 
@@ -1306,18 +1310,20 @@ public class Map extends AbstractConfigurable implements GameComponent, MouseLis
    */
   @Override
   public void mouseReleased(MouseEvent e) {
+    //BR// Bug13137 - don't write over java's mouse event
+    MouseEvent mapEvent = new MouseEvent(e.getComponent(), e.getID(), e.getWhen(), e.getModifiersEx(), e.getX(), e.getY(), e.getXOnScreen(), e.getYOnScreen(), e.getClickCount(), e.isPopupTrigger(), e.getButton());
     Point p = e.getPoint();
     p.translate(theMap.getX(), theMap.getY());
     if (theMap.getBounds().contains(p)) {
       if (!mouseListenerStack.isEmpty()) {
-        p = componentToMap(e.getPoint());
-        e.translatePoint(p.x - e.getX(), p.y - e.getY());
-        mouseListenerStack.get(mouseListenerStack.size()-1).mouseReleased(e);
+        p = componentToMap(mapEvent.getPoint());
+        mapEvent.translatePoint(p.x - mapEvent.getX(), p.y - mapEvent.getY());
+        mouseListenerStack.get(mouseListenerStack.size()-1).mouseReleased(mapEvent);
       }
       else if (multicaster != null) {
-        p = componentToMap(e.getPoint());
-        e.translatePoint(p.x - e.getX(), p.y - e.getY());
-        multicaster.mouseReleased(e);
+        p = componentToMap(mapEvent.getPoint());
+        mapEvent.translatePoint(p.x - mapEvent.getX(), p.y - mapEvent.getY());
+        multicaster.mouseReleased(mapEvent);
       }
       // Request Focus so that keyboard input will be recognized
       theMap.requestFocus();

--- a/src/main/java/VASSAL/build/module/map/PieceMover.java
+++ b/src/main/java/VASSAL/build/module/map/PieceMover.java
@@ -1216,9 +1216,7 @@ public class PieceMover extends AbstractBuildable
       final Map map = dge.getComponent() instanceof Map.View ?
                       ((Map.View) dge.getComponent()).getMap() : null;
 
-      final Point mousePosition = (map == null)
-                        ? dge.getDragOrigin()
-                        : map.mapToComponent(dge.getDragOrigin());
+      final Point mousePosition = dge.getDragOrigin(); //BR// Bug13137 - now that we're not pre-adulterating dge's event, it already arrives in component coordinates
       Point piecePosition = (map == null)
                     ?  piece.getPosition()
                     : map.mapToComponent(piece.getPosition());

--- a/src/main/resources/VASSAL/i18n/VASSAL.properties
+++ b/src/main/resources/VASSAL/i18n/VASSAL.properties
@@ -474,6 +474,7 @@ GlobalOptions.initial_heap=JVM initial heap (in MB):
 GlobalOptions.maximum_heap=JVM maximum heap (in MB):
 GlobalOptions.bug10295=Drag ghost bug correction?
 GlobalOptions.classic_mfd=Use Classic Move Fixed Distance trait move batching?
+GlobalOptions.mouse_drag_threshold=Mouse Drag Threshold
 
 # Help Window
 Help.error_log=Show Error Log


### PR DESCRIPTION
Map's mouse listeners were translating the coordinates of mouse events from component coordinates to map coordinates before passing them on, but doing so in a way that actually overwrote the original event that awt DragGestureRecognizer was still using, resulting in an apples-to-oranges coordinate comparison that effectively reduced the dragThreshold to 1 at any zoom other than 100%. This is now fixed, and a user preference added to adjust the drag threshold (because 5 is still actually pretty damn tight)