### PR TITLE
Chatter depreciated calls

### DIFF
--- a/src/main/java/VASSAL/build/module/Chatter.java
+++ b/src/main/java/VASSAL/build/module/Chatter.java
@@ -375,7 +375,7 @@ public class Chatter extends JPanel implements CommandEncoder, Buildable {
     }
   }
 
-  private int drawColoredText(Graphics g, int x, int y, TabExpander ex, Document doc,
+  private float drawColoredText(Graphics g, float x, float y, TabExpander ex, Document doc,
                               int p0, int p1, Element elem) throws BadLocationException {
     final Segment s = new Segment();
     doc.getText(p0, p1 - p0, s);
@@ -383,7 +383,12 @@ public class Chatter extends JPanel implements CommandEncoder, Buildable {
 
     final Graphics2D g2d = (Graphics2D) g;
     g2d.addRenderingHints(SwingUtils.FONT_HINTS);
-    return Utilities.drawTabbedText(s, x, y, g, ex, p0);
+    return Utilities.drawTabbedText(s, x, y, g2d, ex, p0);
+  }
+
+  @Deprecated private int drawColoredText(Graphics g, int x, int y, TabExpander ex, Document doc,
+                              int p0, int p1, Element elem) throws BadLocationException {
+    return (int) drawColoredText(g, (float) x, (float) y, ex, doc, p0, p1, elem);
   }
 
   private class WrappedView extends WrappedPlainView {
@@ -392,10 +397,17 @@ public class Chatter extends JPanel implements CommandEncoder, Buildable {
     }
 
     @Override
-    protected int drawUnselectedText(Graphics g, int x, int y,
+    protected float drawUnselectedText(Graphics2D g, float x, float y,
                                      int p0, int p1) throws BadLocationException {
       final Element root = getElement();
       return drawColoredText(g, x, y, this, getDocument(), p0, p1, root.getElement(root.getElementIndex(p0)));
+    }
+
+    @Override
+    @Deprecated protected int drawUnselectedText(Graphics g, int x, int y,
+                                     int p0, int p1) throws BadLocationException {
+      final Graphics2D g2d = (Graphics2D) g;
+      return (int) drawUnselectedText(g2d, (float) x, (float) y, p0, p1);
     }
   }
 
@@ -405,10 +417,17 @@ public class Chatter extends JPanel implements CommandEncoder, Buildable {
     }
 
     @Override
-    protected int drawUnselectedText(Graphics g, int x, int y,
+    protected float drawUnselectedText(Graphics2D g, float x, float y,
                                      int p0, int p1) throws BadLocationException {
       Element root = getElement();
       return drawColoredText(g, x, y, this, getDocument(), p0, p1, root.getElement(root.getElementIndex(p0)));
+    }
+
+    @Override
+    @Deprecated protected int drawUnselectedText(Graphics g, int x, int y,
+                                     int p0, int p1) throws BadLocationException {
+      final Graphics2D g2d = (Graphics2D) g;
+      return (int) drawUnselectedText(g2d, (float) x, (float) y, p0, p1);
     }
   }
 

--- a/src/main/java/VASSAL/build/module/Chatter.java
+++ b/src/main/java/VASSAL/build/module/Chatter.java
@@ -386,11 +386,6 @@ public class Chatter extends JPanel implements CommandEncoder, Buildable {
     return Utilities.drawTabbedText(s, x, y, g2d, ex, p0);
   }
 
-  @Deprecated private int drawColoredText(Graphics g, int x, int y, TabExpander ex, Document doc,
-                              int p0, int p1, Element elem) throws BadLocationException {
-    return (int) drawColoredText(g, (float) x, (float) y, ex, doc, p0, p1, elem);
-  }
-
   private class WrappedView extends WrappedPlainView {
     private WrappedView(Element el, boolean wrap) {
       super(el, wrap);
@@ -401,13 +396,6 @@ public class Chatter extends JPanel implements CommandEncoder, Buildable {
                                      int p0, int p1) throws BadLocationException {
       final Element root = getElement();
       return drawColoredText(g, x, y, this, getDocument(), p0, p1, root.getElement(root.getElementIndex(p0)));
-    }
-
-    @Override
-    @Deprecated protected int drawUnselectedText(Graphics g, int x, int y,
-                                     int p0, int p1) throws BadLocationException {
-      final Graphics2D g2d = (Graphics2D) g;
-      return (int) drawUnselectedText(g2d, (float) x, (float) y, p0, p1);
     }
   }
 
@@ -421,13 +409,6 @@ public class Chatter extends JPanel implements CommandEncoder, Buildable {
                                      int p0, int p1) throws BadLocationException {
       Element root = getElement();
       return drawColoredText(g, x, y, this, getDocument(), p0, p1, root.getElement(root.getElementIndex(p0)));
-    }
-
-    @Override
-    @Deprecated protected int drawUnselectedText(Graphics g, int x, int y,
-                                     int p0, int p1) throws BadLocationException {
-      final Graphics2D g2d = (Graphics2D) g;
-      return (int) drawUnselectedText(g2d, (float) x, (float) y, p0, p1);
     }
   }
 


### PR DESCRIPTION
Found Depreciated swing calls in Chatter.java 

I'm not 100% on one or two things here:
1) I couldn't find these methods (over-ridden or otherwise) being called from anywhere else in the code, so I've assumed they are intended to be public, and should be depreciated, so I've
  1.1) Marked them as depreciated
  1.2) Made them call the new over-ridden methods
2) the new methods require floats, not ints, casting ints to floats is all good, but I've cast floats to int for the return from the depreciated call.. which is blasphemous.

Thoughts would be appreciated, so I can know what to do in this project in future.