### PR TITLE
Removed calls to deprecated IOUtils.closeQuietly

### DIFF
--- a/src/main/java/VASSAL/build/AbstractBuildable.java
+++ b/src/main/java/VASSAL/build/AbstractBuildable.java
@@ -50,24 +50,26 @@ public abstract class AbstractBuildable implements Buildable, ValidityChecker, P
    */
   @Override
   public void build(Element e) {
-    if (e != null) {
-      final NamedNodeMap n = e.getAttributes();
-      for (int i = 0; i < n.getLength(); ++i) {
-        final Attr att = (Attr) n.item(i);
-        setAttribute(att.getName(), att.getValue());
-
-        /*
-         * Save a record of all Attributes for later translation. Need to save
-         * all attributes, not just translatable ones as the current component
-         * has not been completely built yet and a ComponentI18nData object
-         * cannot be built.
-         */
-        if (this instanceof Translatable) {
-          Localization.getInstance().saveTranslatableAttribute((Translatable) this, att.getName(), att.getValue());
-        }
-      }
-      Builder.build(e, this);
+    if (e == null) {
+      return;
     }
+
+    final NamedNodeMap n = e.getAttributes();
+    for (int i = 0; i < n.getLength(); ++i) {
+      final Attr att = (Attr) n.item(i);
+      setAttribute(att.getName(), att.getValue());
+
+      /*
+       * Save a record of all Attributes for later translation. Need to save
+       * all attributes, not just translatable ones as the current component
+       * has not been completely built yet and a ComponentI18nData object
+       * cannot be built.
+       */
+      if (this instanceof Translatable) {
+        Localization.getInstance().saveTranslatableAttribute((Translatable) this, att.getName(), att.getValue());
+      }
+    }
+    Builder.build(e, this);
   }
 
   /**

--- a/src/main/java/VASSAL/build/GameModule.java
+++ b/src/main/java/VASSAL/build/GameModule.java
@@ -104,7 +104,6 @@ import VASSAL.tools.WriteErrorDialog;
 import VASSAL.tools.filechooser.FileChooser;
 import VASSAL.tools.image.ImageTileSource;
 import VASSAL.tools.image.tilecache.ImageTileDiskCache;
-import VASSAL.tools.io.IOUtils;
 
 /**
  * The GameModule class is the base class for a VASSAL module.  It is
@@ -726,15 +725,22 @@ public abstract class GameModule extends AbstractConfigurable implements Command
       try {
         p = getPrefs();
         p.write();
-        p.close();
       }
       catch (IOException e) {
         WriteErrorDialog.error(e, p.getFile());
       }
       finally {
-        IOUtils.closeQuietly(p);
+        if (p != null) {
+          try {
+            p.close();
+          }
+          catch (IOException e) {
+            log.error("Error while closing module preferences", e);
+          }
+        }
       }
 
+      // TODO remove this code if it is not needed anymore
       // write and close global prefs
       // Bug 10179 - Global prefs are now written out each time a preference is changed
       // try {

--- a/src/main/java/VASSAL/build/module/ModuleExtension.java
+++ b/src/main/java/VASSAL/build/module/ModuleExtension.java
@@ -22,6 +22,7 @@ import java.awt.event.ActionListener;
 import java.io.BufferedInputStream;
 import java.io.ByteArrayInputStream;
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
@@ -59,7 +60,6 @@ import VASSAL.configure.StringConfigurer;
 import VASSAL.i18n.Resources;
 import VASSAL.tools.ArchiveWriter;
 import VASSAL.tools.DataArchive;
-import VASSAL.tools.io.IOUtils;
 
 /**
  * An optional extension to a GameModule
@@ -122,30 +122,24 @@ public class ModuleExtension extends AbstractBuildable implements GameComponent,
     // Record that we are currently building this Extension
     GameModule.getGameModule().setGpIdSupport(this);
 
-    BufferedInputStream in = null;
-    try {
-      in = new BufferedInputStream(archive.getInputStream(fileName));
-    }
-// FIXME: should this be a FileNotFoundException?
-    catch (IOException e) {
-    }
-
-    if (in == null) {
-      build(null);
-    }
-    else {
+    try (BufferedInputStream in = new BufferedInputStream(archive.getInputStream(fileName))) {
       try {
         final Document doc = Builder.createDocument(in);
-        build(doc.getDocumentElement());
-        in.close();
+        if (doc != null) {
+          build(doc.getDocumentElement());
+        }
       }
-      // FIXME: review error message
       catch (IOException e) {
+        // FIXME: review error message
+        logger.error("Error while creating document from file {}", fileName, e);
         throw new ExtensionsLoader.LoadExtensionException(e);
       }
-      finally {
-        IOUtils.closeQuietly(in);
-      }
+    }
+    catch (FileNotFoundException e) {
+      logger.error("File {} not found in archive", fileName, e);
+    }
+    catch (IOException e) {
+      logger.error("Error while reading file {} from archive", fileName, e);
     }
 
     GameModule.getGameModule().add(this);

--- a/src/main/java/VASSAL/build/module/dice/BonesDiceServer.java
+++ b/src/main/java/VASSAL/build/module/dice/BonesDiceServer.java
@@ -33,7 +33,6 @@ import java.util.Vector;
 import VASSAL.build.module.DieRoll;
 import VASSAL.tools.ErrorDialog;
 import VASSAL.tools.FormattedString;
-import VASSAL.tools.io.IOUtils;
 
 public class BonesDiceServer extends DieServer {
 
@@ -113,18 +112,12 @@ public class BonesDiceServer extends DieServer {
     connection.setRequestMethod("GET");
     connection.connect();
 
-    BufferedReader in = null;
-    try {
-      in = new BufferedReader(
-        new InputStreamReader(connection.getInputStream()));
+    try (BufferedReader in = new BufferedReader(
+      new InputStreamReader(connection.getInputStream()))) {
 
       String line;
-      while ((line = in.readLine()) != null) returnString.add(line);
-
-      in.close();
-    }
-    finally {
-      IOUtils.closeQuietly(in);
+      while ((line = in.readLine()) != null)
+        returnString.add(line);
     }
 
     parseInternetRollString(toss, returnString);

--- a/src/main/java/VASSAL/launch/AbstractLaunchAction.java
+++ b/src/main/java/VASSAL/launch/AbstractLaunchAction.java
@@ -67,7 +67,6 @@ import VASSAL.tools.concurrent.FutureUtils;
 import VASSAL.tools.concurrent.listener.EventListener;
 import VASSAL.tools.filechooser.FileChooser;
 import VASSAL.tools.filechooser.ModuleFileFilter;
-import VASSAL.tools.io.IOUtils;
 import VASSAL.tools.io.ProcessLauncher;
 import VASSAL.tools.io.ProcessWrapper;
 import VASSAL.tools.ipc.IPCMessage;
@@ -77,7 +76,7 @@ import VASSAL.tools.lang.MemoryUtils;
 
 /**
  *
- * The base class for {@link Action}s which launch processes from the
+ * The base class for {@link javax.swing.Action}s which launch processes from the
  * {@link ModuleManagerWindow}.
  *
  * @author Joel Uckelman
@@ -618,8 +617,23 @@ e.printStackTrace();
         }
       }
       finally {
-        IOUtils.closeQuietly(clientSocket);
-        IOUtils.closeQuietly(serverSocket);
+        if (clientSocket != null) {
+          try {
+            clientSocket.close();
+          }
+          catch (IOException e) {
+            logger.error("Error while closing clientSocket", e);
+          }
+        }
+
+        if (serverSocket != null) {
+          try {
+            serverSocket.close();
+          }
+          catch (IOException e) {
+            logger.error("Error while closing serverSocket", e);
+          }
+        }
         children.remove(ipc);
       }
     }

--- a/src/main/java/VASSAL/launch/ModuleManager.java
+++ b/src/main/java/VASSAL/launch/ModuleManager.java
@@ -411,7 +411,14 @@ public class ModuleManager {
             ErrorDialog.bug(e);
           }
           finally {
-            IOUtils.closeQuietly(clientSocket);
+            if (clientSocket != null) {
+              try {
+                clientSocket.close();
+              }
+              catch (IOException e) {
+                logger.error("Error while closing client socket", e);
+              }
+            }
           }
         }
       }

--- a/src/main/java/VASSAL/launch/ModuleManager.java
+++ b/src/main/java/VASSAL/launch/ModuleManager.java
@@ -19,7 +19,6 @@ package VASSAL.launch;
 
 import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
-import java.io.Closeable;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -33,6 +32,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.net.InetAddress;
 import java.net.ServerSocket;
 import java.net.Socket;
+import java.net.UnknownHostException;
 import java.nio.channels.FileLock;
 import java.nio.channels.OverlappingFileLockException;
 
@@ -202,30 +202,25 @@ public class ModuleManager {
     lr.key = key;
 
     // pass launch parameters on to the ModuleManager via the socket
-    Socket clientSocket = null;
-    ObjectOutputStream out = null;
-    InputStream in = null;
-    try {
-      clientSocket = new Socket((String) null, port);
+    try (Socket clientSocket = new Socket((String) null, port);
+         ObjectOutputStream out = new ObjectOutputStream(
+           new BufferedOutputStream(clientSocket.getOutputStream()))) {
 
-      out = new ObjectOutputStream(
-              new BufferedOutputStream(clientSocket.getOutputStream()));
       out.writeObject(lr);
       out.flush();
 
-      in = clientSocket.getInputStream();
-      IOUtils.copy(in, System.err);
+      try (InputStream in = clientSocket.getInputStream()) {
+        IOUtils.copy(in, System.err);
+      }
+    }
+    catch (UnknownHostException e) {
+      logger.error("Unable to open socket for loopback device", e);
+      System.exit(1);
     }
     catch (IOException e) {
 // FIXME: should be a dialog...
-      System.err.println("VASSAL: Problem with socket on port " + port);
-      e.printStackTrace();
+      logger.error("VASSAL: Problem with socket on port {}", port, e);
       System.exit(1);
-    }
-    finally {
-      IOUtils.closeQuietly(in);
-      IOUtils.closeQuietly((Closeable) out);
-      IOUtils.closeQuietly(clientSocket);
     }
   }
 
@@ -382,25 +377,28 @@ public class ModuleManager {
     @Override
     public void run() {
       try {
-        ObjectInputStream in = null;
-        PrintStream out = null;
         Socket clientSocket = null;
+
+        // TODO while can only complete by throwing, do not use exceptions for ordinary control flow
         while (true) {
           try {
             clientSocket = serverSocket.accept();
-            in = new ObjectInputStream(
-                  new BufferedInputStream(clientSocket.getInputStream()));
+            final String message;
 
-            final String message = execute(in.readObject());
-            in.close();
+            try (ObjectInputStream in = new ObjectInputStream(
+              new BufferedInputStream(clientSocket.getInputStream()))) {
+
+              message = execute(in.readObject());
+            }
             clientSocket.close();
 
             if (message == null || clientSocket.isClosed()) continue;
 
-            out = new PrintStream(
-                    new BufferedOutputStream(clientSocket.getOutputStream()));
-            out.println(message);
-            out.close();
+            try (PrintStream out = new PrintStream(
+              new BufferedOutputStream(clientSocket.getOutputStream()))) {
+
+              out.println(message);
+            }
           }
           catch (IOException e) {
             ErrorDialog.showDetails(
@@ -413,14 +411,19 @@ public class ModuleManager {
             ErrorDialog.bug(e);
           }
           finally {
-            IOUtils.closeQuietly((Closeable) in);
-            IOUtils.closeQuietly(out);
             IOUtils.closeQuietly(clientSocket);
           }
         }
       }
       finally {
-        IOUtils.closeQuietly(serverSocket);
+        if (serverSocket != null) {
+          try {
+            serverSocket.close();
+          }
+          catch (IOException e) {
+            logger.error("Error while closing server socket", e);
+          }
+        }
       }
     }
   }

--- a/src/main/java/VASSAL/launch/ModuleManagerWindow.java
+++ b/src/main/java/VASSAL/launch/ModuleManagerWindow.java
@@ -114,7 +114,6 @@ import VASSAL.tools.SequenceEncoder;
 import VASSAL.tools.WriteErrorDialog;
 import VASSAL.tools.filechooser.FileChooser;
 import VASSAL.tools.filechooser.ModuleExtensionFileFilter;
-import VASSAL.tools.io.IOUtils;
 import VASSAL.tools.logging.LogPane;
 import VASSAL.tools.menu.CheckBoxMenuItemProxy;
 import VASSAL.tools.menu.MenuBarProxy;
@@ -195,9 +194,6 @@ public class ModuleManagerWindow extends JFrame {
         }
         catch (IOException ex) {
           WriteErrorDialog.error(ex, gp.getFile());
-        }
-        finally {
-          IOUtils.closeQuietly(gp);
         }
 
         try {

--- a/src/main/java/VASSAL/tools/AudioSystemClip.java
+++ b/src/main/java/VASSAL/tools/AudioSystemClip.java
@@ -28,10 +28,13 @@ import javax.sound.sampled.Clip;
 import javax.sound.sampled.LineUnavailableException;
 import javax.sound.sampled.UnsupportedAudioFileException;
 
-import VASSAL.tools.AudioClip;
-import VASSAL.tools.io.IOUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class AudioSystemClip implements AudioClip {
+
+  private static final Logger log = LoggerFactory.getLogger(AudioSystemClip.class);
+
   protected Clip the_clip;
 
   protected Clip getClip(InputStream in) throws IOException {
@@ -81,7 +84,14 @@ public class AudioSystemClip implements AudioClip {
       }
     }
     catch (Exception e) {
-      IOUtils.closeQuietly(clip);
+      if (clip != null) {
+        try {
+          clip.close();
+        }
+        catch (Exception e2) {
+          log.error("Error while closing clip {}", clip, e2);
+        }
+      }
       throw e;
     }
   }

--- a/src/main/java/VASSAL/tools/image/tilecache/ZipFileImageTiler.java
+++ b/src/main/java/VASSAL/tools/image/tilecache/ZipFileImageTiler.java
@@ -27,8 +27,10 @@ import java.io.DataOutputStream;
 import java.io.File;
 import java.io.InputStreamReader;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.net.InetAddress;
 import java.net.Socket;
+import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
@@ -45,7 +47,6 @@ import VASSAL.tools.image.ImageIOImageLoader;
 import VASSAL.tools.image.ImageLoader;
 import VASSAL.tools.image.ImageTypeConverter;
 import VASSAL.tools.io.FileArchive;
-import VASSAL.tools.io.IOUtils;
 import VASSAL.tools.io.TemporaryFileFactory;
 import VASSAL.tools.io.ZipArchive;
 import VASSAL.tools.lang.Callback;
@@ -84,19 +85,14 @@ public class ZipFileImageTiler {
 
       // Get the image paths from stdin, one per line
       final List<String> pl = new ArrayList<>();
-      BufferedReader stdin = null;
-      try {
-        stdin = new BufferedReader(new InputStreamReader(System.in));
+      try (BufferedReader stdin = new BufferedReader(new InputStreamReader(System.in))) {
         String s;
         while ((s = stdin.readLine()) != null) {
           pl.add(s);
         }
       }
       catch (IOException e) {
-        logger.error("", e);
-      }
-      finally {
-        IOUtils.closeQuietly(stdin);
+        logger.error("Error while reading image paths from stdin", e);
       }
 
       final String[] ipaths = pl.toArray(new String[0]);
@@ -126,74 +122,98 @@ public class ZipFileImageTiler {
 
       final String portProp = System.getProperty("VASSAL.port");
 
-      Socket sock = null;
-      DataOutputStream dout = null;
-
-      try {
-        if (portProp != null) {
-          final int port = Integer.parseInt(portProp);
-          final InetAddress lo = InetAddress.getByName(null);
-          sock = new Socket(lo, port);
-          sock.shutdownInput();
-          dout = new DataOutputStream(sock.getOutputStream());
-        }
-        else {
-          dout = new DataOutputStream(System.err);
-        }
-
-        final DataOutputStream out = dout;
-
-        final Callback<String> imageL = new Callback<>() {
-          @Override
-          public void receive(String ipath) throws IOException {
-            out.writeByte(STARTING_IMAGE);
-            out.writeUTF(ipath);
-            out.flush();
-          }
-        };
-
-        final Callback<Void> tileL = new Callback<>() {
-          @Override
-          public void receive(Void obj) throws IOException {
-            out.writeByte(TILE_WRITTEN);
-            out.flush();
-          }
-        };
-
-        final Callback<Void> doneL = new Callback<>() {
-          @Override
-          public void receive(Void obj) throws IOException {
-            out.writeByte(TILING_FINISHED);
-            out.flush();
-          }
-        };
-
-        try (FileArchive fa = new ZipArchive(zpath)) {
-          // Tile the images
-          tiler.run(
-            fa, tpath, tw, th, ipaths, exec,
-            loader, slicer, imageL, tileL, doneL
-          );
-        }
-        catch (IOException e) {
-          logger.error("", e);
-        }
-
-        dout.close();
-        if (sock != null) {
-          sock.close();
-        }
+      if (portProp != null) {
+        writeToSocket(portProp, zpath, tiler, tpath, tw, th, ipaths, exec,
+          loader, slicer);
       }
-      catch (IOException e) {
-        logger.error("", e);
-      }
-      finally {
-        IOUtils.closeQuietly(dout);
-        IOUtils.closeQuietly(sock);
+      else {
+        writeToSystemErr(zpath, tiler, tpath, tw, th, ipaths, exec,
+          loader, slicer);
       }
     }
     finally {
       logger.info("Exiting");
     }
   }
+
+  private static void writeToSystemErr(String zpath, FileArchiveImageTiler tiler, String tpath, int tw, int th,
+                                       String[] ipaths, ExecutorService exec, ImageLoader loader,
+                                       TileSlicer slicer) {
+
+    writeToOutputStream(System.err, zpath, tiler, tpath, tw, th, ipaths, exec,
+      loader, slicer);
+
+  }
+
+  private static void writeToSocket(String portProp, String zpath,
+                                    FileArchiveImageTiler tiler, String tpath, int tw, int th,
+                                    String[] ipaths, ExecutorService exec, ImageLoader loader,
+                                    TileSlicer slicer) {
+
+    final int port = Integer.parseInt(portProp);
+    final InetAddress lo;
+    try {
+      lo = InetAddress.getByName(null);
+    }
+    catch (UnknownHostException e) {
+      logger.error("Could not determine local IP address", e);
+      return;
+    }
+
+    try (Socket sock = new Socket(lo, port)) {
+      sock.shutdownInput();
+
+      writeToOutputStream(sock.getOutputStream(), zpath, tiler, tpath, tw, th, ipaths, exec,
+        loader, slicer);
+    }
+    catch (IOException e) {
+      logger.error("Error while setting up socket", e);
+    }
+  }
+
+  private static void writeToOutputStream(OutputStream os, String zpath, FileArchiveImageTiler tiler, String tpath, int tw, int th, String[] ipaths, ExecutorService exec,
+                                          ImageLoader loader, TileSlicer slicer) {
+
+    try (final DataOutputStream out = new DataOutputStream(os)) {
+      final Callback<String> imageL = new Callback<>() {
+        @Override
+        public void receive(String ipath) throws IOException {
+          out.writeByte(STARTING_IMAGE);
+          out.writeUTF(ipath);
+          out.flush();
+        }
+      };
+
+      final Callback<Void> tileL = new Callback<>() {
+        @Override
+        public void receive(Void obj) throws IOException {
+          out.writeByte(TILE_WRITTEN);
+          out.flush();
+        }
+      };
+
+      final Callback<Void> doneL = new Callback<>() {
+        @Override
+        public void receive(Void obj) throws IOException {
+          out.writeByte(TILING_FINISHED);
+          out.flush();
+        }
+      };
+
+      try (FileArchive fa = new ZipArchive(zpath)) {
+        // Tile the images
+        tiler.run(
+          fa, tpath, tw, th, ipaths, exec,
+          loader, slicer, imageL, tileL, doneL
+        );
+      }
+      catch (IOException e) {
+        logger.error("", e);
+      }
+    }
+    catch (IOException e) {
+      logger.error("Error while writing to outputstream {}", os, e);
+    }
+  }
+
 }

--- a/src/main/java/VASSAL/tools/io/IOUtils.java
+++ b/src/main/java/VASSAL/tools/io/IOUtils.java
@@ -90,8 +90,10 @@ public class IOUtils extends org.apache.commons.io.IOUtils {
    * Close an {@link AutoCloseable} unconditionally. Equivalent to
    * calling <code>c.close()</code> when <code>c</code> is nonnull.
    *
-   * @param c a (possibly <code>null</code>) <code>AutoCloseable</code>
+   * @param c a (possibly <code>null</code>) {@link AutoCloseable}
+   * @deprecated use try with resources or close and catch manually
    */
+  @Deprecated
   public static void closeQuietly(AutoCloseable c) {
     if (c == null) return;
 

--- a/src/main/java/VASSAL/tools/io/Tailer.java
+++ b/src/main/java/VASSAL/tools/io/Tailer.java
@@ -213,7 +213,14 @@ public class Tailer {
         logger.error("", e);
       }
       finally {
-        IOUtils.closeQuietly(raf);
+        if (raf != null) {
+          try {
+            raf.close();
+          }
+          catch (IOException e) {
+            logger.error("Error while closing the logfile", e);
+          }
+        }
       }
     }
   }

