### PR TITLE
Bug 13143: HTTPS URLs fail to load (handshake_failure)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -20,6 +20,8 @@
 
 3.3.2 - ???
 
+* 13143:  HTTPS URLs fail to load (handshake_failure) due to missing
+    jdk.crypto.ec module
 * 13140: Versions with a build number are incorrectly sorted before versions
     without a build number
 * 13136: Update notifier still has old SourceForge URL for downloads

--- a/Makefile
+++ b/Makefile
@@ -105,7 +105,8 @@ $(TMPDIR)/VASSAL.exe: fast-compile $(TMPDIR)
 	$(LAUNCH4J) $(CURDIR)/$(TMPDIR)/VASSAL.l4j.xml
 
 $(TMPDIR)/module_deps: $(LIBDIR)/Vengine.jar $(TMPDIR)
-	$(JDEPS) --ignore-missing-deps --print-module-deps $(LIBDIR)/*.jar >$@
+	echo -n jdk.crypto.ec, >$@
+	$(JDEPS) --ignore-missing-deps --print-module-deps $(LIBDIR)/*.jar >>$@
 
 #dist/windows/VASSAL.ico:
 #	convert -bordercolor Transparent -border 1x1 src/icons/22x22/VASSAL.png $(TMPDIR)/VASSAL-24.png


### PR DESCRIPTION
The jdk.crypto.ec module is required to resolve HTTPS URLs. Add that to the module dependencies for jlink.