### PR TITLE
Fix JavaDoc search feature

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,6 +82,15 @@ JDOC:=$(JAVAPATH)/javadoc
 JDEPS:=$(JAVAPATH)/jdeps
 JLINK:=$(JAVAPATH)/jlink
 
+# fixes javadoc 11 bug that generates invalid search urls
+JDOCVER:=$(shell javadoc --version 2>/dev/null | sed 's/^[^0-9]*\([0-9]\+\).*/\1/')
+ifeq ($(JDOCVER),11)
+  JDOCOPS:=--no-module-directories 
+else ifeq ($(JDOCVER),12)
+  JDOCOPS:=--no-module-directories 
+endif
+
+
 NSIS:=makensis
 #DMG:=dmg
 DMG:=../libdmg-hfsplus/dmg/dmg
@@ -241,7 +250,7 @@ upload:
 	rsync -vP $(TMPDIR)/VASSAL-$(VERSION)-{windows.exe,macosx.dmg,linux.tar.bz2,other.zip,src.zip} web.sourceforge.net:/home/project-web/vassalengine/htdocs/builds
 
 javadoc:
-	$(JDOC) --no-module-directories -d $(JDOCDIR) -link $(JDOCLINK) -classpath $(CLASSPATH) -sourcepath $(SRCDIR) -subpackages VASSAL
+	$(JDOC) $(JDOCOPS) -d $(JDOCDIR) -link $(JDOCLINK) -classpath $(CLASSPATH) -sourcepath $(SRCDIR) -subpackages VASSAL
 
 clean-javadoc:
 	$(RM) -r $(JDOCDIR)

--- a/Makefile
+++ b/Makefile
@@ -241,7 +241,7 @@ upload:
 	rsync -vP $(TMPDIR)/VASSAL-$(VERSION)-{windows.exe,macosx.dmg,linux.tar.bz2,other.zip,src.zip} web.sourceforge.net:/home/project-web/vassalengine/htdocs/builds
 
 javadoc:
-	$(JDOC) -d $(JDOCDIR) -link $(JDOCLINK) -classpath $(CLASSPATH) -sourcepath $(SRCDIR) -subpackages VASSAL
+	$(JDOC) --no-module-directories -d $(JDOCDIR) -link $(JDOCLINK) -classpath $(CLASSPATH) -sourcepath $(SRCDIR) -subpackages VASSAL
 
 clean-javadoc:
 	$(RM) -r $(JDOCDIR)


### PR DESCRIPTION
This commit fixes `make javadoc` so that it generates pages that return correct search results.

**PROBLEM DESCRIPTION**

`make javadoc` generates JavaDoc HTML documentation from the VASSAL source code. This documentation includes a SEARCH field in the upper-right corner of each page.  After filling in a search term in a browser and clicking on a search result, the browser follows a broken link. The page *does* exist, the link is just broken.

Example of the relative portion of an erroneous link:
```
   javadoc/undefined/VASSAL/command/AddPiece.html
```
Correct link:
```
   javadoc/VASSAL/command/AddPiece.html
```

**STEPS TO REPRODUCE PROBLEM**

1. From a command line, change to the root VASSAL project directory and run `make javadoc`
2. Use a browser to view `javadoc/index.html`
3. Enter `AddPiece` in the SEARCH field on the page
4. Click on the top result, `VASSAL.command.AddPiece`

The browser returns `ERR_FILE_NOT_FOUND` or something to that effect