### PR TITLE
Increase checkstyle strictness

### DIFF
--- a/vassal-app/src/test/resources/checkstyle-checks.xml
+++ b/vassal-app/src/test/resources/checkstyle-checks.xml
@@ -77,7 +77,7 @@
             <property name="tokens" value="PACKAGE_DEF, IMPORT, STATIC_IMPORT"/>
         </module>
         <module name="EmptyBlock">
-            <property name="severity" value="warning"/>
+            <property name="severity" value="error"/>
             <property name="option" value="TEXT"/>
             <property name="tokens"
              value="LITERAL_TRY, LITERAL_FINALLY, LITERAL_IF, LITERAL_ELSE, LITERAL_SWITCH"/>
@@ -89,7 +89,7 @@
         </module>
         -->
         <module name="LeftCurly">
-            <property name="severity" value="warning"/>
+            <property name="severity" value="error"/>
             <property name="tokens"
              value="ANNOTATION_DEF, CLASS_DEF, CTOR_DEF, ENUM_CONSTANT_DEF, ENUM_DEF,
                     INTERFACE_DEF, LAMBDA, LITERAL_CASE, LITERAL_CATCH, LITERAL_DEFAULT,
@@ -97,14 +97,12 @@
                     LITERAL_SWITCH, LITERAL_SYNCHRONIZED, LITERAL_TRY, LITERAL_WHILE, METHOD_DEF,
                     OBJBLOCK, STATIC_INIT"/>
         </module>
-        <!--
         <module name="RightCurly">
+            <property name="severity" value="error"/>
             <property name="id" value="RightCurlySame"/>
             <property name="tokens"
-             value="LITERAL_TRY, LITERAL_CATCH, LITERAL_FINALLY, LITERAL_IF, LITERAL_ELSE,
-                    LITERAL_DO"/>
+             value="LITERAL_DO"/>
         </module>
-        -->
         <module name="RightCurly">
             <property name="severity" value="error"/>
             <property name="id" value="RightCurlyAlone"/>
@@ -122,12 +120,13 @@
           <property name="query" value="//RCURLY[parent::SLIST[count(./*)=1]
                                                  or preceding-sibling::*[last()][self::LCURLY]]"/>
         </module>
-        <!--
         <module name="WhitespaceAfter">
+            <property name="severity" value="warning"/>
             <property name="tokens"
              value="COMMA, SEMI, TYPECAST, LITERAL_IF, LITERAL_ELSE,
                     LITERAL_WHILE, LITERAL_DO, LITERAL_FOR, DO_WHILE"/>
         </module>
+        <!--
         <module name="WhitespaceAround">
             <property name="allowEmptyConstructors" value="true"/>
             <property name="allowEmptyLambdas" value="true"/>
@@ -163,7 +162,7 @@
             <property name="severity" value="error"/>
         </module>
         <module name="ModifierOrder">
-            <property name="severity" value="warning"/>
+            <property name="severity" value="error"/>
         </module>
         <!--
         <module name="EmptyLineSeparator">
@@ -174,13 +173,13 @@
         </module>
         -->
         <module name="SeparatorWrap">
-            <property name="severity" value="warning"/>
+            <property name="severity" value="error"/>
             <property name="id" value="SeparatorWrapDot"/>
             <property name="tokens" value="DOT"/>
             <property name="option" value="nl"/>
         </module>
         <module name="SeparatorWrap">
-            <property name="severity" value="warning"/>
+            <property name="severity" value="error"/>
             <property name="id" value="SeparatorWrapComma"/>
             <property name="tokens" value="COMMA"/>
             <property name="option" value="EOL"/>
@@ -266,7 +265,7 @@
             <property name="severity" value="warning"/>
         </module>
         <module name="GenericWhitespace">
-            <property name="severity" value="warning"/>
+            <property name="severity" value="error"/>
             <message key="ws.followed"
              value="GenericWhitespace ''{0}'' is followed by whitespace."/>
             <message key="ws.preceded"


### PR DESCRIPTION
This change the severity level of all previously removed checkstyle violations from `warning` to `error`, except the one violation of the "no finalize()" rule.

And activates the next set of violations on the `warning` level, after this having no whitespace after `,`, `;`, `typecast`, `if`, `else`, `while`, `do`, `for` and the `do while` will be reported.