### PR TITLE
Bug 13178.

### DIFF
--- a/src/main/java/VASSAL/build/GameModule.java
+++ b/src/main/java/VASSAL/build/GameModule.java
@@ -65,6 +65,7 @@ import VASSAL.build.module.PlayerRoster;
 import VASSAL.build.module.Plugin;
 import VASSAL.build.module.PredefinedSetup;
 import VASSAL.build.module.PrivateMap;
+import VASSAL.build.module.PrototypeDefinition;
 import VASSAL.build.module.PrototypesContainer;
 import VASSAL.build.module.RandomTextButton;
 import VASSAL.build.module.ServerConnection;
@@ -952,6 +953,12 @@ public abstract class GameModule extends AbstractConfigurable implements Command
     for (PieceSlot pieceSlot : theModule.getAllDescendantComponentsOf(PieceSlot.class)) {
       checker.add(pieceSlot);
     }
+    // Add any PieceSlots in Prototype Definitions
+    for (PrototypesContainer pc : theModule.getComponentsOf(PrototypesContainer.class)) {
+      for (PrototypeDefinition pd : pc.getDefinitions()) {
+        checker.add(pd);
+      }
+    }  
     checker.fixErrors();
   }
 

--- a/src/main/java/VASSAL/build/module/GameRefresher.java
+++ b/src/main/java/VASSAL/build/module/GameRefresher.java
@@ -34,8 +34,6 @@ import javax.swing.JPanel;
 import javax.swing.JTextArea;
 import javax.swing.WindowConstants;
 
-import net.miginfocom.swing.MigLayout;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -55,6 +53,7 @@ import VASSAL.counters.Properties;
 import VASSAL.counters.Stack;
 import VASSAL.i18n.Resources;
 import VASSAL.tools.ErrorDialog;
