### PR TITLE
Bug 13126: Right mouse button and Control-Click broken on Macs

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -41,6 +41,7 @@
 * 13140: Versions with a build number are incorrectly sorted before versions
     without a build number
 * 13136: Update notifier still has old SourceForge URL for downloads
+* 13126: Right mouse button and Control-Click broken on Macs
 
 3.3.1 - 22 June 2020
 

--- a/pom.xml
+++ b/pom.xml
@@ -128,7 +128,7 @@
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
-			<version>4.7</version>
+			<version>4.13</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
@@ -153,6 +153,12 @@
 			<groupId>org.mockito</groupId>
 			<artifactId>mockito-core</artifactId>
 			<version>3.3.12</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>com.github.stefanbirkner</groupId>
+			<artifactId>system-rules</artifactId>
+			<version>1.19.0</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/src/main/java/VASSAL/build/module/Map.java
+++ b/src/main/java/VASSAL/build/module/Map.java
@@ -1424,7 +1424,7 @@ public class Map extends AbstractConfigurable implements GameComponent, MouseLis
    */
   @Override
   public void mouseDragged(MouseEvent e) {
-    if (e.getButton() != 3) {
+    if (!SwingUtils.isRightMouseButton(e)) {
       scrollAtEdge(e.getPoint(), SCROLL_ZONE);
     }
     else {

--- a/src/main/java/VASSAL/build/module/Map.java
+++ b/src/main/java/VASSAL/build/module/Map.java
@@ -658,7 +658,9 @@ public class Map extends AbstractConfigurable implements GameComponent, MouseLis
     final DragGestureListener dgl = new DragGestureListener() {
       @Override
       public void dragGestureRecognized(DragGestureEvent dge) {
-        if (mouseListenerStack.isEmpty() && dragGestureListener != null) {
+        if (dragGestureListener != null &&
+            mouseListenerStack.isEmpty() &&
+            SwingUtils.isDragTrigger(dge)) {
           dragGestureListener.dragGestureRecognized(dge);
         }
       }
@@ -1181,10 +1183,12 @@ public class Map extends AbstractConfigurable implements GameComponent, MouseLis
   }
 
   /**
-   * Because MouseEvents are received in component coordinates, it is inconvenient for MouseListeners on the map to have
-   * to translate to map coordinates. MouseListeners added with this method will receive mouse events with points
-   * already translated into map coordinates.
-   * addLocalMouseListenerFirst inserts the new listener at the start of the chain.
+   * Because MouseEvents are received in component coordinates, it is
+   * inconvenient for MouseListeners on the map to have to translate to map
+   * coordinates. MouseListeners added with this method will receive mouse
+   * events with points already translated into map coordinates.
+   * addLocalMouseListenerFirst inserts the new listener at the start of the
+   * chain.
    */
   public void addLocalMouseListener(MouseListener l) {
     multicaster = AWTEventMulticaster.add(multicaster, l);
@@ -1224,8 +1228,12 @@ public class Map extends AbstractConfigurable implements GameComponent, MouseLis
   
   
   public MouseEvent translateEvent(MouseEvent e) {
-    //don't write over java's mouse event
-    MouseEvent mapEvent = new MouseEvent(e.getComponent(), e.getID(), e.getWhen(), e.getModifiersEx(), e.getX(), e.getY(), e.getXOnScreen(), e.getYOnScreen(), e.getClickCount(), e.isPopupTrigger(), e.getButton());
+    // don't write over Java's mouse event
+    final MouseEvent mapEvent = new MouseEvent(
+      e.getComponent(), e.getID(), e.getWhen(), e.getModifiersEx(),
+      e.getX(), e.getY(), e.getXOnScreen(), e.getYOnScreen(),
+      e.getClickCount(), e.isPopupTrigger(), e.getButton()
+    );
     final Point p = componentToMap(mapEvent.getPoint());
     mapEvent.translatePoint(p.x - mapEvent.getX(), p.y - mapEvent.getY());
     return mapEvent;
@@ -1307,7 +1315,7 @@ public class Map extends AbstractConfigurable implements GameComponent, MouseLis
    */
   @Override
   public void mouseReleased(MouseEvent e) {
-    // don't write over java's mouse event
+    // don't write over Java's mouse event
     Point p = e.getPoint();
     p.translate(theMap.getX(), theMap.getY());
     if (theMap.getBounds().contains(p)) {
@@ -1354,7 +1362,8 @@ public class Map extends AbstractConfigurable implements GameComponent, MouseLis
   }
 
   /**
-   * This listener will be notified when a drag event is initiated, assuming that no MouseListeners are on the stack.
+   * This listener will be notified when a drag event is initiated, assuming
+   * that no MouseListeners are on the stack.
    *
    * @see #pushMouseListener
    * @param dragGestureListener
@@ -1400,7 +1409,8 @@ public class Map extends AbstractConfigurable implements GameComponent, MouseLis
         dtde.getLocation().x,
         dtde.getLocation().y,
         1,
-        false
+        false,
+        MouseEvent.NOBUTTON
       );
       theMap.dispatchEvent(evt);
       dtde.dropComplete(true);

--- a/src/main/java/VASSAL/build/module/map/GlobalMap.java
+++ b/src/main/java/VASSAL/build/module/map/GlobalMap.java
@@ -561,9 +561,12 @@ public class GlobalMap implements AutoConfigurable,
     public void mouseClicked(MouseEvent e) {
     }
 
+// FIXME: mouseClicked()?
     @Override
     public void mouseReleased(MouseEvent e) {
-      map.centerAt(componentToMap(e.getPoint()));
+      if (SwingUtils.isLeftMouseButton(e)) {
+        map.centerAt(componentToMap(e.getPoint()));
+      }
     }
 
     @Override

--- a/src/main/java/VASSAL/build/module/map/KeyBufferer.java
+++ b/src/main/java/VASSAL/build/module/map/KeyBufferer.java
@@ -49,6 +49,7 @@ import VASSAL.counters.PieceFinder;
 import VASSAL.counters.PieceVisitorDispatcher;
 import VASSAL.counters.Properties;
 import VASSAL.counters.Stack;
+import VASSAL.tools.swing.SwingUtils;
 
 /**
  * This component listens for mouse clicks on a map and draws the selection
@@ -130,7 +131,7 @@ public class KeyBufferer extends MouseAdapter implements Buildable, MouseMotionL
           if (movingStacksPickupUnits ||
               p.getParent() == null ||
               p.getParent().isExpanded() ||
-              e.getButton() == 3 ||
+              SwingUtils.isRightMouseButton(e) ||
               Boolean.TRUE.equals(p.getProperty(Properties.SELECTED)))
           {
             kbuf.add(p);

--- a/src/main/java/VASSAL/build/module/map/KeyBufferer.java
+++ b/src/main/java/VASSAL/build/module/map/KeyBufferer.java
@@ -123,13 +123,13 @@ public class KeyBufferer extends MouseAdapter implements Buildable, MouseMotionL
     if (p != null && !ignoreEvent) {
       boolean movingStacksPickupUnits = (Boolean) GameModule.getGameModule().getPrefs().getValue(Map.MOVING_STACKS_PICKUP_UNITS);
       if (!kbuf.contains(p)) {
-        if (!e.isShiftDown() && !e.isControlDown()) {
+        if (!e.isShiftDown() && !SwingUtils.isControlDown(e)) {
           kbuf.clear();
         }
         // RFE 1629255 - If the top piece of an unexpanded stack is left-clicked
         // while not selected, then select all of the pieces in the stack
         // RFE 1659481 - Control clicking only deselects
-        if (!e.isControlDown()) {
+        if (!SwingUtils.isControlDown(e)) {
           if (movingStacksPickupUnits ||
               p.getParent() == null ||
               p.getParent().isExpanded() ||
@@ -147,7 +147,7 @@ public class KeyBufferer extends MouseAdapter implements Buildable, MouseMotionL
       }
       else {
         // RFE 1659481 Ctrl-click deselects clicked units
-        if (e.isControlDown() && Boolean.TRUE.equals(p.getProperty(Properties.SELECTED))) {
+        if (SwingUtils.isControlDown(e) && Boolean.TRUE.equals(p.getProperty(Properties.SELECTED))) {
           Stack s = p.getParent();
           if (s == null) {
             kbuf.remove(p);
@@ -168,7 +168,7 @@ public class KeyBufferer extends MouseAdapter implements Buildable, MouseMotionL
     
     if (bandSelect != BandSelectType.NONE) {
       bandSelectPiece = null;
-      if (!e.isShiftDown() && !e.isControlDown()) { // No deselect if shift key down
+      if (!e.isShiftDown() && !SwingUtils.isControlDown(e)) { // No deselect if shift key down
         kbuf.clear();
         
         //BR// This section allows band-select to be attempted from non-moving pieces w/o preventing click-to-select from working 
@@ -194,7 +194,7 @@ public class KeyBufferer extends MouseAdapter implements Buildable, MouseMotionL
     }
 
     PieceVisitorDispatcher d = createDragSelector(
-      !e.isControlDown(), e.isAltDown(), map.componentToMap(selection)
+      !SwingUtils.isControlDown(e), e.isAltDown(), map.componentToMap(selection)
     );
     
     // If it was a legit band-select drag (not just a click), our special case
@@ -217,7 +217,7 @@ public class KeyBufferer extends MouseAdapter implements Buildable, MouseMotionL
     
     // RFE 1659481 Don't clear the entire selection buffer if either shift
     // or control is down - we select/deselect lassoed counters instead
-    if (bandSelectPiece == null && !e.isShiftDown() && !e.isControlDown()) {
+    if (bandSelectPiece == null && !e.isShiftDown() && !SwingUtils.isControlDown(e)) {
       KeyBuffer.getBuffer().clear();
     }
 

--- a/src/main/java/VASSAL/build/module/map/LOS_Thread.java
+++ b/src/main/java/VASSAL/build/module/map/LOS_Thread.java
@@ -67,6 +67,7 @@ import VASSAL.tools.LaunchButton;
 import VASSAL.tools.NamedKeyStroke;
 import VASSAL.tools.SequenceEncoder;
 import VASSAL.tools.UniqueIdManager;
+import VASSAL.tools.swing.SwingUtils;
 
 /**
  * A class that allows the user to draw a straight line on a Map (LOS
@@ -566,6 +567,10 @@ public class LOS_Thread extends AbstractConfigurable implements
 
   @Override
   public void mousePressed(MouseEvent e) {
+    if (!SwingUtils.isLeftMouseButton(e)) {
+      return;
+    }
+
     initializing = false;
     if (visible && !persisting && !mirroring) {
       Point p = e.getPoint();
@@ -585,6 +590,10 @@ public class LOS_Thread extends AbstractConfigurable implements
 
   @Override
   public void mouseReleased(MouseEvent e) {
+    if (!SwingUtils.isLeftMouseButton(e)) {
+      return;
+    }
+
     if (!persisting && !mirroring) {
       if (retainAfterRelease && !(ctrlWhenClick && persistence.equals(CTRL_CLICK))) {
         retainAfterRelease = false;
@@ -686,6 +695,10 @@ public class LOS_Thread extends AbstractConfigurable implements
 
   @Override
   public void mouseDragged(MouseEvent e) {
+    if (!SwingUtils.isLeftMouseButton(e)) {
+      return;
+    }
+
     if (visible && !persisting && !mirroring) {
       retainAfterRelease = true;
 

--- a/src/main/java/VASSAL/build/module/map/LOS_Thread.java
+++ b/src/main/java/VASSAL/build/module/map/LOS_Thread.java
@@ -584,7 +584,7 @@ public class LOS_Thread extends AbstractConfigurable implements
       lastLocation = anchorLocation;
       lastRange = "";
       checkList.clear();
-      ctrlWhenClick = e.isControlDown();
+      ctrlWhenClick = SwingUtils.isControlDown(e);
     }
   }
 

--- a/src/main/java/VASSAL/build/module/map/MapCenterer.java
+++ b/src/main/java/VASSAL/build/module/map/MapCenterer.java
@@ -29,6 +29,7 @@ import VASSAL.counters.EventFilter;
 import VASSAL.counters.GamePiece;
 import VASSAL.counters.PieceFinder;
 import VASSAL.counters.Properties;
+import VASSAL.tools.swing.SwingUtils;
 
 /**
  * Centers the map when user right-clicks on an empty hex
@@ -76,7 +77,7 @@ public class MapCenterer extends AbstractBuildable implements MouseListener {
 
   @Override
   public void mouseReleased(MouseEvent e) {
-    if (e.getButton() == 3) {
+    if (SwingUtils.isRightMouseButton(e)) {
       GamePiece found = map.findPiece(e.getPoint(), finder);
       if (found != null) {
         EventFilter filter = (EventFilter) found.getProperty(Properties.SELECT_EVENT_FILTER);

--- a/src/main/java/VASSAL/build/module/map/MapCenterer.java
+++ b/src/main/java/VASSAL/build/module/map/MapCenterer.java
@@ -75,10 +75,12 @@ public class MapCenterer extends AbstractBuildable implements MouseListener {
   public void setAttribute(String attName, Object value) {
   }
 
+// FIXME: mouseClicked()?
   @Override
   public void mouseReleased(MouseEvent e) {
     if (SwingUtils.isRightMouseButton(e)) {
       GamePiece found = map.findPiece(e.getPoint(), finder);
+
       if (found != null) {
         EventFilter filter = (EventFilter) found.getProperty(Properties.SELECT_EVENT_FILTER);
         if (filter != null
@@ -86,6 +88,7 @@ public class MapCenterer extends AbstractBuildable implements MouseListener {
           found = null;
         }
       }
+
       if (found == null) {
         Map.View m = (Map.View) e.getSource();
         m.getMap().centerAt(e.getPoint());

--- a/src/main/java/VASSAL/build/module/map/PieceMover.java
+++ b/src/main/java/VASSAL/build/module/map/PieceMover.java
@@ -735,7 +735,7 @@ public class PieceMover extends AbstractBuildable
   protected boolean canHandleEvent(MouseEvent e) {
     return !e.isConsumed() &&
            !e.isShiftDown() &&
-           !e.isControlDown() &&
+           !SwingUtils.isControlDown(e) &&
            e.getClickCount() < 2 &&
            (e.getButton() == MouseEvent.NOBUTTON ||
             SwingUtils.isLeftMouseButton(e));

--- a/src/main/java/VASSAL/build/module/map/PieceMover.java
+++ b/src/main/java/VASSAL/build/module/map/PieceMover.java
@@ -94,6 +94,7 @@ import VASSAL.counters.Stack;
 import VASSAL.tools.LaunchButton;
 import VASSAL.tools.image.ImageUtils;
 import VASSAL.tools.imageop.Op;
+import VASSAL.tools.swing.SwingUtils;
 
 /**
  * This is a MouseListener that moves pieces onto a Map window
@@ -734,7 +735,7 @@ public class PieceMover extends AbstractBuildable
   protected boolean canHandleEvent(MouseEvent e) {
     return !e.isShiftDown() &&
            !e.isControlDown() &&
-            e.getButton() != 3 &&
+           !SwingUtils.isRightMouseButton(e) &&
             e.getClickCount() < 2 &&
            !e.isConsumed();
   }

--- a/src/main/java/VASSAL/build/module/map/PieceMover.java
+++ b/src/main/java/VASSAL/build/module/map/PieceMover.java
@@ -733,11 +733,12 @@ public class PieceMover extends AbstractBuildable
   }
 
   protected boolean canHandleEvent(MouseEvent e) {
-    return !e.isShiftDown() &&
+    return !e.isConsumed() &&
+           !e.isShiftDown() &&
            !e.isControlDown() &&
-           !SwingUtils.isRightMouseButton(e) &&
-            e.getClickCount() < 2 &&
-           !e.isConsumed();
+           e.getClickCount() < 2 &&
+           (e.getButton() == MouseEvent.NOBUTTON ||
+            SwingUtils.isLeftMouseButton(e));
   }
 
   /**

--- a/src/main/java/VASSAL/build/module/map/SetupStack.java
+++ b/src/main/java/VASSAL/build/module/map/SetupStack.java
@@ -1000,8 +1000,6 @@ public class SetupStack extends AbstractConfigurable implements GameComponent, U
 
     @Override
     public void dragEnter(DropTargetDragEvent arg0) {
-      return;
-
     }
 
     @Override
@@ -1036,8 +1034,6 @@ public class SetupStack extends AbstractConfigurable implements GameComponent, U
 
     @Override
     public void dropActionChanged(DropTargetDragEvent arg0) {
-      return;
-
     }
 
     @Override
@@ -1049,49 +1045,38 @@ public class SetupStack extends AbstractConfigurable implements GameComponent, U
       myStack.pos.y = pos.y;
       myStack.stackConfigurer.updateDisplay();
       repaint();
-      return;
-
     }
 
     @Override
     public void dragExit(DropTargetEvent arg0) {
-      return;
-
     }
 
     @Override
     public void dragEnter(DragSourceDragEvent arg0) {
-      return;
-
     }
 
     @Override
     public void dragOver(DragSourceDragEvent arg0) {
-      return;
-
     }
 
     @Override
     public void dropActionChanged(DragSourceDragEvent arg0) {
-      return;
-
     }
 
     @Override
     public void dragDropEnd(DragSourceDropEvent arg0) {
       removeDragCursor();
-      return;
-
     }
 
     @Override
     public void dragExit(DragSourceEvent arg0) {
-      return;
-
     }
 
     @Override
     public void dragGestureRecognized(DragGestureEvent dge) {
+      if (!SwingUtils.isDragTrigger(dge)) {
+        return;
+      }
 
       Point mousePosition = dge.getDragOrigin();
       Point piecePosition = new Point(myStack.pos);

--- a/src/main/java/VASSAL/build/module/map/StackExpander.java
+++ b/src/main/java/VASSAL/build/module/map/StackExpander.java
@@ -29,6 +29,7 @@ import VASSAL.counters.GamePiece;
 import VASSAL.counters.KeyBuffer;
 import VASSAL.counters.PieceFinder;
 import VASSAL.counters.Stack;
+import VASSAL.tools.swing.SwingUtils;
 
 public class StackExpander extends MouseAdapter implements Buildable {
   protected Map map;
@@ -52,18 +53,18 @@ public class StackExpander extends MouseAdapter implements Buildable {
   public void build(Element e) {
   }
 
+// FIXME: should be mouseClicked()?
   @Override
   public void mouseReleased(MouseEvent e) {
-    if (!e.isConsumed()) {
-      if (e.getClickCount() == 2) {
-        GamePiece p = map.findPiece(e.getPoint(), PieceFinder.STACK_ONLY);
-        if (p != null) {
-          KeyBuffer.getBuffer().clear();
-          ((Stack) p).setExpanded(!((Stack) p).isExpanded());
-          KeyBuffer.getBuffer().add(((Stack) p).topPiece());
-        }
-        e.consume();
+    if (!e.isConsumed() && e.getClickCount() == 2
+                        && SwingUtils.isLeftMouseButton(e)) {
+      final GamePiece p = map.findPiece(e.getPoint(), PieceFinder.STACK_ONLY);
+      if (p != null) {
+        KeyBuffer.getBuffer().clear();
+        ((Stack) p).setExpanded(!((Stack) p).isExpanded());
+        KeyBuffer.getBuffer().add(((Stack) p).topPiece());
       }
+      e.consume();
     }
   }
 }

--- a/src/main/java/VASSAL/build/module/map/boardPicker/board/GridEditor.java
+++ b/src/main/java/VASSAL/build/module/map/boardPicker/board/GridEditor.java
@@ -340,7 +340,7 @@ public abstract class GridEditor extends JDialog implements MouseListener, KeyLi
 
   @Override
   public void mouseClicked(MouseEvent e) {
-    if (setMode) {
+    if (setMode && SwingUtils.isLeftMouseButton(e)) {
       if (hp1 == null) {
         hp1 = e.getPoint();
       }

--- a/src/main/java/VASSAL/build/module/map/boardPicker/board/RegionGrid.java
+++ b/src/main/java/VASSAL/build/module/map/boardPicker/board/RegionGrid.java
@@ -91,6 +91,7 @@ import VASSAL.i18n.Resources;
 import VASSAL.tools.AdjustableSpeedScrollPane;
 import VASSAL.tools.ErrorDialog;
 import VASSAL.tools.image.ImageUtils;
+import VASSAL.tools.swing.SwingUtils;
 
 public class RegionGrid extends AbstractConfigurable implements MapGrid, ConfigureTree.Mutable {
   private static final long serialVersionUID = 1L;
@@ -1145,7 +1146,7 @@ public class RegionGrid extends AbstractConfigurable implements MapGrid, Configu
     // Scroll map if necessary
     @Override
     public void mouseDragged(MouseEvent e) {
-      if (e.getButton() != 3) {
+      if (!SwingUtils.isRightMouseButton(e)) {
         scrollAtEdge(e.getPoint(), 15);
       }
 

--- a/src/main/java/VASSAL/build/module/map/boardPicker/board/RegionGrid.java
+++ b/src/main/java/VASSAL/build/module/map/boardPicker/board/RegionGrid.java
@@ -1100,7 +1100,7 @@ public class RegionGrid extends AbstractConfigurable implements MapGrid, Configu
         lastClick = p;
         lastClickedRegion = grid.getRegion(p);
 
-        if (!e.isShiftDown() && !e.isControlDown() &&
+        if (!e.isShiftDown() && !SwingUtils.isControlDown(e) &&
             (lastClickedRegion==null || !lastClickedRegion.isSelected())) {
           unSelectAll();
         }
@@ -1110,7 +1110,7 @@ public class RegionGrid extends AbstractConfigurable implements MapGrid, Configu
           selectionRect = new Rectangle(anchor.x, anchor.y, 0, 0);
         }
         else {
-          if (e.isControlDown()) {
+          if (SwingUtils.isControlDown(e)) {
             unselect(lastClickedRegion);
           }
           else {
@@ -1128,7 +1128,7 @@ public class RegionGrid extends AbstractConfigurable implements MapGrid, Configu
       else if (selectionRect != null && SwingUtils.isLeftMouseButton(e)) {
         for (Region r : grid.regionList.values()) {
           if (selectionRect.contains(r.getOrigin())) {
-            if (e.isControlDown()) {
+            if (SwingUtils.isControlDown(e)) {
               unselect(r);
             }
             else {

--- a/src/main/java/VASSAL/build/module/map/boardPicker/board/mapgrid/PolygonEditor.java
+++ b/src/main/java/VASSAL/build/module/map/boardPicker/board/mapgrid/PolygonEditor.java
@@ -201,14 +201,13 @@ public class PolygonEditor extends JPanel {
   }
 
   private class ModifyPolygon extends MouseInputAdapter {
-    // implements java.awt.event.MouseMotionListener
     @Override
     public void mouseDragged(MouseEvent e) {
-      moveSelectedPoint(e);
       if (SwingUtilities.isLeftMouseButton(e)) {
+        moveSelectedPoint(e);
         scrollAtEdge(e.getPoint(), 15);
+        repaint();
       }
-      repaint();
     }
 
     private void moveSelectedPoint(MouseEvent e) {
@@ -218,20 +217,20 @@ public class PolygonEditor extends JPanel {
       }
     }
 
-    // implements java.awt.event.MouseListener
     @Override
     public void mouseReleased(MouseEvent e) {
-      moveSelectedPoint(e);
-      repaint();
+      if (SwingUtils.isLeftMouseButton(e)) {
+        moveSelectedPoint(e);
+        repaint();
+      }
     }
 
-    // implements java.awt.event.MouseListener
     @Override
     public void mousePressed(MouseEvent e) {
        selected = -1;
        double minDist = Float.MAX_VALUE;
 
-       if (!SwingUtils.isRightMouseButton(e)) {
+       if (SwingUtils.isLeftMouseButton(e)) {
          // move an existing vertex
                for (int i = 0; i < polygon.npoints; ++i) {
                        double dist = Point2D.distance(polygon.xpoints[i], polygon.ypoints[i], e.getX(), e.getY());
@@ -241,7 +240,7 @@ public class PolygonEditor extends JPanel {
                        }
                }
        } 
-       else {
+       else if (SwingUtils.isRightMouseButton(e)) {
                // find closest segment/vertex
                selected = -1;
                minDist = Float.MAX_VALUE;
@@ -338,34 +337,37 @@ public class PolygonEditor extends JPanel {
   }
 
   private class DefineRectangle extends MouseInputAdapter {
-    // implements java.awt.event.MouseListener
     @Override
     public void mousePressed(MouseEvent e) {
-      polygon = new Polygon();
-      polygon.addPoint(e.getX(), e.getY());
-      polygon.addPoint(e.getX(), e.getY());
-      polygon.addPoint(e.getX(), e.getY());
-      polygon.addPoint(e.getX(), e.getY());
-      addMouseMotionListener(this);
+      if (SwingUtils.isLeftMouseButton(e)) {
+        polygon = new Polygon();
+        polygon.addPoint(e.getX(), e.getY());
+        polygon.addPoint(e.getX(), e.getY());
+        polygon.addPoint(e.getX(), e.getY());
+        polygon.addPoint(e.getX(), e.getY());
+        addMouseMotionListener(this);
+      }
     }
 
-    // implements java.awt.event.MouseMotionListener
     @Override
     public void mouseDragged(MouseEvent e) {
-      polygon.xpoints[1] = e.getX();
-      polygon.xpoints[2] = e.getX();
-      polygon.ypoints[2] = e.getY();
-      polygon.ypoints[3] = e.getY();
-      repaint();
+      if (SwingUtils.isLeftMouseButton(e)) {
+        polygon.xpoints[1] = e.getX();
+        polygon.xpoints[2] = e.getX();
+        polygon.ypoints[2] = e.getY();
+        polygon.ypoints[3] = e.getY();
+        repaint();
+      }
     }
 
     @Override
     public void mouseReleased(MouseEvent e) {
-      removeMouseListener(this);
-      removeMouseMotionListener(this);
-      setupForEdit();
+      if (SwingUtils.isLeftMouseButton(e)) {
+        removeMouseListener(this);
+        removeMouseMotionListener(this);
+        setupForEdit();
+      }
     }
-
   }
 
   public static void main(String[] args) {

--- a/src/main/java/VASSAL/build/module/map/boardPicker/board/mapgrid/PolygonEditor.java
+++ b/src/main/java/VASSAL/build/module/map/boardPicker/board/mapgrid/PolygonEditor.java
@@ -43,6 +43,7 @@ import javax.swing.SwingUtilities;
 import javax.swing.event.MouseInputAdapter;
 
 import VASSAL.tools.SequenceEncoder;
+import VASSAL.tools.swing.SwingUtils;
 
 public class PolygonEditor extends JPanel {
   private static final long serialVersionUID = 1L;
@@ -230,7 +231,7 @@ public class PolygonEditor extends JPanel {
        selected = -1;
        double minDist = Float.MAX_VALUE;
 
-       if (e.getButton() != 3) {
+       if (!SwingUtils.isRightMouseButton(e)) {
          // move an existing vertex
                for (int i = 0; i < polygon.npoints; ++i) {
                        double dist = Point2D.distance(polygon.xpoints[i], polygon.ypoints[i], e.getX(), e.getY());

--- a/src/main/java/VASSAL/build/module/map/boardPicker/board/mapgrid/PolygonEditor.java
+++ b/src/main/java/VASSAL/build/module/map/boardPicker/board/mapgrid/PolygonEditor.java
@@ -225,93 +225,106 @@ public class PolygonEditor extends JPanel {
     }
 
     @Override
-    public void mousePressed(MouseEvent e) {
+    public void mouseClicked(MouseEvent e) {
+      if (!SwingUtils.isRightMouseButton(e)) {
+        return;
+      }
+
+      // find closest segment/vertex
       selected = -1;
       double minDist = Float.MAX_VALUE;
+      boolean isVertex = false;
 
+      int x0 = e.getX();
+      int y0 = e.getY();
+
+      for (int i = 0; i < polygon.npoints; ++i) {
+        int x1 = polygon.xpoints[i];
+        int y1 = polygon.ypoints[i];
+        int x2, y2;
+        if (i == polygon.npoints-1) {
+          x2 = polygon.xpoints[0];
+          y2 = polygon.ypoints[0];
+        }
+        else {
+          x2 = polygon.xpoints[i+1];
+          y2 = polygon.ypoints[i+1];
+        }
+
+        if (y2 == y1 && x2 == x1) // two verteces on top of each other: skip
+          continue;
+
+        double d = Point2D.distance(x1, y1, x2, y2); // segment length
+        double comp = ((x2-x1)*(x0-x1) + (y2-y1)*(y0-y1)) / d; // component of projection of selection on segment
+        double dist; // orthogonal distance to segment
+
+        if (comp <= 0.0) { // too far out beyond first vertex: just move that vertex if it's closest
+          dist = Point2D.distance(x1, y1, x0, y0);
+          if (dist < minDist) {
+            isVertex = true;
+            minDist = dist;
+            selected = i;
+          }
+        }
+        else if (comp >= d) { // too far out beyond second vertex: just move that vertex: just move that virtex if it's closest
+          dist = Point2D.distance(x0, y0, x2, y2);
+          if (dist < minDist) {
+            isVertex = true;
+            minDist = dist;
+            selected = i+1;
+          }
+        }
+        else { // calculate orthogonal distance to segment
+          dist = Math.abs((y2-y1)*e.getX() - (x2-x1)*e.getY() + x2*y1 - y2*x1) / Math.sqrt((y2-y1)*(y2-y1) + (x2-x1)*(x2-x1));
+          if (dist < minDist) {
+            isVertex = false;
+            minDist = dist;
+            selected = i+1;
+           }
+        }
+      }
+
+      if (!isVertex) { // insert a point near segment
+        polygon.addPoint(e.getX(), e.getY());
+        if (selected >= 0) {
+          for (int i = polygon.npoints - 1; i > selected; --i) {
+            polygon.xpoints[i] = polygon.xpoints[i - 1];
+            polygon.ypoints[i] = polygon.ypoints[i - 1];
+          }
+          polygon.xpoints[selected] = e.getX();
+          polygon.ypoints[selected] = e.getY();
+        }
+      }
+
+      repaint();
+    }
+
+    @Override
+    public void mousePressed(MouseEvent e) {
       if (SwingUtils.isLeftMouseButton(e)) {
+        selected = -1;
+        double minDist = Float.MAX_VALUE;
+
         // move an existing vertex
         for (int i = 0; i < polygon.npoints; ++i) {
-        double dist = Point2D.distance(polygon.xpoints[i], polygon.ypoints[i], e.getX(), e.getY());
+          double dist = Point2D.distance(
+            polygon.xpoints[i], polygon.ypoints[i], e.getX(), e.getY()
+          );
           if (dist < minDist) {
             minDist = dist;
             selected = i;
           }
         }
-      } 
-      else if (SwingUtils.isRightMouseButton(e)) {
-        // find closest segment/vertex
-        selected = -1;
-        minDist = Float.MAX_VALUE;
-        boolean isVertex = false;
 
-        int x0 = e.getX();
-        int y0 = e.getY();
-
-        for (int i = 0; i < polygon.npoints; ++i) {
-          int x1 = polygon.xpoints[i];
-          int y1 = polygon.ypoints[i];
-          int x2, y2;
-          if (i == polygon.npoints-1) {
-            x2 = polygon.xpoints[0];
-            y2 = polygon.ypoints[0];
-          } 
-          else {
-            x2 = polygon.xpoints[i+1];
-            y2 = polygon.ypoints[i+1];
-          }
-
-          if (y2 == y1 && x2 == x1) // two verteces on top of each other: skip
-            continue;
-
-          double d = Point2D.distance(x1, y1, x2, y2); // segment length
-          double comp = ((x2-x1)*(x0-x1) + (y2-y1)*(y0-y1)) / d; // component of projection of selection on segment
-          double dist; // orthogonal distance to segment
-
-          if (comp <= 0.0) { // too far out beyond first vertex: just move that vertex if it's closest
-            dist = Point2D.distance(x1, y1, x0, y0);
-            if (dist < minDist) {
-              isVertex = true;
-              minDist = dist;
-              selected = i;
-            }
-          }
-          else if (comp >= d) { // too far out beyond second vertex: just move that vertex: just move that virtex if it's closest
-            dist = Point2D.distance(x0, y0, x2, y2);
-            if (dist < minDist) {
-              isVertex = true;
-              minDist = dist;
-              selected = i+1;
-            }
-          }
-          else { // calculate orthogonal distance to segment
-            dist = Math.abs((y2-y1)*e.getX() - (x2-x1)*e.getY() + x2*y1 - y2*x1) / Math.sqrt((y2-y1)*(y2-y1) + (x2-x1)*(x2-x1));
-            if (dist < minDist) {
-              isVertex = false;
-              minDist = dist;
-              selected = i+1;
-             }
-          }
-        }
-
-        if (!isVertex) { // insert a point near segment
-          polygon.addPoint(e.getX(), e.getY());
-          if (selected >= 0) {
-            for (int i = polygon.npoints - 1; i > selected; --i) {
-              polygon.xpoints[i] = polygon.xpoints[i - 1];
-              polygon.ypoints[i] = polygon.ypoints[i - 1];
-            }
-            polygon.xpoints[selected] = e.getX();
-            polygon.ypoints[selected] = e.getY();
-          }
-        }
+        repaint();
       }
     }
 
     public void scrollAtEdge(Point evtPt, int dist) {
-
-      Point p = new Point(evtPt.x - myScroll.getViewport().getViewPosition().x,
-          evtPt.y - myScroll.getViewport().getViewPosition().y);
+      Point p = new Point(
+        evtPt.x - myScroll.getViewport().getViewPosition().x,
+        evtPt.y - myScroll.getViewport().getViewPosition().y
+      );
       int dx = 0, dy = 0;
       if (p.x < dist && p.x >= 0)
         dx = -1;

--- a/src/main/java/VASSAL/build/module/map/boardPicker/board/mapgrid/PolygonEditor.java
+++ b/src/main/java/VASSAL/build/module/map/boardPicker/board/mapgrid/PolygonEditor.java
@@ -39,7 +39,6 @@ import javax.swing.JFrame;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 import javax.swing.KeyStroke;
-import javax.swing.SwingUtilities;
 import javax.swing.event.MouseInputAdapter;
 
 import VASSAL.tools.SequenceEncoder;
@@ -203,7 +202,7 @@ public class PolygonEditor extends JPanel {
   private class ModifyPolygon extends MouseInputAdapter {
     @Override
     public void mouseDragged(MouseEvent e) {
-      if (SwingUtilities.isLeftMouseButton(e)) {
+      if (SwingUtils.isLeftMouseButton(e)) {
         moveSelectedPoint(e);
         scrollAtEdge(e.getPoint(), 15);
         repaint();

--- a/src/main/java/VASSAL/build/module/map/boardPicker/board/mapgrid/PolygonEditor.java
+++ b/src/main/java/VASSAL/build/module/map/boardPicker/board/mapgrid/PolygonEditor.java
@@ -226,88 +226,86 @@ public class PolygonEditor extends JPanel {
 
     @Override
     public void mousePressed(MouseEvent e) {
-       selected = -1;
-       double minDist = Float.MAX_VALUE;
+      selected = -1;
+      double minDist = Float.MAX_VALUE;
 
-       if (SwingUtils.isLeftMouseButton(e)) {
-         // move an existing vertex
-               for (int i = 0; i < polygon.npoints; ++i) {
-                       double dist = Point2D.distance(polygon.xpoints[i], polygon.ypoints[i], e.getX(), e.getY());
-                       if (dist < minDist) {
-                               minDist = dist;
-                               selected = i;
-                       }
-               }
-       } 
-       else if (SwingUtils.isRightMouseButton(e)) {
-               // find closest segment/vertex
-               selected = -1;
-               minDist = Float.MAX_VALUE;
-               boolean isVertex = false;
+      if (SwingUtils.isLeftMouseButton(e)) {
+        // move an existing vertex
+        for (int i = 0; i < polygon.npoints; ++i) {
+        double dist = Point2D.distance(polygon.xpoints[i], polygon.ypoints[i], e.getX(), e.getY());
+          if (dist < minDist) {
+            minDist = dist;
+            selected = i;
+          }
+        }
+      } 
+      else if (SwingUtils.isRightMouseButton(e)) {
+        // find closest segment/vertex
+        selected = -1;
+        minDist = Float.MAX_VALUE;
+        boolean isVertex = false;
 
-               int x0 = e.getX();
-               int y0 = e.getY();
+        int x0 = e.getX();
+        int y0 = e.getY();
 
-               for (int i = 0; i < polygon.npoints; ++i) {
+        for (int i = 0; i < polygon.npoints; ++i) {
+          int x1 = polygon.xpoints[i];
+          int y1 = polygon.ypoints[i];
+          int x2, y2;
+          if (i == polygon.npoints-1) {
+            x2 = polygon.xpoints[0];
+            y2 = polygon.ypoints[0];
+          } 
+          else {
+            x2 = polygon.xpoints[i+1];
+            y2 = polygon.ypoints[i+1];
+          }
 
-                       int x1 = polygon.xpoints[i];
-                       int y1 = polygon.ypoints[i];
-                       int x2, y2;
-                       if (i == polygon.npoints-1) {
-                               x2 = polygon.xpoints[0];
-                               y2 = polygon.ypoints[0];
-                       } 
-                       else {
-                               x2 = polygon.xpoints[i+1];
-                               y2 = polygon.ypoints[i+1];
-                       }
+          if (y2 == y1 && x2 == x1) // two verteces on top of each other: skip
+            continue;
 
-                       if (y2 == y1 && x2 == x1) // two verteces on top of each other: skip
-                               continue;
+          double d = Point2D.distance(x1, y1, x2, y2); // segment length
+          double comp = ((x2-x1)*(x0-x1) + (y2-y1)*(y0-y1)) / d; // component of projection of selection on segment
+          double dist; // orthogonal distance to segment
 
-                       double d = Point2D.distance(x1, y1, x2, y2); // segment length
-                       double comp = ((x2-x1)*(x0-x1) + (y2-y1)*(y0-y1)) / d; // component of projection of selection on segment
-                       double dist; // orthogonal distance to segment
+          if (comp <= 0.0) { // too far out beyond first vertex: just move that vertex if it's closest
+            dist = Point2D.distance(x1, y1, x0, y0);
+            if (dist < minDist) {
+              isVertex = true;
+              minDist = dist;
+              selected = i;
+            }
+          }
+          else if (comp >= d) { // too far out beyond second vertex: just move that vertex: just move that virtex if it's closest
+            dist = Point2D.distance(x0, y0, x2, y2);
+            if (dist < minDist) {
+              isVertex = true;
+              minDist = dist;
+              selected = i+1;
+            }
+          }
+          else { // calculate orthogonal distance to segment
+            dist = Math.abs((y2-y1)*e.getX() - (x2-x1)*e.getY() + x2*y1 - y2*x1) / Math.sqrt((y2-y1)*(y2-y1) + (x2-x1)*(x2-x1));
+            if (dist < minDist) {
+              isVertex = false;
+              minDist = dist;
+              selected = i+1;
+             }
+          }
+        }
 
-                       if (comp <= 0.0) { // too far out beyond first vertex: just move that vertex if it's closest
-                               dist = Point2D.distance(x1, y1, x0, y0);
-                               if (dist < minDist) {
-                                       isVertex = true;
-                                       minDist = dist;
-                                       selected = i;
-                               }
-                       } 
-                       else if (comp >= d) { // too far out beyond second vertex: just move that vertex: just move that virtex if it's closest
-                               dist = Point2D.distance(x0, y0, x2, y2);
-                               if (dist < minDist) {
-                                       isVertex = true;
-                                       minDist = dist;
-                                       selected = i+1;
-                               }
-                       } 
-                       else { // calculate orthogonal distance to segment
-                               dist = Math.abs((y2-y1)*e.getX() - (x2-x1)*e.getY() + x2*y1 - y2*x1) / 
-                                               Math.sqrt((y2-y1)*(y2-y1) + (x2-x1)*(x2-x1));
-                               if (dist < minDist) {
-                                       isVertex = false;
-                                       minDist = dist;
-                                       selected = i+1;
-                               }
-                       }
-               }
-
-               if (!isVertex) { // insert a point near segment
-                       polygon.addPoint(e.getX(), e.getY());
-                       if (selected >= 0) {
-                               for (int i = polygon.npoints - 1; i > selected; --i) {
-                                       polygon.xpoints[i] = polygon.xpoints[i - 1];
-                                       polygon.ypoints[i] = polygon.ypoints[i - 1];
-                               }
-                               polygon.xpoints[selected] = e.getX();
-                               polygon.ypoints[selected] = e.getY();
-                       }
-               }
-       }
+        if (!isVertex) { // insert a point near segment
+          polygon.addPoint(e.getX(), e.getY());
+          if (selected >= 0) {
+            for (int i = polygon.npoints - 1; i > selected; --i) {
+              polygon.xpoints[i] = polygon.xpoints[i - 1];
+              polygon.ypoints[i] = polygon.ypoints[i - 1];
+            }
+            polygon.xpoints[selected] = e.getX();
+            polygon.ypoints[selected] = e.getY();
+          }
+        }
+      }
     }
 
     public void scrollAtEdge(Point evtPt, int dist) {

--- a/src/main/java/VASSAL/chat/ServerAddressBook.java
+++ b/src/main/java/VASSAL/chat/ServerAddressBook.java
@@ -66,6 +66,7 @@ import VASSAL.tools.SequenceEncoder;
 import VASSAL.tools.icon.IconFactory;
 import VASSAL.tools.icon.IconFamily;
 import VASSAL.tools.swing.Dialogs;
+import VASSAL.tools.swing.SwingUtils;
 
 public class ServerAddressBook {
   public static final String CURRENT_SERVER = "currentServer"; //$NON-NLS-1$
@@ -249,10 +250,11 @@ public class ServerAddressBook {
       myList.addMouseListener(new MouseAdapter() {
         @Override
         public void mouseClicked(MouseEvent e) {
-            if (editButton.isEnabled() && e.getClickCount() == 2) {
-                int index = myList.locationToIndex(e.getPoint());
-                editServer(index);
-             }
+          if (editButton.isEnabled() && e.getClickCount() == 2
+                                     && SwingUtils.isLeftMouseButton(e)) {
+            int index = myList.locationToIndex(e.getPoint());
+            editServer(index);
+          }
         }
       });
 

--- a/src/main/java/VASSAL/chat/ui/RoomInteractionControlsInitializer.java
+++ b/src/main/java/VASSAL/chat/ui/RoomInteractionControlsInitializer.java
@@ -36,6 +36,7 @@ import VASSAL.chat.Player;
 import VASSAL.chat.Room;
 import VASSAL.chat.SimplePlayer;
 import VASSAL.chat.SimpleRoom;
+import VASSAL.tools.swing.SwingUtils;
 
 /**
  * Adds mouse listeners to the RoomTree components: double-click to join a room, etc. Builds a popup when right-clicking
@@ -64,19 +65,19 @@ public class RoomInteractionControlsInitializer implements ChatControlsInitializ
   public void initializeControls(final ChatServerControls controls) {
     currentRoomPopupBuilder = new MouseAdapter() {
       @Override
-      public void mousePressed(MouseEvent evt) {
-        maybePopup(evt);
+      public void mousePressed(MouseEvent e) {
+        maybePopup(e);
       }
 
       @Override
-      public void mouseReleased(MouseEvent evt) {
-        maybePopup(evt);
+      public void mouseReleased(MouseEvent e) {
+        maybePopup(e);
       }
 
-      private void maybePopup(MouseEvent evt) {
-        if (evt.isPopupTrigger()) {
-          JTree tree = (JTree) evt.getSource();
-          TreePath path = tree.getPathForLocation(evt.getX(), evt.getY());
+      private void maybePopup(MouseEvent e) {
+        if (e.isPopupTrigger()) {
+          JTree tree = (JTree) e.getSource();
+          TreePath path = tree.getPathForLocation(e.getX(), e.getY());
           if (path != null) {
             Object target = ((DefaultMutableTreeNode) path.getLastPathComponent()).getUserObject();
             if (target instanceof Player) {
@@ -85,7 +86,7 @@ public class RoomInteractionControlsInitializer implements ChatControlsInitializ
                 for (int i = 0, n = popup.getComponentCount(); i < n; ++i) {
                   popup.getComponent(i).setFont(POPUP_MENU_FONT);
                 }
-                popup.show(tree, evt.getX(), evt.getY());
+                popup.show(tree, e.getX(), e.getY());
               }
             }
           }
@@ -95,24 +96,24 @@ public class RoomInteractionControlsInitializer implements ChatControlsInitializ
     controls.getCurrentRoom().addMouseListener(currentRoomPopupBuilder);
     roomPopupBuilder = new MouseAdapter() {
       @Override
-      public void mousePressed(MouseEvent evt) {
-        if (evt.isPopupTrigger()) {
-          maybePopup(evt);
+      public void mousePressed(MouseEvent e) {
+        if (e.isPopupTrigger()) {
+          maybePopup(e);
         }
       }
 
       @Override
-      public void mouseReleased(MouseEvent evt) {
-        if (evt.isPopupTrigger()) {
-          maybePopup(evt);
+      public void mouseReleased(MouseEvent e) {
+        if (e.isPopupTrigger()) {
+          maybePopup(e);
         }
-        else if (evt.getClickCount() == 2) {
-          JTree tree = (JTree) evt.getSource();
-          TreePath path = tree.getPathForLocation(evt.getX(), evt.getY());
+        else if (e.getClickCount() == 2 && SwingUtils.isLeftMouseButton(e)) {
+          JTree tree = (JTree) e.getSource();
+          TreePath path = tree.getPathForLocation(e.getX(), e.getY());
           if (path != null) {
             Object target = ((DefaultMutableTreeNode) path.getLastPathComponent()).getUserObject();
             if (target instanceof SimpleRoom) {
-              int row = tree.getRowForLocation(evt.getX(), evt.getY());
+              int row = tree.getRowForLocation(e.getX(), e.getY());
               if (tree.isCollapsed(row)) {
                 tree.expandRow(row);
               }
@@ -125,9 +126,9 @@ public class RoomInteractionControlsInitializer implements ChatControlsInitializ
         }
       }
 
-      private void maybePopup(MouseEvent evt) {
-        JTree tree = (JTree) evt.getSource();
-        TreePath path = tree.getPathForLocation(evt.getX(), evt.getY());
+      private void maybePopup(MouseEvent e) {
+        JTree tree = (JTree) e.getSource();
+        TreePath path = tree.getPathForLocation(e.getX(), e.getY());
         if (path != null) {
           Object target = ((DefaultMutableTreeNode) path.getLastPathComponent()).getUserObject();
           JPopupMenu popup = null;
@@ -143,7 +144,7 @@ public class RoomInteractionControlsInitializer implements ChatControlsInitializ
             for (int i = 0, n = popup.getComponentCount(); i < n; ++i) {
               popup.getComponent(i).setFont(POPUP_MENU_FONT);
             }
-            popup.show(tree, evt.getX(), evt.getY());
+            popup.show(tree, e.getX(), e.getY());
           }
         }
       }

--- a/src/main/java/VASSAL/configure/ChooseComponentDialog.java
+++ b/src/main/java/VASSAL/configure/ChooseComponentDialog.java
@@ -34,6 +34,7 @@ import javax.swing.tree.TreePath;
 import VASSAL.build.Buildable;
 import VASSAL.build.Configurable;
 import VASSAL.build.GameModule;
+import VASSAL.configure.ConfigureTree;
 import VASSAL.tools.ScrollPane;
 
 /**
@@ -52,9 +53,12 @@ public class ChooseComponentDialog extends JDialog implements TreeSelectionListe
     this.targetClass = targetClass;
     setDefaultCloseOperation(DISPOSE_ON_CLOSE);
     setLayout(new BoxLayout(getContentPane(), BoxLayout.Y_AXIS));
-    tree =
-     new VASSAL.configure.ConfigureTree(GameModule.getGameModule(), null) {
+    tree = new ConfigureTree(GameModule.getGameModule(), null) {
       private static final long serialVersionUID = 1L;
+
+      @Override
+      public void mousePressed(MouseEvent e) {
+      }
 
       @Override
       public void mouseReleased(MouseEvent e) {

--- a/src/main/java/VASSAL/configure/ConfigureTree.java
+++ b/src/main/java/VASSAL/configure/ConfigureTree.java
@@ -80,6 +80,7 @@ import VASSAL.launch.EditorWindow;
 import VASSAL.tools.ErrorDialog;
 import VASSAL.tools.ReflectionUtils;
 import VASSAL.tools.menu.MenuManager;
+import VASSAL.tools.swing.SwingUtils;
 
 /**
  * This is the Configuration Tree that appears in the Configuration window
@@ -895,12 +896,13 @@ public class ConfigureTree extends JTree implements PropertyChangeListener, Mous
     }
   }
 
+// FIXME: should clicked handling be in mouseClicked()?
   @Override
   public void mouseReleased(MouseEvent e) {
     if (e.isPopupTrigger()) {
       maybePopup(e);
     }
-    else if (e.getClickCount() == 2) {
+    else if (e.getClickCount() == 2 && SwingUtils.isLeftMouseButton(e)) {
       Configurable target = getTarget(e.getX(), e.getY());
       if (target == null) {
         return;

--- a/src/main/java/VASSAL/counters/ActionButton.java
+++ b/src/main/java/VASSAL/counters/ActionButton.java
@@ -43,6 +43,7 @@ import VASSAL.tools.RecursionLimitException;
 import VASSAL.tools.RecursionLimiter;
 import VASSAL.tools.RecursionLimiter.Loopable;
 import VASSAL.tools.SequenceEncoder;
+import VASSAL.tools.swing.SwingUtils;
 
 /**
  * A trait that acts like a button on a GamePiece, such that clicking on a
@@ -299,12 +300,14 @@ public class ActionButton extends Decorator implements EditablePiece, Loopable {
 
       @Override
       public void mouseClicked(MouseEvent e) {
-        Point point = e.getPoint();
-        final GamePiece p = map.findPiece(point, PieceFinder.PIECE_IN_STACK);
-        if (p != null) {
-          Point rel = map.positionOf(p);
-          point.translate(-rel.x, -rel.y);
-          doClick(p, point);
+        if (SwingUtils.isLeftMouseButton(e)) {
+          final Point point = e.getPoint();
+          final GamePiece p = map.findPiece(point, PieceFinder.PIECE_IN_STACK);
+          if (p != null) {
+            final Point rel = map.positionOf(p);
+            point.translate(-rel.x, -rel.y);
+            doClick(p, point);
+          }
         }
       }
     }
@@ -322,13 +325,13 @@ public class ActionButton extends Decorator implements EditablePiece, Loopable {
 
       @Override
       public void mouseClicked(MouseEvent e) {
-        Point point = e.getPoint();
-        point.translate(-xOffset,-yOffset);
-        doClick(target, point);
-        e.getComponent().repaint();
+        if (SwingUtils.isLeftMouseButton(e)) {
+          final Point point = e.getPoint();
+          point.translate(-xOffset,-yOffset);
+          doClick(target, point);
+          e.getComponent().repaint();
+        }
       }
     }
-
   }
-
 }

--- a/src/main/java/VASSAL/counters/Decorator.java
+++ b/src/main/java/VASSAL/counters/Decorator.java
@@ -27,8 +27,7 @@ import java.util.NoSuchElementException;
 import javax.swing.KeyStroke;
 import javax.swing.SwingUtilities;
 
-//import org.apache.commons.lang3.ArrayUtils;
-import VASSAL.tools.ArrayUtils;
+import org.apache.commons.lang3.ArrayUtils;
 
 import VASSAL.build.BadDataReport;
 import VASSAL.build.module.Map;
@@ -295,7 +294,7 @@ public abstract class Decorator implements GamePiece, StateMergeable, PropertyNa
 
     if (c == null) return myC;
     else if (myC == null)  return c;
-    else return ArrayUtils.append(KeyCommand[].class, myC, c);
+    else return ArrayUtils.addAll(myC, c);
   }
 
   /**

--- a/src/main/java/VASSAL/counters/Decorator.java
+++ b/src/main/java/VASSAL/counters/Decorator.java
@@ -27,7 +27,8 @@ import java.util.NoSuchElementException;
 import javax.swing.KeyStroke;
 import javax.swing.SwingUtilities;
 
-import org.apache.commons.lang3.ArrayUtils;
+//import org.apache.commons.lang3.ArrayUtils;
+import VASSAL.tools.ArrayUtils;
 
 import VASSAL.build.BadDataReport;
 import VASSAL.build.module.Map;
@@ -294,7 +295,7 @@ public abstract class Decorator implements GamePiece, StateMergeable, PropertyNa
 
     if (c == null) return myC;
     else if (myC == null)  return c;
-    else return ArrayUtils.addAll(myC, c);
+    else return ArrayUtils.append(KeyCommand[].class, myC, c);
   }
 
   /**

--- a/src/main/java/VASSAL/counters/DragBuffer.java
+++ b/src/main/java/VASSAL/counters/DragBuffer.java
@@ -86,14 +86,14 @@ public class DragBuffer {
       public void mouseReleased(MouseEvent e) {
         e.getComponent().setCursor(null);
         Component source = (Component) e.getSource();
+
+        e.translatePoint(source.getLocationOnScreen().x,
+                         source.getLocationOnScreen().y);
+
         if (dropTarget == null) {
-          e.translatePoint(source.getLocationOnScreen().x,
-                           source.getLocationOnScreen().y);
           lastRelease = e;
         }
         else {
-          e.translatePoint(source.getLocationOnScreen().x,
-                           source.getLocationOnScreen().y);
           e.translatePoint(-dropTarget.getLocationOnScreen().x,
                            -dropTarget.getLocationOnScreen().y);
           dropHandler.mouseReleased(e);

--- a/src/main/java/VASSAL/counters/DynamicProperty.java
+++ b/src/main/java/VASSAL/counters/DynamicProperty.java
@@ -30,6 +30,8 @@ import java.util.List;
 import javax.swing.Box;
 import javax.swing.KeyStroke;
 
+import org.apache.commons.lang3.StringUtils;
+
 import VASSAL.build.GameModule;
 import VASSAL.build.module.Map;
 import VASSAL.build.module.documentation.HelpFile;
@@ -102,7 +104,7 @@ public class DynamicProperty extends Decorator implements TranslatablePiece, Pro
       new DynamicKeyCommand[0]);
 
     menuCommands = Arrays.stream(keyCommands).filter(
-      kc -> kc.getName() != null && !kc.getName().isEmpty()
+      kc -> !StringUtils.isEmpty(kc.getName())
     ).toArray(KeyCommand[]::new);
   }
 

--- a/src/main/java/VASSAL/counters/ImagePicker.java
+++ b/src/main/java/VASSAL/counters/ImagePicker.java
@@ -43,6 +43,7 @@ import VASSAL.tools.filechooser.FileChooser;
 import VASSAL.tools.filechooser.ImageFileFilter;
 import VASSAL.tools.imageop.Op;
 import VASSAL.tools.imageop.OpIcon;
+import VASSAL.tools.swing.SwingUtils;
 
 public class ImagePicker extends JPanel
                          implements MouseListener, ItemListener {
@@ -133,6 +134,9 @@ public class ImagePicker extends JPanel
 
   @Override
   public void mouseClicked(MouseEvent e) {
+    if (SwingUtils.isLeftMouseButton(e) && e.getClickCount() > 1) {
+      pickImage();
+    }
   }
 
   @Override
@@ -141,9 +145,6 @@ public class ImagePicker extends JPanel
 
   @Override
   public void mouseReleased(MouseEvent e) {
-    if (e.getClickCount() > 1) {
-      pickImage();
-    }
   }
 
   @Override

--- a/src/main/java/VASSAL/counters/ImagePicker.java
+++ b/src/main/java/VASSAL/counters/ImagePicker.java
@@ -134,7 +134,7 @@ public class ImagePicker extends JPanel
 
   @Override
   public void mouseClicked(MouseEvent e) {
-    if (SwingUtils.isLeftMouseButton(e) && e.getClickCount() > 1) {
+    if (e.getClickCount() > 1 && SwingUtils.isLeftMouseButton(e)) {
       pickImage();
     }
   }

--- a/src/main/java/VASSAL/counters/PieceDefiner.java
+++ b/src/main/java/VASSAL/counters/PieceDefiner.java
@@ -54,6 +54,7 @@ import VASSAL.build.widget.PieceSlot;
 import VASSAL.tools.BrowserSupport;
 import VASSAL.tools.ErrorDialog;
 import VASSAL.tools.ReflectionUtils;
+import VASSAL.tools.swing.SwingUtils;
 
 /**
  * This is the GamePiece designer dialog.  It appears when you edit
@@ -381,9 +382,10 @@ public class PieceDefiner extends JPanel implements HelpWindowExtension {
 
     inUseList.addMouseListener(new MouseAdapter() {
       @Override
-      public void mouseReleased(MouseEvent evt) {
-        if (evt.getClickCount() == 2) {
-          int index = inUseList.locationToIndex(evt.getPoint());
+// FIXME: mouseClicked()?
+      public void mouseReleased(MouseEvent e) {
+        if (e.getClickCount() == 2 && SwingUtils.isLeftMouseButton(e)) {
+          int index = inUseList.locationToIndex(e.getPoint());
           if (index >= 0) {
             edit(index);
           }

--- a/src/main/java/VASSAL/counters/PropertySheet.java
+++ b/src/main/java/VASSAL/counters/PropertySheet.java
@@ -1298,26 +1298,29 @@ public class PropertySheet extends Decorator implements TranslatablePiece {
     }
 
     @Override
-    public void mouseClicked(MouseEvent event) {
-      if (panelType != TICKS_VALMAX && (event.isShiftDown() || SwingUtils.isRightMouseButton(event))) {
+    public void mouseClicked(MouseEvent e) {
+      if (panelType != TICKS_VALMAX &&
+          ((SwingUtils.isLeftMouseButton(e) && e.isShiftDown()) ||
+            SwingUtils.isRightMouseButton(e))) {
         new EditTickLabelValueDialog(this);
-        return;
       }
-      int col = Math.min((event.getX() - leftMargin + 1) / dx, numCols - 1);
-      int row = Math.min((event.getY() - topMargin + 1) / dx, numRows - 1);
-      int num = row * numCols + col + 1;
+      else if (SwingUtils.isLeftMouseButton(e)) {
+        int col = Math.min((e.getX() - leftMargin + 1) / dx, numCols - 1);
+        int row = Math.min((e.getY() - topMargin + 1) / dx, numRows - 1);
+        int num = row * numCols + col + 1;
 
-      // Checkbox behavior; toggle the box clicked on
-      // numTicks = num > numTicks ? num : num - 1;
+        // Checkbox behavior; toggle the box clicked on
+        // numTicks = num > numTicks ? num : num - 1;
 
-      // Slider behavior; set the box clicked on and all to left and clear all boxes to right,
-      // UNLESS user clicked on last set box (which would do nothing), in this case, toggle the
-      // box clicked on.  This is the only way the user can clear the first box.
+        // Slider behavior; set the box clicked on and all to left and clear all boxes to right,
+        // UNLESS user clicked on last set box (which would do nothing), in this case, toggle the
+        // box clicked on.  This is the only way the user can clear the first box.
 
-      numTicks = (num == numTicks) ? num - 1 : num;
-      fireActionEvent();
+        numTicks = (num == numTicks) ? num - 1 : num;
+        fireActionEvent();
 
-      repaint();
+        repaint();
+      }
     }
 
     public void fireActionEvent() {

--- a/src/main/java/VASSAL/counters/PropertySheet.java
+++ b/src/main/java/VASSAL/counters/PropertySheet.java
@@ -81,6 +81,7 @@ import VASSAL.i18n.TranslatablePiece;
 import VASSAL.tools.NamedKeyStroke;
 import VASSAL.tools.ScrollPane;
 import VASSAL.tools.SequenceEncoder;
+import VASSAL.tools.swing.SwingUtils;
 
 /**
  * A Decorator class that endows a GamePiece with a dialog.
@@ -1298,8 +1299,7 @@ public class PropertySheet extends Decorator implements TranslatablePiece {
 
     @Override
     public void mouseClicked(MouseEvent event) {
-
-      if ((event.getButton() == 3 || event.isShiftDown()) && panelType != TICKS_VALMAX) {
+      if (panelType != TICKS_VALMAX && (event.isShiftDown() || SwingUtils.isRightMouseButton(event))) {
         new EditTickLabelValueDialog(this);
         return;
       }

--- a/src/main/java/VASSAL/counters/SetGlobalProperty.java
+++ b/src/main/java/VASSAL/counters/SetGlobalProperty.java
@@ -30,6 +30,8 @@ import javax.swing.JLabel;
 import javax.swing.KeyStroke;
 import javax.swing.SwingUtilities;
 
+import org.apache.commons.lang3.StringUtils;
+
 import VASSAL.build.BadDataReport;
 import VASSAL.build.GameModule;
 import VASSAL.build.module.Map;
@@ -97,7 +99,7 @@ public class SetGlobalProperty extends DynamicProperty {
       new DynamicKeyCommand[0]);
 
     menuCommands = Arrays.stream(keyCommands).filter(
-      kc -> kc.getName() != null && !kc.getName().isEmpty()
+      kc -> !StringUtils.isEmpty(kc.getName())
     ).toArray(KeyCommand[]::new);
 
     description = sd.nextToken("");

--- a/src/main/java/VASSAL/launch/ModuleManagerWindow.java
+++ b/src/main/java/VASSAL/launch/ModuleManagerWindow.java
@@ -122,6 +122,7 @@ import VASSAL.tools.menu.MenuItemProxy;
 import VASSAL.tools.menu.MenuManager;
 import VASSAL.tools.menu.MenuProxy;
 import VASSAL.tools.swing.Dialogs;
+import VASSAL.tools.swing.SwingUtils;
 import VASSAL.tools.version.UpdateCheckAction;
 
 public class ModuleManagerWindow extends JFrame {
@@ -571,7 +572,7 @@ public class ModuleManagerWindow extends JFrame {
     tree.addMouseListener(new MouseAdapter() {
       @Override
       public void mouseClicked(MouseEvent e) {
-        if (e.getClickCount() == 2) {
+        if (e.getClickCount() == 2 && SwingUtils.isLeftMouseButton(e)) {
           final TreePath path =
             tree.getPathForLocation(e.getPoint().x, e.getPoint().y);
 

--- a/src/main/java/VASSAL/tools/SplashScreen.java
+++ b/src/main/java/VASSAL/tools/SplashScreen.java
@@ -29,6 +29,8 @@ import javax.swing.ImageIcon;
 import javax.swing.JLabel;
 import javax.swing.JWindow;
 
+import VASSAL.tools.swing.SwingUtils;
+
 /**
  * Displays an image centered on the screen
  */
@@ -46,8 +48,10 @@ public class SplashScreen extends JWindow {
                 d.height / 2 - getSize().height / 2);
     addMouseListener(new MouseAdapter() {
       @Override
-      public void mouseReleased(MouseEvent evt) {
-        setVisible(false);
+      public void mouseReleased(MouseEvent e) {
+        if (SwingUtils.isLeftMouseButton(e)) {
+          setVisible(false);
+        }
       }
     });
   }

--- a/src/main/java/VASSAL/tools/swing/AboutWindow.java
+++ b/src/main/java/VASSAL/tools/swing/AboutWindow.java
@@ -31,6 +31,8 @@ import javax.swing.ImageIcon;
 import javax.swing.JLabel;
 import javax.swing.JWindow;
 
+import VASSAL.tools.swing.SwingUtils;
+
 /**
  * @since 3.1.0
  * @author Joel Uckelman
@@ -63,9 +65,11 @@ public class AboutWindow extends JWindow {
 
     addMouseListener(new MouseAdapter() {
       @Override
-      public void mouseReleased(MouseEvent evt) {
-        setVisible(false);
-        dispose();
+      public void mouseReleased(MouseEvent e) {
+        if (SwingUtils.isLeftMouseButton(e)) {
+          setVisible(false);
+          dispose();
+        }
       }
     });
   }

--- a/src/main/java/VASSAL/tools/swing/SwingUtils.java
+++ b/src/main/java/VASSAL/tools/swing/SwingUtils.java
@@ -49,6 +49,11 @@ public class SwingUtils {
      * @return whether the event is effectively for the right button
      */
     boolean isRightMouseButton(MouseEvent e);
+
+    /*
+     * @return whether the event effectively has Control down
+     */
+    boolean isControlDown(MouseEvent e);
   }
 
   private static class DefaultInputClassifier implements InputClassifier {
@@ -58,6 +63,10 @@ public class SwingUtils {
 
     public boolean isRightMouseButton(MouseEvent e) {
       return SwingUtilities.isRightMouseButton(e);
+    }
+
+    public boolean isControlDown(MouseEvent e) {
+      return e.isControlDown();
     }
   }
 
@@ -112,6 +121,10 @@ public class SwingUtils {
                (e.getModifiersEx() & MouseEvent.CTRL_DOWN_MASK) != 0);
       }
     }
+
+    public boolean isControlDown(MouseEvent e) {
+      return e.isControlDown();
+    }
   }
 
   private static final InputClassifier inputClassifier =
@@ -138,5 +151,12 @@ public class SwingUtils {
   public static boolean isDragTrigger(DragGestureEvent e) {
     final InputEvent te = e.getTriggerEvent();
     return !(te instanceof MouseEvent) || isLeftMouseButton((MouseEvent) te);
+  }
+
+  /*
+   * @return whether the event effectively has Control down
+   */
+  public static boolean isControlDown(MouseEvent e) {
+    return inputClassifier.isControlDown(e);
   }
 }

--- a/src/main/java/VASSAL/tools/swing/SwingUtils.java
+++ b/src/main/java/VASSAL/tools/swing/SwingUtils.java
@@ -18,6 +18,8 @@
 package VASSAL.tools.swing;
 
 import java.awt.Toolkit;
+import java.awt.dnd.DragGestureEvent;
+import java.awt.event.InputEvent;
 import java.awt.event.MouseEvent;
 import java.awt.geom.AffineTransform;
 import java.util.Map;
@@ -37,20 +39,104 @@ public class SwingUtils {
 
   public static final Map<?,?> FONT_HINTS = (Map<?,?>) Toolkit.getDefaultToolkit().getDesktopProperty("awt.font.desktophints");
 
-  public static boolean isLeftMouseButton(MouseEvent e) {
-    return SwingUtilities.isLeftMouseButton(e);
+  private static interface MouseButtonClassifier {
+    /*
+     * @return whether the event is effectively for the left button
+     */
+    boolean isLeftMouseButton(MouseEvent e);
+
+    /*
+     * @return whether the event is effectively for the right button
+     */
+    boolean isRightMouseButton(MouseEvent e);
   }
 
+  private static class DefaultMouseButtonClassifier implements MouseButtonClassifier {
+    public boolean isLeftMouseButton(MouseEvent e) {
+      return SwingUtilities.isLeftMouseButton(e);
+    }
+
+    public boolean isRightMouseButton(MouseEvent e) {
+      return SwingUtilities.isRightMouseButton(e);
+    }
+  }
+
+  private static class MacMouseButtonClassifier implements MouseButtonClassifier {
+    private static final int B1_MASK = MouseEvent.BUTTON1_DOWN_MASK |
+                                       MouseEvent.CTRL_DOWN_MASK;
+
+    public boolean isLeftMouseButton(MouseEvent e) {
+      // The left button on a Mac is the left button, except when it's the
+      // right button because Ctrl is depressed.
+      switch (e.getID()) {
+      case MouseEvent.MOUSE_PRESSED:
+      case MouseEvent.MOUSE_RELEASED:
+      case MouseEvent.MOUSE_CLICKED:
+        return e.getButton() == MouseEvent.BUTTON1 &&
+               (e.getModifiersEx() & MouseEvent.CTRL_DOWN_MASK) == 0;
+
+      case MouseEvent.MOUSE_ENTERED:
+      case MouseEvent.MOUSE_EXITED:
+      case MouseEvent.MOUSE_DRAGGED:
+        return (e.getModifiersEx() & B1_MASK) == MouseEvent.BUTTON1_DOWN_MASK;
+
+      default:
+        return (e.getModifiersEx() & B1_MASK) == MouseEvent.BUTTON1_DOWN_MASK ||
+               (e.getButton() == MouseEvent.BUTTON1 &&
+                (e.getModifiersEx() & MouseEvent.CTRL_DOWN_MASK) == 0);
+      }
+    }
+
+    public boolean isRightMouseButton(MouseEvent e) {
+      // The right button on a Mac can be either a real right button, or
+      // Ctrl + the left button.
+      switch (e.getID()) {
+      case MouseEvent.MOUSE_PRESSED:
+      case MouseEvent.MOUSE_RELEASED:
+      case MouseEvent.MOUSE_CLICKED:
+        return e.getButton() == MouseEvent.BUTTON3 ||
+               (e.getButton() == MouseEvent.BUTTON1 &&
+                (e.getModifiersEx() & MouseEvent.CTRL_DOWN_MASK) != 0);
+
+      case MouseEvent.MOUSE_ENTERED:
+      case MouseEvent.MOUSE_EXITED:
+      case MouseEvent.MOUSE_DRAGGED:
+        return (e.getModifiersEx() & MouseEvent.BUTTON3_DOWN_MASK) != 0 ||
+               (e.getModifiersEx() & B1_MASK) == B1_MASK;
+
+      default:
+        return (e.getModifiersEx() & MouseEvent.BUTTON3_DOWN_MASK) != 0 ||
+               (e.getModifiersEx() & B1_MASK) == B1_MASK ||
+               e.getButton() == MouseEvent.BUTTON3 ||
+               (e.getButton() == MouseEvent.BUTTON1 &&
+               (e.getModifiersEx() & MouseEvent.CTRL_DOWN_MASK) != 0);
+      }
+    }
+  }
+
+  private static final MouseButtonClassifier mouseButtonClassifier =
+    SystemUtils.IS_OS_MAC_OSX ?
+      new MacMouseButtonClassifier() : new DefaultMouseButtonClassifier();
+
+  /*
+   * @return whether the event is effectively for the left button
+   */
+  public static boolean isLeftMouseButton(MouseEvent e) {
+    return mouseButtonClassifier.isLeftMouseButton(e);
+  }
+
+  /*
+   * @return whether the event is effectively for the right button
+   */
   public static boolean isRightMouseButton(MouseEvent e) {
-    if (e.getButton() == MouseEvent.BUTTON3) {
-      return true;
-    }
+    return mouseButtonClassifier.isRightMouseButton(e);
+  }
 
-    if (!SystemUtils.IS_OS_MAC_OSX) {
-      return false;
-    }
-
-    return e.getButton() == MouseEvent.BUTTON1 &&
-      (e.getModifiersEx() & MouseEvent.CTRL_DOWN_MASK) != 0;
+  /*
+   * @return whether the drag is non-mouse or effectively from the left button
+   */
+  public static boolean isDragTrigger(DragGestureEvent e) {
+    final InputEvent te = e.getTriggerEvent();
+    return !(te instanceof MouseEvent) || isLeftMouseButton((MouseEvent) te);
   }
 }

--- a/src/main/java/VASSAL/tools/swing/SwingUtils.java
+++ b/src/main/java/VASSAL/tools/swing/SwingUtils.java
@@ -39,7 +39,7 @@ public class SwingUtils {
 
   public static final Map<?,?> FONT_HINTS = (Map<?,?>) Toolkit.getDefaultToolkit().getDesktopProperty("awt.font.desktophints");
 
-  private static interface InputClassifier {
+  private interface InputClassifier {
     /*
      * @return whether the event is effectively for the left button
      */

--- a/src/main/java/VASSAL/tools/swing/SwingUtils.java
+++ b/src/main/java/VASSAL/tools/swing/SwingUtils.java
@@ -18,8 +18,11 @@
 package VASSAL.tools.swing;
 
 import java.awt.Toolkit;
+import java.awt.event.MouseEvent;
 import java.awt.geom.AffineTransform;
 import java.util.Map;
+
+import org.apache.commons.lang3.SystemUtils;
 
 public class SwingUtils {
   public static AffineTransform descaleTransform(AffineTransform t) {
@@ -31,4 +34,17 @@ public class SwingUtils {
   }
 
   public static final Map<?,?> FONT_HINTS = (Map<?,?>) Toolkit.getDefaultToolkit().getDesktopProperty("awt.font.desktophints");
+
+  public static boolean isRightMouseButton(MouseEvent e) {
+    if (e.getButton() == MouseEvent.BUTTON3) {
+      return true;
+    }
+
+    if (!SystemUtils.IS_OS_MAC_OSX) {
+      return false;
+    }
+
+    return e.getButton() == MouseEvent.BUTTON1 &&
+      (e.getModifiersEx() & MouseEvent.CTRL_DOWN_MASK) != 0;
+  }
 }

--- a/src/main/java/VASSAL/tools/swing/SwingUtils.java
+++ b/src/main/java/VASSAL/tools/swing/SwingUtils.java
@@ -39,7 +39,7 @@ public class SwingUtils {
 
   public static final Map<?,?> FONT_HINTS = (Map<?,?>) Toolkit.getDefaultToolkit().getDesktopProperty("awt.font.desktophints");
 
-  private static interface MouseButtonClassifier {
+  private static interface InputClassifier {
     /*
      * @return whether the event is effectively for the left button
      */
@@ -51,7 +51,7 @@ public class SwingUtils {
     boolean isRightMouseButton(MouseEvent e);
   }
 
-  private static class DefaultMouseButtonClassifier implements MouseButtonClassifier {
+  private static class DefaultInputClassifier implements InputClassifier {
     public boolean isLeftMouseButton(MouseEvent e) {
       return SwingUtilities.isLeftMouseButton(e);
     }
@@ -61,7 +61,7 @@ public class SwingUtils {
     }
   }
 
-  private static class MacMouseButtonClassifier implements MouseButtonClassifier {
+  private static class MacInputClassifier implements InputClassifier {
     private static final int B1_MASK = MouseEvent.BUTTON1_DOWN_MASK |
                                        MouseEvent.CTRL_DOWN_MASK;
 
@@ -114,22 +114,22 @@ public class SwingUtils {
     }
   }
 
-  private static final MouseButtonClassifier mouseButtonClassifier =
+  private static final InputClassifier inputClassifier =
     SystemUtils.IS_OS_MAC_OSX ?
-      new MacMouseButtonClassifier() : new DefaultMouseButtonClassifier();
+      new MacInputClassifier() : new DefaultInputClassifier();
 
   /*
    * @return whether the event is effectively for the left button
    */
   public static boolean isLeftMouseButton(MouseEvent e) {
-    return mouseButtonClassifier.isLeftMouseButton(e);
+    return inputClassifier.isLeftMouseButton(e);
   }
 
   /*
    * @return whether the event is effectively for the right button
    */
   public static boolean isRightMouseButton(MouseEvent e) {
-    return mouseButtonClassifier.isRightMouseButton(e);
+    return inputClassifier.isRightMouseButton(e);
   }
 
   /*

--- a/src/main/java/VASSAL/tools/swing/SwingUtils.java
+++ b/src/main/java/VASSAL/tools/swing/SwingUtils.java
@@ -123,7 +123,10 @@ public class SwingUtils {
     }
 
     public boolean isControlDown(MouseEvent e) {
-      return e.isControlDown();
+      // The Command key on a Mac corresponds to Control everywhere else,
+      // but it obviously can't be called "Command" in Java; here it's
+      // called "Meta".
+      return e.isMetaDown();
     }
   }
 

--- a/src/main/java/VASSAL/tools/swing/SwingUtils.java
+++ b/src/main/java/VASSAL/tools/swing/SwingUtils.java
@@ -22,6 +22,8 @@ import java.awt.event.MouseEvent;
 import java.awt.geom.AffineTransform;
 import java.util.Map;
 
+import javax.swing.SwingUtilities;
+
 import org.apache.commons.lang3.SystemUtils;
 
 public class SwingUtils {
@@ -34,6 +36,10 @@ public class SwingUtils {
   }
 
   public static final Map<?,?> FONT_HINTS = (Map<?,?>) Toolkit.getDefaultToolkit().getDesktopProperty("awt.font.desktophints");
+
+  public static boolean isLeftMouseButton(MouseEvent e) {
+    return SwingUtilities.isLeftMouseButton(e);
+  }
 
   public static boolean isRightMouseButton(MouseEvent e) {
     if (e.getButton() == MouseEvent.BUTTON3) {

--- a/src/main/java/VASSAL/tools/swing/SwingUtils.java
+++ b/src/main/java/VASSAL/tools/swing/SwingUtils.java
@@ -130,7 +130,7 @@ public class SwingUtils {
     }
   }
 
-  private static final InputClassifier inputClassifier =
+  private static final InputClassifier INPUT_CLASSIFIER =
     SystemUtils.IS_OS_MAC_OSX ?
       new MacInputClassifier() : new DefaultInputClassifier();
 
@@ -138,28 +138,30 @@ public class SwingUtils {
    * @return whether the event is effectively for the left button
    */
   public static boolean isLeftMouseButton(MouseEvent e) {
-    return inputClassifier.isLeftMouseButton(e);
+    return INPUT_CLASSIFIER.isLeftMouseButton(e);
   }
 
   /*
    * @return whether the event is effectively for the right button
    */
   public static boolean isRightMouseButton(MouseEvent e) {
-    return inputClassifier.isRightMouseButton(e);
-  }
-
-  /*
-   * @return whether the drag is non-mouse or effectively from the left button
-   */
-  public static boolean isDragTrigger(DragGestureEvent e) {
-    final InputEvent te = e.getTriggerEvent();
-    return !(te instanceof MouseEvent) || isLeftMouseButton((MouseEvent) te);
+    return INPUT_CLASSIFIER.isRightMouseButton(e);
   }
 
   /*
    * @return whether the event effectively has Control down
    */
   public static boolean isControlDown(MouseEvent e) {
-    return inputClassifier.isControlDown(e);
+    return INPUT_CLASSIFIER.isControlDown(e);
+  }
+
+  /*
+   * @return whether the drag is non-mouse or effectively from the left button
+   */
+  public static boolean isDragTrigger(DragGestureEvent e) {
+    // NB: Will any non-mouse drags happen? Not sure, but as we never checked
+    // for them before, this won't change behavior by excluding them.
+    final InputEvent te = e.getTriggerEvent();
+    return !(te instanceof MouseEvent) || isLeftMouseButton((MouseEvent) te);
   }
 }

--- a/src/test/java/VASSAL/tools/swing/AbstractSwingUtilsTestIsMouseButton.java
+++ b/src/test/java/VASSAL/tools/swing/AbstractSwingUtilsTestIsMouseButton.java
@@ -1,0 +1,66 @@
+package VASSAL.tools.swing;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.awt.event.InputEvent;
+import java.awt.event.MouseEvent;
+
+import org.junit.Test;
+
+public abstract class AbstractSwingUtilsTestIsMouseButton {
+  /**
+   * index 0: {@link MouseEvent#getID()}
+   *   e.g. {@link MouseEvent#MOUSE_PRESSED}
+   *
+   * index 1: {@link MouseEvent#getButton()}
+   *   e.g. {@link MouseEvent#BUTTON1}
+   *
+   * index 2: {@link MouseEvent#getModifiersEx()}
+   *   e.g. {@link InputEvent#BUTTON1_DOWN_MASK}
+   */
+  protected final int[] mouseEventParams;
+  /**
+   * index 0: result for isMouseLeft
+   * index 1: result for isMouseRight
+   */
+  protected final boolean[] expectedResult;
+
+  public AbstractSwingUtilsTestIsMouseButton(int[] mouseEventParams,
+                                             boolean[] expectedResult) {
+    this.mouseEventParams = mouseEventParams;
+    this.expectedResult = expectedResult;
+  }
+
+  @Test
+  public void testIsLeftMouseButton() {
+    // prepare
+    final MouseEvent mouseEvent = mock(MouseEvent.class);
+    when(mouseEvent.getID()).thenReturn(mouseEventParams[0]);
+    when(mouseEvent.getButton()).thenReturn(mouseEventParams[1]);
+    when(mouseEvent.getModifiersEx()).thenReturn(mouseEventParams[2]);
+
+    // run
+    final boolean result = SwingUtils.isLeftMouseButton(mouseEvent);
+
+    // assert
+    assertThat(result, is(expectedResult[0]));
+  }
+
+  @Test
+  public void testIsRightMouseButton() {
+    // prepare
+    final MouseEvent mouseEvent = mock(MouseEvent.class);
+    when(mouseEvent.getID()).thenReturn(mouseEventParams[0]);
+    when(mouseEvent.getButton()).thenReturn(mouseEventParams[1]);
+    when(mouseEvent.getModifiersEx()).thenReturn(mouseEventParams[2]);
+
+    // run
+    final boolean result = SwingUtils.isRightMouseButton(mouseEvent);
+
+    // assert
+    assertThat(result, is(expectedResult[1]));
+  }
+}

--- a/src/test/java/VASSAL/tools/swing/SwingUtilsTestIsMouseButtonMacOsX.java
+++ b/src/test/java/VASSAL/tools/swing/SwingUtilsTestIsMouseButtonMacOsX.java
@@ -1,45 +1,20 @@
 package VASSAL.tools.swing;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-
 import java.awt.event.InputEvent;
 import java.awt.event.MouseEvent;
 import java.util.Arrays;
 import java.util.Collection;
 
 import org.junit.Rule;
-import org.junit.Test;
 import org.junit.contrib.java.lang.system.ProvideSystemProperty;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 @RunWith(Parameterized.class)
-public class SwingUtilsTestIsMouseButtonMacOsX {
-
-  /**
-   * index 0: {@link MouseEvent#getID()}
-   *   e.g. {@link MouseEvent#MOUSE_PRESSED}
-   *
-   * index 1: {@link MouseEvent#getButton()}
-   *   e.g. {@link MouseEvent#BUTTON1}
-   *
-   * index 2: {@link MouseEvent#getModifiersEx()}
-   *   e.g. {@link InputEvent#BUTTON1_DOWN_MASK}
-   */
-  private final int[] mouseEventParams;
-
-  /**
-   * index 0: result for isMouseLeft
-   * index 1: result for isMouseRight
-   */
-  private final boolean[] expectedResult;
+public class SwingUtilsTestIsMouseButtonMacOsX extends AbstractSwingUtilsTestIsMouseButton {
 
   public SwingUtilsTestIsMouseButtonMacOsX(int[] mouseEventParams, boolean[] expectedResult) {
-    this.mouseEventParams = mouseEventParams;
-    this.expectedResult = expectedResult;
+    super(mouseEventParams, expectedResult);
   }
 
   @Parameterized.Parameters
@@ -91,37 +66,7 @@ public class SwingUtilsTestIsMouseButtonMacOsX {
   }
 
   @Rule
-  public final ProvideSystemProperty myPropertyHasMyValue =
+  public final ProvideSystemProperty osNameProperty =
       new ProvideSystemProperty("os.name", "Mac OS X");
-
-  @Test
-  public void testIsLeftMouseButton() {
-    // prepare
-    final MouseEvent mouseEvent = mock(MouseEvent.class);
-    when(mouseEvent.getID()).thenReturn(mouseEventParams[0]);
-    when(mouseEvent.getButton()).thenReturn(mouseEventParams[1]);
-    when(mouseEvent.getModifiersEx()).thenReturn(mouseEventParams[2]);
-
-    // run
-    final boolean result = SwingUtils.isLeftMouseButton(mouseEvent);
-
-    // assert
-    assertThat(result, is(expectedResult[0]));
-  }
-
-  @Test
-  public void testIsRightMouseButton() {
-    // prepare
-    final MouseEvent mouseEvent = mock(MouseEvent.class);
-    when(mouseEvent.getID()).thenReturn(mouseEventParams[0]);
-    when(mouseEvent.getButton()).thenReturn(mouseEventParams[1]);
-    when(mouseEvent.getModifiersEx()).thenReturn(mouseEventParams[2]);
-
-    // run
-    final boolean result = SwingUtils.isRightMouseButton(mouseEvent);
-
-    // assert
-    assertThat(result, is(expectedResult[1]));
-  }
 
 }

--- a/src/test/java/VASSAL/tools/swing/SwingUtilsTestIsMouseButtonMacOsX.java
+++ b/src/test/java/VASSAL/tools/swing/SwingUtilsTestIsMouseButtonMacOsX.java
@@ -1,0 +1,127 @@
+package VASSAL.tools.swing;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.awt.event.InputEvent;
+import java.awt.event.MouseEvent;
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.contrib.java.lang.system.ProvideSystemProperty;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+@RunWith(Parameterized.class)
+public class SwingUtilsTestIsMouseButtonMacOsX {
+
+  /**
+   * index 0: {@link MouseEvent#getID()}
+   *   e.g. {@link MouseEvent#MOUSE_PRESSED}
+   *
+   * index 1: {@link MouseEvent#getButton()}
+   *   e.g. {@link MouseEvent#BUTTON1}
+   *
+   * index 2: {@link MouseEvent#getModifiersEx()}
+   *   e.g. {@link InputEvent#BUTTON1_DOWN_MASK}
+   */
+  private final int[] mouseEventParams;
+
+  /**
+   * index 0: result for isMouseLeft
+   * index 1: result for isMouseRight
+   */
+  private final boolean[] expectedResult;
+
+  public SwingUtilsTestIsMouseButtonMacOsX(int[] mouseEventParams, boolean[] expectedResult) {
+    this.mouseEventParams = mouseEventParams;
+    this.expectedResult = expectedResult;
+  }
+
+  @Parameterized.Parameters
+  public static Collection<Object[]> testData() {
+    return Arrays.asList(new Object[][]{
+      // left
+      { new int[] {MouseEvent.MOUSE_PRESSED, MouseEvent.BUTTON1, 0}, new boolean[] {true, false}},
+      { new int[] {MouseEvent.MOUSE_RELEASED, MouseEvent.BUTTON1, 0}, new boolean[] {true, false}},
+      { new int[] {MouseEvent.MOUSE_CLICKED, MouseEvent.BUTTON1, 0}, new boolean[] {true, false}},
+      // left + ctrl -> right button on Mac
+      { new int[] {MouseEvent.MOUSE_PRESSED, MouseEvent.BUTTON1, MouseEvent.CTRL_DOWN_MASK}, new boolean[] {false, true}},
+      { new int[] {MouseEvent.MOUSE_RELEASED, MouseEvent.BUTTON1, MouseEvent.CTRL_DOWN_MASK}, new boolean[] {false, true}},
+      { new int[] {MouseEvent.MOUSE_CLICKED, MouseEvent.BUTTON1, MouseEvent.CTRL_DOWN_MASK}, new boolean[] {false, true}},
+      // left movement
+      { new int[] {MouseEvent.MOUSE_ENTERED, 0, InputEvent.BUTTON1_DOWN_MASK}, new boolean[] {true, false}},
+      { new int[] {MouseEvent.MOUSE_EXITED, 0, InputEvent.BUTTON1_DOWN_MASK}, new boolean[] {true, false}},
+      { new int[] {MouseEvent.MOUSE_DRAGGED, 0, InputEvent.BUTTON1_DOWN_MASK}, new boolean[] {true, false}},
+      // left movement + ctrl -> right button on Mac
+      { new int[] {MouseEvent.MOUSE_ENTERED, 0, InputEvent.BUTTON1_DOWN_MASK | MouseEvent.CTRL_DOWN_MASK}, new boolean[] {false, true}},
+      { new int[] {MouseEvent.MOUSE_EXITED, 0, InputEvent.BUTTON1_DOWN_MASK | MouseEvent.CTRL_DOWN_MASK}, new boolean[] {false, true}},
+      { new int[] {MouseEvent.MOUSE_DRAGGED, 0, InputEvent.BUTTON1_DOWN_MASK | MouseEvent.CTRL_DOWN_MASK}, new boolean[] {false, true}},
+
+      // middle
+      { new int[] {MouseEvent.MOUSE_PRESSED, MouseEvent.BUTTON2, 0}, new boolean[] {false, false}},
+      { new int[] {MouseEvent.MOUSE_RELEASED, MouseEvent.BUTTON2, 0}, new boolean[] {false, false}},
+      { new int[] {MouseEvent.MOUSE_CLICKED, MouseEvent.BUTTON2, 0}, new boolean[] {false, false}},
+      // middle movement
+      { new int[] {MouseEvent.MOUSE_ENTERED, 0, InputEvent.BUTTON2_DOWN_MASK}, new boolean[] {false, false}},
+      { new int[] {MouseEvent.MOUSE_EXITED, 0, InputEvent.BUTTON2_DOWN_MASK}, new boolean[] {false, false}},
+      { new int[] {MouseEvent.MOUSE_DRAGGED, 0, InputEvent.BUTTON2_DOWN_MASK}, new boolean[] {false, false}},
+
+      // right
+      { new int[] {MouseEvent.MOUSE_PRESSED, MouseEvent.BUTTON3, 0}, new boolean[] {false, true}},
+      { new int[] {MouseEvent.MOUSE_RELEASED, MouseEvent.BUTTON3, 0}, new boolean[] {false, true}},
+      { new int[] {MouseEvent.MOUSE_CLICKED, MouseEvent.BUTTON3, 0}, new boolean[] {false, true}},
+      // right + ctrl
+      { new int[] {MouseEvent.MOUSE_PRESSED, MouseEvent.BUTTON3, MouseEvent.CTRL_DOWN_MASK}, new boolean[] {false, true}},
+      { new int[] {MouseEvent.MOUSE_RELEASED, MouseEvent.BUTTON3, MouseEvent.CTRL_DOWN_MASK}, new boolean[] {false, true}},
+      { new int[] {MouseEvent.MOUSE_CLICKED, MouseEvent.BUTTON3, MouseEvent.CTRL_DOWN_MASK}, new boolean[] {false, true}},
+      // right movement
+      { new int[] {MouseEvent.MOUSE_ENTERED, 0, InputEvent.BUTTON3_DOWN_MASK}, new boolean[] {false, true}},
+      { new int[] {MouseEvent.MOUSE_EXITED, 0, InputEvent.BUTTON3_DOWN_MASK}, new boolean[] {false, true}},
+      { new int[] {MouseEvent.MOUSE_DRAGGED, 0, InputEvent.BUTTON3_DOWN_MASK}, new boolean[] {false, true}},
+      // right movement + ctrl
+      { new int[] {MouseEvent.MOUSE_ENTERED, 0, InputEvent.BUTTON3_DOWN_MASK | MouseEvent.CTRL_DOWN_MASK}, new boolean[] {false, true}},
+      { new int[] {MouseEvent.MOUSE_EXITED, 0, InputEvent.BUTTON3_DOWN_MASK | MouseEvent.CTRL_DOWN_MASK}, new boolean[] {false, true}},
+      { new int[] {MouseEvent.MOUSE_DRAGGED, 0, InputEvent.BUTTON3_DOWN_MASK | MouseEvent.CTRL_DOWN_MASK}, new boolean[] {false, true}},
+    });
+  }
+
+  @Rule
+  public final ProvideSystemProperty myPropertyHasMyValue =
+      new ProvideSystemProperty("os.name", "Mac OS X");
+
+  @Test
+  public void testIsLeftMouseButton() {
+    // prepare
+    final MouseEvent mouseEvent = mock(MouseEvent.class);
+    when(mouseEvent.getID()).thenReturn(mouseEventParams[0]);
+    when(mouseEvent.getButton()).thenReturn(mouseEventParams[1]);
+    when(mouseEvent.getModifiersEx()).thenReturn(mouseEventParams[2]);
+
+    // run
+    final boolean result = SwingUtils.isLeftMouseButton(mouseEvent);
+
+    // assert
+    assertThat(result, is(expectedResult[0]));
+  }
+
+  @Test
+  public void testIsRightMouseButton() {
+    // prepare
+    final MouseEvent mouseEvent = mock(MouseEvent.class);
+    when(mouseEvent.getID()).thenReturn(mouseEventParams[0]);
+    when(mouseEvent.getButton()).thenReturn(mouseEventParams[1]);
+    when(mouseEvent.getModifiersEx()).thenReturn(mouseEventParams[2]);
+
+    // run
+    final boolean result = SwingUtils.isRightMouseButton(mouseEvent);
+
+    // assert
+    assertThat(result, is(expectedResult[1]));
+  }
+
+}

--- a/src/test/java/VASSAL/tools/swing/SwingUtilsTestIsMouseButtonNonMacOsX.java
+++ b/src/test/java/VASSAL/tools/swing/SwingUtilsTestIsMouseButtonNonMacOsX.java
@@ -1,0 +1,127 @@
+package VASSAL.tools.swing;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.awt.event.InputEvent;
+import java.awt.event.MouseEvent;
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.contrib.java.lang.system.ProvideSystemProperty;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+@RunWith(Parameterized.class)
+public class SwingUtilsTestIsMouseButtonNonMacOsX {
+
+  /**
+   * index 0: {@link MouseEvent#getID()}
+   *   e.g. {@link MouseEvent#MOUSE_PRESSED}
+   *
+   * index 1: {@link MouseEvent#getButton()}
+   *   e.g. {@link MouseEvent#BUTTON1}
+   *
+   * index 2: {@link MouseEvent#getModifiersEx()}
+   *   e.g. {@link InputEvent#BUTTON1_DOWN_MASK}
+   */
+  private final int[] mouseEventParams;
+
+  /**
+   * index 0: result for isMouseLeft
+   * index 1: result for isMouseRight
+   */
+  private final boolean[] expectedResult;
+
+  public SwingUtilsTestIsMouseButtonNonMacOsX(int[] mouseEventParams, boolean[] expectedResult) {
+    this.mouseEventParams = mouseEventParams;
+    this.expectedResult = expectedResult;
+  }
+
+  @Parameterized.Parameters
+  public static Collection<Object[]> testData() {
+    return Arrays.asList(new Object[][]{
+      // left
+      { new int[] {MouseEvent.MOUSE_PRESSED, MouseEvent.BUTTON1, 0}, new boolean[] {true, false}},
+      { new int[] {MouseEvent.MOUSE_RELEASED, MouseEvent.BUTTON1, 0}, new boolean[] {true, false}},
+      { new int[] {MouseEvent.MOUSE_CLICKED, MouseEvent.BUTTON1, 0}, new boolean[] {true, false}},
+      // left + ctrl
+      { new int[] {MouseEvent.MOUSE_PRESSED, MouseEvent.BUTTON1, MouseEvent.CTRL_DOWN_MASK}, new boolean[] {true, false}},
+      { new int[] {MouseEvent.MOUSE_RELEASED, MouseEvent.BUTTON1, MouseEvent.CTRL_DOWN_MASK}, new boolean[] {true, false}},
+      { new int[] {MouseEvent.MOUSE_CLICKED, MouseEvent.BUTTON1, MouseEvent.CTRL_DOWN_MASK}, new boolean[] {true, false}},
+      // left movement
+      { new int[] {MouseEvent.MOUSE_ENTERED, 0, InputEvent.BUTTON1_DOWN_MASK}, new boolean[] {true, false}},
+      { new int[] {MouseEvent.MOUSE_EXITED, 0, InputEvent.BUTTON1_DOWN_MASK}, new boolean[] {true, false}},
+      { new int[] {MouseEvent.MOUSE_DRAGGED, 0, InputEvent.BUTTON1_DOWN_MASK}, new boolean[] {true, false}},
+      // left movement + ctrl
+      { new int[] {MouseEvent.MOUSE_ENTERED, 0, InputEvent.BUTTON1_DOWN_MASK | MouseEvent.CTRL_DOWN_MASK}, new boolean[] {true, false}},
+      { new int[] {MouseEvent.MOUSE_EXITED, 0, InputEvent.BUTTON1_DOWN_MASK | MouseEvent.CTRL_DOWN_MASK}, new boolean[] {true, false}},
+      { new int[] {MouseEvent.MOUSE_DRAGGED, 0, InputEvent.BUTTON1_DOWN_MASK | MouseEvent.CTRL_DOWN_MASK}, new boolean[] {true, false}},
+
+      // middle
+      { new int[] {MouseEvent.MOUSE_PRESSED, MouseEvent.BUTTON2, 0}, new boolean[] {false, false}},
+      { new int[] {MouseEvent.MOUSE_RELEASED, MouseEvent.BUTTON2, 0}, new boolean[] {false, false}},
+      { new int[] {MouseEvent.MOUSE_CLICKED, MouseEvent.BUTTON2, 0}, new boolean[] {false, false}},
+      // middle movement
+      { new int[] {MouseEvent.MOUSE_ENTERED, 0, InputEvent.BUTTON2_DOWN_MASK}, new boolean[] {false, false}},
+      { new int[] {MouseEvent.MOUSE_EXITED, 0, InputEvent.BUTTON2_DOWN_MASK}, new boolean[] {false, false}},
+      { new int[] {MouseEvent.MOUSE_DRAGGED, 0, InputEvent.BUTTON2_DOWN_MASK}, new boolean[] {false, false}},
+
+      // right
+      { new int[] {MouseEvent.MOUSE_PRESSED, MouseEvent.BUTTON3, 0}, new boolean[] {false, true}},
+      { new int[] {MouseEvent.MOUSE_RELEASED, MouseEvent.BUTTON3, 0}, new boolean[] {false, true}},
+      { new int[] {MouseEvent.MOUSE_CLICKED, MouseEvent.BUTTON3, 0}, new boolean[] {false, true}},
+      // right + ctrl
+      { new int[] {MouseEvent.MOUSE_PRESSED, MouseEvent.BUTTON3, MouseEvent.CTRL_DOWN_MASK}, new boolean[] {false, true}},
+      { new int[] {MouseEvent.MOUSE_RELEASED, MouseEvent.BUTTON3, MouseEvent.CTRL_DOWN_MASK}, new boolean[] {false, true}},
+      { new int[] {MouseEvent.MOUSE_CLICKED, MouseEvent.BUTTON3, MouseEvent.CTRL_DOWN_MASK}, new boolean[] {false, true}},
+      // right movement
+      { new int[] {MouseEvent.MOUSE_ENTERED, 0, InputEvent.BUTTON3_DOWN_MASK}, new boolean[] {false, true}},
+      { new int[] {MouseEvent.MOUSE_EXITED, 0, InputEvent.BUTTON3_DOWN_MASK}, new boolean[] {false, true}},
+      { new int[] {MouseEvent.MOUSE_DRAGGED, 0, InputEvent.BUTTON3_DOWN_MASK}, new boolean[] {false, true}},
+      // right movement + ctrl
+      { new int[] {MouseEvent.MOUSE_ENTERED, 0, InputEvent.BUTTON3_DOWN_MASK | MouseEvent.CTRL_DOWN_MASK}, new boolean[] {false, true}},
+      { new int[] {MouseEvent.MOUSE_EXITED, 0, InputEvent.BUTTON3_DOWN_MASK | MouseEvent.CTRL_DOWN_MASK}, new boolean[] {false, true}},
+      { new int[] {MouseEvent.MOUSE_DRAGGED, 0, InputEvent.BUTTON3_DOWN_MASK | MouseEvent.CTRL_DOWN_MASK}, new boolean[] {false, true}},
+    });
+  }
+
+  @Rule
+  public final ProvideSystemProperty myPropertyHasMyValue =
+      new ProvideSystemProperty("os.name", "anythingButMacOsx");
+
+  @Test
+  public void testIsLeftMouseButton() {
+    // prepare
+    final MouseEvent mouseEvent = mock(MouseEvent.class);
+    when(mouseEvent.getID()).thenReturn(mouseEventParams[0]);
+    when(mouseEvent.getButton()).thenReturn(mouseEventParams[1]);
+    when(mouseEvent.getModifiersEx()).thenReturn(mouseEventParams[2]);
+
+    // run
+    final boolean result = SwingUtils.isLeftMouseButton(mouseEvent);
+
+    // assert
+    assertThat(result, is(expectedResult[0]));
+  }
+
+  @Test
+  public void testIsRightMouseButton() {
+    // prepare
+    final MouseEvent mouseEvent = mock(MouseEvent.class);
+    when(mouseEvent.getID()).thenReturn(mouseEventParams[0]);
+    when(mouseEvent.getButton()).thenReturn(mouseEventParams[1]);
+    when(mouseEvent.getModifiersEx()).thenReturn(mouseEventParams[2]);
+
+    // run
+    final boolean result = SwingUtils.isRightMouseButton(mouseEvent);
+
+    // assert
+    assertThat(result, is(expectedResult[1]));
+  }
+
+}

--- a/src/test/java/VASSAL/tools/swing/SwingUtilsTestIsMouseButtonNonMacOsX.java
+++ b/src/test/java/VASSAL/tools/swing/SwingUtilsTestIsMouseButtonNonMacOsX.java
@@ -1,45 +1,20 @@
 package VASSAL.tools.swing;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-
 import java.awt.event.InputEvent;
 import java.awt.event.MouseEvent;
 import java.util.Arrays;
 import java.util.Collection;
 
 import org.junit.Rule;
-import org.junit.Test;
 import org.junit.contrib.java.lang.system.ProvideSystemProperty;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 @RunWith(Parameterized.class)
-public class SwingUtilsTestIsMouseButtonNonMacOsX {
-
-  /**
-   * index 0: {@link MouseEvent#getID()}
-   *   e.g. {@link MouseEvent#MOUSE_PRESSED}
-   *
-   * index 1: {@link MouseEvent#getButton()}
-   *   e.g. {@link MouseEvent#BUTTON1}
-   *
-   * index 2: {@link MouseEvent#getModifiersEx()}
-   *   e.g. {@link InputEvent#BUTTON1_DOWN_MASK}
-   */
-  private final int[] mouseEventParams;
-
-  /**
-   * index 0: result for isMouseLeft
-   * index 1: result for isMouseRight
-   */
-  private final boolean[] expectedResult;
+public class SwingUtilsTestIsMouseButtonNonMacOsX extends AbstractSwingUtilsTestIsMouseButton {
 
   public SwingUtilsTestIsMouseButtonNonMacOsX(int[] mouseEventParams, boolean[] expectedResult) {
-    this.mouseEventParams = mouseEventParams;
-    this.expectedResult = expectedResult;
+    super(mouseEventParams, expectedResult);
   }
 
   @Parameterized.Parameters
@@ -91,37 +66,7 @@ public class SwingUtilsTestIsMouseButtonNonMacOsX {
   }
 
   @Rule
-  public final ProvideSystemProperty myPropertyHasMyValue =
-      new ProvideSystemProperty("os.name", "anythingButMacOsx");
-
-  @Test
-  public void testIsLeftMouseButton() {
-    // prepare
-    final MouseEvent mouseEvent = mock(MouseEvent.class);
-    when(mouseEvent.getID()).thenReturn(mouseEventParams[0]);
-    when(mouseEvent.getButton()).thenReturn(mouseEventParams[1]);
-    when(mouseEvent.getModifiersEx()).thenReturn(mouseEventParams[2]);
-
-    // run
-    final boolean result = SwingUtils.isLeftMouseButton(mouseEvent);
-
-    // assert
-    assertThat(result, is(expectedResult[0]));
-  }
-
-  @Test
-  public void testIsRightMouseButton() {
-    // prepare
-    final MouseEvent mouseEvent = mock(MouseEvent.class);
-    when(mouseEvent.getID()).thenReturn(mouseEventParams[0]);
-    when(mouseEvent.getButton()).thenReturn(mouseEventParams[1]);
-    when(mouseEvent.getModifiersEx()).thenReturn(mouseEventParams[2]);
-
-    // run
-    final boolean result = SwingUtils.isRightMouseButton(mouseEvent);
-
-    // assert
-    assertThat(result, is(expectedResult[1]));
-  }
+  public final ProvideSystemProperty osNameProperty =
+    new ProvideSystemProperty("os.name", "anythingButMacOsx");
 
 }


### PR DESCRIPTION
* When we want the left mouse button, check for it explicitly rather than checking that it's NOT the right mouse button. (Other buttons exist!)
    
* Check for the left mouse button when it makes no sense for other mouse buttons to trigger the operation. (It was possible to drag pieces with the middle button, for example.)
    
* Ctrl+Button is the right button on a Mac, so we have to distinguish that from just the left button by itself.