### PR TITLE
Updated the the project version for Maven

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
 	<groupId>org.vassal</groupId>
 	<artifactId>vassalengine</artifactId>
-	<version>3.3.1-SNAPSHOT</version>
+	<version>3.3.2-SNAPSHOT</version>
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
Maven uses its own project version, this is now largely irrelevant but already appears in the CI build and might become more useful later on.