### PR TITLE
Rewrote tests not to use org.jmock.lib.legacy.ClassImposteriser

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,6 @@
 		<vassal.jarlocation>${project.build.directory}/lib</vassal.jarlocation>
 
 		<version.batik>1.13</version.batik>
-		<version.jmock>2.11.0</version.jmock>
 	</properties>
 
 	<dependencies>
@@ -140,13 +139,7 @@
 		<dependency>
 			<groupId>org.jmock</groupId>
 			<artifactId>jmock-junit4</artifactId>
-			<version>${version.jmock}</version>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.jmock</groupId>
-			<artifactId>jmock-legacy</artifactId>
-			<version>${version.jmock}</version>
+			<version>2.11.0</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/src/test/java/VASSAL/build/MockModuleTest.java
+++ b/src/test/java/VASSAL/build/MockModuleTest.java
@@ -1,21 +1,16 @@
 package VASSAL.build;
 
-import org.jmock.Expectations;
-import org.jmock.Mockery;
-import org.jmock.lib.legacy.ClassImposteriser;
-import org.junit.After;
+import VASSAL.tools.DataArchive;
+
 import org.junit.Before;
 import org.junit.Ignore;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 @Ignore
 public class MockModuleTest {
   private static boolean initialized = false;
-
-  protected Mockery context = new Mockery() {
-    {
-      setImposteriser(ClassImposteriser.INSTANCE);
-    }
-  };
 
   @SuppressWarnings("unchecked")
   @Before
@@ -23,23 +18,13 @@ public class MockModuleTest {
     if (initialized) {
       return;
     }
-    final GameModule module = context.mock(GameModule.class);
-    context.checking(new Expectations() {
-      {
-        allowing(module).setGpIdSupport(with(any(GameModule.class)));
-        allowing(module).build();
-        allowing(module).getDataArchive();
-        allowing(module).getComponentsOf(with(any(Class.class)));
-//        allowing(module).sliceLargeImages();
-        allowing(module).getFrame();
-      }
-    });
+
+    final GameModule module = mock(GameModule.class);
+    final DataArchive arch = mock(DataArchive.class);
+
+    when(module.getDataArchive()).thenReturn(arch);
+
     GameModule.init(module);
     initialized = true;
-  }
-
-  @After
-  public void assertContextSatisfied() {
-    context.assertIsSatisfied();
   }
 }

--- a/src/test/java/VASSAL/counters/SerializeTest.java
+++ b/src/test/java/VASSAL/counters/SerializeTest.java
@@ -4,10 +4,7 @@ import java.lang.reflect.Constructor;
 
 import VASSAL.build.MockModuleTest;
 
-
-
 public abstract class SerializeTest<T extends Decorator> extends MockModuleTest {
-
   public void serializeTest(Class<T>clazz, T trait) throws Exception {
     BasicPiece basicPiece = new BasicPiece();
     trait.setInner(basicPiece);
@@ -19,7 +16,8 @@ public abstract class SerializeTest<T extends Decorator> extends MockModuleTest 
     try {
       constructor = clazz.getConstructor(String.class, GamePiece.class);
       deserialized = constructor.newInstance(typeString, null);
-    } catch (NoSuchMethodException e) {
+    }
+    catch (NoSuchMethodException e) {
       constructor = clazz.getConstructor(GamePiece.class, String.class);
       deserialized = constructor.newInstance(null, typeString);
     }

--- a/src/test/java/VASSAL/tools/io/CompositeInputStreamTest.java
+++ b/src/test/java/VASSAL/tools/io/CompositeInputStreamTest.java
@@ -23,23 +23,14 @@ import java.io.InputStream;
 import java.io.IOException;
 import java.util.Arrays;
 
-import org.jmock.Expectations;
-import org.jmock.Mockery;
-import org.jmock.integration.junit4.JMock;
-import org.jmock.lib.legacy.ClassImposteriser;
-
 import org.junit.Test;
-import org.junit.runner.RunWith;
-
 import static org.junit.Assert.*;
 
-public class CompositeInputStreamTest {
-  protected final Mockery context = new Mockery() {
-    {
-      setImposteriser(ClassImposteriser.INSTANCE);
-    }
-  };
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
+public class CompositeInputStreamTest {
   protected InputStream[] prepareStreams() {
     final ByteArrayInputStream[] ch = new ByteArrayInputStream[10];
     for (int i = 0; i < ch.length; ++i) {
@@ -94,16 +85,12 @@ public class CompositeInputStreamTest {
   @Test
   public void testClose() throws IOException {
     final InputStream[] ch = new InputStream[10];
-    final InputStream child = context.mock(InputStream.class);
+    final InputStream child = mock(InputStream.class);
     Arrays.fill(ch, child);
-
-    context.checking(new Expectations() {
-      {
-        exactly(ch.length).of(child).close();
-      }
-    });
 
     final InputStream in = new CompositeInputStream(ch);
     in.close();
+
+    verify(child, times(ch.length)).close();
   }
 }

--- a/src/test/java/VASSAL/tools/io/RereadableInputStreamTest.java
+++ b/src/test/java/VASSAL/tools/io/RereadableInputStreamTest.java
@@ -24,24 +24,14 @@ import java.io.IOException;
 
 import org.apache.commons.io.input.NullInputStream;
 
-import org.jmock.Expectations;
-import org.jmock.Mockery;
-import org.jmock.integration.junit4.JMock;
-import org.jmock.lib.legacy.ClassImposteriser;
-
 import org.junit.Test;
-import org.junit.runner.RunWith;
-
 import static org.junit.Assert.*;
 
-@RunWith(JMock.class)
-public class RereadableInputStreamTest {
-  protected final Mockery context = new Mockery() {
-    {
-      setImposteriser(ClassImposteriser.INSTANCE);
-    }
-  };
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
+public class RereadableInputStreamTest {
   @Test
   public void testMarkSupported() {
     final InputStream in = new RereadableInputStream(new NullInputStream(10));
@@ -107,15 +97,11 @@ public class RereadableInputStreamTest {
 
   @Test
   public void testClose() throws IOException {
-    final InputStream child = context.mock(InputStream.class);
-
-    context.checking(new Expectations() {
-      {
-        oneOf(child).close();
-      }
-    });
+    final InputStream child = mock(InputStream.class);
 
     final InputStream in = new RereadableInputStream(child);
     in.close();
+
+    verify(child, times(1)).close();
   }
 }


### PR DESCRIPTION
This lets us drop our dependency on jmock-legacy.