### PR TITLE
Bug 13197: Mac interface cleanup and Legacy preference

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/GameModule.java
+++ b/vassal-app/src/main/java/VASSAL/build/GameModule.java
@@ -394,9 +394,7 @@ public abstract class GameModule extends AbstractConfigurable implements Command
    * If our keyboard mapping paradigm changes (example: Mac Legacy preference checked/unchecked), we need to reregister all of our KeyStrokeListeners 
    */
   public void refreshKeyStrokeListeners() {
-    for (KeyStrokeListener kl : keyStrokeListeners) {
-      kl.setKeyStroke(kl.getKeyStroke());
-    }
+    keyStrokeListeners.forEach(l -> l.setKeyStroke(l.getKeyStroke()));
   }
   
 

--- a/vassal-app/src/main/java/VASSAL/build/GameModule.java
+++ b/vassal-app/src/main/java/VASSAL/build/GameModule.java
@@ -388,6 +388,17 @@ public abstract class GameModule extends AbstractConfigurable implements Command
       l.addKeyStrokeSource(s);
     }
   }
+  
+  
+  /**
+   * If our keyboard mapping paradigm changes (example: Mac Legacy preference checked/unchecked), we need to reregister all of our KeyStrokeListeners 
+   */
+  public void refreshKeyStrokeListeners() {
+    for (KeyStrokeListener kl : keyStrokeListeners) {
+      kl.setKeyStroke(kl.getKeyStroke());
+    }
+  }
+  
 
   @Deprecated public void fireKeyStroke(KeyStroke stroke) {
     if (stroke != null) {

--- a/vassal-app/src/main/java/VASSAL/build/module/Chatter.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/Chatter.java
@@ -185,7 +185,7 @@ public class Chatter extends JPanel implements CommandEncoder, Buildable {
     s = StringUtils.capitalize(s);
     s = s.replace(' ', '_');        
     
-    final int mods = SwingUtils.getKeyVassalToSystem(k).getModifiers();
+    final int mods = SwingUtils.genericToSystem(k).getModifiers();
     if ((mods & KeyEvent.SHIFT_DOWN_MASK) > 0) {
       s = Resources.getString("Keys.shift") + " " + s; //$NON-NLS-1$ //$NON-NLS-2$
     }

--- a/vassal-app/src/main/java/VASSAL/build/module/Chatter.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/Chatter.java
@@ -137,6 +137,38 @@ public class Chatter extends JPanel implements CommandEncoder, Buildable {
   public void show(String s) {
     conversation.append("\n" + s); //$NON-NLS-1$
   }
+  
+  
+  /**
+   * A plain text representation of a KeyStroke.  Doesn't differ much
+   * from {@link KeyEvent#getKeyText}
+   * 
+   * In the Chatter for module overridability (Many of Java's default names are ugly/terrible)
+   */
+  public static String getKeyString(KeyStroke k) {
+    if (k == null) {
+      return null;
+    }
+        
+    String s;
+    s = KeyEvent.getKeyText(k.getKeyCode());    
+    s = s.replace(' ', '_');        
+
+    final int mods = SwingUtils.getKeyVassalToSystem(k).getModifiers();
+    if ((mods & KeyEvent.SHIFT_DOWN_MASK) > 0) {
+      s = Resources.getString("Keys.shift") + " " + s; //$NON-NLS-1$ //$NON-NLS-2$
+    }
+    if ((mods & KeyEvent.CTRL_DOWN_MASK) > 0) {
+      s = Resources.getString("Keys.ctrl") + " " + s; //$NON-NLS-1$ //$NON-NLS-2$
+    }
+    if ((mods & KeyEvent.META_DOWN_MASK) > 0) {  // This is "Command" key on Mac
+      s = Resources.getString("Keys.meta") + " " + s; //$NON-NLS-1$ //$NON-NLS-2$
+    }
+    if ((mods & KeyEvent.ALT_DOWN_MASK) > 0) {
+      s = Resources.getString("Keys.alt") + " " + s; //$NON-NLS-1$ //$NON-NLS-2$
+    }
+    return s.toUpperCase();
+  }
 
   /**
    * Set the Font used by the text area

--- a/vassal-app/src/main/java/VASSAL/build/module/Chatter.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/Chatter.java
@@ -141,67 +141,6 @@ public class Chatter extends JPanel implements CommandEncoder, Buildable {
   }
   
   /**
-   * A plain text representation of a KeyStroke.  Doesn't differ much
-   * from {@link KeyEvent#getKeyText}
-   * 
-   * In the Chatter for module custom class overridability (Many of Java's default names are ugly/terrible)
-   */
-  public static String getKeyString(KeyStroke k) {
-    if (k == null) {
-      return null;
-    }
-        
-    String s;
-    int code = k.getKeyCode();
-    switch (code) {
-    // The addition of underscores screws up these names
-    case KeyEvent.VK_ADD:
-      s = Resources.getString("Keys.numplus"); //$NON-NLS-1$ //$NON-NLS-2$
-      break;
-    case KeyEvent.VK_SUBTRACT:
-      s = Resources.getString("Keys.numminus"); //$NON-NLS-1$ //$NON-NLS-2$
-      break;
-    // More compact name, also commonly printed keys  
-    case KeyEvent.VK_PAGE_UP:
-      s = Resources.getString("Keys.pgup"); //$NON-NLS-1$ //$NON-NLS-2$
-      break;
-    case KeyEvent.VK_PAGE_DOWN:
-      s = Resources.getString("Keys.pgdn"); //$NON-NLS-1$ //$NON-NLS-2$
-      break;
-    // Non-Americans were (rightly) commenting about this
-    case KeyEvent.VK_OPEN_BRACKET:
-      s = Resources.getString("Keys.bropen"); //$NON-NLS-1$ //$NON-NLS-2$
-      break;
-    case KeyEvent.VK_CLOSE_BRACKET:
-      s = Resources.getString("Keys.brclose"); //$NON-NLS-1$ //$NON-NLS-2$
-      break;
-    default:
-      s = "";
-      break;
-    }
-    if (s.isEmpty() || s.contains("Keys.")) { //$NON-NLS-1$
-      s = KeyEvent.getKeyText(code); 
-    }
-    s = StringUtils.capitalize(s);
-    s = s.replace(' ', '_');        
-    
-    final int mods = SwingUtils.genericToSystem(k).getModifiers();
-    if ((mods & KeyEvent.SHIFT_DOWN_MASK) > 0) {
-      s = Resources.getString("Keys.shift") + " " + s; //$NON-NLS-1$ //$NON-NLS-2$
-    }
-    if ((mods & KeyEvent.CTRL_DOWN_MASK) > 0) {
-      s = Resources.getString("Keys.ctrl") + " " + s; //$NON-NLS-1$ //$NON-NLS-2$
-    }
-    if ((mods & KeyEvent.META_DOWN_MASK) > 0) {  // This is "Command" key on Mac
-      s = Resources.getString("Keys.meta") + " " + s; //$NON-NLS-1$ //$NON-NLS-2$
-    }
-    if ((mods & KeyEvent.ALT_DOWN_MASK) > 0) {
-      s = Resources.getString("Keys.alt") + " " + s; //$NON-NLS-1$ //$NON-NLS-2$
-    }
-    return s;
-  }
-
-  /**
    * Set the Font used by the text area
    */
   @Override

--- a/vassal-app/src/main/java/VASSAL/build/module/Chatter.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/Chatter.java
@@ -50,6 +50,8 @@ import javax.swing.text.Utilities;
 import javax.swing.text.View;
 import javax.swing.text.WrappedPlainView;
 
+import org.apache.commons.lang3.StringUtils;
+
 import VASSAL.build.Buildable;
 import VASSAL.build.GameModule;
 import VASSAL.command.Command;
@@ -138,12 +140,11 @@ public class Chatter extends JPanel implements CommandEncoder, Buildable {
     conversation.append("\n" + s); //$NON-NLS-1$
   }
   
-  
   /**
    * A plain text representation of a KeyStroke.  Doesn't differ much
    * from {@link KeyEvent#getKeyText}
    * 
-   * In the Chatter for module overridability (Many of Java's default names are ugly/terrible)
+   * In the Chatter for module custom class overridability (Many of Java's default names are ugly/terrible)
    */
   public static String getKeyString(KeyStroke k) {
     if (k == null) {
@@ -151,9 +152,39 @@ public class Chatter extends JPanel implements CommandEncoder, Buildable {
     }
         
     String s;
-    s = KeyEvent.getKeyText(k.getKeyCode());    
+    int code = k.getKeyCode();
+    switch (code) {
+    // The addition of underscores screws up these names
+    case KeyEvent.VK_ADD:
+      s = Resources.getString("Keys.numplus"); //$NON-NLS-1$ //$NON-NLS-2$
+      break;
+    case KeyEvent.VK_SUBTRACT:
+      s = Resources.getString("Keys.numminus"); //$NON-NLS-1$ //$NON-NLS-2$
+      break;
+    // More compact name, also commonly printed keys  
+    case KeyEvent.VK_PAGE_UP:
+      s = Resources.getString("Keys.pgup"); //$NON-NLS-1$ //$NON-NLS-2$
+      break;
+    case KeyEvent.VK_PAGE_DOWN:
+      s = Resources.getString("Keys.pgdn"); //$NON-NLS-1$ //$NON-NLS-2$
+      break;
+    // Non-Americans were (rightly) commenting about this
+    case KeyEvent.VK_OPEN_BRACKET:
+      s = Resources.getString("Keys.bropen"); //$NON-NLS-1$ //$NON-NLS-2$
+      break;
+    case KeyEvent.VK_CLOSE_BRACKET:
+      s = Resources.getString("Keys.brclose"); //$NON-NLS-1$ //$NON-NLS-2$
+      break;
+    default:
+      s = "";
+      break;
+    }
+    if (s.isEmpty() || s.contains("Keys.")) { //$NON-NLS-1$
+      s = KeyEvent.getKeyText(code); 
+    }
+    s = StringUtils.capitalize(s);
     s = s.replace(' ', '_');        
-
+    
     final int mods = SwingUtils.getKeyVassalToSystem(k).getModifiers();
     if ((mods & KeyEvent.SHIFT_DOWN_MASK) > 0) {
       s = Resources.getString("Keys.shift") + " " + s; //$NON-NLS-1$ //$NON-NLS-2$
@@ -167,7 +198,7 @@ public class Chatter extends JPanel implements CommandEncoder, Buildable {
     if ((mods & KeyEvent.ALT_DOWN_MASK) > 0) {
       s = Resources.getString("Keys.alt") + " " + s; //$NON-NLS-1$ //$NON-NLS-2$
     }
-    return s.toUpperCase();
+    return s;
   }
 
   /**

--- a/vassal-app/src/main/java/VASSAL/build/module/GlobalOptions.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/GlobalOptions.java
@@ -209,7 +209,11 @@ public class GlobalOptions extends AbstractConfigurable {
         Resources.getString("GlobalOptions.mac_legacy"),
         Boolean.FALSE);
     macLegacyConf.addPropertyChangeListener( (evt) -> setPrefMacLegacy(macLegacyConf.getValueBoolean()));
-    prefs.addOption(macLegacyConf);
+    
+    if (SystemUtils.IS_OS_MAC_OSX) { 
+      // Only need to *display* this preference if we're running on a Mac.
+      prefs.addOption(macLegacyConf);
+    }
     
     validator = new SingleChildInstance(gm, getClass());
   }
@@ -238,7 +242,10 @@ public class GlobalOptions extends AbstractConfigurable {
   
   public void setPrefMacLegacy(boolean b) {
     macLegacy = b;
+    // Tell SwingUtils we've changed our mind about Macs
     SwingUtils.setMacLegacy(b);
+    // Since we've changed our key mapping paradigm, we need to refresh all the keystroke listeners.
+    GameModule.getGameModule().refreshKeyStrokeListeners(); 
   }
  
 

--- a/vassal-app/src/main/java/VASSAL/build/module/GlobalOptions.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/GlobalOptions.java
@@ -63,6 +63,7 @@ import VASSAL.preferences.StringPreference;
 import VASSAL.preferences.TextPreference;
 import VASSAL.tools.ErrorDialog;
 import VASSAL.tools.FormattedString;
+import VASSAL.tools.swing.SwingUtils;
 
 public class GlobalOptions extends AbstractConfigurable {
   public static final String NON_OWNER_UNMASKABLE = "nonOwnerUnmaskable"; //$NON-NLS-1$
@@ -79,6 +80,7 @@ public class GlobalOptions extends AbstractConfigurable {
   public static final String BUG_10295 = "bug10295"; //$NON-NLS-1$
   public static final String CLASSIC_MFD = "classicMfd"; //$NON-NLS-1$
   public static final String DRAG_THRESHOLD = "dragThreshold"; //$NON-NLS-1$
+  public static final String MAC_LEGACY = "macLegacy"; //$NON-NLS-1$
 
   public static final String PLAYER_NAME = "PlayerName"; //$NON-NLS-1$
   public static final String PLAYER_NAME_ALT = "playerName"; //$NON-NLS-1$
@@ -95,6 +97,8 @@ public class GlobalOptions extends AbstractConfigurable {
   private String markMoved = NEVER;
   
   private int dragThreshold = 10;
+  
+  private boolean macLegacy;
 
   private final Map<String,Object> properties = new HashMap<>();
   private static final Map<String,Configurer> OPTION_CONFIGURERS = new LinkedHashMap<>();
@@ -199,6 +203,14 @@ public class GlobalOptions extends AbstractConfigurable {
     });
     prefs.addOption(dragThresholdConf);
     
+    //BR// Mac Legacy (essentially swaps Control and Command functions to their "old, bad, pre-3.3.3" mappings)
+    final BooleanConfigurer macLegacyConf = new BooleanConfigurer(
+        MAC_LEGACY,
+        Resources.getString("GlobalOptions.mac_legacy"),
+        Boolean.FALSE);
+    macLegacyConf.addPropertyChangeListener( (evt) -> setMacLegacy(macLegacyConf.getValueBoolean()));
+    prefs.addOption(macLegacyConf);
+    
     validator = new SingleChildInstance(gm, getClass());
   }
 
@@ -217,6 +229,18 @@ public class GlobalOptions extends AbstractConfigurable {
   public void setUseClassicMoveFixedDistance(boolean b) {
     useClassicMoveFixedDistance = b;
   }
+  
+  
+  public boolean isMacLegacy() {
+    return macLegacy;
+  }
+  
+  
+  public void setMacLegacy(boolean b) {
+    macLegacy = b;
+    SwingUtils.setMacLegacy(b);
+  }
+ 
 
   public static String getConfigureTypeName() {
     return Resources.getString("Editor.GlobalOption.component_type"); //$NON-NLS-1$

--- a/vassal-app/src/main/java/VASSAL/build/module/GlobalOptions.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/GlobalOptions.java
@@ -185,7 +185,7 @@ public class GlobalOptions extends AbstractConfigurable {
         Resources.getString("GlobalOptions.classic_mfd"),
         Boolean.FALSE
       );
-    classicMfd.addPropertyChangeListener( (evt) -> setUseClassicMoveFixedDistance(classicMfd.getValueBoolean()));
+    classicMfd.addPropertyChangeListener( evt -> setUseClassicMoveFixedDistance(classicMfd.getValueBoolean()));
     prefs.addOption(classicMfd);
 
     //BR// Drag Threshold
@@ -208,7 +208,7 @@ public class GlobalOptions extends AbstractConfigurable {
         MAC_LEGACY,
         Resources.getString("GlobalOptions.mac_legacy"),
         Boolean.FALSE);
-    macLegacyConf.addPropertyChangeListener( (evt) -> setPrefMacLegacy(macLegacyConf.getValueBoolean()));
+    macLegacyConf.addPropertyChangeListener( evt -> setPrefMacLegacy(macLegacyConf.getValueBoolean()));
     
     if (SystemUtils.IS_OS_MAC_OSX) { 
       // Only need to *display* this preference if we're running on a Mac.

--- a/vassal-app/src/main/java/VASSAL/build/module/GlobalOptions.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/GlobalOptions.java
@@ -208,7 +208,7 @@ public class GlobalOptions extends AbstractConfigurable {
         MAC_LEGACY,
         Resources.getString("GlobalOptions.mac_legacy"),
         Boolean.FALSE);
-    macLegacyConf.addPropertyChangeListener( (evt) -> setMacLegacy(macLegacyConf.getValueBoolean()));
+    macLegacyConf.addPropertyChangeListener( (evt) -> setPrefMacLegacy(macLegacyConf.getValueBoolean()));
     prefs.addOption(macLegacyConf);
     
     validator = new SingleChildInstance(gm, getClass());
@@ -231,12 +231,12 @@ public class GlobalOptions extends AbstractConfigurable {
   }
   
   
-  public boolean isMacLegacy() {
+  public boolean isPrefMacLegacy() {
     return macLegacy;
   }
   
   
-  public void setMacLegacy(boolean b) {
+  public void setPrefMacLegacy(boolean b) {
     macLegacy = b;
     SwingUtils.setMacLegacy(b);
   }

--- a/vassal-app/src/main/java/VASSAL/build/module/Inventory.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/Inventory.java
@@ -978,17 +978,17 @@ public class Inventory extends AbstractConfigurable
 
     @Override
     public void keyPressed(KeyEvent e) {
-      keyCommand(KeyStroke.getKeyStrokeForEvent(e));
+      keyCommand(SwingUtils.getKeyStrokeForEvent(e));
     }
 
     @Override
     public void keyReleased(KeyEvent e) {
-      keyCommand(KeyStroke.getKeyStrokeForEvent(e));
+      keyCommand(SwingUtils.getKeyStrokeForEvent(e));
     }
 
     @Override
     public void keyTyped(KeyEvent e) {
-      keyCommand(KeyStroke.getKeyStrokeForEvent(e));
+      keyCommand(SwingUtils.getKeyStrokeForEvent(e));
     }
 
   }

--- a/vassal-app/src/main/java/VASSAL/build/module/Map.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/Map.java
@@ -1414,7 +1414,7 @@ public class Map extends AbstractConfigurable implements GameComponent, MouseLis
    */
   @Override
   public void mouseDragged(MouseEvent e) {
-    if (!SwingUtils.isRightMouseButton(e)) {
+    if (!SwingUtils.isContextMouseButtonDown(e)) {
       scrollAtEdge(e.getPoint(), SCROLL_ZONE);
     }
     else {

--- a/vassal-app/src/main/java/VASSAL/build/module/map/CounterDetailViewer.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/CounterDetailViewer.java
@@ -80,6 +80,7 @@ import VASSAL.counters.Properties;
 import VASSAL.counters.Stack;
 import VASSAL.i18n.Resources;
 import VASSAL.tools.FormattedString;
+import VASSAL.tools.swing.SwingUtils;
 
 /**
  * This is a {@link Drawable} class that draws the counters horizontally when
@@ -708,7 +709,7 @@ public class CounterDetailViewer extends AbstractConfigurable implements Drawabl
   @Override
   public void keyPressed(KeyEvent e) {
     if (hotkey != null && Boolean.TRUE.equals(GameModule.getGameModule().getPrefs().getValue(USE_KEYBOARD))) {
-      if (hotkey.equals(KeyStroke.getKeyStrokeForEvent(e))) {
+      if (hotkey.equals(SwingUtils.getKeyStrokeForEvent(e))) {
         showDetails();
       }
       else {

--- a/vassal-app/src/main/java/VASSAL/build/module/map/ForwardToChatter.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/ForwardToChatter.java
@@ -26,6 +26,7 @@ import javax.swing.KeyStroke;
 import VASSAL.build.Buildable;
 import VASSAL.build.GameModule;
 import VASSAL.build.module.Map;
+import VASSAL.tools.swing.SwingUtils;
 
 /**
  * This KeyListener forwards key event from a {@link Map} to the
@@ -71,7 +72,7 @@ public class ForwardToChatter implements Buildable, KeyListener {
 
   private void process(KeyEvent e) {
     if (!e.isConsumed()) {
-      GameModule.getGameModule().getChatter().keyCommand(KeyStroke.getKeyStrokeForEvent(e));
+      GameModule.getGameModule().getChatter().keyCommand(SwingUtils.getKeyStrokeForEvent(e));
     }
   }
 }

--- a/vassal-app/src/main/java/VASSAL/build/module/map/ForwardToKeyBuffer.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/ForwardToKeyBuffer.java
@@ -28,6 +28,7 @@ import VASSAL.build.GameModule;
 import VASSAL.build.module.Map;
 import VASSAL.command.Command;
 import VASSAL.counters.KeyBuffer;
+import VASSAL.tools.swing.SwingUtils;
 
 /**
  * This KeyListener forwards key event from a {@link Map} to the
@@ -87,10 +88,10 @@ public class ForwardToKeyBuffer implements Buildable, KeyListener {
       lastConsumedEvent = null;
     }
     final int c = e.getKeyCode();
-    // Don't pass SHIFT or CONTROL only to counters
-    if (!e.isConsumed() && c != KeyEvent.VK_SHIFT && c != KeyEvent.VK_CONTROL) {
+    // Don't pass modifier keys alone to counters
+    if (!e.isConsumed() && c != KeyEvent.VK_SHIFT && c != KeyEvent.VK_CONTROL && c != KeyEvent.VK_ALT && c != KeyEvent.VK_META) {
       Command comm = KeyBuffer.getBuffer().keyCommand
-          (KeyStroke.getKeyStrokeForEvent(e));
+          (SwingUtils.getKeyStrokeForEvent(e));
       if (comm != null && !comm.isNull()) {
         GameModule.getGameModule().sendAndLog(comm);
         e.consume();

--- a/vassal-app/src/main/java/VASSAL/build/module/map/ForwardToKeyBuffer.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/ForwardToKeyBuffer.java
@@ -89,7 +89,8 @@ public class ForwardToKeyBuffer implements Buildable, KeyListener {
     }
     final int c = e.getKeyCode();
     // Don't pass modifier keys alone to counters
-    if (!e.isConsumed() && c != KeyEvent.VK_SHIFT && c != KeyEvent.VK_CONTROL && c != KeyEvent.VK_ALT && c != KeyEvent.VK_META) {
+    final boolean onlyModifierKeys = (c == KeyEvent.VK_SHIFT || c == KeyEvent.VK_CONTROL || c == KeyEvent.VK_ALT || c == KeyEvent.VK_META);
+    if (!e.isConsumed() && !onlyModifierKeys) { 
       Command comm = KeyBuffer.getBuffer().keyCommand
           (SwingUtils.getKeyStrokeForEvent(e));
       if (comm != null && !comm.isNull()) {

--- a/vassal-app/src/main/java/VASSAL/build/module/map/GlobalMap.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/GlobalMap.java
@@ -537,10 +537,10 @@ public class GlobalMap implements AutoConfigurable,
     public void mouseClicked(MouseEvent e) {
     }
 
-// FIXME: mouseClicked()?
+    // FIXME: mouseClicked()?
     @Override
     public void mouseReleased(MouseEvent e) {
-      if (SwingUtils.isLeftMouseButton(e)) {
+      if (SwingUtils.isVanillaLeftButtonDown(e)) {
         map.centerAt(componentToMap(e.getPoint()));
       }
     }

--- a/vassal-app/src/main/java/VASSAL/build/module/map/GlobalMap.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/GlobalMap.java
@@ -540,7 +540,7 @@ public class GlobalMap implements AutoConfigurable,
     // FIXME: mouseClicked()?
     @Override
     public void mouseReleased(MouseEvent e) {
-      if (SwingUtils.isVanillaLeftButtonDown(e)) {
+      if (SwingUtils.isMainMouseButtonDown(e)) {
         map.centerAt(componentToMap(e.getPoint()));
       }
     }

--- a/vassal-app/src/main/java/VASSAL/build/module/map/KeyBufferer.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/KeyBufferer.java
@@ -126,17 +126,17 @@ public class KeyBufferer extends MouseAdapter implements Buildable, MouseMotionL
         }
         // RFE 1629255 - If the top piece of an unexpanded stack is left-clicked
         // while not selected, then select all of the pieces in the stack
-        if (movingStacksPickupUnits ||
-            p.getParent() == null ||
-            p.getParent().isExpanded() ||
+          if (movingStacksPickupUnits ||
+              p.getParent() == null ||
+              p.getParent().isExpanded() ||
             SwingUtils.isSelectionToggle(e) ||
             Boolean.TRUE.equals(p.getProperty(Properties.SELECTED))) {
-          kbuf.add(p);
-        }
-        else {
-          Stack s = p.getParent();
-          s.asList().forEach(gamePiece -> KeyBuffer.getBuffer().add(gamePiece));
-        }
+            kbuf.add(p);
+          }
+          else {
+            Stack s = p.getParent();
+            s.asList().forEach(gamePiece -> KeyBuffer.getBuffer().add(gamePiece));
+          }
         // End RFE 1629255
       }
       else {

--- a/vassal-app/src/main/java/VASSAL/build/module/map/KeyBufferer.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/KeyBufferer.java
@@ -50,7 +50,7 @@ import VASSAL.counters.Stack;
 import VASSAL.tools.swing.SwingUtils;
 
 /**
- * This component listens for mouse clicks on a map and draws the selection
+ * This component listens for mouse clicks on a map and draws the selection 
  * rectangle.
  *
  * If the user clicks on a {@link GamePiece}, that piece is added to the

--- a/vassal-app/src/main/java/VASSAL/build/module/map/KeyBufferer.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/KeyBufferer.java
@@ -51,7 +51,7 @@ import VASSAL.tools.swing.SwingUtils;
 
 /**
  * This component listens for mouse clicks on a map and draws the selection 
- * rectangle.
+ * rectangle. ...
  *
  * If the user clicks on a {@link GamePiece}, that piece is added to the
  * {@link KeyBuffer}. {@link #draw(Graphics, Map)} is responsible for

--- a/vassal-app/src/main/java/VASSAL/build/module/map/KeyBufferer.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/KeyBufferer.java
@@ -126,17 +126,17 @@ public class KeyBufferer extends MouseAdapter implements Buildable, MouseMotionL
         }
         // RFE 1629255 - If the top piece of an unexpanded stack is left-clicked
         // while not selected, then select all of the pieces in the stack
-          if (movingStacksPickupUnits ||
-              p.getParent() == null ||
-              p.getParent().isExpanded() ||
-            SwingUtils.isSelectionToggle(e) ||
-            Boolean.TRUE.equals(p.getProperty(Properties.SELECTED))) {
-            kbuf.add(p);
-          }
-          else {
-            Stack s = p.getParent();
-            s.asList().forEach(gamePiece -> KeyBuffer.getBuffer().add(gamePiece));
-          }
+        if (movingStacksPickupUnits ||
+            p.getParent() == null ||
+            p.getParent().isExpanded() ||
+          SwingUtils.isSelectionToggle(e) ||
+          Boolean.TRUE.equals(p.getProperty(Properties.SELECTED))) {
+          kbuf.add(p);
+        }
+        else {
+          Stack s = p.getParent();
+          s.asList().forEach(gamePiece -> KeyBuffer.getBuffer().add(gamePiece));
+        }
         // End RFE 1629255
       }
       else {

--- a/vassal-app/src/main/java/VASSAL/build/module/map/KeyBufferer.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/KeyBufferer.java
@@ -111,7 +111,7 @@ public class KeyBufferer extends MouseAdapter implements Buildable, MouseMotionL
     BandSelectType bandSelect = BandSelectType.NONE;
     if (p != null) {
       filter = (EventFilter) p.getProperty(Properties.SELECT_EVENT_FILTER);      
-      if (SwingUtils.isVanillaLeftButtonDown(e) && Boolean.TRUE.equals(p.getProperty(Properties.NON_MOVABLE))) {
+      if (SwingUtils.isMainMouseButtonDown(e) && Boolean.TRUE.equals(p.getProperty(Properties.NON_MOVABLE))) {
         // Don't "eat" band-selects if unit found is non-movable
         bandSelect = BandSelectType.SPECIAL;
       }
@@ -371,7 +371,7 @@ public class KeyBufferer extends MouseAdapter implements Buildable, MouseMotionL
    */
   @Override
   public void mouseDragged(MouseEvent e) {
-    if (selection == null || !SwingUtils.isVanillaLeftButtonDown(e)) {
+    if (selection == null || !SwingUtils.isMainMouseButtonDown(e)) {
       return;
     }
 

--- a/vassal-app/src/main/java/VASSAL/build/module/map/KeyBufferer.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/KeyBufferer.java
@@ -111,7 +111,7 @@ public class KeyBufferer extends MouseAdapter implements Buildable, MouseMotionL
     BandSelectType bandSelect = BandSelectType.NONE;
     if (p != null) {
       filter = (EventFilter) p.getProperty(Properties.SELECT_EVENT_FILTER);      
-      if (!e.isPopupTrigger() && Boolean.TRUE.equals(p.getProperty(Properties.NON_MOVABLE))) {
+      if (SwingUtils.isVanillaLeftButtonDown(e) && Boolean.TRUE.equals(p.getProperty(Properties.NON_MOVABLE))) {
         // Don't "eat" band-selects if unit found is non-movable
         bandSelect = BandSelectType.SPECIAL;
       }
@@ -121,7 +121,7 @@ public class KeyBufferer extends MouseAdapter implements Buildable, MouseMotionL
     if (p != null && !ignoreEvent) {
       boolean movingStacksPickupUnits = (Boolean) GameModule.getGameModule().getPrefs().getValue(Map.MOVING_STACKS_PICKUP_UNITS);
       if (!kbuf.contains(p)) {
-        if (!e.isShiftDown() && !SwingUtils.isControlDown(e)) {
+        if (!e.isShiftDown() && !SwingUtils.isSelectionToggle(e)) {
           kbuf.clear();
         }
         // RFE 1629255 - If the top piece of an unexpanded stack is left-clicked
@@ -129,7 +129,7 @@ public class KeyBufferer extends MouseAdapter implements Buildable, MouseMotionL
         if (movingStacksPickupUnits ||
             p.getParent() == null ||
             p.getParent().isExpanded() ||
-            SwingUtils.isRightMouseButton(e) ||
+            SwingUtils.isSelectionToggle(e) ||
             Boolean.TRUE.equals(p.getProperty(Properties.SELECTED))) {
           kbuf.add(p);
         }
@@ -141,7 +141,7 @@ public class KeyBufferer extends MouseAdapter implements Buildable, MouseMotionL
       }
       else {
         // RFE 1659481 Ctrl-click deselects clicked units
-        if (SwingUtils.isControlDown(e) && Boolean.TRUE.equals(p.getProperty(Properties.SELECTED))) {
+        if (SwingUtils.isSelectionToggle(e) && Boolean.TRUE.equals(p.getProperty(Properties.SELECTED))) {
           Stack s = p.getParent();
           if (s == null) {
             kbuf.remove(p);
@@ -165,7 +165,7 @@ public class KeyBufferer extends MouseAdapter implements Buildable, MouseMotionL
     
     if (bandSelect != BandSelectType.NONE) {
       bandSelectPiece = null;
-      if (!e.isShiftDown() && !SwingUtils.isControlDown(e)) { // No deselect if shift key down
+      if (!e.isShiftDown() && !SwingUtils.isSelectionToggle(e)) { // No deselect if shift key down
         kbuf.clear();
         
         //BR// This section allows band-select to be attempted from non-moving pieces w/o preventing click-to-select from working 
@@ -191,7 +191,7 @@ public class KeyBufferer extends MouseAdapter implements Buildable, MouseMotionL
     }
 
     PieceVisitorDispatcher d = createDragSelector(
-      !SwingUtils.isControlDown(e), e.isAltDown(), map.componentToMap(selection)
+      !SwingUtils.isSelectionToggle(e), e.isAltDown(), map.componentToMap(selection)
     );
     
     // If it was a legit band-select drag (not just a click), our special case
@@ -214,7 +214,7 @@ public class KeyBufferer extends MouseAdapter implements Buildable, MouseMotionL
     
     // RFE 1659481 Don't clear the entire selection buffer if either shift
     // or control is down - we select/deselect lassoed counters instead
-    if (bandSelectPiece == null && !e.isShiftDown() && !SwingUtils.isControlDown(e)) {
+    if (bandSelectPiece == null && !e.isShiftDown() && !SwingUtils.isSelectionToggle(e)) {
       KeyBuffer.getBuffer().clear();
     }
 
@@ -371,7 +371,7 @@ public class KeyBufferer extends MouseAdapter implements Buildable, MouseMotionL
    */
   @Override
   public void mouseDragged(MouseEvent e) {
-    if (selection == null || !SwingUtils.isLeftMouseButton(e)) {
+    if (selection == null || !SwingUtils.isVanillaLeftButtonDown(e)) {
       return;
     }
 

--- a/vassal-app/src/main/java/VASSAL/build/module/map/LOS_Thread.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/LOS_Thread.java
@@ -567,7 +567,7 @@ public class LOS_Thread extends AbstractConfigurable implements
 
   @Override
   public void mousePressed(MouseEvent e) {
-    if (!SwingUtils.isVanillaLeftButtonDown(e)) {
+    if (!SwingUtils.isMainMouseButtonDown(e)) {
       return;
     }
 
@@ -590,7 +590,7 @@ public class LOS_Thread extends AbstractConfigurable implements
 
   @Override
   public void mouseReleased(MouseEvent e) {
-    if (!SwingUtils.isVanillaLeftButtonDown(e)) {
+    if (!SwingUtils.isMainMouseButtonDown(e)) {
       return;
     }
 
@@ -695,7 +695,7 @@ public class LOS_Thread extends AbstractConfigurable implements
 
   @Override
   public void mouseDragged(MouseEvent e) {
-    if (!SwingUtils.isVanillaLeftButtonDown(e)) {
+    if (!SwingUtils.isMainMouseButtonDown(e)) {
       return;
     }
 

--- a/vassal-app/src/main/java/VASSAL/build/module/map/LOS_Thread.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/LOS_Thread.java
@@ -567,7 +567,7 @@ public class LOS_Thread extends AbstractConfigurable implements
 
   @Override
   public void mousePressed(MouseEvent e) {
-    if (!SwingUtils.isLeftMouseButton(e)) {
+    if (!SwingUtils.isVanillaLeftButtonDown(e)) {
       return;
     }
 
@@ -584,13 +584,13 @@ public class LOS_Thread extends AbstractConfigurable implements
       lastLocation = anchorLocation;
       lastRange = "";
       checkList.clear();
-      ctrlWhenClick = SwingUtils.isControlDown(e);
+      ctrlWhenClick = SwingUtils.isSelectionToggle(e);
     }
   }
 
   @Override
   public void mouseReleased(MouseEvent e) {
-    if (!SwingUtils.isLeftMouseButton(e)) {
+    if (!SwingUtils.isVanillaLeftButtonDown(e)) {
       return;
     }
 
@@ -695,7 +695,7 @@ public class LOS_Thread extends AbstractConfigurable implements
 
   @Override
   public void mouseDragged(MouseEvent e) {
-    if (!SwingUtils.isLeftMouseButton(e)) {
+    if (!SwingUtils.isVanillaLeftButtonDown(e)) {
       return;
     }
 

--- a/vassal-app/src/main/java/VASSAL/build/module/map/MapCenterer.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/MapCenterer.java
@@ -78,7 +78,7 @@ public class MapCenterer extends AbstractBuildable implements MouseListener {
 // FIXME: mouseClicked()?
   @Override
   public void mouseReleased(MouseEvent e) {
-    if (SwingUtils.isRightMouseButton(e)) {
+    if (SwingUtils.isContextMouseButtonDown(e)) {
       GamePiece found = map.findPiece(e.getPoint(), finder);
 
       if (found != null) {

--- a/vassal-app/src/main/java/VASSAL/build/module/map/PieceMover.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/PieceMover.java
@@ -721,7 +721,7 @@ public class PieceMover extends AbstractBuildable
            !SwingUtils.isSelectionToggle(e) &&
            e.getClickCount() < 2 &&
            (e.getButton() == MouseEvent.NOBUTTON ||
-            SwingUtils.isVanillaLeftButtonDown(e));
+            SwingUtils.isMainMouseButtonDown(e));
   }
 
   /**

--- a/vassal-app/src/main/java/VASSAL/build/module/map/PieceMover.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/PieceMover.java
@@ -718,10 +718,10 @@ public class PieceMover extends AbstractBuildable
   protected boolean canHandleEvent(MouseEvent e) {
     return !e.isConsumed() &&
            !e.isShiftDown() &&
-           !SwingUtils.isControlDown(e) &&
+           !SwingUtils.isSelectionToggle(e) &&
            e.getClickCount() < 2 &&
            (e.getButton() == MouseEvent.NOBUTTON ||
-            SwingUtils.isLeftMouseButton(e));
+            SwingUtils.isVanillaLeftButtonDown(e));
   }
 
   /**

--- a/vassal-app/src/main/java/VASSAL/build/module/map/SetupStack.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/SetupStack.java
@@ -808,7 +808,7 @@ public class SetupStack extends AbstractConfigurable implements GameComponent, U
         break;
       default :
         if (myPiece != null) {
-          myPiece.keyEvent(KeyStroke.getKeyStrokeForEvent(e));
+          myPiece.keyEvent(SwingUtils.getKeyStrokeForEvent(e));
         }
         break;
       }

--- a/vassal-app/src/main/java/VASSAL/build/module/map/StackExpander.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/StackExpander.java
@@ -57,7 +57,7 @@ public class StackExpander extends MouseAdapter implements Buildable {
   @Override
   public void mouseReleased(MouseEvent e) {
     if (!e.isConsumed() && e.getClickCount() == 2
-                        && SwingUtils.isLeftMouseButton(e)) {
+                        && SwingUtils.isVanillaLeftButtonDown(e)) {
       final GamePiece p = map.findPiece(e.getPoint(), PieceFinder.STACK_ONLY);
       if (p != null) {
         KeyBuffer.getBuffer().clear();

--- a/vassal-app/src/main/java/VASSAL/build/module/map/StackExpander.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/StackExpander.java
@@ -57,7 +57,7 @@ public class StackExpander extends MouseAdapter implements Buildable {
   @Override
   public void mouseReleased(MouseEvent e) {
     if (!e.isConsumed() && e.getClickCount() == 2
-                        && SwingUtils.isVanillaLeftButtonDown(e)) {
+                        && SwingUtils.isMainMouseButtonDown(e)) {
       final GamePiece p = map.findPiece(e.getPoint(), PieceFinder.STACK_ONLY);
       if (p != null) {
         KeyBuffer.getBuffer().clear();

--- a/vassal-app/src/main/java/VASSAL/build/module/map/boardPicker/board/GridEditor.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/boardPicker/board/GridEditor.java
@@ -340,7 +340,7 @@ public abstract class GridEditor extends JDialog implements MouseListener, KeyLi
 
   @Override
   public void mouseClicked(MouseEvent e) {
-    if (setMode && SwingUtils.isLeftMouseButton(e)) {
+    if (setMode && SwingUtils.isVanillaLeftButtonDown(e)) {
       if (hp1 == null) {
         hp1 = e.getPoint();
       }

--- a/vassal-app/src/main/java/VASSAL/build/module/map/boardPicker/board/GridEditor.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/boardPicker/board/GridEditor.java
@@ -340,7 +340,7 @@ public abstract class GridEditor extends JDialog implements MouseListener, KeyLi
 
   @Override
   public void mouseClicked(MouseEvent e) {
-    if (setMode && SwingUtils.isVanillaLeftButtonDown(e)) {
+    if (setMode && SwingUtils.isMainMouseButtonDown(e)) {
       if (hp1 == null) {
         hp1 = e.getPoint();
       }

--- a/vassal-app/src/main/java/VASSAL/build/module/map/boardPicker/board/RegionGrid.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/boardPicker/board/RegionGrid.java
@@ -857,13 +857,8 @@ public class RegionGrid extends AbstractConfigurable implements MapGrid, Configu
         if (lastClickedRegion != null) {
           if (e.getClickCount() >= 2) { // Double click show properties
             if (lastClickedRegion.getConfigurer() != null) {
-              final Action a =
-                new EditPropertiesAction(lastClickedRegion, null, this);
-              a.actionPerformed(
-                new ActionEvent(
-                e.getSource(),
-                ActionEvent.ACTION_PERFORMED,
-                "Edit")); //$NON-NLS-1$
+              final Action a = new EditPropertiesAction(lastClickedRegion, null, this);
+              a.actionPerformed(new ActionEvent(e.getSource(), ActionEvent.ACTION_PERFORMED, "Edit")); //$NON-NLS-1$
             }
           }
         }
@@ -935,13 +930,8 @@ public class RegionGrid extends AbstractConfigurable implements MapGrid, Configu
         select(r);
         lastClickedRegion = r;
         setDirty(true);
-        final Action a =
-          new EditPropertiesAction(lastClickedRegion, null, this);
-        a.actionPerformed(
-          new ActionEvent(
-          e.getSource(),
-          ActionEvent.ACTION_PERFORMED,
-          "Edit")); //$NON-NLS-1$
+        final Action a = new EditPropertiesAction(lastClickedRegion, null, this);
+        a.actionPerformed(new ActionEvent(e.getSource(),ActionEvent.ACTION_PERFORMED,"Edit")); //$NON-NLS-1$
         view.repaint();
       }
       else if (command.equals(DELETE_REGION)) {
@@ -956,13 +946,8 @@ public class RegionGrid extends AbstractConfigurable implements MapGrid, Configu
       }
       else if (command.equals(PROPERTIES)) { //$NON-NLS-1$
         if (lastClickedRegion != null) {
-          final Action a =
-            new EditRegionAction(lastClickedRegion, null, this);
-          a.actionPerformed(
-            new ActionEvent(
-            e.getSource(),
-            ActionEvent.ACTION_PERFORMED,
-            "Edit")); //$NON-NLS-1$
+          final Action a = new EditRegionAction(lastClickedRegion, null, this);
+          a.actionPerformed(new ActionEvent(e.getSource(),ActionEvent.ACTION_PERFORMED,"Edit")); //$NON-NLS-1$
         }
       }
     }

--- a/vassal-app/src/main/java/VASSAL/build/module/map/boardPicker/board/RegionGrid.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/boardPicker/board/RegionGrid.java
@@ -937,11 +937,11 @@ public class RegionGrid extends AbstractConfigurable implements MapGrid, Configu
         setDirty(true);
         final Action a =
           new EditPropertiesAction(lastClickedRegion, null, this);
-          a.actionPerformed(
-              new ActionEvent(
-                  e.getSource(),
-                  ActionEvent.ACTION_PERFORMED,
-              "Edit")); //$NON-NLS-1$
+        a.actionPerformed(
+          new ActionEvent(
+          e.getSource(),
+          ActionEvent.ACTION_PERFORMED,
+          "Edit")); //$NON-NLS-1$
         view.repaint();
       }
       else if (command.equals(DELETE_REGION)) {
@@ -958,14 +958,14 @@ public class RegionGrid extends AbstractConfigurable implements MapGrid, Configu
         if (lastClickedRegion != null) {
           final Action a =
             new EditRegionAction(lastClickedRegion, null, this);
-            a.actionPerformed(
-                new ActionEvent(
-                    e.getSource(),
-                    ActionEvent.ACTION_PERFORMED,
-                    "Edit")); //$NON-NLS-1$
-          }
+          a.actionPerformed(
+            new ActionEvent(
+            e.getSource(),
+            ActionEvent.ACTION_PERFORMED,
+            "Edit")); //$NON-NLS-1$
         }
       }
+    }
 
     /*
      * Version of EditProperties Action that repaints it's owning frame

--- a/vassal-app/src/main/java/VASSAL/build/module/map/boardPicker/board/RegionGrid.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/boardPicker/board/RegionGrid.java
@@ -851,7 +851,7 @@ public class RegionGrid extends AbstractConfigurable implements MapGrid, Configu
     // Mouse clicked, see if it is on a Region Point
     @Override
     public void mouseClicked(MouseEvent e) {
-      if (SwingUtils.isLeftMouseButton(e)) {
+      if (SwingUtils.isVanillaLeftButtonDown(e)) {
         lastClick = e.getPoint();
 
         if (lastClickedRegion != null) {
@@ -859,14 +859,14 @@ public class RegionGrid extends AbstractConfigurable implements MapGrid, Configu
             if (lastClickedRegion.getConfigurer() != null) {
               final Action a =
                 new EditPropertiesAction(lastClickedRegion, null, this);
-              a.actionPerformed(
-                  new ActionEvent(
-                      e.getSource(),
-                      ActionEvent.ACTION_PERFORMED,
-                      "Edit")); //$NON-NLS-1$
+                a.actionPerformed(
+                    new ActionEvent(
+                        e.getSource(),
+                        ActionEvent.ACTION_PERFORMED,
+                        "Edit")); //$NON-NLS-1$
+              }
             }
           }
-        }
         view.repaint(); // Clean up selection
       }
     }
@@ -937,11 +937,11 @@ public class RegionGrid extends AbstractConfigurable implements MapGrid, Configu
         setDirty(true);
         final Action a =
           new EditPropertiesAction(lastClickedRegion, null, this);
-        a.actionPerformed(
-            new ActionEvent(
-                e.getSource(),
-                ActionEvent.ACTION_PERFORMED,
-            "Edit")); //$NON-NLS-1$
+          a.actionPerformed(
+              new ActionEvent(
+                  e.getSource(),
+                  ActionEvent.ACTION_PERFORMED,
+              "Edit")); //$NON-NLS-1$
         view.repaint();
       }
       else if (command.equals(DELETE_REGION)) {
@@ -958,14 +958,14 @@ public class RegionGrid extends AbstractConfigurable implements MapGrid, Configu
         if (lastClickedRegion != null) {
           final Action a =
             new EditRegionAction(lastClickedRegion, null, this);
-          a.actionPerformed(
-              new ActionEvent(
-                  e.getSource(),
-                  ActionEvent.ACTION_PERFORMED,
-                  "Edit")); //$NON-NLS-1$
+            a.actionPerformed(
+                new ActionEvent(
+                    e.getSource(),
+                    ActionEvent.ACTION_PERFORMED,
+                    "Edit")); //$NON-NLS-1$
+          }
         }
       }
-    }
 
     /*
      * Version of EditProperties Action that repaints it's owning frame
@@ -1066,12 +1066,12 @@ public class RegionGrid extends AbstractConfigurable implements MapGrid, Configu
       if (e.isPopupTrigger()) {
         doPopupMenu(e);
       }
-      else if (SwingUtils.isLeftMouseButton(e)) {
+      else if (SwingUtils.isVanillaLeftButtonDown(e)) {
         final Point p = e.getPoint();
         lastClick = p;
         lastClickedRegion = grid.getRegion(p);
 
-        if (!e.isShiftDown() && !SwingUtils.isControlDown(e) &&
+        if (!e.isShiftDown() && !SwingUtils.isSelectionToggle(e) &&
             (lastClickedRegion==null || !lastClickedRegion.isSelected())) {
           unSelectAll();
         }
@@ -1081,7 +1081,7 @@ public class RegionGrid extends AbstractConfigurable implements MapGrid, Configu
           selectionRect = new Rectangle(anchor.x, anchor.y, 0, 0);
         }
         else {
-          if (SwingUtils.isControlDown(e)) {
+          if (SwingUtils.isSelectionToggle(e)) {
             unselect(lastClickedRegion);
           }
           else {
@@ -1096,10 +1096,10 @@ public class RegionGrid extends AbstractConfigurable implements MapGrid, Configu
       if (e.isPopupTrigger()) {
         doPopupMenu(e);
       }
-      else if (selectionRect != null && SwingUtils.isLeftMouseButton(e)) {
+      else if (selectionRect != null && SwingUtils.isVanillaLeftButtonDown(e)) {
         for (Region r : grid.regionList.values()) {
           if (selectionRect.contains(r.getOrigin())) {
-            if (SwingUtils.isControlDown(e)) {
+            if (SwingUtils.isSelectionToggle(e)) {
               unselect(r);
             }
             else {
@@ -1119,7 +1119,7 @@ public class RegionGrid extends AbstractConfigurable implements MapGrid, Configu
     // Scroll map if necessary
     @Override
     public void mouseDragged(MouseEvent e) {
-      if (SwingUtils.isLeftMouseButton(e)) {
+      if (SwingUtils.isVanillaLeftButtonDown(e)) {
         scrollAtEdge(e.getPoint(), 15);
       }
 

--- a/vassal-app/src/main/java/VASSAL/build/module/map/boardPicker/board/RegionGrid.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/boardPicker/board/RegionGrid.java
@@ -851,7 +851,7 @@ public class RegionGrid extends AbstractConfigurable implements MapGrid, Configu
     // Mouse clicked, see if it is on a Region Point
     @Override
     public void mouseClicked(MouseEvent e) {
-      if (SwingUtils.isVanillaLeftButtonDown(e)) {
+      if (SwingUtils.isMainMouseButtonDown(e)) {
         lastClick = e.getPoint();
 
         if (lastClickedRegion != null) {
@@ -1066,7 +1066,7 @@ public class RegionGrid extends AbstractConfigurable implements MapGrid, Configu
       if (e.isPopupTrigger()) {
         doPopupMenu(e);
       }
-      else if (SwingUtils.isVanillaLeftButtonDown(e)) {
+      else if (SwingUtils.isMainMouseButtonDown(e)) {
         final Point p = e.getPoint();
         lastClick = p;
         lastClickedRegion = grid.getRegion(p);
@@ -1096,7 +1096,7 @@ public class RegionGrid extends AbstractConfigurable implements MapGrid, Configu
       if (e.isPopupTrigger()) {
         doPopupMenu(e);
       }
-      else if (selectionRect != null && SwingUtils.isVanillaLeftButtonDown(e)) {
+      else if (selectionRect != null && SwingUtils.isMainMouseButtonDown(e)) {
         for (Region r : grid.regionList.values()) {
           if (selectionRect.contains(r.getOrigin())) {
             if (SwingUtils.isSelectionToggle(e)) {
@@ -1119,7 +1119,7 @@ public class RegionGrid extends AbstractConfigurable implements MapGrid, Configu
     // Scroll map if necessary
     @Override
     public void mouseDragged(MouseEvent e) {
-      if (SwingUtils.isVanillaLeftButtonDown(e)) {
+      if (SwingUtils.isMainMouseButtonDown(e)) {
         scrollAtEdge(e.getPoint(), 15);
       }
 

--- a/vassal-app/src/main/java/VASSAL/build/module/map/boardPicker/board/RegionGrid.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/boardPicker/board/RegionGrid.java
@@ -859,14 +859,14 @@ public class RegionGrid extends AbstractConfigurable implements MapGrid, Configu
             if (lastClickedRegion.getConfigurer() != null) {
               final Action a =
                 new EditPropertiesAction(lastClickedRegion, null, this);
-                a.actionPerformed(
-                    new ActionEvent(
-                        e.getSource(),
-                        ActionEvent.ACTION_PERFORMED,
-                        "Edit")); //$NON-NLS-1$
-              }
+              a.actionPerformed(
+                new ActionEvent(
+                e.getSource(),
+                ActionEvent.ACTION_PERFORMED,
+                "Edit")); //$NON-NLS-1$
             }
           }
+        }
         view.repaint(); // Clean up selection
       }
     }

--- a/vassal-app/src/main/java/VASSAL/build/module/map/boardPicker/board/mapgrid/PolygonEditor.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/boardPicker/board/mapgrid/PolygonEditor.java
@@ -202,7 +202,7 @@ public class PolygonEditor extends JPanel {
   private class ModifyPolygon extends MouseInputAdapter {
     @Override
     public void mouseDragged(MouseEvent e) {
-      if (SwingUtils.isVanillaLeftButtonDown(e)) {
+      if (SwingUtils.isMainMouseButtonDown(e)) {
         moveSelectedPoint(e);
         scrollAtEdge(e.getPoint(), 15);
         repaint();
@@ -218,7 +218,7 @@ public class PolygonEditor extends JPanel {
 
     @Override
     public void mouseReleased(MouseEvent e) {
-      if (SwingUtils.isVanillaLeftButtonDown(e)) {
+      if (SwingUtils.isMainMouseButtonDown(e)) {
         moveSelectedPoint(e);
         repaint();
       }
@@ -301,7 +301,7 @@ public class PolygonEditor extends JPanel {
 
     @Override
     public void mousePressed(MouseEvent e) {
-      if (SwingUtils.isVanillaLeftButtonDown(e)) {
+      if (SwingUtils.isMainMouseButtonDown(e)) {
         selected = -1;
         double minDist = Float.MAX_VALUE;
 
@@ -349,7 +349,7 @@ public class PolygonEditor extends JPanel {
   private class DefineRectangle extends MouseInputAdapter {
     @Override
     public void mousePressed(MouseEvent e) {
-      if (SwingUtils.isVanillaLeftButtonDown(e)) {
+      if (SwingUtils.isMainMouseButtonDown(e)) {
         polygon = new Polygon();
         polygon.addPoint(e.getX(), e.getY());
         polygon.addPoint(e.getX(), e.getY());
@@ -361,7 +361,7 @@ public class PolygonEditor extends JPanel {
 
     @Override
     public void mouseDragged(MouseEvent e) {
-      if (SwingUtils.isVanillaLeftButtonDown(e)) {
+      if (SwingUtils.isMainMouseButtonDown(e)) {
         polygon.xpoints[1] = e.getX();
         polygon.xpoints[2] = e.getX();
         polygon.ypoints[2] = e.getY();
@@ -372,7 +372,7 @@ public class PolygonEditor extends JPanel {
 
     @Override
     public void mouseReleased(MouseEvent e) {
-      if (SwingUtils.isVanillaLeftButtonDown(e)) {
+      if (SwingUtils.isMainMouseButtonDown(e)) {
         removeMouseListener(this);
         removeMouseMotionListener(this);
         setupForEdit();

--- a/vassal-app/src/main/java/VASSAL/build/module/map/boardPicker/board/mapgrid/PolygonEditor.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/boardPicker/board/mapgrid/PolygonEditor.java
@@ -202,7 +202,7 @@ public class PolygonEditor extends JPanel {
   private class ModifyPolygon extends MouseInputAdapter {
     @Override
     public void mouseDragged(MouseEvent e) {
-      if (SwingUtils.isLeftMouseButton(e)) {
+      if (SwingUtils.isVanillaLeftButtonDown(e)) {
         moveSelectedPoint(e);
         scrollAtEdge(e.getPoint(), 15);
         repaint();
@@ -218,7 +218,7 @@ public class PolygonEditor extends JPanel {
 
     @Override
     public void mouseReleased(MouseEvent e) {
-      if (SwingUtils.isLeftMouseButton(e)) {
+      if (SwingUtils.isVanillaLeftButtonDown(e)) {
         moveSelectedPoint(e);
         repaint();
       }
@@ -226,7 +226,7 @@ public class PolygonEditor extends JPanel {
 
     @Override
     public void mouseClicked(MouseEvent e) {
-      if (!SwingUtils.isRightMouseButton(e)) {
+      if (!SwingUtils.isContextMouseButtonDown(e)) {
         return;
       }
 
@@ -301,7 +301,7 @@ public class PolygonEditor extends JPanel {
 
     @Override
     public void mousePressed(MouseEvent e) {
-      if (SwingUtils.isLeftMouseButton(e)) {
+      if (SwingUtils.isVanillaLeftButtonDown(e)) {
         selected = -1;
         double minDist = Float.MAX_VALUE;
 
@@ -349,7 +349,7 @@ public class PolygonEditor extends JPanel {
   private class DefineRectangle extends MouseInputAdapter {
     @Override
     public void mousePressed(MouseEvent e) {
-      if (SwingUtils.isLeftMouseButton(e)) {
+      if (SwingUtils.isVanillaLeftButtonDown(e)) {
         polygon = new Polygon();
         polygon.addPoint(e.getX(), e.getY());
         polygon.addPoint(e.getX(), e.getY());
@@ -361,7 +361,7 @@ public class PolygonEditor extends JPanel {
 
     @Override
     public void mouseDragged(MouseEvent e) {
-      if (SwingUtils.isLeftMouseButton(e)) {
+      if (SwingUtils.isVanillaLeftButtonDown(e)) {
         polygon.xpoints[1] = e.getX();
         polygon.xpoints[2] = e.getX();
         polygon.ypoints[2] = e.getY();
@@ -372,7 +372,7 @@ public class PolygonEditor extends JPanel {
 
     @Override
     public void mouseReleased(MouseEvent e) {
-      if (SwingUtils.isLeftMouseButton(e)) {
+      if (SwingUtils.isVanillaLeftButtonDown(e)) {
         removeMouseListener(this);
         removeMouseMotionListener(this);
         setupForEdit();

--- a/vassal-app/src/main/java/VASSAL/build/widget/PieceSlot.java
+++ b/vassal-app/src/main/java/VASSAL/build/widget/PieceSlot.java
@@ -298,7 +298,7 @@ public class PieceSlot extends Widget implements MouseListener, KeyListener {
     if (e.isPopupTrigger()) {
       doPopup(e);
     }
-    else if (SwingUtils.isLeftMouseButton(e)) {
+    else if (SwingUtils.isVanillaLeftButtonDown(e)) {
       KeyBuffer.getBuffer().clear();
       Map.clearActiveMap();
       if (getPiece() != null) {
@@ -320,7 +320,7 @@ public class PieceSlot extends Widget implements MouseListener, KeyListener {
       }
       doClear = true;
     }
-    else if (SwingUtils.isLeftMouseButton(e)) {
+    else if (SwingUtils.isVanillaLeftButtonDown(e)) {
       doClear = true;
     }
 

--- a/vassal-app/src/main/java/VASSAL/build/widget/PieceSlot.java
+++ b/vassal-app/src/main/java/VASSAL/build/widget/PieceSlot.java
@@ -346,7 +346,7 @@ public class PieceSlot extends Widget implements MouseListener, KeyListener {
 
   @Override
   public void keyPressed(KeyEvent e) {
-    KeyBuffer.getBuffer().keyCommand(KeyStroke.getKeyStrokeForEvent(e));
+    KeyBuffer.getBuffer().keyCommand(SwingUtils.getKeyStrokeForEvent(e));
     e.consume();
     clearExpandedPiece();
     panel.repaint();
@@ -354,7 +354,7 @@ public class PieceSlot extends Widget implements MouseListener, KeyListener {
 
   @Override
   public void keyTyped(KeyEvent e) {
-    KeyBuffer.getBuffer().keyCommand(KeyStroke.getKeyStrokeForEvent(e));
+    KeyBuffer.getBuffer().keyCommand(SwingUtils.getKeyStrokeForEvent(e));
     e.consume();
     clearExpandedPiece();
     panel.repaint();
@@ -362,7 +362,7 @@ public class PieceSlot extends Widget implements MouseListener, KeyListener {
 
   @Override
   public void keyReleased(KeyEvent e) {
-    KeyBuffer.getBuffer().keyCommand(KeyStroke.getKeyStrokeForEvent(e));
+    KeyBuffer.getBuffer().keyCommand(SwingUtils.getKeyStrokeForEvent(e));
     e.consume();
     clearExpandedPiece();
     panel.repaint();

--- a/vassal-app/src/main/java/VASSAL/build/widget/PieceSlot.java
+++ b/vassal-app/src/main/java/VASSAL/build/widget/PieceSlot.java
@@ -298,7 +298,7 @@ public class PieceSlot extends Widget implements MouseListener, KeyListener {
     if (e.isPopupTrigger()) {
       doPopup(e);
     }
-    else if (SwingUtils.isVanillaLeftButtonDown(e)) {
+    else if (SwingUtils.isMainMouseButtonDown(e)) {
       KeyBuffer.getBuffer().clear();
       Map.clearActiveMap();
       if (getPiece() != null) {
@@ -320,7 +320,7 @@ public class PieceSlot extends Widget implements MouseListener, KeyListener {
       }
       doClear = true;
     }
-    else if (SwingUtils.isVanillaLeftButtonDown(e)) {
+    else if (SwingUtils.isMainMouseButtonDown(e)) {
       doClear = true;
     }
 

--- a/vassal-app/src/main/java/VASSAL/chat/ServerAddressBook.java
+++ b/vassal-app/src/main/java/VASSAL/chat/ServerAddressBook.java
@@ -251,7 +251,7 @@ public class ServerAddressBook {
         @Override
         public void mouseClicked(MouseEvent e) {
           if (editButton.isEnabled() && e.getClickCount() == 2
-                                     && SwingUtils.isVanillaLeftButtonDown(e)) {
+                                     && SwingUtils.isMainMouseButtonDown(e)) {
             int index = myList.locationToIndex(e.getPoint());
             editServer(index);
           }

--- a/vassal-app/src/main/java/VASSAL/chat/ServerAddressBook.java
+++ b/vassal-app/src/main/java/VASSAL/chat/ServerAddressBook.java
@@ -251,7 +251,7 @@ public class ServerAddressBook {
         @Override
         public void mouseClicked(MouseEvent e) {
           if (editButton.isEnabled() && e.getClickCount() == 2
-                                     && SwingUtils.isLeftMouseButton(e)) {
+                                     && SwingUtils.isVanillaLeftButtonDown(e)) {
             int index = myList.locationToIndex(e.getPoint());
             editServer(index);
           }

--- a/vassal-app/src/main/java/VASSAL/chat/ui/RoomInteractionControlsInitializer.java
+++ b/vassal-app/src/main/java/VASSAL/chat/ui/RoomInteractionControlsInitializer.java
@@ -107,7 +107,7 @@ public class RoomInteractionControlsInitializer implements ChatControlsInitializ
         if (e.isPopupTrigger()) {
           maybePopup(e);
         }
-        else if (e.getClickCount() == 2 && SwingUtils.isLeftMouseButton(e)) {
+        else if (e.getClickCount() == 2 && SwingUtils.isVanillaLeftButtonDown(e)) {
           JTree tree = (JTree) e.getSource();
           TreePath path = tree.getPathForLocation(e.getX(), e.getY());
           if (path != null) {

--- a/vassal-app/src/main/java/VASSAL/chat/ui/RoomInteractionControlsInitializer.java
+++ b/vassal-app/src/main/java/VASSAL/chat/ui/RoomInteractionControlsInitializer.java
@@ -107,7 +107,7 @@ public class RoomInteractionControlsInitializer implements ChatControlsInitializ
         if (e.isPopupTrigger()) {
           maybePopup(e);
         }
-        else if (e.getClickCount() == 2 && SwingUtils.isVanillaLeftButtonDown(e)) {
+        else if (e.getClickCount() == 2 && SwingUtils.isMainMouseButtonDown(e)) {
           JTree tree = (JTree) e.getSource();
           TreePath path = tree.getPathForLocation(e.getX(), e.getY());
           if (path != null) {

--- a/vassal-app/src/main/java/VASSAL/configure/ConfigureTree.java
+++ b/vassal-app/src/main/java/VASSAL/configure/ConfigureTree.java
@@ -902,7 +902,7 @@ public class ConfigureTree extends JTree implements PropertyChangeListener, Mous
     if (e.isPopupTrigger()) {
       maybePopup(e);
     }
-    else if (e.getClickCount() == 2 && SwingUtils.isLeftMouseButton(e)) {
+    else if (e.getClickCount() == 2 && SwingUtils.isVanillaLeftButtonDown(e)) {
       Configurable target = getTarget(e.getX(), e.getY());
       if (target == null) {
         return;

--- a/vassal-app/src/main/java/VASSAL/configure/ConfigureTree.java
+++ b/vassal-app/src/main/java/VASSAL/configure/ConfigureTree.java
@@ -902,7 +902,7 @@ public class ConfigureTree extends JTree implements PropertyChangeListener, Mous
     if (e.isPopupTrigger()) {
       maybePopup(e);
     }
-    else if (e.getClickCount() == 2 && SwingUtils.isVanillaLeftButtonDown(e)) {
+    else if (e.getClickCount() == 2 && SwingUtils.isMainMouseButtonDown(e)) {
       Configurable target = getTarget(e.getX(), e.getY());
       if (target == null) {
         return;

--- a/vassal-app/src/main/java/VASSAL/configure/HotKeyConfigurer.java
+++ b/vassal-app/src/main/java/VASSAL/configure/HotKeyConfigurer.java
@@ -157,16 +157,16 @@ public class HotKeyConfigurer extends Configurer implements KeyListener {
 
     final int mods = SwingUtils.genericToSystem(k).getModifiers();
     if ((mods & KeyEvent.SHIFT_DOWN_MASK) > 0) {
-      s = Resources.getString("Keys.shift") + " " + s; //$NON-NLS-1$ //$NON-NLS-2$
+      s = Resources.getString("Keys.shift") + "+" + s; //$NON-NLS-1$ //$NON-NLS-2$
     }
     if ((mods & KeyEvent.CTRL_DOWN_MASK) > 0) {
-      s = Resources.getString("Keys.ctrl") + " " + s; //$NON-NLS-1$ //$NON-NLS-2$
+      s = Resources.getString("Keys.ctrl") + "+" + s; //$NON-NLS-1$ //$NON-NLS-2$
     }
     if ((mods & KeyEvent.META_DOWN_MASK) > 0) {  // This is "Command" key on Mac
-      s = Resources.getString("Keys.meta") + " " + s; //$NON-NLS-1$ //$NON-NLS-2$
+      s = Resources.getString("Keys.meta") + "+" + s; //$NON-NLS-1$ //$NON-NLS-2$
     }
     if ((mods & KeyEvent.ALT_DOWN_MASK) > 0) {
-      s = Resources.getString("Keys.alt") + " " + s; //$NON-NLS-1$ //$NON-NLS-2$
+      s = Resources.getString("Keys.alt") + "+" + s; //$NON-NLS-1$ //$NON-NLS-2$
     }
     return s;
   }

--- a/vassal-app/src/main/java/VASSAL/configure/HotKeyConfigurer.java
+++ b/vassal-app/src/main/java/VASSAL/configure/HotKeyConfigurer.java
@@ -27,7 +27,9 @@ import javax.swing.JPanel;
 import javax.swing.JTextField;
 import javax.swing.KeyStroke;
 
+import VASSAL.build.module.Chatter;
 import VASSAL.i18n.Resources;
+import VASSAL.tools.swing.SwingUtils;
 
 /**
  * A Configurer for {@link KeyStroke} values
@@ -99,7 +101,7 @@ public class HotKeyConfigurer extends Configurer implements KeyListener {
     case KeyEvent.VK_ALT:
       break;
     default:
-      setValue(KeyStroke.getKeyStrokeForEvent(e));
+      setValue(SwingUtils.getKeySystemToVassal(KeyStroke.getKeyStrokeForEvent(e)));
     }
   }
 
@@ -113,28 +115,7 @@ public class HotKeyConfigurer extends Configurer implements KeyListener {
    * from {@link KeyEvent#getKeyText}
    */
   public static String getString(KeyStroke k) {
-    if (k == null) {
-      return null;
-    }
-
-    String s = KeyEvent.getKeyText(k.getKeyCode());
-    s = s.replace(' ', '_');
-
-    final int mods = k.getModifiers();
-
-    if ((mods & KeyEvent.SHIFT_DOWN_MASK) > 0) {
-      s = Resources.getString("Keys.shift") + " " + s; //$NON-NLS-1$ //$NON-NLS-2$
-    }
-    if ((mods & KeyEvent.CTRL_DOWN_MASK) > 0) {
-      s = Resources.getString("Keys.ctrl") + " " + s; //$NON-NLS-1$ //$NON-NLS-2$
-    }
-    if ((mods & KeyEvent.META_DOWN_MASK) > 0) {
-      s = Resources.getString("Keys.meta") + " " + s; //$NON-NLS-1$ //$NON-NLS-2$
-    }
-    if ((mods & KeyEvent.ALT_DOWN_MASK) > 0) {
-      s = Resources.getString("Keys.alt") + " " + s; //$NON-NLS-1$ //$NON-NLS-2$
-    }
-    return s.toUpperCase();
+    return Chatter.getKeyString(k);    
   }
 
   /**

--- a/vassal-app/src/main/java/VASSAL/configure/HotKeyConfigurer.java
+++ b/vassal-app/src/main/java/VASSAL/configure/HotKeyConfigurer.java
@@ -101,7 +101,7 @@ public class HotKeyConfigurer extends Configurer implements KeyListener {
     case KeyEvent.VK_ALT:
       break;
     default:
-      setValue(SwingUtils.getKeySystemToVassal(SwingUtils.getKeyStrokeForEvent(e)));
+      setValue(SwingUtils.systemToGeneric(SwingUtils.getKeyStrokeForEvent(e)));
     }
   }
 

--- a/vassal-app/src/main/java/VASSAL/configure/HotKeyConfigurer.java
+++ b/vassal-app/src/main/java/VASSAL/configure/HotKeyConfigurer.java
@@ -27,6 +27,8 @@ import javax.swing.JPanel;
 import javax.swing.JTextField;
 import javax.swing.KeyStroke;
 
+import org.apache.commons.lang3.StringUtils;
+
 import VASSAL.build.module.Chatter;
 import VASSAL.i18n.Resources;
 import VASSAL.tools.swing.SwingUtils;
@@ -115,7 +117,58 @@ public class HotKeyConfigurer extends Configurer implements KeyListener {
    * from {@link KeyEvent#getKeyText}
    */
   public static String getString(KeyStroke k) {
-    return Chatter.getKeyString(k);    
+    if (k == null) {
+      return null;
+    }
+
+    String s;
+    int code = k.getKeyCode();
+    switch (code) {
+    // The addition of underscores screws up these names
+    case KeyEvent.VK_ADD:
+      s = Resources.getString("Keys.numplus"); //$NON-NLS-1$ //$NON-NLS-2$
+      break;
+    case KeyEvent.VK_SUBTRACT:
+      s = Resources.getString("Keys.numminus"); //$NON-NLS-1$ //$NON-NLS-2$
+      break;
+    // More compact name, also commonly printed keys  
+    case KeyEvent.VK_PAGE_UP:
+      s = Resources.getString("Keys.pgup"); //$NON-NLS-1$ //$NON-NLS-2$
+      break;
+    case KeyEvent.VK_PAGE_DOWN:
+      s = Resources.getString("Keys.pgdn"); //$NON-NLS-1$ //$NON-NLS-2$
+      break;
+    // Non-Americans were (rightly) commenting about this
+    case KeyEvent.VK_OPEN_BRACKET:
+      s = Resources.getString("Keys.bropen"); //$NON-NLS-1$ //$NON-NLS-2$
+      break;
+    case KeyEvent.VK_CLOSE_BRACKET:
+      s = Resources.getString("Keys.brclose"); //$NON-NLS-1$ //$NON-NLS-2$
+      break;
+    default:
+      s = "";
+      break;
+    }
+    if (s.isEmpty() || s.contains("Keys.")) { //$NON-NLS-1$
+      s = KeyEvent.getKeyText(code); 
+    }
+    s = StringUtils.capitalize(s);
+    s = s.replace(' ', '_');        
+
+    final int mods = SwingUtils.genericToSystem(k).getModifiers();
+    if ((mods & KeyEvent.SHIFT_DOWN_MASK) > 0) {
+      s = Resources.getString("Keys.shift") + " " + s; //$NON-NLS-1$ //$NON-NLS-2$
+    }
+    if ((mods & KeyEvent.CTRL_DOWN_MASK) > 0) {
+      s = Resources.getString("Keys.ctrl") + " " + s; //$NON-NLS-1$ //$NON-NLS-2$
+    }
+    if ((mods & KeyEvent.META_DOWN_MASK) > 0) {  // This is "Command" key on Mac
+      s = Resources.getString("Keys.meta") + " " + s; //$NON-NLS-1$ //$NON-NLS-2$
+    }
+    if ((mods & KeyEvent.ALT_DOWN_MASK) > 0) {
+      s = Resources.getString("Keys.alt") + " " + s; //$NON-NLS-1$ //$NON-NLS-2$
+    }
+    return s;
   }
 
   /**

--- a/vassal-app/src/main/java/VASSAL/configure/HotKeyConfigurer.java
+++ b/vassal-app/src/main/java/VASSAL/configure/HotKeyConfigurer.java
@@ -101,7 +101,7 @@ public class HotKeyConfigurer extends Configurer implements KeyListener {
     case KeyEvent.VK_ALT:
       break;
     default:
-      setValue(SwingUtils.getKeySystemToVassal(KeyStroke.getKeyStrokeForEvent(e)));
+      setValue(SwingUtils.getKeySystemToVassal(SwingUtils.getKeyStrokeForEvent(e)));
     }
   }
 

--- a/vassal-app/src/main/java/VASSAL/counters/ActionButton.java
+++ b/vassal-app/src/main/java/VASSAL/counters/ActionButton.java
@@ -300,7 +300,7 @@ public class ActionButton extends Decorator implements EditablePiece, Loopable {
 
       @Override
       public void mouseClicked(MouseEvent e) {
-        if (SwingUtils.isVanillaLeftButtonDown(e)) {
+        if (SwingUtils.isMainMouseButtonDown(e)) {
           final Point point = e.getPoint();
           final GamePiece p = map.findPiece(point, PieceFinder.PIECE_IN_STACK);
           if (p != null) {
@@ -325,7 +325,7 @@ public class ActionButton extends Decorator implements EditablePiece, Loopable {
 
       @Override
       public void mouseClicked(MouseEvent e) {
-        if (SwingUtils.isVanillaLeftButtonDown(e)) {
+        if (SwingUtils.isMainMouseButtonDown(e)) {
           final Point point = e.getPoint();
           point.translate(-xOffset,-yOffset);
           doClick(target, point);

--- a/vassal-app/src/main/java/VASSAL/counters/ActionButton.java
+++ b/vassal-app/src/main/java/VASSAL/counters/ActionButton.java
@@ -300,7 +300,7 @@ public class ActionButton extends Decorator implements EditablePiece, Loopable {
 
       @Override
       public void mouseClicked(MouseEvent e) {
-        if (SwingUtils.isLeftMouseButton(e)) {
+        if (SwingUtils.isVanillaLeftButtonDown(e)) {
           final Point point = e.getPoint();
           final GamePiece p = map.findPiece(point, PieceFinder.PIECE_IN_STACK);
           if (p != null) {
@@ -325,7 +325,7 @@ public class ActionButton extends Decorator implements EditablePiece, Loopable {
 
       @Override
       public void mouseClicked(MouseEvent e) {
-        if (SwingUtils.isLeftMouseButton(e)) {
+        if (SwingUtils.isVanillaLeftButtonDown(e)) {
           final Point point = e.getPoint();
           point.translate(-xOffset,-yOffset);
           doClick(target, point);

--- a/vassal-app/src/main/java/VASSAL/counters/FreeRotator.java
+++ b/vassal-app/src/main/java/VASSAL/counters/FreeRotator.java
@@ -550,7 +550,7 @@ public class FreeRotator extends Decorator
 
   @Override
   public void mousePressed(MouseEvent e) {
-    if (SwingUtils.isLeftMouseButton(e)) {
+    if (SwingUtils.isVanillaLeftButtonDown(e)) {
       if (hasPieceMoved()) {
         endInteractiveRotate();
         return;
@@ -562,7 +562,7 @@ public class FreeRotator extends Decorator
 
   @Override
   public void mouseReleased(MouseEvent e) {
-    if (SwingUtils.isLeftMouseButton(e)) {
+    if (SwingUtils.isVanillaLeftButtonDown(e)) {
       if (hasPieceMoved()) {
         endInteractiveRotate();
         return;
@@ -626,7 +626,7 @@ public class FreeRotator extends Decorator
 
   @Override
   public void mouseDragged(MouseEvent e) {
-    if (SwingUtils.isLeftMouseButton(e)) {
+    if (SwingUtils.isVanillaLeftButtonDown(e)) {
       if (drawGhost) {
         final Point mousePos = getMap().componentToMap(e.getPoint());
         final double myAngle = getRelativeAngle(mousePos, pivot);

--- a/vassal-app/src/main/java/VASSAL/counters/FreeRotator.java
+++ b/vassal-app/src/main/java/VASSAL/counters/FreeRotator.java
@@ -550,7 +550,7 @@ public class FreeRotator extends Decorator
 
   @Override
   public void mousePressed(MouseEvent e) {
-    if (SwingUtils.isVanillaLeftButtonDown(e)) {
+    if (SwingUtils.isMainMouseButtonDown(e)) {
       if (hasPieceMoved()) {
         endInteractiveRotate();
         return;
@@ -562,7 +562,7 @@ public class FreeRotator extends Decorator
 
   @Override
   public void mouseReleased(MouseEvent e) {
-    if (SwingUtils.isVanillaLeftButtonDown(e)) {
+    if (SwingUtils.isMainMouseButtonDown(e)) {
       if (hasPieceMoved()) {
         endInteractiveRotate();
         return;
@@ -626,7 +626,7 @@ public class FreeRotator extends Decorator
 
   @Override
   public void mouseDragged(MouseEvent e) {
-    if (SwingUtils.isVanillaLeftButtonDown(e)) {
+    if (SwingUtils.isMainMouseButtonDown(e)) {
       if (drawGhost) {
         final Point mousePos = getMap().componentToMap(e.getPoint());
         final double myAngle = getRelativeAngle(mousePos, pivot);

--- a/vassal-app/src/main/java/VASSAL/counters/ImagePicker.java
+++ b/vassal-app/src/main/java/VASSAL/counters/ImagePicker.java
@@ -134,7 +134,7 @@ public class ImagePicker extends JPanel
 
   @Override
   public void mouseClicked(MouseEvent e) {
-    if (e.getClickCount() > 1 && SwingUtils.isVanillaLeftButtonDown(e)) {
+    if (e.getClickCount() > 1 && SwingUtils.isMainMouseButtonDown(e)) {
       pickImage();
     }
   }

--- a/vassal-app/src/main/java/VASSAL/counters/ImagePicker.java
+++ b/vassal-app/src/main/java/VASSAL/counters/ImagePicker.java
@@ -134,7 +134,7 @@ public class ImagePicker extends JPanel
 
   @Override
   public void mouseClicked(MouseEvent e) {
-    if (e.getClickCount() > 1 && SwingUtils.isLeftMouseButton(e)) {
+    if (e.getClickCount() > 1 && SwingUtils.isVanillaLeftButtonDown(e)) {
       pickImage();
     }
   }

--- a/vassal-app/src/main/java/VASSAL/counters/PieceDefiner.java
+++ b/vassal-app/src/main/java/VASSAL/counters/PieceDefiner.java
@@ -384,7 +384,7 @@ public class PieceDefiner extends JPanel implements HelpWindowExtension {
       @Override
 // FIXME: mouseClicked()?
       public void mouseReleased(MouseEvent e) {
-        if (e.getClickCount() == 2 && SwingUtils.isVanillaLeftButtonDown(e)) {
+        if (e.getClickCount() == 2 && SwingUtils.isMainMouseButtonDown(e)) {
           int index = inUseList.locationToIndex(e.getPoint());
           if (index >= 0) {
             edit(index);

--- a/vassal-app/src/main/java/VASSAL/counters/PieceDefiner.java
+++ b/vassal-app/src/main/java/VASSAL/counters/PieceDefiner.java
@@ -384,7 +384,7 @@ public class PieceDefiner extends JPanel implements HelpWindowExtension {
       @Override
 // FIXME: mouseClicked()?
       public void mouseReleased(MouseEvent e) {
-        if (e.getClickCount() == 2 && SwingUtils.isLeftMouseButton(e)) {
+        if (e.getClickCount() == 2 && SwingUtils.isVanillaLeftButtonDown(e)) {
           int index = inUseList.locationToIndex(e.getPoint());
           if (index >= 0) {
             edit(index);

--- a/vassal-app/src/main/java/VASSAL/counters/PropertySheet.java
+++ b/vassal-app/src/main/java/VASSAL/counters/PropertySheet.java
@@ -1302,11 +1302,11 @@ public class PropertySheet extends Decorator implements TranslatablePiece {
     @Override
     public void mouseClicked(MouseEvent e) {
       if (panelType != TICKS_VALMAX &&
-          ((SwingUtils.isLeftMouseButton(e) && e.isShiftDown()) ||
-            SwingUtils.isRightMouseButton(e))) {
+          ((SwingUtils.isVanillaLeftButtonDown(e) && e.isShiftDown()) ||
+            SwingUtils.isContextMouseButtonDown(e))) {
         new EditTickLabelValueDialog(this);
       }
-      else if (SwingUtils.isLeftMouseButton(e)) {
+      else if (SwingUtils.isVanillaLeftButtonDown(e)) {
         int col = Math.min((e.getX() - leftMargin + 1) / dx, numCols - 1);
         int row = Math.min((e.getY() - topMargin + 1) / dx, numRows - 1);
         int num = row * numCols + col + 1;

--- a/vassal-app/src/main/java/VASSAL/counters/PropertySheet.java
+++ b/vassal-app/src/main/java/VASSAL/counters/PropertySheet.java
@@ -1302,11 +1302,11 @@ public class PropertySheet extends Decorator implements TranslatablePiece {
     @Override
     public void mouseClicked(MouseEvent e) {
       if (panelType != TICKS_VALMAX &&
-          ((SwingUtils.isVanillaLeftButtonDown(e) && e.isShiftDown()) ||
+          ((SwingUtils.isMainMouseButtonDown(e) && e.isShiftDown()) ||
             SwingUtils.isContextMouseButtonDown(e))) {
         new EditTickLabelValueDialog(this);
       }
-      else if (SwingUtils.isVanillaLeftButtonDown(e)) {
+      else if (SwingUtils.isMainMouseButtonDown(e)) {
         int col = Math.min((e.getX() - leftMargin + 1) / dx, numCols - 1);
         int row = Math.min((e.getY() - topMargin + 1) / dx, numRows - 1);
         int num = row * numCols + col + 1;

--- a/vassal-app/src/main/java/VASSAL/launch/ModuleManagerWindow.java
+++ b/vassal-app/src/main/java/VASSAL/launch/ModuleManagerWindow.java
@@ -569,7 +569,7 @@ public class ModuleManagerWindow extends JFrame {
     tree.addMouseListener(new MouseAdapter() {
       @Override
       public void mouseClicked(MouseEvent e) {
-        if (e.getClickCount() == 2 && SwingUtils.isVanillaLeftButtonDown(e)) {
+        if (e.getClickCount() == 2 && SwingUtils.isMainMouseButtonDown(e)) {
           final TreePath path =
             tree.getPathForLocation(e.getPoint().x, e.getPoint().y);
 

--- a/vassal-app/src/main/java/VASSAL/launch/ModuleManagerWindow.java
+++ b/vassal-app/src/main/java/VASSAL/launch/ModuleManagerWindow.java
@@ -569,7 +569,7 @@ public class ModuleManagerWindow extends JFrame {
     tree.addMouseListener(new MouseAdapter() {
       @Override
       public void mouseClicked(MouseEvent e) {
-        if (e.getClickCount() == 2 && SwingUtils.isLeftMouseButton(e)) {
+        if (e.getClickCount() == 2 && SwingUtils.isVanillaLeftButtonDown(e)) {
           final TreePath path =
             tree.getPathForLocation(e.getPoint().x, e.getPoint().y);
 

--- a/vassal-app/src/main/java/VASSAL/tools/HotkeySpecifier.java
+++ b/vassal-app/src/main/java/VASSAL/tools/HotkeySpecifier.java
@@ -23,6 +23,8 @@ import java.awt.event.KeyListener;
 import javax.swing.JTextField;
 import javax.swing.KeyStroke;
 
+import VASSAL.tools.swing.SwingUtils;
+
 /**
  * Text component for specifying a hot key
  */
@@ -57,7 +59,7 @@ public class HotkeySpecifier extends JTextField implements KeyListener {
 
   @Override
   public void keyPressed(KeyEvent e) {
-    stroke = KeyStroke.getKeyStrokeForEvent(e);
+    stroke = SwingUtils.getKeyStrokeForEvent(e);
   }
 
   @Override

--- a/vassal-app/src/main/java/VASSAL/tools/KeyStrokeListener.java
+++ b/vassal-app/src/main/java/VASSAL/tools/KeyStrokeListener.java
@@ -53,6 +53,7 @@ public class KeyStrokeListener {
     }
     if (key != null) {
       for (KeyStrokeSource s : sources) {
+        //BR// We are registering/unregistering events directly with components, so we perform our special Mac keyboard translations.
         s.getComponent().unregisterKeyboardAction(SwingUtils.getKeyVassalToSystem(key));
       }
     }
@@ -67,7 +68,8 @@ public class KeyStrokeListener {
   }
 
   public void keyPressed(KeyStroke stroke) {
-    if (stroke != null && stroke.equals(key)) {
+    //BR// We are receiving events directly from components, so we perform our special Mac keyboard translations.
+    if (stroke != null && stroke.equals(SwingUtils.getKeyVassalToSystem(key))) {
       l.actionPerformed(new ActionEvent(this,0,"Direct Invocation"));
     }
   }
@@ -77,6 +79,7 @@ public class KeyStrokeListener {
       sources.add(src);
     }
     if (key != null) {
+      //BR// We are registering with components directly, so we perform our special Mac keyboard translations.
       src.getComponent().registerKeyboardAction(l, SwingUtils.getKeyVassalToSystem(key), src.getMode());
     }
   }

--- a/vassal-app/src/main/java/VASSAL/tools/KeyStrokeListener.java
+++ b/vassal-app/src/main/java/VASSAL/tools/KeyStrokeListener.java
@@ -54,7 +54,7 @@ public class KeyStrokeListener {
     if (key != null) {
       for (KeyStrokeSource s : sources) {
         //BR// We are registering/unregistering events directly with components, so we perform our special Mac keyboard translations.
-        s.getComponent().unregisterKeyboardAction(SwingUtils.getKeyVassalToSystem(key));
+        s.getComponent().unregisterKeyboardAction(SwingUtils.genericToSystem(key));
       }
     }
     key = newKey;
@@ -69,7 +69,7 @@ public class KeyStrokeListener {
 
   public void keyPressed(KeyStroke stroke) {
     //BR// We are receiving events directly from components, so we perform our special Mac keyboard translations.
-    if (stroke != null && stroke.equals(SwingUtils.getKeyVassalToSystem(key))) {
+    if (stroke != null && stroke.equals(SwingUtils.genericToSystem(key))) {
       l.actionPerformed(new ActionEvent(this,0,"Direct Invocation"));
     }
   }
@@ -80,7 +80,7 @@ public class KeyStrokeListener {
     }
     if (key != null) {
       //BR// We are registering with components directly, so we perform our special Mac keyboard translations.
-      src.getComponent().registerKeyboardAction(l, SwingUtils.getKeyVassalToSystem(key), src.getMode());
+      src.getComponent().registerKeyboardAction(l, SwingUtils.genericToSystem(key), src.getMode());
     }
   }
 }

--- a/vassal-app/src/main/java/VASSAL/tools/KeyStrokeListener.java
+++ b/vassal-app/src/main/java/VASSAL/tools/KeyStrokeListener.java
@@ -24,6 +24,8 @@ import java.util.List;
 
 import javax.swing.KeyStroke;
 
+import VASSAL.tools.swing.SwingUtils;
+
 /**
  * Utility class for associating an Action with a keystroke from multiple
  * different component sources
@@ -51,7 +53,7 @@ public class KeyStrokeListener {
     }
     if (key != null) {
       for (KeyStrokeSource s : sources) {
-        s.getComponent().unregisterKeyboardAction(key);
+        s.getComponent().unregisterKeyboardAction(SwingUtils.getKeyVassalToSystem(key));
       }
     }
     key = newKey;
@@ -75,7 +77,7 @@ public class KeyStrokeListener {
       sources.add(src);
     }
     if (key != null) {
-      src.getComponent().registerKeyboardAction(l, key, src.getMode());
+      src.getComponent().registerKeyboardAction(l, SwingUtils.getKeyVassalToSystem(key), src.getMode());
     }
   }
 }

--- a/vassal-app/src/main/java/VASSAL/tools/NamedKeyStroke.java
+++ b/vassal-app/src/main/java/VASSAL/tools/NamedKeyStroke.java
@@ -22,6 +22,8 @@ import java.awt.event.KeyEvent;
 
 import javax.swing.KeyStroke;
 
+import VASSAL.tools.swing.SwingUtils;
+
 /**
  * A NamedKeyStroke is a KeyStroke with a name given by the module developer.
  * An actual KeyStroke is allocated from a pool of KeyStrokes at run-time and
@@ -135,7 +137,7 @@ public class NamedKeyStroke {
   }
 
   public static NamedKeyStroke getKeyStrokeForEvent(KeyEvent e) {
-    return new NamedKeyStroke(KeyStroke.getKeyStrokeForEvent(e));
+    return new NamedKeyStroke(SwingUtils.getKeyStrokeForEvent(e));
   }
 
 }

--- a/vassal-app/src/main/java/VASSAL/tools/SplashScreen.java
+++ b/vassal-app/src/main/java/VASSAL/tools/SplashScreen.java
@@ -49,7 +49,7 @@ public class SplashScreen extends JWindow {
     addMouseListener(new MouseAdapter() {
       @Override
       public void mouseReleased(MouseEvent e) {
-        if (SwingUtils.isLeftMouseButton(e)) {
+        if (SwingUtils.isVanillaLeftButtonDown(e)) {
           setVisible(false);
         }
       }

--- a/vassal-app/src/main/java/VASSAL/tools/SplashScreen.java
+++ b/vassal-app/src/main/java/VASSAL/tools/SplashScreen.java
@@ -49,7 +49,7 @@ public class SplashScreen extends JWindow {
     addMouseListener(new MouseAdapter() {
       @Override
       public void mouseReleased(MouseEvent e) {
-        if (SwingUtils.isVanillaLeftButtonDown(e)) {
+        if (SwingUtils.isMainMouseButtonDown(e)) {
           setVisible(false);
         }
       }

--- a/vassal-app/src/main/java/VASSAL/tools/swing/AboutWindow.java
+++ b/vassal-app/src/main/java/VASSAL/tools/swing/AboutWindow.java
@@ -66,7 +66,7 @@ public class AboutWindow extends JWindow {
     addMouseListener(new MouseAdapter() {
       @Override
       public void mouseReleased(MouseEvent e) {
-        if (SwingUtils.isLeftMouseButton(e)) {
+        if (SwingUtils.isVanillaLeftButtonDown(e)) {
           setVisible(false);
           dispose();
         }

--- a/vassal-app/src/main/java/VASSAL/tools/swing/AboutWindow.java
+++ b/vassal-app/src/main/java/VASSAL/tools/swing/AboutWindow.java
@@ -66,7 +66,7 @@ public class AboutWindow extends JWindow {
     addMouseListener(new MouseAdapter() {
       @Override
       public void mouseReleased(MouseEvent e) {
-        if (SwingUtils.isVanillaLeftButtonDown(e)) {
+        if (SwingUtils.isMainMouseButtonDown(e)) {
           setVisible(false);
           dispose();
         }

--- a/vassal-app/src/main/java/VASSAL/tools/swing/SwingUtils.java
+++ b/vassal-app/src/main/java/VASSAL/tools/swing/SwingUtils.java
@@ -20,6 +20,7 @@ package VASSAL.tools.swing;
 import java.awt.Toolkit;
 import java.awt.dnd.DragGestureEvent;
 import java.awt.event.InputEvent;
+import java.awt.event.KeyEvent;
 import java.awt.event.MouseEvent;
 import java.awt.geom.AffineTransform;
 import java.util.Map;
@@ -96,7 +97,7 @@ public class SwingUtils {
     /*
      * @returns translation of keystroke from Vassal to local system (to handle Mac platform support)
      */
-    KeyStroke getKeyVassalToSystem (KeyStroke k);
+    KeyStroke getKeyVassalToSystem (KeyStroke k);    
   }
 
   
@@ -131,15 +132,44 @@ public class SwingUtils {
       return e.isControlDown();
     }
     
+    //@Override
+    //public KeyStroke getKeySystemToVassal (KeyStroke k) {
+    //  return k;
+    //}
+    
+    //@Override
+    //public KeyStroke getKeyVassalToSystem (KeyStroke k) {
+    //  return k;
+    //}
+    
+    
     @Override
     public KeyStroke getKeySystemToVassal (KeyStroke k) {
-      return k;
+      int modifiers = k.getModifiers();
+      if ((modifiers & InputEvent.ALT_DOWN_MASK) != 0) {
+        modifiers &= ~(InputEvent.ALT_DOWN_MASK | InputEvent.ALT_MASK);
+        modifiers |= InputEvent.CTRL_DOWN_MASK;
+        KeyStroke k2 = KeyStroke.getKeyStroke(k.getKeyCode(), modifiers); 
+        return k2; 
+      } 
+      else {
+        return k; 
+      }      
     }
     
     @Override
     public KeyStroke getKeyVassalToSystem (KeyStroke k) {
-      return k;
-    }
+      int modifiers = k.getModifiers();
+      if ((modifiers & InputEvent.CTRL_DOWN_MASK) != 0) {
+        modifiers &= ~(InputEvent.CTRL_DOWN_MASK | InputEvent.CTRL_MASK);
+        modifiers |= InputEvent.ALT_DOWN_MASK;
+        KeyStroke k2 = KeyStroke.getKeyStroke(k.getKeyCode(), modifiers); 
+        return k2; 
+      } 
+      else {
+        return k; 
+      }      
+    }    
   }
 
   
@@ -336,8 +366,23 @@ public class SwingUtils {
   public static KeyStroke getKeyVassalToSystem(KeyStroke k) {
     return INPUT_CLASSIFIER.getKeyVassalToSystem(k);
   }
-
   
+  
+  
+  /**
+   * @returns translation of KeyEvent (local system) to Vassal (to handle Mac platform support)
+   * 
+   * The main idea here is that on Macs we want the common shortcut keys represented by e.g. Ctrl+C on 
+   * Windows and Linux platforms to be represented by Command+C on the Mac, and likewise when module
+   * designers on Mac implement a Command+C shortcut we want that to appear as Ctrl+C for the same module
+   * running on other platforms. But we also support a "legacy" preference to allow Mac users used to 
+   * Vassal 3.2.17 and prior mappings to continue with them.
+   */
+  public static KeyStroke getKeyStrokeForEvent (KeyEvent e) {
+    return getKeySystemToVassal(KeyStroke.getKeyStrokeForEvent(e));
+  }
+
+
 
   /**
    * @return whether the drag is non-mouse or effectively from the left button

--- a/vassal-app/src/main/java/VASSAL/tools/swing/SwingUtils.java
+++ b/vassal-app/src/main/java/VASSAL/tools/swing/SwingUtils.java
@@ -244,7 +244,7 @@ public class SwingUtils {
       else if ((modifiers & InputEvent.CTRL_DOWN_MASK) != 0) {
         // Don't let Vassal recognize the Mac "Control" key as a "Ctrl" keystroke for keyboard commands. Because that would be bad-app-behavior, naughty naughty.
         modifiers &= ~(InputEvent.CTRL_DOWN_MASK | InputEvent.CTRL_MASK);
-        return KeyStroke.getKeyStroke(k.getKeyCode(), modifiers);
+        return KeyStroke.getKeyStroke(k.getKeyCode(), modifiers, k.isOnKeyRelease());
       }
       else {
         return k; 
@@ -263,7 +263,7 @@ public class SwingUtils {
         // We must also remove the deprecated CTRL_MASK, or Java will end up restoring the CTRL_DOWN_MASK
         modifiers &= ~(InputEvent.CTRL_DOWN_MASK | InputEvent.CTRL_MASK);
         modifiers |= InputEvent.META_DOWN_MASK;
-        return KeyStroke.getKeyStroke(k.getKeyCode(), modifiers);
+        return KeyStroke.getKeyStroke(k.getKeyCode(), modifiers, k.isOnKeyRelease());
       } 
       else {
         return k; 

--- a/vassal-app/src/main/java/VASSAL/tools/swing/SwingUtils.java
+++ b/vassal-app/src/main/java/VASSAL/tools/swing/SwingUtils.java
@@ -77,12 +77,12 @@ public class SwingUtils {
     /**
      * @returns translation of keystroke from local system to Vassal (to handle Mac platform support)
      */
-    KeyStroke getKeySystemToVassal (KeyStroke k);
+    KeyStroke systemToGeneric (KeyStroke k);
     
     /**
      * @returns translation of keystroke from Vassal to local system (to handle Mac platform support)
      */
-    KeyStroke getKeyVassalToSystem (KeyStroke k);    
+    KeyStroke genericToSystem (KeyStroke k);    
   }
 
   
@@ -106,12 +106,12 @@ public class SwingUtils {
     }
     
     @Override
-    public KeyStroke getKeySystemToVassal (KeyStroke k) {
+    public KeyStroke systemToGeneric (KeyStroke k) {
       return k;
     }
     
     @Override
-    public KeyStroke getKeyVassalToSystem (KeyStroke k) {
+    public KeyStroke genericToSystem (KeyStroke k) {
       return k;
     }
   }
@@ -200,7 +200,7 @@ public class SwingUtils {
      */
     @Override
     @SuppressWarnings("deprecation")
-    public KeyStroke getKeySystemToVassal (KeyStroke k) {
+    public KeyStroke systemToGeneric (KeyStroke k) {
       if (macLegacy) {
         return k;
       }
@@ -234,7 +234,7 @@ public class SwingUtils {
      */
     @Override
     @SuppressWarnings("deprecation")
-    public KeyStroke getKeyVassalToSystem (KeyStroke k) {
+    public KeyStroke genericToSystem (KeyStroke k) {
       if (macLegacy) {
         return k;
       }
@@ -314,8 +314,8 @@ public class SwingUtils {
    * running on other platforms. But we also support a "legacy" preference to allow Mac users used to 
    * Vassal 3.2.17 and prior mappings to continue with them.
    */
-  public static KeyStroke getKeySystemToVassal(KeyStroke k) {
-    return INPUT_CLASSIFIER.getKeySystemToVassal(k);
+  public static KeyStroke systemToGeneric(KeyStroke k) {
+    return INPUT_CLASSIFIER.systemToGeneric(k);
   }  
 
   /**
@@ -327,8 +327,8 @@ public class SwingUtils {
    * running on other platforms. But we also support a "legacy" preference to allow Mac users used to 
    * Vassal 3.2.17 and prior mappings to continue with them.
    */
-  public static KeyStroke getKeyVassalToSystem(KeyStroke k) {
-    return INPUT_CLASSIFIER.getKeyVassalToSystem(k);
+  public static KeyStroke genericToSystem(KeyStroke k) {
+    return INPUT_CLASSIFIER.genericToSystem(k);
   }    
   
   /**
@@ -341,7 +341,7 @@ public class SwingUtils {
    * Vassal 3.2.17 and prior mappings to continue with them.
    */
   public static KeyStroke getKeyStrokeForEvent (KeyEvent e) {
-    return getKeySystemToVassal(KeyStroke.getKeyStrokeForEvent(e));
+    return systemToGeneric(KeyStroke.getKeyStrokeForEvent(e));
   }
 
   /**

--- a/vassal-app/src/main/java/VASSAL/tools/swing/SwingUtils.java
+++ b/vassal-app/src/main/java/VASSAL/tools/swing/SwingUtils.java
@@ -101,34 +101,42 @@ public class SwingUtils {
 
   
   private static class DefaultInputClassifier implements InputClassifier {
+    @Override
     public boolean isLeftMouseButton(MouseEvent e) {
       return SwingUtilities.isLeftMouseButton(e);
     }
 
+    @Override
     public boolean isRightMouseButton(MouseEvent e) {
       return SwingUtilities.isRightMouseButton(e);
     }
 
+    @Override
     public boolean isControlDown(MouseEvent e) {
       return e.isControlDown();
     }
     
+    @Override
     public boolean isContextMouseButtonDown(MouseEvent e) {
       return SwingUtilities.isRightMouseButton(e);  
     }
         
+    @Override
     public boolean isVanillaLeftButtonDown(MouseEvent e) {
       return SwingUtilities.isLeftMouseButton(e);
     }
     
+    @Override
     public boolean isSelectionToggle(MouseEvent e) {
       return e.isControlDown();
     }
     
+    @Override
     public boolean isShortcutKeyDown(MouseEvent e) {
       return e.isControlDown(); 
     }
     
+    @Override
     public int getShortcutKey() {
       return InputEvent.CTRL_DOWN_MASK;
     }           
@@ -140,16 +148,19 @@ public class SwingUtils {
                                        MouseEvent.CTRL_DOWN_MASK;
 
     @Deprecated
+    @Override
     public boolean isLeftMouseButton(MouseEvent e) {
       return isVanillaLeftButtonDown(e);
     }
 
     @Deprecated
+    @Override
     public boolean isRightMouseButton(MouseEvent e) {
       return isContextMouseButtonDown(e);
     }
 
     @Deprecated
+    @Override
     public boolean isControlDown(MouseEvent e) {
       // The Command key on a Mac corresponds to Control everywhere else,
       // but it obviously can't be called "Command" in Java; here it's
@@ -157,7 +168,7 @@ public class SwingUtils {
       return e.isMetaDown();
     }
         
-    
+    @Override
     public boolean isContextMouseButtonDown(MouseEvent e) {
       // A "right click" on a Mac can be either a real right button, or
       // Ctrl + the left button (or Command + left button in legacy)
@@ -184,6 +195,7 @@ public class SwingUtils {
       }                 
     }
     
+    @Override
     public boolean isVanillaLeftButtonDown(MouseEvent e) {
       // The left button on a Mac is the left button, except when it's the
       // right button because Ctrl is depressed.
@@ -206,15 +218,17 @@ public class SwingUtils {
       }      
     }
     
-    
+    @Override
     public boolean isSelectionToggle(MouseEvent e) {
       return macLegacy ? e.isControlDown() : e.isMetaDown();       
     }
     
+    @Override
     public boolean isShortcutKeyDown(MouseEvent e) {
       return macLegacy ? e.isControlDown() : e.isMetaDown(); 
     }
     
+    @Override
     public int getShortcutKey() {
       return macLegacy ? InputEvent.META_DOWN_MASK : InputEvent.CTRL_DOWN_MASK;
     }       

--- a/vassal-app/src/main/java/VASSAL/tools/swing/SwingUtils.java
+++ b/vassal-app/src/main/java/VASSAL/tools/swing/SwingUtils.java
@@ -20,6 +20,7 @@ package VASSAL.tools.swing;
 import java.awt.Toolkit;
 import java.awt.dnd.DragGestureEvent;
 import java.awt.event.InputEvent;
+import java.awt.event.KeyEvent;
 import java.awt.event.MouseEvent;
 import java.awt.geom.AffineTransform;
 import java.util.Map;
@@ -29,6 +30,23 @@ import javax.swing.SwingUtilities;
 import org.apache.commons.lang3.SystemUtils;
 
 public class SwingUtils {
+  
+  private static boolean macLegacy;
+    
+  /**
+   * Supports swapping most Control and Command button functions on Mac so as not to punish long-time users for our "old non-standard implementations"
+   */
+  public static boolean isMacLegacy() {
+    return macLegacy;
+  }
+  
+  /**
+   * Supports swapping most Control and Command button functions on Mac so as not to punish long-time users for our "old non-standard implementations"
+   */
+  public static void setMacLegacy(boolean b) {
+    macLegacy = b;
+  }
+  
   public static AffineTransform descaleTransform(AffineTransform t) {
     return new AffineTransform(
       1.0, 0.0,
@@ -53,9 +71,35 @@ public class SwingUtils {
     /*
      * @return whether the event effectively has Control down
      */
-    boolean isControlDown(MouseEvent e);
+    boolean isControlDown(MouseEvent e);    
+
+    /*
+     * @return whether this is key/mouse combo that brings up context menus on our platform (whether or not it brings them up right this moment)
+     */
+    boolean isContextMouseButtonDown(MouseEvent e);
+        
+    /*
+     * @return whether this the key/mouse combo for clicking on things to select them. (normally just plain old Left Mouse Button - but on Mac only when not pretending to be right button)
+     */
+    boolean isVanillaLeftButtonDown(MouseEvent e);
+    
+    /*
+     * @return whether this is key/mouse combo that toggles items in and out of selections on our platform (e.g. Ctrl+LeftClick on non-Mac)
+     */
+    boolean isSelectionToggle(MouseEvent e);
+    
+    /*
+     * @return whether key that activates primary shortcut keys is down (e.g. Ctrl on most platforms, Command on Mac) 
+     */
+    boolean isShortcutKeyDown(MouseEvent e);
+        
+    /*
+     * @returns key that activates primary shortcut keys for our platform (e.g. Ctrl on most platforms, Command on Mac)
+     */
+    int getShortcutKey();
   }
 
+  
   private static class DefaultInputClassifier implements InputClassifier {
     public boolean isLeftMouseButton(MouseEvent e) {
       return SwingUtilities.isLeftMouseButton(e);
@@ -68,44 +112,62 @@ public class SwingUtils {
     public boolean isControlDown(MouseEvent e) {
       return e.isControlDown();
     }
+    
+    public boolean isContextMouseButtonDown(MouseEvent e) {
+      return SwingUtilities.isRightMouseButton(e);  
+    }
+        
+    public boolean isVanillaLeftButtonDown(MouseEvent e) {
+      return SwingUtilities.isLeftMouseButton(e);
+    }
+    
+    public boolean isSelectionToggle(MouseEvent e) {
+      return e.isControlDown();
+    }
+    
+    public boolean isShortcutKeyDown(MouseEvent e) {
+      return e.isControlDown(); 
+    }
+    
+    public int getShortcutKey() {
+      return InputEvent.CTRL_DOWN_MASK;
+    }           
   }
 
+  
   private static class MacInputClassifier implements InputClassifier {
     private static final int B1_MASK = MouseEvent.BUTTON1_DOWN_MASK |
                                        MouseEvent.CTRL_DOWN_MASK;
 
+    @Deprecated
     public boolean isLeftMouseButton(MouseEvent e) {
-      // The left button on a Mac is the left button, except when it's the
-      // right button because Ctrl is depressed.
-      switch (e.getID()) {
-      case MouseEvent.MOUSE_PRESSED:
-      case MouseEvent.MOUSE_RELEASED:
-      case MouseEvent.MOUSE_CLICKED:
-        return e.getButton() == MouseEvent.BUTTON1 &&
-               (e.getModifiersEx() & MouseEvent.CTRL_DOWN_MASK) == 0;
-
-      case MouseEvent.MOUSE_ENTERED:
-      case MouseEvent.MOUSE_EXITED:
-      case MouseEvent.MOUSE_DRAGGED:
-        return (e.getModifiersEx() & B1_MASK) == MouseEvent.BUTTON1_DOWN_MASK;
-
-      default:
-        return (e.getModifiersEx() & B1_MASK) == MouseEvent.BUTTON1_DOWN_MASK ||
-               (e.getButton() == MouseEvent.BUTTON1 &&
-                (e.getModifiersEx() & MouseEvent.CTRL_DOWN_MASK) == 0);
-      }
+      return isVanillaLeftButtonDown(e);
     }
 
+    @Deprecated
     public boolean isRightMouseButton(MouseEvent e) {
-      // The right button on a Mac can be either a real right button, or
-      // Ctrl + the left button.
+      return isContextMouseButtonDown(e);
+    }
+
+    @Deprecated
+    public boolean isControlDown(MouseEvent e) {
+      // The Command key on a Mac corresponds to Control everywhere else,
+      // but it obviously can't be called "Command" in Java; here it's
+      // called "Meta".
+      return e.isMetaDown();
+    }
+        
+    
+    public boolean isContextMouseButtonDown(MouseEvent e) {
+      // A "right click" on a Mac can be either a real right button, or
+      // Ctrl + the left button (or Command + left button in legacy)
       switch (e.getID()) {
       case MouseEvent.MOUSE_PRESSED:
       case MouseEvent.MOUSE_RELEASED:
       case MouseEvent.MOUSE_CLICKED:
         return e.getButton() == MouseEvent.BUTTON3 ||
                (e.getButton() == MouseEvent.BUTTON1 &&
-                (e.getModifiersEx() & MouseEvent.CTRL_DOWN_MASK) != 0);
+                (e.getModifiersEx() & (macLegacy ? MouseEvent.META_DOWN_MASK : MouseEvent.CTRL_DOWN_MASK)) != 0);
 
       case MouseEvent.MOUSE_ENTERED:
       case MouseEvent.MOUSE_EXITED:
@@ -118,50 +180,121 @@ public class SwingUtils {
                (e.getModifiersEx() & B1_MASK) == B1_MASK ||
                e.getButton() == MouseEvent.BUTTON3 ||
                (e.getButton() == MouseEvent.BUTTON1 &&
-               (e.getModifiersEx() & MouseEvent.CTRL_DOWN_MASK) != 0);
-      }
+               (e.getModifiersEx() & (macLegacy ? MouseEvent.META_DOWN_MASK : MouseEvent.CTRL_DOWN_MASK)) != 0);
+      }                 
     }
+    
+    public boolean isVanillaLeftButtonDown(MouseEvent e) {
+      // The left button on a Mac is the left button, except when it's the
+      // right button because Ctrl is depressed.
+      switch (e.getID()) {
+      case MouseEvent.MOUSE_PRESSED:
+      case MouseEvent.MOUSE_RELEASED:
+      case MouseEvent.MOUSE_CLICKED:
+        return e.getButton() == MouseEvent.BUTTON1 &&
+               (e.getModifiersEx() & (macLegacy ? MouseEvent.META_DOWN_MASK : MouseEvent.CTRL_DOWN_MASK)) == 0;
 
-    public boolean isControlDown(MouseEvent e) {
-      // The Command key on a Mac corresponds to Control everywhere else,
-      // but it obviously can't be called "Command" in Java; here it's
-      // called "Meta".
-      return e.isMetaDown();
+      case MouseEvent.MOUSE_ENTERED:
+      case MouseEvent.MOUSE_EXITED:
+      case MouseEvent.MOUSE_DRAGGED:
+        return (e.getModifiersEx() & B1_MASK) == MouseEvent.BUTTON1_DOWN_MASK;
+
+      default:
+        return (e.getModifiersEx() & B1_MASK) == MouseEvent.BUTTON1_DOWN_MASK ||
+               (e.getButton() == MouseEvent.BUTTON1 &&
+                (e.getModifiersEx() & (macLegacy ? MouseEvent.META_DOWN_MASK : MouseEvent.CTRL_DOWN_MASK)) == 0);
+      }      
     }
+    
+    
+    public boolean isSelectionToggle(MouseEvent e) {
+      return macLegacy ? e.isControlDown() : e.isMetaDown();       
+    }
+    
+    public boolean isShortcutKeyDown(MouseEvent e) {
+      return macLegacy ? e.isControlDown() : e.isMetaDown(); 
+    }
+    
+    public int getShortcutKey() {
+      return macLegacy ? InputEvent.META_DOWN_MASK : InputEvent.CTRL_DOWN_MASK;
+    }       
   }
 
   private static final InputClassifier INPUT_CLASSIFIER =
     SystemUtils.IS_OS_MAC_OSX ?
       new MacInputClassifier() : new DefaultInputClassifier();
 
-  /*
+  /**
    * @return whether the event is effectively for the left button
    */
+  @Deprecated      
   public static boolean isLeftMouseButton(MouseEvent e) {
     return INPUT_CLASSIFIER.isLeftMouseButton(e);
   }
 
-  /*
+  /**
    * @return whether the event is effectively for the right button
    */
+  @Deprecated
   public static boolean isRightMouseButton(MouseEvent e) {
     return INPUT_CLASSIFIER.isRightMouseButton(e);
   }
 
-  /*
+  /**
    * @return whether the event effectively has Control down
    */
+  @Deprecated
   public static boolean isControlDown(MouseEvent e) {
     return INPUT_CLASSIFIER.isControlDown(e);
   }
+  
+  
+  /**
+   * @return whether the event has the key/mouse combo for Context Menu active, whether it would raise one "right now" or not. (normally plain right mouse button, but some funky mac bonuses)
+   */
+  public static boolean isContextMouseButtonDown(MouseEvent e) {
+    return INPUT_CLASSIFIER.isContextMouseButtonDown(e);
+  }
+  
+    
+  /**
+   * @return whether the event has the key/mouse combo for selecting things down (normally just plain left mouse button, but on Mac only if not pretending to be right button)
+   */
+  public static boolean isVanillaLeftButtonDown(MouseEvent e) {
+    return INPUT_CLASSIFIER.isVanillaLeftButtonDown(e);
+  }
 
-  /*
+  
+  /**
+   * @return whether the event has the key/mouse combo toggling targets in and out of selection (normally Ctrl+Click on most platforms, normally Command+Click on Mac)
+   */  
+  public static boolean isSelectionToggle(MouseEvent e) {
+    return INPUT_CLASSIFIER.isSelectionToggle(e);
+  }
+  
+  
+  /**
+   * @return whether the event has the primary shortcut key for this platform down (normally Ctrl for most platforms, normally Command on Mac)
+   */  
+  public static boolean isShortcutKeyDown(MouseEvent e) {
+    return INPUT_CLASSIFIER.isShortcutKeyDown(e);
+  }
+  
+  /**
+   * @return return the primary shortcut key for this platform (normally Ctrl for most platforms, normally Command aka "Meta" for Mac)
+   */  
+  public static int getShortcutKey() {
+    return INPUT_CLASSIFIER.getShortcutKey();
+  }
+  
+
+  /**
    * @return whether the drag is non-mouse or effectively from the left button
    */
   public static boolean isDragTrigger(DragGestureEvent e) {
     // NB: Will any non-mouse drags happen? Not sure, but as we never checked
     // for them before, this won't change behavior by excluding them.
     final InputEvent te = e.getTriggerEvent();
-    return !(te instanceof MouseEvent) || isLeftMouseButton((MouseEvent) te);
+    return !(te instanceof MouseEvent) || isVanillaLeftButtonDown((MouseEvent) te);
   }
 }

--- a/vassal-app/src/main/java/VASSAL/tools/swing/SwingUtils.java
+++ b/vassal-app/src/main/java/VASSAL/tools/swing/SwingUtils.java
@@ -239,7 +239,7 @@ public class SwingUtils {
         // We must also remove the deprecated META_MASK, or Java will end up restoring the META_DOWN_MASK.
         modifiers &= ~(InputEvent.META_DOWN_MASK | InputEvent.META_MASK);
         modifiers |= InputEvent.CTRL_DOWN_MASK;
-        return KeyStroke.getKeyStroke(k.getKeyCode(), modifiers);
+        return KeyStroke.getKeyStroke(k.getKeyCode(), modifiers, k.isOnKeyRelease());
       }
       else if ((modifiers & InputEvent.CTRL_DOWN_MASK) != 0) {
         // Don't let Vassal recognize the Mac "Control" key as a "Ctrl" keystroke for keyboard commands. Because that would be bad-app-behavior, naughty naughty.

--- a/vassal-app/src/main/java/VASSAL/tools/swing/SwingUtils.java
+++ b/vassal-app/src/main/java/VASSAL/tools/swing/SwingUtils.java
@@ -67,7 +67,7 @@ public class SwingUtils {
     /**
      * @return whether this the key/mouse combo for clicking on things to select them. (Left click, except on Macs when left click has a modifier that makes it pretend to be right click)
      */
-    boolean isVanillaLeftButtonDown(MouseEvent e);
+    boolean isMainMouseButtonDown(MouseEvent e);
     
     /**
      * @return whether this is key/mouse combo that toggles items in and out of selections on our platform (e.g. Ctrl+LeftClick on non-Mac, and usually Command+LeftClick on Mac)
@@ -96,7 +96,7 @@ public class SwingUtils {
     }
         
     @Override
-    public boolean isVanillaLeftButtonDown(MouseEvent e) {
+    public boolean isMainMouseButtonDown(MouseEvent e) {
       return SwingUtilities.isLeftMouseButton(e);
     }
     
@@ -159,7 +159,7 @@ public class SwingUtils {
      * (Control+Click for proper Mac interface, Command+Click for legacy Vassal interface) is present.
      */
     @Override
-    public boolean isVanillaLeftButtonDown(MouseEvent e) {
+    public boolean isMainMouseButtonDown(MouseEvent e) {
       switch (e.getID()) {
       case MouseEvent.MOUSE_PRESSED:
       case MouseEvent.MOUSE_RELEASED:
@@ -257,11 +257,11 @@ public class SwingUtils {
   /**
    * @return whether the event is effectively for the left button. 
    * 
-   * @Deprecated in favor of {@link #isVanillaLeftButtonDown(MouseEvent)}
+   * @Deprecated in favor of {@link #isMainMouseButtonDown(MouseEvent)}
    */
   @Deprecated      
   public static boolean isLeftMouseButton(MouseEvent e) {
-    return INPUT_CLASSIFIER.isVanillaLeftButtonDown(e);
+    return INPUT_CLASSIFIER.isMainMouseButtonDown(e);
   }
 
   /**
@@ -294,8 +294,8 @@ public class SwingUtils {
   /**
    * @return whether the event has the key/mouse combo for selecting things down (normally just plain left mouse button, but on Mac only if not pretending to be right button)
    */
-  public static boolean isVanillaLeftButtonDown(MouseEvent e) {
-    return INPUT_CLASSIFIER.isVanillaLeftButtonDown(e);
+  public static boolean isMainMouseButtonDown(MouseEvent e) {
+    return INPUT_CLASSIFIER.isMainMouseButtonDown(e);
   }
   
   /**
@@ -351,6 +351,6 @@ public class SwingUtils {
     // NB: Will any non-mouse drags happen? Not sure, but as we never checked
     // for them before, this won't change behavior by excluding them.
     final InputEvent te = e.getTriggerEvent();
-    return !(te instanceof MouseEvent) || isVanillaLeftButtonDown((MouseEvent) te);
+    return !(te instanceof MouseEvent) || isMainMouseButtonDown((MouseEvent) te);
   }
 }

--- a/vassal-app/src/main/resources/VASSAL/i18n/VASSAL.properties
+++ b/vassal-app/src/main/resources/VASSAL/i18n/VASSAL.properties
@@ -463,14 +463,16 @@ General.exit=Exit
 General.run=Run
 
 # Hotkeys
-Keys.alt=ALT
-Keys.shift=SHIFT
-Keys.ctrl=CTRL
-Keys.meta=COMMAND
-Keys.numplus=NumPad+Plus
-Keys.numminus=NumPad-Minus
+Keys.alt=Alt
+Keys.shift=Shift
+Keys.ctrl=Ctrl
+Keys.meta=Cmd
+Keys.numplus=Num+Plus
+Keys.numminus=Num-Minus
 Keys.pgup=PgUp
 Keys.pgdn=PgDn
+Keys.bropen=[
+Keys.brclose=]
 
 # GlobalOptions
 GlobalOptions.use_combined=Use combined application window (requires restart)?

--- a/vassal-app/src/main/resources/VASSAL/i18n/VASSAL.properties
+++ b/vassal-app/src/main/resources/VASSAL/i18n/VASSAL.properties
@@ -478,6 +478,7 @@ GlobalOptions.maximum_heap=JVM maximum heap (in MB):
 GlobalOptions.bug10295=Drag ghost bug correction?
 GlobalOptions.classic_mfd=Use Classic Move Fixed Distance trait move batching?
 GlobalOptions.mouse_drag_threshold=Mouse Drag Threshold
+GlobalOptions.mac_legacy=Use Legacy Mac mouse mappings (Control for shortcuts and selection toggle, Command for context menu)
 
 # Help Window
 Help.error_log=Show Error Log

--- a/vassal-app/src/main/resources/VASSAL/i18n/VASSAL.properties
+++ b/vassal-app/src/main/resources/VASSAL/i18n/VASSAL.properties
@@ -466,7 +466,11 @@ General.run=Run
 Keys.alt=ALT
 Keys.shift=SHIFT
 Keys.ctrl=CTRL
-Keys.meta=META
+Keys.meta=COMMAND
+Keys.numplus=NumPad+Plus
+Keys.numminus=NumPad-Minus
+Keys.pgup=PgUp
+Keys.pgdn=PgDn
 
 # GlobalOptions
 GlobalOptions.use_combined=Use combined application window (requires restart)?

--- a/vassal-app/src/test/java/VASSAL/tools/swing/AbstractSwingUtilsTestIsMouseButton.java
+++ b/vassal-app/src/test/java/VASSAL/tools/swing/AbstractSwingUtilsTestIsMouseButton.java
@@ -43,7 +43,7 @@ public abstract class AbstractSwingUtilsTestIsMouseButton {
     when(mouseEvent.getModifiersEx()).thenReturn(mouseEventParams[2]);
 
     // run
-    final boolean result = SwingUtils.isLeftMouseButton(mouseEvent);
+    final boolean result = SwingUtils.isVanillaLeftButtonDown(mouseEvent);
 
     // assert
     assertThat(result, is(expectedResult[0]));
@@ -58,7 +58,7 @@ public abstract class AbstractSwingUtilsTestIsMouseButton {
     when(mouseEvent.getModifiersEx()).thenReturn(mouseEventParams[2]);
 
     // run
-    final boolean result = SwingUtils.isRightMouseButton(mouseEvent);
+    final boolean result = SwingUtils.isContextMouseButtonDown(mouseEvent);
 
     // assert
     assertThat(result, is(expectedResult[1]));

--- a/vassal-app/src/test/java/VASSAL/tools/swing/AbstractSwingUtilsTestIsMouseButton.java
+++ b/vassal-app/src/test/java/VASSAL/tools/swing/AbstractSwingUtilsTestIsMouseButton.java
@@ -43,7 +43,7 @@ public abstract class AbstractSwingUtilsTestIsMouseButton {
     when(mouseEvent.getModifiersEx()).thenReturn(mouseEventParams[2]);
 
     // run
-    final boolean result = SwingUtils.isVanillaLeftButtonDown(mouseEvent);
+    final boolean result = SwingUtils.isMainMouseButtonDown(mouseEvent);
 
     // assert
     assertThat(result, is(expectedResult[0]));


### PR DESCRIPTION
**STAGE 1** - This should clean up the rest of the Mac Mouse bullshit and add the legacy preference. Keyboard shortcuts will be more of a bear.

Rather than have methods named e.g. "isRightMouse" but they lie to us and screw with our heads when we deal with Macs (wait, does "Control" mean "Control" right now, or does "Control" mean "Command"?), I have created names that hopefully are both understandable when read by a non-initiate but also "different enough" to remind us they have special meaning (and let us keep things straight in our heads when dealing with Macs).
**SwingUtils.isVanillaLeftButtonDown()** -- is left mouse button down ("except on Mac when it's pretending to be right mouse")
**SwingUtils.isContextMouseButtonDown()** -- is right button down (OR on Mac is left button pretending to be right button)
**SwingUtils.isSelectionToggle()** -- normally "Ctrl+LeftClick" on non-Macs. Other things on Macs, depending on "stuff".

**STAGE 2** - Module KeyStroke's translated back and forth from "Command" to "Control" at the appropriate places. 
**SwingUtils.getKeySystemToVassal()** - Translate's Mac's platform-specific Command key into "Ctrl" for storing-in-module purposes
**SwingUtils.getKeyVassalToSystem()** - Translate's Vassal-stored keystrokes from "Ctrl" into Command key if we're on a Mac for checking-for-actual-keystroke purposes.
* if **macLegacy** preference is in effect, then this is all just a pass-through.