+import net.miginfocom.swing.MigLayout;
 
 /**
  * GameRefresher Replace all counters in the same game with the current version
@@ -122,6 +121,14 @@ public final class GameRefresher implements GameComponent {
     for (PieceSlot slot : theModule.getAllDescendantComponentsOf(PieceSlot.class)) {
       gpIdChecker.add(slot);
     }
+    
+    // Add any PieceSlots in Prototype Definitions
+    for (PrototypesContainer pc : theModule.getComponentsOf(PrototypesContainer.class)) {
+      for (PrototypeDefinition pd : pc.getDefinitions()) {
+        gpIdChecker.add(pd);
+      }
+    }    
+    
     if (gpIdChecker.hasErrors()) {
       // Any errors should have been resolved by the GpId check at startup, so
       // this error indicates
@@ -146,8 +153,7 @@ public final class GameRefresher implements GameComponent {
       else if (piece instanceof Stack) {
         for (Iterator<GamePiece> i = ((Stack) piece).getPiecesInVisibleOrderIterator(); i.hasNext();) {
           final GamePiece p = i.next();
-          if (!Boolean.TRUE.equals(p.getProperty(Properties.INVISIBLE_TO_ME))
-              && !Boolean.TRUE.equals(p.getProperty(Properties.OBSCURED_TO_ME))) {
+          if (!Boolean.TRUE.equals(p.getProperty(Properties.INVISIBLE_TO_ME)) && !Boolean.TRUE.equals(p.getProperty(Properties.OBSCURED_TO_ME))) {
             pieces.add(0, p);
           }
           else {
@@ -156,8 +162,7 @@ public final class GameRefresher implements GameComponent {
         }
       }
       else if (piece.getParent() == null) {
-        if (!Boolean.TRUE.equals(piece.getProperty(Properties.INVISIBLE_TO_ME))
-            && !Boolean.TRUE.equals(piece.getProperty(Properties.OBSCURED_TO_ME))) {
+        if (!Boolean.TRUE.equals(piece.getProperty(Properties.INVISIBLE_TO_ME)) && !Boolean.TRUE.equals(piece.getProperty(Properties.OBSCURED_TO_ME))) {
           pieces.add(0, piece);
         }
         else {
@@ -234,7 +239,7 @@ public final class GameRefresher implements GameComponent {
     else {
       updatedCount++;
 
-      if (! isTestMode()) {
+      if (!isTestMode()) {
         // Place the new Piece.
         final Command place = map.placeOrMerge(newPiece, pos);
         command.append(place);
@@ -246,7 +251,7 @@ public final class GameRefresher implements GameComponent {
       }
     }
 
-    if (! isTestMode()) {
+    if (!isTestMode()) {
       // If still in the same stack, move to correct position
       final Stack newStack = newPiece.getParent();
       if (newStack != null && oldStack != null && newStack == oldStack) {
@@ -296,7 +301,7 @@ public final class GameRefresher implements GameComponent {
     private JTextArea results;
     private JCheckBox nameCheck;
 
-    RefreshDialog (GameRefresher refresher) {
+    RefreshDialog(GameRefresher refresher) {
       this.refresher = refresher;
       setTitle(Resources.getString("GameRefresher.refresh_counters"));
       setModal(true);
@@ -308,10 +313,10 @@ public final class GameRefresher implements GameComponent {
       addWindowListener(new WindowAdapter() {
         @Override
         public void windowClosing(WindowEvent we) {
-           exit();
+          exit();
         }
       });
-      setLayout(new MigLayout("wrap 1","[center]"));
+      setLayout(new MigLayout("wrap 1", "[center]"));
 
       final JPanel buttonPanel = new JPanel(new MigLayout());
 
@@ -320,21 +325,24 @@ public final class GameRefresher implements GameComponent {
         @Override
         public void actionPerformed(ActionEvent e) {
           test();
-        }});
+        }
+      });
 
       final JButton runButton = new JButton(Resources.getString("General.run"));
       runButton.addActionListener(new ActionListener() {
         @Override
         public void actionPerformed(ActionEvent e) {
           run();
-        }});
+        }
+      });
 
       final JButton exitButton = new JButton(Resources.getString("General.exit"));
       exitButton.addActionListener(new ActionListener() {
         @Override
         public void actionPerformed(ActionEvent e) {
           exit();
-        }});
+        }
+      });
 
       buttonPanel.add(testButton);
       buttonPanel.add(runButton);
@@ -352,23 +360,23 @@ public final class GameRefresher implements GameComponent {
       pack();
     }
 
-     protected void exit() {
-       setVisible(false);
-     }
+    protected void exit() {
+      setVisible(false);
+    }
 
-     protected void test() {
-       results.setText(Resources.getString("GameRefresher.refresh_counters_test"));
-       refresher.execute (true, nameCheck.isSelected());
-     }
+    protected void test() {
+      results.setText(Resources.getString("GameRefresher.refresh_counters_test"));
+      refresher.execute(true, nameCheck.isSelected());
+    }
 
-     protected void run() {
-       results.setText("");
-       refresher.execute (false, nameCheck.isSelected());
-       exit();
-     }
+    protected void run() {
+      results.setText("");
+      refresher.execute(false, nameCheck.isSelected());
+      exit();
+    }
 
-     public void addMessage(String mess) {
-       results.setText(results.getText()+"\n"+mess);
-     }
+    public void addMessage(String mess) {
+      results.setText(results.getText() + "\n" + mess);
+    }
   }
 }

--- a/src/main/java/VASSAL/build/module/ModuleExtension.java
+++ b/src/main/java/VASSAL/build/module/ModuleExtension.java
@@ -169,12 +169,16 @@ public class ModuleExtension extends AbstractBuildable implements GameComponent,
     }
   }
 
+  // Recursively add all sub-components of a Buildable to the GPId checker
   protected void checkGpIds(Buildable b, GpIdChecker checker) {
     if (b instanceof PieceSlot) {
       checker.add((PieceSlot) b);
     }
+    else if (b instanceof PrototypeDefinition) {
+      checker.add((PrototypeDefinition) b);
+    }
     else if (b instanceof ExtensionElement) {
-     checkGpIds(((ExtensionElement) b).getExtension(), checker);
+      checkGpIds(((ExtensionElement) b).getExtension(), checker);
     }
     else if (b instanceof AbstractBuildable) {
       for ( Buildable buildable : ((AbstractBuildable) b).getBuildables()) {
@@ -552,7 +556,7 @@ public class ModuleExtension extends AbstractBuildable implements GameComponent,
         if (ext.getName().equals(name)) {
           containsExtension = true;
           if (Info.compareVersions(ext.getVersion(), version) > 0) {
-             GameModule.getGameModule().warn(getVersionErrorMsg(ext.getVersion()));
+            GameModule.getGameModule().warn(getVersionErrorMsg(ext.getVersion()));
           }
           break;
         }

--- a/src/main/java/VASSAL/build/module/PrototypeDefinition.java
+++ b/src/main/java/VASSAL/build/module/PrototypeDefinition.java
@@ -323,4 +323,4 @@ public class PrototypeDefinition extends AbstractConfigurable
      */
     return new ComponentI18nData(this, getPiece());
   }
- }
+}

--- a/src/main/java/VASSAL/build/module/PrototypesContainer.java
+++ b/src/main/java/VASSAL/build/module/PrototypesContainer.java
@@ -19,6 +19,7 @@ package VASSAL.build.module;
 
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
@@ -43,6 +44,10 @@ public class PrototypesContainer extends AbstractConfigurable {
   private Map<String,PrototypeDefinition> definitions =
     new HashMap<>();
 
+  public Collection<PrototypeDefinition> getDefinitions() {
+    return definitions.values();
+  }
+  
   @Override
   public String[] getAttributeDescriptions() {
     return new String[0];


### PR DESCRIPTION
1. Add Place Marker traits in Prototype definitions to the list of
pieceSlot definitions used to refresh module.
2. Fix bug in recording of Place Marker traits that could cause pieces
to be refreshed to their creating piece, not their own updated
definition.
3. Minor formatting fixes in affected classes.
4. Report GPId updates by checker in Chat Window when updating modules in Editor. [Will normally never be seen except for first edit after naive editing of the buildfile, but many modules may get some reports after this fix as Place Markers in old Prototypes are assessed for the first time.