### PR TITLE
13153 fix the start-a-log-file at beginning of game preference to work right, and give it a comprehensible name

### DIFF
--- a/src/main/java/VASSAL/build/module/GameState.java
+++ b/src/main/java/VASSAL/build/module/GameState.java
@@ -339,6 +339,18 @@ public class GameState implements CommandEncoder {
 
     if (gameStarted) {
       adjustSplitter();
+
+      if (gameStarting) {
+        SwingUtilities.invokeLater(new Runnable() {
+          @Override
+          public void run() {
+            Logger logger = GameModule.getGameModule().getLogger();
+            if (logger instanceof BasicLogger) {
+              ((BasicLogger)logger).queryNewLogFile(true);
+            }
+          }
+        });
+      }
     }
   }
 
@@ -827,10 +839,6 @@ public class GameState implements CommandEncoder {
           }
 
           GameModule.getGameModule().warn(msg);
-          Logger logger = GameModule.getGameModule().getLogger();
-          if (logger instanceof BasicLogger) {
-            ((BasicLogger)logger).queryNewLogFile(true);
-          }
         }
         finally {
           frame.setCursor(Cursor.getPredefinedCursor(Cursor.DEFAULT_CURSOR));

--- a/src/main/resources/VASSAL/i18n/VASSAL.properties
+++ b/src/main/resources/VASSAL/i18n/VASSAL.properties
@@ -182,7 +182,7 @@ AdjustableSpeedScrollPane.scroll_increment=Scroll increment (pixels):
 
 # BasicLogger
 BasicLogger.undo_last_move=Undo last move
-BasicLogger.replay_commencing=New game loaded
+BasicLogger.replay_commencing=New Session Beginning
 BasicLogger.replay_completed=End of Logfile
 BasicLogger.dont_prompt_again=Don't prompt again
 BasicLogger.logfile_written=Logfile written.
@@ -193,7 +193,7 @@ BasicLogger.step_forward_tooltip=Step forward through logfile [Page Down]
 BasicLogger.step_forward_tooltip2=Step Forward through logfile [%1$s]
 BasicLogger.step_forward_button=Step forward button icon:  
 BasicLogger.step_forward_hotkey=Step forward hotkey:  
-BasicLogger.prompt_new_log_before=Ask to start logging before a Replay?
+BasicLogger.prompt_new_log_before=Ask to ensure logging when starting or loading a game?
 BasicLogger.prompt_new_log_after=Ask to ensure logging after a replay?
 BasicLogger.save_log=You are writing a logfile.\nSave now?
 BasicLogger.cant_log=Can't log a LogCommand


### PR DESCRIPTION
Possibly we don't want this to fire for an online game, but afaik it would have fired before (in the paths where it actually fired) -- but the implementation had grown so full of weeds that it's hard to know what was really intended. Anyway it would be easy to just ignore this in an online game. 