### PR TITLE
13218 - Inform a piece "that wants to know" where the context menu click was

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/module/map/MenuDisplayer.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/MenuDisplayer.java
@@ -37,7 +37,10 @@ import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
 import VASSAL.build.Buildable;
+import VASSAL.build.GameModule;
 import VASSAL.build.module.Map;
+import VASSAL.command.ChangeTracker;
+import VASSAL.command.Command;
 import VASSAL.counters.Deck;
 import VASSAL.counters.EventFilter;
 import VASSAL.counters.GamePiece;
@@ -267,6 +270,16 @@ public class MenuDisplayer extends MouseAdapter implements Buildable {
 
     // It is possible for the map to close before the menu is displayed
     if (map.getView().isShowing()) {
+      
+      // Inform the piece where player clicked, if it wants to know.  
+      final ChangeTracker ch = new ChangeTracker(p);
+      p.setProperty("ClickedX", e.getPoint().x);
+      p.setProperty("ClickedY", e.getPoint().y);
+      Command comm = ch.getChangeCommand();
+      if ((comm != null) && !comm.isNull()) {
+        GameModule.getGameModule().sendAndLog(comm);
+      }      
+      
       popup.show(map.getView(), pt.x, pt.y);
     }
 

--- a/vassal-app/src/main/java/VASSAL/launch/EditorWindow.java
+++ b/vassal-app/src/main/java/VASSAL/launch/EditorWindow.java
@@ -136,8 +136,6 @@ public abstract class EditorWindow extends JFrame {
     editMenu.add(mm.addKey("Editor.paste"));
     editMenu.add(mm.addKey("Editor.move"));
     editMenu.addSeparator();
-    editMenu.add(mm.addKey("Editor.search"));
-    editMenu.addSeparator();
     editMenu.add(mm.addKey("Editor.ModuleEditor.properties"));
     editMenu.add(mm.addKey("Editor.ModuleEditor.translate"));
 

--- a/vassal-app/src/main/resources/VASSAL/i18n/Editor.properties
+++ b/vassal-app/src/main/resources/VASSAL/i18n/Editor.properties
@@ -30,14 +30,6 @@ Editor.undo=Undo
 Editor.move=Move
 Editor.save=Save
 Editor.save_as=Save As...
-Editor.search=Search...
-Editor.search_next=Find Next
-Editor.search_case=Match Case
-Editor.search_names=Match Names
-Editor.search_types=Match [Class Names]
-Editor.search_all_off=Warning - both 'Match Names' and 'Match [Class Names]' are unchecked - turning on 'Match Names'
-Editor.search_none_found=Search string not found: 
-Editor.search_count= Matches found for search string:  
 Editor.edit_extension=Edit Extension
 Editor.new_extension=New Extension
 


### PR DESCRIPTION
http://www.vassalengine.org/forum/viewtopic.php?f=2&t=12170

This was getting mentioned again in the forums, and I have a really lightweight solution I'd been using in a custom class. It seems like something that many module designers might like to do.

What it actually does: when something gets executed from a right-click menu of a piece, then IF the piece has dynamic properties for "ClickedX" and "ClickedY" they are updated with the map coordinates of the most recent click.

Use Case:
(1) I have a "big" piece (e.g. a picture of a province, or a battleship or whatever)
(2) I right click on it, and a context menu comes up
(3) Maybe what I pick from the menu is "Put a tank here"
(4) Piece that's processing the click can retrieve the map coordinates where the right-click took place, and use that to allow "placing the tank" to be at the location of the click rather than always at one exact spot. 

Why I did it that way: lightweight and doesn't create any "Command" traffic _unless_ the target piece actually has those properties. 