### PR TITLE
Bug 13205: Upgrade miglayout-swing to 5.2

### DIFF
--- a/vassal-app/pom.xml
+++ b/vassal-app/pom.xml
@@ -31,7 +31,7 @@
 		<dependency>
 			<groupId>com.miglayout</groupId>
 			<artifactId>miglayout-swing</artifactId>
-			<version>4.2</version>
+			<version>5.2</version>
 		</dependency>
 		<dependency>
 			<groupId>javazoom</groupId>


### PR DESCRIPTION
Upgraded miglayout-swing to 5.2. This recovers the patch I contributed o 4.2 which we lost when we switched to maven and picked up an unpatched 4.2 JAR. Fixes Bug 13205.