### PR TITLE
3042 - Improved "Retire"/"Resign"/"Switch Sides" button flow.

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/module/PlayerRoster.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/PlayerRoster.java
@@ -471,46 +471,23 @@ public class PlayerRoster extends AbstractConfigurable implements CommandEncoder
     // Thus hotseat players can easily cycle through the player positions as they will appear successively as the default.
     // Common names for Solitaire players (Solitaire, Solo, Referee) do not count as "real" player sides, and will be skipped.
     // If we have no "next" side available to offer, we stay with the observer side as our default offering.
-    boolean found = false;       // Haven't found our own side in the list.
+    boolean found = false;       // If we find a usable side
     String mySide = getMySide(); // Get our own side, so we can find the "next" one
-    String nextChoice = translatedObserver; // For now default to observer
-    if (mySide != null) {                   // If I'm presently an observer, then my next side is just going to be the first real one we find later
-      for (String s : sides) {
-        if (mySide.equals(s)) {             // We're looking for "our" side
-          found = true;                     // We found it, so next "real" one is the one we want
-          continue;            
-        }
-        if (alreadyTaken.contains(s)) {     // Don't want anything that's already taken
-          continue;
-        }
-        if (Resources.getString("PlayerRoster.solitaire").equals(s) ||   // Don't want a solitaire side
-            Resources.getString("PlayerRoster.solo").equals(s) ||
-            Resources.getString("PlayerRoster.referee").equals(s)) {
-          continue;
-        }
-        if (!found) {                       // Don't actually want ANYTHING until we've found "our" current side in the list
-          continue;
-        }
-        nextChoice = s;                     // Aha! We've found a next side after ours, AND it's not taken. THAT's the default we want. 
+    int myidx = (mySide != null) ? sides.indexOf(mySide) : -1; // See if we have a current non-observe side.
+    int i = (myidx >= 0) ? ((myidx + 1) % sides.size()) : 0;   // If we do, start looking in the "next" slot, otherwise start at beginning.
+    for (int tries = 0; i != myidx && tries < sides.size(); i = (i+1) % sides.size(), tries++) { // Wrap-around search of sides
+      String s = sides.get(i);
+      if (!alreadyTaken.contains(s) &&  
+          !Resources.getString("PlayerRoster.solitaire").equals(s) &&
+          !Resources.getString("PlayerRoster.solo").equals(s) &&
+          !Resources.getString("PlayerRoster.referee").equals(s)) {
+        found = true; // Found an available slot that's not our current one and not a "solo" slot.
         break;
-      }      
+      }
     }
     
-    if (translatedObserver.equals(nextChoice)) {
-      // If we get in here, that either means "our" side was the last available one we found in the list,
-      // or that there are no other "real" sides left. In either case we now want the first "real" side in the
-      // that's not taken. And if we don't find one we'll just stick with observer as the default.
-      for (String s : availableSides) {
-        if (Resources.getString("PlayerRoster.solitaire").equals(s) ||
-            Resources.getString("PlayerRoster.solo").equals(s) ||
-            Resources.getString("PlayerRoster.referee").equals(s)) {
-          continue;
-        }
-        nextChoice = s;
-        break;
-      }                  
-    }
-
+    String nextChoice = found ? sides.get(i) : translatedObserver; // This will be our defaulted choice for the dropdown.
+    
     availableSides.add(0, translatedObserver);
 
     final GameModule g = GameModule.getGameModule();

--- a/vassal-app/src/main/java/VASSAL/build/module/PlayerRoster.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/PlayerRoster.java
@@ -20,6 +20,8 @@ package VASSAL.build.module;
 import java.awt.Component;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
+import java.awt.event.InputEvent;
+import java.awt.event.KeyEvent;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.io.IOException;
@@ -48,6 +50,7 @@ import VASSAL.command.Command;
 import VASSAL.command.CommandEncoder;
 import VASSAL.configure.Configurer;
 import VASSAL.configure.IconConfigurer;
+import VASSAL.configure.NamedHotKeyConfigurer;
 import VASSAL.configure.StringArrayConfigurer;
 import VASSAL.configure.StringConfigurer;
 import VASSAL.configure.StringEnumConfigurer;
@@ -55,6 +58,8 @@ import VASSAL.i18n.Localization;
 import VASSAL.i18n.Resources;
 import VASSAL.tools.DataArchive;
 import VASSAL.tools.LaunchButton;
+import VASSAL.tools.NamedKeyStroke;
+import VASSAL.tools.NamedKeyStrokeListener;
 import VASSAL.tools.SequenceEncoder;
 
 /**
@@ -67,6 +72,7 @@ public class PlayerRoster extends AbstractConfigurable implements CommandEncoder
   public static final String SIDES = "sides"; //$NON-NLS-1$
   public static final String COMMAND_PREFIX = "PLAYER\t"; //$NON-NLS-1$
   public static final String OBSERVER = "<observer>"; //$NON-NLS-1$
+  public static final String BUTTON_KEYSTROKE = "buttonKeyStroke"; //$NON-NLS-1$
   protected List<PlayerInfo> players = new ArrayList<>();
   protected List<String> sides = new ArrayList<>();
   protected String[] untranslatedSides;
@@ -85,17 +91,19 @@ public class PlayerRoster extends AbstractConfigurable implements CommandEncoder
         launch();
       }
     };
-    retireButton = new LaunchButton(Resources.getString("PlayerRoster.retire"), TOOL_TIP, BUTTON_TEXT, null, BUTTON_ICON, al); //$NON-NLS-1$
+            
+    retireButton = new LaunchButton(Resources.getString("PlayerRoster.retire"), TOOL_TIP, BUTTON_TEXT, BUTTON_KEYSTROKE, BUTTON_ICON, al); //$NON-NLS-1$
     retireButton.setToolTipText(Resources.getString("PlayerRoster.allow_another")); //$NON-NLS-1$
-    retireButton.setVisible(false);
+    retireButton.setVisible(false);    
 
-    translatedObserver = Resources.getString("PlayerRoster.observer"); //$NON-NLS-1$
+    translatedObserver = Resources.getString("PlayerRoster.observer"); //$NON-NLS-1$    
   }
 
   @Override
   public void removeFrom(Buildable parent) {
-    GameModule.getGameModule().getGameState().removeGameComponent(this);
-    GameModule.getGameModule().removeCommandEncoder(this);
+    final GameModule gm = GameModule.getGameModule();
+    gm.getGameState().removeGameComponent(this);
+    gm.removeCommandEncoder(this);
   }
 
   @Override
@@ -174,6 +182,10 @@ public class PlayerRoster extends AbstractConfigurable implements CommandEncoder
     att = retireButton.getAttributeValueString(TOOL_TIP);
     if (att != null)
       el.setAttribute(TOOL_TIP, att);
+    att = retireButton.getAttributeValueString(BUTTON_KEYSTROKE);
+    if (att != null) {
+      el.setAttribute(BUTTON_KEYSTROKE, att);
+    }
     for (String s : sides) {
       Element sub = doc.createElement("entry"); //$NON-NLS-1$
       sub.appendChild(doc.createTextNode(s));
@@ -221,13 +233,15 @@ public class PlayerRoster extends AbstractConfigurable implements CommandEncoder
   }
 
   @Override
-  public void addTo(Buildable b) {
-    GameModule.getGameModule().getGameState().addGameComponent(this);
-    GameModule.getGameModule().getGameState().addGameSetupStep(this);
-    GameModule.getGameModule().addCommandEncoder(this);
-    GameModule.getGameModule().getToolBar().add(retireButton);
+  public void addTo(Buildable b) {  
+    final GameModule gm = GameModule.getGameModule();
+    gm.getGameState().addGameComponent(this);
+    gm.getGameState().addGameSetupStep(this);
+    gm.addCommandEncoder(this);
+    gm.getToolBar().add(retireButton);    
   }
 
+  
   protected void launch() {
     final String mySide = getMySide();
     if (mySide == null && allSidesAllocated()) {
@@ -583,6 +597,7 @@ public class PlayerRoster extends AbstractConfigurable implements CommandEncoder
     private IconConfigurer iconConfig;
     private StringConfigurer textConfig;
     private StringConfigurer tooltipConfig;
+    private NamedHotKeyConfigurer keyConfig;
     private JPanel controls;
 
     private Con() {
@@ -598,6 +613,7 @@ public class PlayerRoster extends AbstractConfigurable implements CommandEncoder
         }
       });
       controls.add(sidesConfig.getControls());
+      
       textConfig = new StringConfigurer(BUTTON_TEXT, Resources.getString("Editor.PlayerRoster.retire_button_text"), retireButton.getAttributeValueString(BUTTON_TEXT)); //$NON-NLS-1$
       textConfig.addPropertyChangeListener(new PropertyChangeListener() {
         @Override
@@ -606,6 +622,7 @@ public class PlayerRoster extends AbstractConfigurable implements CommandEncoder
         }
       });
       controls.add(textConfig.getControls());
+      
       tooltipConfig = new StringConfigurer(TOOL_TIP, Resources.getString("Editor.PlayerRoster.retire_button_tooltip"), retireButton.getAttributeValueString(TOOL_TIP)); //$NON-NLS-1$
       tooltipConfig.addPropertyChangeListener(new PropertyChangeListener() {
         @Override
@@ -614,6 +631,7 @@ public class PlayerRoster extends AbstractConfigurable implements CommandEncoder
         }
       });
       controls.add(tooltipConfig.getControls());
+      
       iconConfig = new IconConfigurer(BUTTON_ICON, Resources.getString("Editor.PlayerRoster.retire_button_icon"), null); //$NON-NLS-1$
       iconConfig.setValue(retireButton.getIcon());
       iconConfig.addPropertyChangeListener(new PropertyChangeListener() {
@@ -623,6 +641,16 @@ public class PlayerRoster extends AbstractConfigurable implements CommandEncoder
         }
       });
       controls.add(iconConfig.getControls());
+      
+      keyConfig = (NamedHotKeyConfigurer)retireButton.getHotkeyConfigurer();
+      keyConfig.setName(Resources.getString("Editor.PlayerRoster.retire_button_keystroke"));
+      keyConfig.addPropertyChangeListener(new PropertyChangeListener() {
+        @Override
+        public void propertyChange(PropertyChangeEvent evt) {
+          retireButton.setAttribute(BUTTON_KEYSTROKE, keyConfig.getValueString());
+        }
+      });
+      controls.add(keyConfig.getControls());
     }
 
     @Override
@@ -657,7 +685,8 @@ public class PlayerRoster extends AbstractConfigurable implements CommandEncoder
     return new String[] {
       BUTTON_TEXT,
       TOOL_TIP,
-      SIDES
+      SIDES,
+      BUTTON_KEYSTROKE,
     };
   }
 
@@ -666,7 +695,8 @@ public class PlayerRoster extends AbstractConfigurable implements CommandEncoder
     return new Class<?>[] {
       String.class,
       String.class,
-      String.class
+      String.class,
+      NamedKeyStroke.class,
     };
   }
 
@@ -734,7 +764,8 @@ public class PlayerRoster extends AbstractConfigurable implements CommandEncoder
     return new String[] {
       Resources.getString("Editor.button_text_label"),
       Resources.getString("Editor.tooltip_text_label"),
-      Resources.getString("Editor.PlayerRoster.sides_label")
+      Resources.getString("Editor.PlayerRoster.sides_label"),
+      Resources.getString("Editor.hotkey_label")
     };
   }
 }

--- a/vassal-app/src/main/java/VASSAL/build/module/PlayerRoster.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/PlayerRoster.java
@@ -233,59 +233,28 @@ public class PlayerRoster extends AbstractConfigurable implements CommandEncoder
     if (mySide == null && allSidesAllocated()) {
       return;
     }
+          
+    final String oldSide = getMySide();
 
-    final String[] options = allSidesAllocated() ?
-      new String[]{
-        Resources.getString(Resources.YES),
-        Resources.getString(Resources.NO)
-      } :
-      new String[]{
-        Resources.getString("PlayerRoster.become_observer"), //$NON-NLS-1$
-        Resources.getString("PlayerRoster.join_another_side"), //$NON-NLS-1$
-        Resources.getString(Resources.CANCEL)
-      };
-
-    final int CANCEL = options.length - 1;
-
-    final int option = JOptionPane.showOptionDialog(
-      GameModule.getGameModule().getFrame(),
-      Resources.getString("PlayerRoster.give_up_position", getMyLocalizedSide()),
-      Resources.getString("PlayerRoster.retire"), //$NON-NLS-1$
-      JOptionPane.YES_NO_OPTION,
-      JOptionPane.QUESTION_MESSAGE,
-      null,
-      options,
-      Resources.getString("PlayerRoster.become_observer") //$NON-NLS-1$
-    );
-
-    if (option != CANCEL) {
-      final String oldSide = getMySide();
-
-      String newSide;
-      if (option == 0) {
-        newSide = OBSERVER;
-      }
-      else {
-        newSide = promptForSide();
-        if (newSide == null) {
-          return;
-        }
-      }
-
-      remove(GameModule.getUserId());
-
-      final PlayerInfo me = new PlayerInfo(
-        GameModule.getUserId(),
-        GlobalOptions.getInstance().getPlayerId(),
-        newSide
-      );
-      final Add a = new Add(this, me.playerId, me.playerName, me.side);
-      a.execute();
-      GameModule.getGameModule().getServer().sendToOthers(a);
-
-      newSide = getMySide();
-      fireSideChange(oldSide, newSide);
+    String newSide;
+    newSide = promptForSide();
+    if (newSide == null) {
+      return;
     }
+
+    remove(GameModule.getUserId());
+
+    final PlayerInfo me = new PlayerInfo(
+      GameModule.getUserId(),
+      GlobalOptions.getInstance().getPlayerId(),
+      newSide
+    );
+    final Add a = new Add(this, me.playerId, me.playerName, me.side);
+    a.execute();
+    GameModule.getGameModule().getServer().sendToOthers(a);
+
+    newSide = getMySide();
+    fireSideChange(oldSide, newSide);      
   }
 
   protected void fireSideChange(String oldSide, String newSide) {
@@ -488,7 +457,7 @@ public class PlayerRoster extends AbstractConfigurable implements CommandEncoder
     final GameModule g = GameModule.getGameModule();
     String newSide = (String) JOptionPane.showInputDialog(
       g.getFrame(),
-      Resources.getString("PlayerRoster.join_game_as"), //$NON-NLS-1$
+      Resources.getString("PlayerRoster.switch_sides"), //$NON-NLS-1$
       Resources.getString("PlayerRoster.choose_side"), //$NON-NLS-1$
       JOptionPane.QUESTION_MESSAGE,
       null,

--- a/vassal-app/src/main/resources/VASSAL/i18n/Editor.properties
+++ b/vassal-app/src/main/resources/VASSAL/i18n/Editor.properties
@@ -54,6 +54,7 @@ Editor.PlayerRoster.retire_button_text='Retire' button text:
 Editor.PlayerRoster.retire_button_tooltip='Retire' button tooltip:  
 Editor.PlayerRoster.retire_button_icon='Retire' button icon:  
 Editor.PlayerRoster.sides_label=Sides:  
+Editor.PlayerRoster.retire_button_keystroke='Retire' button keystroke:
 
 # ToolbarMenu
 Editor.ToolbarMenu.component_type=Toolbar Menu

--- a/vassal-app/src/main/resources/VASSAL/i18n/VASSAL.properties
+++ b/vassal-app/src/main/resources/VASSAL/i18n/VASSAL.properties
@@ -640,7 +640,7 @@ Player.app_name=Player
 
 # Player Roster
 PlayerRoster.retire=Retire
-PlayerRoster.allow_another=Allow another player to take your side in this game
+PlayerRoster.allow_another=Switch sides, become an observer, or allow another player to take your side in this game
 PlayerRoster.become_observer=Become observer
 PlayerRoster.join_another_side=Join another side
 PlayerRoster.give_up_position=Give up your position as %1$s?

--- a/vassal-app/src/main/resources/VASSAL/i18n/VASSAL.properties
+++ b/vassal-app/src/main/resources/VASSAL/i18n/VASSAL.properties
@@ -648,6 +648,9 @@ PlayerRoster.join_game_as=Join game as which side?
 PlayerRoster.switch_sides=Switch to which side?
 PlayerRoster.choose_side=Choose side
 PlayerRoster.observer=<observer>
+PlayerRoster.solitaire=Solitaire
+PlayerRoster.solo=Solo
+PlayerRoster.referee=Referee
 
 #PlayerWindow
 

--- a/vassal-app/src/main/resources/VASSAL/i18n/VASSAL.properties
+++ b/vassal-app/src/main/resources/VASSAL/i18n/VASSAL.properties
@@ -645,6 +645,7 @@ PlayerRoster.become_observer=Become observer
 PlayerRoster.join_another_side=Join another side
 PlayerRoster.give_up_position=Give up your position as %1$s?
 PlayerRoster.join_game_as=Join game as which side?  
+PlayerRoster.switch_sides=Switch to which side?
 PlayerRoster.choose_side=Choose side
 PlayerRoster.observer=<observer>
 


### PR DESCRIPTION
STEP 1 - Removed the pointless first dialog box from the "Retire" flow. This box added no actual additional choices, only added a needless extra step, especially for the common use case of "hotseat" players.

STEP 2 - Further improved the flow for Hotseat use case by offering the next "real" player slot (if one is available) as the default-selected option. Filtered out of the list are (a) player slots already occupied, and (b) player slots using any of the common names for "Solitaire" / "Solo" / "Referee".  If no available "real" slot is found, then the Observer option is selected as the default. 

Hotseat players can now click the button and hit Enter (or click Okay) to cycle to next player, which removes THREE extra clicks from their present flow. Meanwhile no other use cases should suffer negative effects.

Should correctly handle any number of sides.

Did a bunch of testing, but this obviously belongs in a "beta" build.

STEP 3 - "Retire" button gets an assignable hotkey field, just like Big Boy toolbar buttons get. 

COMMENT - I wish we would change the configurer name of this button to "Switch Sides" or "Switch Sides or Retire" something more intuitive to what the most common use case of this button is, but I'll leave that aside unless folks get interested in it. It's literally just a few text changes in the .properties files. 
