### PR TITLE
Remove unnecessary modifiers from interfaces

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/AutoConfigurable.java
+++ b/vassal-app/src/main/java/VASSAL/build/AutoConfigurable.java
@@ -73,7 +73,7 @@ public interface AutoConfigurable extends Configurable {
    */
   public VisibilityCondition getAttributeVisibility(String name);
 
-  public static class Util {
+  public class Util {
     public static void buildAttributes(Element e, AutoConfigurable parent) {
       if (e != null) {
         NamedNodeMap n = e.getAttributes();

--- a/vassal-app/src/main/java/VASSAL/build/Configurable.java
+++ b/vassal-app/src/main/java/VASSAL/build/Configurable.java
@@ -28,7 +28,7 @@ import VASSAL.i18n.Translatable;
  * the Configuration window.
  */
 public interface Configurable extends Translatable {
-  public static final String NAME_PROPERTY = "name"; //$NON-NLS-1$
+  String NAME_PROPERTY = "name"; //$NON-NLS-1$
 
   /**
    * Remove this component from its parent

--- a/vassal-app/src/main/java/VASSAL/build/module/BasicCommandEncoder.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/BasicCommandEncoder.java
@@ -541,11 +541,11 @@ public class BasicCommandEncoder implements CommandEncoder, Buildable {
     }
   }
 
-  public static interface DecoratorFactory {
+  public interface DecoratorFactory {
     Decorator createDecorator(String type, GamePiece inner);
   }
 
-  public static interface BasicPieceFactory {
+  public interface BasicPieceFactory {
     GamePiece createBasicPiece(String type);
   }
 }

--- a/vassal-app/src/main/java/VASSAL/build/module/PlayerRoster.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/PlayerRoster.java
@@ -643,7 +643,7 @@ public class PlayerRoster extends AbstractConfigurable implements CommandEncoder
   }
 
   /** Call-back interface for when a player changes sides during a game */
-  public static interface SideChangeListener {
+  public interface SideChangeListener {
     void sideChanged(String oldSide, String newSide);
   }
 

--- a/vassal-app/src/main/java/VASSAL/build/module/ServerConnection.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/ServerConnection.java
@@ -24,7 +24,7 @@ import VASSAL.command.Command;
  */
 public interface ServerConnection {
   /** Name of the property fired when the connection is opened/clused. Value is Boolean.TRUE or Boolean.FALSE */
-  public static final String CONNECTED = "Connected"; //$NON-NLS-1$
+  String CONNECTED = "Connected"; //$NON-NLS-1$
 
   /** Send a command to other players on the server */
   void sendToOthers(Command c);

--- a/vassal-app/src/main/java/VASSAL/build/module/map/MapShader.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/MapShader.java
@@ -885,7 +885,7 @@ public class MapShader extends AbstractConfigurable implements GameComponent, Dr
   /**
    * Pieces that contribute to shading must implement this interface
    */
-  public static interface ShadedPiece {
+  public interface ShadedPiece {
     /**
      * Returns the Area to add to (or subtract from) the area drawn by the MapShader's.
      * Area is assumed to be at zoom factor 1.0

--- a/vassal-app/src/main/java/VASSAL/build/module/map/boardPicker/board/MapGrid.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/boardPicker/board/MapGrid.java
@@ -67,7 +67,7 @@ public interface MapGrid {
 
   public GridNumbering getGridNumbering();
 
-  public static final class BadCoords extends Exception {
+  public final class BadCoords extends Exception {
     private static final long serialVersionUID = 1L;
 
     public BadCoords() {

--- a/vassal-app/src/main/java/VASSAL/build/module/noteswindow/AddSecretNoteCommand.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/noteswindow/AddSecretNoteCommand.java
@@ -46,7 +46,7 @@ public class AddSecretNoteCommand extends Command {
     return null;
   }
 
-  public static interface Interface {
+  public interface Interface {
     void addSecretNote(SecretNote note);
   }
 }

--- a/vassal-app/src/main/java/VASSAL/build/module/noteswindow/SetPrivateTextCommand.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/noteswindow/SetPrivateTextCommand.java
@@ -46,7 +46,7 @@ public class SetPrivateTextCommand extends Command {
     return null;
   }
 
-  public static interface Interface {
+  public interface Interface {
     void addPrivateText(PrivateText p);
   }
 }

--- a/vassal-app/src/main/java/VASSAL/build/module/properties/IncrementProperty.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/properties/IncrementProperty.java
@@ -88,7 +88,7 @@ public class IncrementProperty implements PropertyChanger {
     return format.getFormat();
   }
 
-  public static interface Constraints extends PropertySource {
+  public interface Constraints extends PropertySource {
     int getMinimumValue();
     int getMaximumValue();
     boolean isWrap();

--- a/vassal-app/src/main/java/VASSAL/build/module/properties/MutablePropertiesContainer.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/properties/MutablePropertiesContainer.java
@@ -53,7 +53,7 @@ public interface MutablePropertiesContainer {
    * @author rkinney
    *
    */
-  public static class Impl implements MutablePropertiesContainer {
+  public class Impl implements MutablePropertiesContainer {
     private Map<String,MutableProperty> props = new HashMap<>();
     private String id;
 

--- a/vassal-app/src/main/java/VASSAL/build/module/properties/MutableProperty.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/properties/MutableProperty.java
@@ -41,7 +41,7 @@ public interface MutableProperty {
 
   MutablePropertiesContainer getParent();
 
-  public static class Util {
+  public class Util {
     /**
      * Look for a {@link MutableProperty} in the list of {@link MutablePropertiesContainer}. Return the first one
      * found, searching the lists in order. The list may contain null references, which are skipped
@@ -68,7 +68,7 @@ public interface MutableProperty {
    * @author rkinney
    *
    */
-  public static class Impl implements MutableProperty {
+  public class Impl implements MutableProperty {
     private PropertyChangeSupport propSupport;
     private String value="";
     private String propertyName;

--- a/vassal-app/src/main/java/VASSAL/build/module/properties/PropertyChangerConfigurer.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/properties/PropertyChangerConfigurer.java
@@ -228,6 +228,7 @@ public class PropertyChangerConfigurer extends Configurer {
     }
     setValue(p);
   }
-  public static interface Constraints extends PropertyPrompt.Constraints, IncrementProperty.Constraints, PropertySource {
+
+  public interface Constraints extends PropertyPrompt.Constraints, IncrementProperty.Constraints, PropertySource {
   }
 }

--- a/vassal-app/src/main/java/VASSAL/build/module/properties/PropertyPrompt.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/properties/PropertyPrompt.java
@@ -53,11 +53,11 @@ public class PropertyPrompt implements PropertyChanger {
     return promptText;
   }
 
-  public static interface DialogParent {
+  public interface DialogParent {
     Component getComponent();
   }
 
-  public static interface Constraints extends DialogParent {
+  public interface Constraints extends DialogParent {
     boolean isNumeric();
 
     int getMaximumValue();

--- a/vassal-app/src/main/java/VASSAL/chat/ChatServerConnection.java
+++ b/vassal-app/src/main/java/VASSAL/chat/ChatServerConnection.java
@@ -27,19 +27,19 @@ import VASSAL.command.Command;
   */
 public interface ChatServerConnection extends ServerConnection {
   /** Property representing the currently-occupied room */
-  public static final String ROOM = "Room"; //$NON-NLS-1$
+  String ROOM = "Room"; //$NON-NLS-1$
   /** Property representing the list of all rooms */
-  public static final String AVAILABLE_ROOMS = "AvailableRooms"; //$NON-NLS-1$
+  String AVAILABLE_ROOMS = "AvailableRooms"; //$NON-NLS-1$
   /** Property representing an informational message (e.g. "Connection succeeded")*/
-  public static final String STATUS = "Status"; //$NON-NLS-1$
+  String STATUS = "Status"; //$NON-NLS-1$
   /** Property representing the current player's information */
-  public static final String PLAYER_INFO = "Player"; //$NON-NLS-1$
+  String PLAYER_INFO = "Player"; //$NON-NLS-1$
   /** Property representing a message received from the remove server */
-  public static final String INCOMING_MSG = "Msg"; //$NON-NLS-1$
+  String INCOMING_MSG = "Msg"; //$NON-NLS-1$
   /** Property representing the StatusServer implementation */
-  public static final String STATUS_SERVER = "StatusServer"; //$NON-NLS-1$
+  String STATUS_SERVER = "StatusServer"; //$NON-NLS-1$
 
-  public static final String DEFAULT_ROOM_NAME = "Main Room"; //$NON-NLS-1$
+  String DEFAULT_ROOM_NAME = "Main Room"; //$NON-NLS-1$
 
 
   /** Return the room currently occupied by the player */

--- a/vassal-app/src/main/java/VASSAL/chat/ServerStatus.java
+++ b/vassal-app/src/main/java/VASSAL/chat/ServerStatus.java
@@ -38,7 +38,7 @@ public interface ServerStatus {
    */
   public ModuleSummary[] getHistory(String timeRange);
 
-  public static class ModuleSummary {
+  public class ModuleSummary {
     private String moduleName;
     private Map<String,Room> rooms = new HashMap<>();
 

--- a/vassal-app/src/main/java/VASSAL/configure/ValidationReportDialog.java
+++ b/vassal-app/src/main/java/VASSAL/configure/ValidationReportDialog.java
@@ -99,7 +99,7 @@ public class ValidationReportDialog extends JDialog {
     return ok;
   }
 
-  public static interface CallBack {
+  public interface CallBack {
     void ok();
     void cancel();
   }

--- a/vassal-app/src/main/java/VASSAL/counters/PieceAccess.java
+++ b/vassal-app/src/main/java/VASSAL/counters/PieceAccess.java
@@ -44,7 +44,7 @@ public interface PieceAccess {
    * @author rkinney
    *
    */
-  public static class GlobalAccess {
+  public class GlobalAccess {
     private static boolean allHidden=false;
     public static void hideAll() {
       allHidden = true;

--- a/vassal-app/src/main/java/VASSAL/counters/PieceFilter.java
+++ b/vassal-app/src/main/java/VASSAL/counters/PieceFilter.java
@@ -23,5 +23,5 @@ package VASSAL.counters;
  * A filter for GamePieces
  */
 public interface PieceFilter {
-  public abstract boolean accept(GamePiece piece);
+  public boolean accept(GamePiece piece);
 }

--- a/vassal-app/src/main/java/VASSAL/counters/PieceFinder.java
+++ b/vassal-app/src/main/java/VASSAL/counters/PieceFinder.java
@@ -31,20 +31,20 @@ public interface PieceFinder {
   public GamePiece select(Map map, GamePiece piece, Point pt);
 
   /** Return a Stack overlapping the given point */
-  public static final PieceFinder STACK_ONLY = new StackOnly();
+  PieceFinder STACK_ONLY = new StackOnly();
 
   /**
    * If a Stack overlaps the given point, return the piece containing that point if expanded,
    * or the top piece if not expanded.
    * */
-  public static final PieceFinder PIECE_IN_STACK = new PieceInStack();
+  PieceFinder PIECE_IN_STACK = new PieceInStack();
 
   /** Returns a Stack if unexpanded and overlapping the given point,
    * or a piece within that stack if expanded and overlapping the given point
    */
-  public static final PieceFinder MOVABLE = new Movable();
+  PieceFinder MOVABLE = new Movable();
 
-  public static class StackOnly extends Movable {
+  public class StackOnly extends Movable {
     @Override
     public Object visitDefault(GamePiece piece) {
       return null;
@@ -62,7 +62,7 @@ public interface PieceFinder {
 
   }
 
-  public static class PieceInStack extends Movable {
+  public class PieceInStack extends Movable {
     @Override
     public Object visitStack(Stack s) {
       GamePiece selected = (GamePiece) super.visitStack(s);
@@ -74,7 +74,7 @@ public interface PieceFinder {
     }
   }
 
-  public static class Movable implements PieceFinder, DeckVisitor {
+  public class Movable implements PieceFinder, DeckVisitor {
     protected Shape[] shapes = new Shape[0];
     protected Map map;
     protected Point pt;

--- a/vassal-app/src/main/java/VASSAL/counters/Properties.java
+++ b/vassal-app/src/main/java/VASSAL/counters/Properties.java
@@ -25,101 +25,101 @@ public interface Properties {
   /**
    * Return Boolean.TRUE if the piece cannot be seen by the user
    */
-  public static final String INVISIBLE_TO_ME = "Invisible";
+  String INVISIBLE_TO_ME = "Invisible";
 
-  public static final String INVISIBLE_TO_OTHERS = "InvisibleToOthers";
+  String INVISIBLE_TO_OTHERS = "InvisibleToOthers";
 
   /**
    * Return Boolean.TRUE if the piece's identity is not known to other players
    */
-  public static final String OBSCURED_TO_OTHERS = "ObscuredToOthers";
+  String OBSCURED_TO_OTHERS = "ObscuredToOthers";
 
   /**
    * Return Boolean.TRUE if the piece's identity is not known to the user
    */
-  public static final String OBSCURED_TO_ME = "Obscured";
+  String OBSCURED_TO_ME = "Obscured";
 
   /**
    * If a piece is obscured to other players, return a String identifying the player who obscured it
    *
    * @see VASSAL.build.GameModule#getUserId
    */
-  public static final String OBSCURED_BY = Obscurable.ID;
+  String OBSCURED_BY = Obscurable.ID;
   
   /**
    * If non-null, then return an instance of {@link EventFilter}. The piece will not respond to band-select events if the
    * filter rejects them
    */
-  public static final String BAND_SELECT_EVENT_FILTER = "bandSelectEventFilter";
+  String BAND_SELECT_EVENT_FILTER = "bandSelectEventFilter";
 
   /**
    * If non-null, then return an instance of {@link EventFilter}. The piece will not respond to selection events if the
    * filter rejects them
    */
-  public static final String SELECT_EVENT_FILTER = "selectEventFilter";
+  String SELECT_EVENT_FILTER = "selectEventFilter";
 
   /**
    * If non-null, then return an instance of {@link EventFilter}. The piece will not respond to move events if the
    * filter rejects them
    */
-  public static final String MOVE_EVENT_FILTER = "moveEventFilter";
+  String MOVE_EVENT_FILTER = "moveEventFilter";
 
   /**
    * If a piece is hidden to other players, return a STring identifying the player who hit it
    *
    * @see VASSAL.build.GameModule#getUserId
    */
-  public static final String HIDDEN_BY = Hideable.HIDDEN_BY;
+  String HIDDEN_BY = Hideable.HIDDEN_BY;
 
   /**
    * Return Boolean.TRUE if the piece behaves more like a terrain feature than a playing piece
    */
-  public static final String TERRAIN = "Immobile";
+  String TERRAIN = "Immobile";
 
   /**
    * Return Boolean.TRUE if the piece should ignore map grids when being moved
    */
-  public static final String IGNORE_GRID = "IgnoreGrid";
+  String IGNORE_GRID = "IgnoreGrid";
 
   /** Return Boolean.TRUE if the piece does not form stacks */
-  public static final String NO_STACK = "NoStack";
+  String NO_STACK = "NoStack";
 
   /**
    * Return Boolean.TRUE if the piece has been marked as selected
    */
-  public static final String SELECTED = "Selected";
+  String SELECTED = "Selected";
 
   /**
    * Return a KeyCommand[] object representing the popup menu equivalencies for the key commands recognized by this
    * piece
    */
-  public static final String KEY_COMMANDS = "KeyCommands";
+  String KEY_COMMANDS = "KeyCommands";
 
   /**
    * If this piece is a Decorator, return the decorated piece
    */
-  public static final String INNER = "Inner";
+  String INNER = "Inner";
 
   /**
    * If this piece decorated by a Decorator, return the Decorator
    */
-  public static final String OUTER = "Outer";
+  String OUTER = "Outer";
 
   /**
    * Return Boolean.TRUE if this piece has Restricted Access
    */
-  public static final String RESTRICTED = "Restricted";
+  String RESTRICTED = "Restricted";
 
   /**
    * Return Boolean.TRUE if this piece has movement restricted by a Restricted Access trait   */
-  public static final String RESTRICTED_MOVEMENT = "RestrictedMovement";
+  String RESTRICTED_MOVEMENT = "RestrictedMovement";
 
 
   /** Return Boolean.TRUE if this piece has been moved */
-  public static final String MOVED = "Moved";
+  String MOVED = "Moved";
 
   /** Used to store a duplicate of the target piece at some point in time */
-  public static final String SNAPSHOT = "snapshot";
+  String SNAPSHOT = "snapshot";
 
   /**
    * If Boolean.TRUE, then treat the piece as if it were not rotated. This effects the value returned by
@@ -127,17 +127,17 @@ public interface Properties {
    *
    * @see FreeRotator
    */
-  public static final String USE_UNROTATED_SHAPE = "useUnrotatedShape";
+  String USE_UNROTATED_SHAPE = "useUnrotatedShape";
 
   /**
    * Return a String representing the visible features of the piece. If this String changes value, then the piece should
    * be refreshed
    */
-  public static final String VISIBLE_STATE = "visibleState";
+  String VISIBLE_STATE = "visibleState";
 
   /** Return Boolean.TRUE if the piece can never be moved */
-  public static final String NON_MOVABLE = "cannotMove";
+  String NON_MOVABLE = "cannotMove";
 
   /** Global Piece Id */
-  public static final String PIECE_ID = "PieceId";
+  String PIECE_ID = "PieceId";
 }

--- a/vassal-app/src/main/java/VASSAL/i18n/TranslatablePiece.java
+++ b/vassal-app/src/main/java/VASSAL/i18n/TranslatablePiece.java
@@ -28,7 +28,7 @@ import VASSAL.counters.EditablePiece;
  */
 public interface TranslatablePiece extends EditablePiece {
 
-  public static final String PREFIX = "Piece.";
+  String PREFIX = "Piece.";
 
   /**
    * Return a PieceI18nData object returning the I18n data about this GamePiece.

--- a/vassal-app/src/main/java/VASSAL/tools/RecursionLimiter.java
+++ b/vassal-app/src/main/java/VASSAL/tools/RecursionLimiter.java
@@ -58,7 +58,7 @@ public class RecursionLimiter {
     return reporting;
   }
 
-  public static interface Loopable {
+  public interface Loopable {
     public String getComponentTypeName();
     public String getComponentName();
   }

--- a/vassal-app/src/main/java/VASSAL/tools/Sort.java
+++ b/vassal-app/src/main/java/VASSAL/tools/Sort.java
@@ -127,7 +127,7 @@ public class Sort {
    * @deprecated Use {@link java.util.Comparator} instead.
    */
   @Deprecated
-  public static interface Comparator {
+  public interface Comparator {
     public int compare(Object o1, Object o2);
   }
 

--- a/vassal-app/src/main/java/VASSAL/tools/UniqueIdManager.java
+++ b/vassal-app/src/main/java/VASSAL/tools/UniqueIdManager.java
@@ -136,7 +136,7 @@ public class UniqueIdManager implements ValidityChecker {
    * An object with an identifier that can be manipulated by a
    * {@link UniqueIdManager}
    */
-  public static interface Identifyable {
+  public interface Identifyable {
     void setId(String id);
 
     String getId();

--- a/vassal-app/src/main/java/VASSAL/tools/image/ImageIOImageLoader.java
+++ b/vassal-app/src/main/java/VASSAL/tools/image/ImageIOImageLoader.java
@@ -380,7 +380,7 @@ public class ImageIOImageLoader implements ImageLoader {
     return img;
   }
 
-  protected static interface Wrapper<T> {
+  protected interface Wrapper<T> {
     T run(String name, InputStream in) throws IOException;
   }
 


### PR DESCRIPTION
There are still lots of unnecessary `public` modifiers in almost all interfaces, even though everything is `public` by default in an interface, anything else would make no sense, an interface is a contract with the outside world and private/protected/package-visibility members don't belong in an interface.