--- a/src/main/java/VASSAL/tools/ipc/IPCMessageDispatcher.java
+++ b/src/main/java/VASSAL/tools/ipc/IPCMessageDispatcher.java
@@ -4,9 +4,12 @@ import java.io.IOException;
 import java.io.ObjectOutput;
 import java.util.concurrent.BlockingQueue;
 
-import VASSAL.tools.io.IOUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class IPCMessageDispatcher implements Runnable {
+
+  private static final Logger log = LoggerFactory.getLogger(IPCMessageDispatcher.class);
 
   protected final BlockingQueue<IPCMessage> queue;
   protected final ObjectOutput out;
@@ -21,21 +24,16 @@ public class IPCMessageDispatcher implements Runnable {
   public void run() {
     IPCMessage msg;
 
-    try {
+    try (out) {
       do {
         msg = queue.take();
         out.writeObject(msg);
         out.flush();
       } while (!(msg instanceof Fin));
-
-      out.close();
     }
     catch (IOException | InterruptedException e) {
-// FIXME
-      e.printStackTrace();
-    }
-    finally {
-      IOUtils.closeQuietly(out);
+      // FIXME
+      log.error("Error while writing into IPC channel", e);
     }
   }
 }

--- a/src/main/java/VASSAL/tools/ipc/IPCMessageReceiver.java
+++ b/src/main/java/VASSAL/tools/ipc/IPCMessageReceiver.java
@@ -11,7 +11,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import VASSAL.tools.concurrent.listener.MultiEventListenerSupport;
-import VASSAL.tools.io.IOUtils;
 
 class IPCMessageReceiver implements Runnable {
 
@@ -31,7 +30,7 @@ class IPCMessageReceiver implements Runnable {
   public void run() {
     IPCMessage msg;
 
-    try {
+    try (in) {
       do {
         msg = (IPCMessage) in.readObject();
 
@@ -39,8 +38,6 @@ class IPCMessageReceiver implements Runnable {
 
         lsup.notify(msg);
       } while (!(msg instanceof Fin));
-
-      in.close();
     }
     catch (ClassCastException | OptionalDataException | StreamCorruptedException
       | InvalidClassException | ClassNotFoundException e) {
@@ -51,10 +48,7 @@ class IPCMessageReceiver implements Runnable {
     }
     catch (IOException e) {
 // FIXME: should communicate this outward somehow
-      logger.error("", e);
-    }
-    finally {
-      IOUtils.closeQuietly(in);
+      logger.error("Error while reading IPC message", e);
     }
   }
 }

--- a/src/test/java/VASSAL/tools/ipc/IPCMessageDispatcherTest.java
+++ b/src/test/java/VASSAL/tools/ipc/IPCMessageDispatcherTest.java
@@ -45,7 +45,7 @@ public class IPCMessageDispatcherTest {
         exactly(msg.length+1).of(out).flush();
 
         oneOf(out).writeObject(fin);
-        exactly(2).of(out).close();
+        exactly(1).of(out).close();
       }
     });
 

--- a/src/test/java/VASSAL/tools/ipc/IPCMessageReceiverTest.java
+++ b/src/test/java/VASSAL/tools/ipc/IPCMessageReceiverTest.java
@@ -62,7 +62,7 @@ public class IPCMessageReceiverTest {
         oneOf(in).readObject(); will(returnValue(fin));
         oneOf(lsup).notify(with(equal(fin)));
 
-        exactly(2).of(in).close();
+        exactly(1).of(in).close();
       }
     });
 


### PR DESCRIPTION
Removes most of the leftover calls to closeQuietly(). In some cases this helped detangle the code and introduce detailed error messages where there was previously one catch-all error.