### PR TITLE
Set git clone depth to 3 in travis build configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,4 @@ cache:
     - $HOME/.m2
 
 git:
-  depth: 3
+  depth: 1

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,6 @@ jdk: openjdk11
 cache:
   directories:
     - $HOME/.m2
+
+git:
+  depth: 3


### PR DESCRIPTION
A depth of 1 would probably be enough since we don't do anything with the git history during the build, but let's go with 3, just in case.