### PR TITLE
Bug 13140: Versions with a build number are incorrectly sorted

### DIFF
--- a/src/main/java/VASSAL/tools/version/VassalVersionTokenizer.java
+++ b/src/main/java/VASSAL/tools/version/VassalVersionTokenizer.java
@@ -53,7 +53,7 @@ public class VassalVersionTokenizer implements VersionTokenizer {
   // alone need to be maintined here. (E.g., the 3.1.0 tags can be removed
   // as soon as 3.1.1 is released.) We keep one tag for testing purposes.
   protected static Map<String,Integer> tags = Map.of(
-    "test", 0
+    "test", -1
   );
 
   /**
@@ -109,7 +109,7 @@ public class VassalVersionTokenizer implements VersionTokenizer {
         case '-':
           state = State.TAG;
           v = v.substring(1);
-          return -2;
+          break;
         default:
           throw new VersionFormatException();
         }

--- a/src/test/java/VASSAL/tools/version/VassalVersionTokenizerTest.java
+++ b/src/test/java/VASSAL/tools/version/VassalVersionTokenizerTest.java
@@ -29,16 +29,17 @@ public class VassalVersionTokenizerTest {
     // expected tokens. A null indicates that a VersionFormatException
     // is expected.
     final Object[][] versions = {
-      { "1.2.3",                   1, 2, 3            },
-      { "1.2.3.4",                 1, 2, 3, 4         },
-      { "1.2.3-rc3",               1, 2, 3, -2, null  },
-      { "foobarbaz",               null               },
-      { "1.2.foo",                 1, 2, null         },
-      { "1.2-foo",                 1, 2, -2, null     },
-      { "3.0b6",                   3, 0, null         },
-      { "3.3.1-test",              3, 3, 1, -2, 0     },
-      { "3.3.1-test-80",           3, 3, 1, -2, 0, 80 },
-      { "3.3.1-test-80-gf8ef2523", 3, 3, 1, -2, 0, 80 }
+      { "1.2.3",                   1, 2, 3         },
+      { "1.2.3.4",                 1, 2, 3, 4      },
+      { "1.2.3-rc3",               1, 2, 3, null   },
+      { "foobarbaz",               null            },
+      { "1.2.foo",                 1, 2, null      },
+      { "3.0b6",                   3, 0, null      },
+      { "3.3.1-test",              3, 3, 1, -1     },
+      { "3.3.1-test-80",           3, 3, 1, -1, 80 },
+      { "3.3.1-test-80-gf8ef2523", 3, 3, 1, -1, 80 },
+      { "3.3.1-80",                3, 3, 1, 80     },
+      { "3.3.1-80-gf8ef2523",      3, 3, 1, 80     }
     };
 
     for (Object[] v : versions) {


### PR DESCRIPTION
Versions with a build number are incorrectly sorted before versions without a build number.

It should be the case that 3.3.1 < 3.3.1-42, but the version tokenizer has it the other way around.