### PR TITLE
Configure travis to run only one maven build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: java
 jdk: openjdk11
 
+install: true
+script: ./mvnw clean test -B
+
 cache:
   directories:
     - $HOME/.m2


### PR DESCRIPTION
Travis originates from the Ruby world and due to this history runs Maven twice in the default setting:
`./mvnw install -DskipTests=true -Dmaven.javadoc.skip=true -B -V`
`./mvnw test -B`

After this commit it will run Maven only once using `./mvnw clean test -B`.