### PR TITLE
Custom VM options

### DIFF
--- a/vassal-app/src/main/java/VASSAL/launch/AbstractLaunchAction.java
+++ b/vassal-app/src/main/java/VASSAL/launch/AbstractLaunchAction.java
@@ -593,6 +593,9 @@ public abstract class AbstractLaunchAction extends AbstractAction {
       result.add(Info.javaBinPath);
       result.add("");   // reserved for initial heap
       result.add("");   // reserved for maximum heap
+
+      result.addAll(new CustomVmOptions().getCustomVmOptions());
+
       result.add("-DVASSAL.id=" + id);  // instance id
       result.add("-DVASSAL.port=" + port); // MM socket port
 

--- a/vassal-app/src/main/java/VASSAL/launch/AbstractLaunchAction.java
+++ b/vassal-app/src/main/java/VASSAL/launch/AbstractLaunchAction.java
@@ -417,61 +417,8 @@ public abstract class AbstractLaunchAction extends AbstractAction {
       final InetAddress lo = InetAddress.getByName(null);
       serverSocket = new ServerSocket(0, 0, lo);
 
-      final int port = serverSocket.getLocalPort();
-
-      // build the argument list
-      final ArrayList<String> al = new ArrayList<>();
-      al.add(Info.javaBinPath);
-      al.add("");   // reserved for initial heap
-      al.add("");   // reserved for maximum heap
-      al.add("-DVASSAL.id=" + id);  // instance id
-      al.add("-DVASSAL.port=" + port); // MM socket port
-
-      // pass on the user's home, if it's set
-      final String userHome = System.getProperty("user.home");
-      if (userHome != null) al.add("-Duser.home=" + userHome);
-
-      // pass on the user's working dir, if it's set
-      final String userDir = System.getProperty("user.dir");
-      if (userDir != null) al.add("-Duser.dir=" + userDir);
-
-      // pass on VASSAL's home dir, if it's set
-      final String vHome = System.getProperty("VASSAL.home");
-      if (vHome != null) al.add("-DVASSAL.home=" + vHome);
-
-      // set the classpath
-      al.add("-cp");
-      al.add(System.getProperty("java.class.path"));
-
-      if (SystemUtils.IS_OS_MAC_OSX) {
-        // set the MacOS X dock parameters
-
-        // use the module name for the dock if we found a module name
-// FIXME: should "Unnamed module" be localized?
-        final String d_name = moduleName != null && moduleName.length() > 0
-          ? moduleName : "Unnamed module";
-
-        // get the path to the app icon
-        final String d_icon = new File(Info.getBaseDir(),
-          "Contents/Resources/VASSAL.icns").getAbsolutePath();
-
-        al.add("-Xdock:name=" + d_name);
-        al.add("-Xdock:icon=" + d_icon);
-      }
-      else if (SystemUtils.IS_OS_WINDOWS) {
-        // Disable the 2D to Direct3D pipeline?
-        final Boolean disableD3d =
-          (Boolean) Prefs.getGlobalPrefs().getValue(Prefs.DISABLE_D3D);
-        if (Boolean.TRUE.equals(disableD3d)) {
-          al.add("-Dsun.java2d.d3d=false");
-        }
-      }
-
-      al.add(entryPoint);
-
-      al.addAll(Arrays.asList(lr.toArgs()));
-
-      final String[] args = al.toArray(new String[0]);
+      final List<String> argumentList = buildArgumentList(moduleName);
+      final String[] args = argumentList.toArray(new String[0]);
 
       // try to start a child process with the given heap sizes
       args[1] = "-Xms" + initialHeap + "M";
@@ -637,7 +584,67 @@ public abstract class AbstractLaunchAction extends AbstractAction {
         children.remove(ipc);
       }
     }
+
+    private List<String> buildArgumentList(String moduleName) {
+      final List<String> result = new ArrayList<>();
+
+      final int port = serverSocket.getLocalPort();
+
+      result.add(Info.javaBinPath);
+      result.add("");   // reserved for initial heap
+      result.add("");   // reserved for maximum heap
+      result.add("-DVASSAL.id=" + id);  // instance id
+      result.add("-DVASSAL.port=" + port); // MM socket port
+
+      // pass on the user's home, if it's set
+      final String userHome = System.getProperty("user.home");
+      if (userHome != null) result.add("-Duser.home=" + userHome);
+
+      // pass on the user's working dir, if it's set
+      final String userDir = System.getProperty("user.dir");
+      if (userDir != null) result.add("-Duser.dir=" + userDir);
+
+      // pass on VASSAL's home dir, if it's set
+      final String vHome = System.getProperty("VASSAL.home");
+      if (vHome != null) result.add("-DVASSAL.home=" + vHome);
+
+      // set the classpath
+      result.add("-cp");
+      result.add(System.getProperty("java.class.path"));
+
+      if (SystemUtils.IS_OS_MAC_OSX) {
+        // set the MacOS X dock parameters
+
+        // use the module name for the dock if we found a module name
+// FIXME: should "Unnamed module" be localized?
+        final String d_name = moduleName != null && moduleName.length() > 0
+          ? moduleName : "Unnamed module";
+
+        // get the path to the app icon
+        final String d_icon = new File(Info.getBaseDir(),
+          "Contents/Resources/VASSAL.icns").getAbsolutePath();
+
+        result.add("-Xdock:name=" + d_name);
+        result.add("-Xdock:icon=" + d_icon);
+      }
+      else if (SystemUtils.IS_OS_WINDOWS) {
+        // Disable the 2D to Direct3D pipeline?
+        final Boolean disableD3d =
+          (Boolean) Prefs.getGlobalPrefs().getValue(Prefs.DISABLE_D3D);
+        if (Boolean.TRUE.equals(disableD3d)) {
+          result.add("-Dsun.java2d.d3d=false");
+        }
+      }
+
+      result.add(entryPoint);
+
+      result.addAll(Arrays.asList(lr.toArgs()));
+
+      return result;
+    }
+
   }
+
 
   //
   // Commands

--- a/vassal-app/src/main/java/VASSAL/launch/CustomVmOptions.java
+++ b/vassal-app/src/main/java/VASSAL/launch/CustomVmOptions.java
@@ -1,0 +1,63 @@
+package VASSAL.launch;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import VASSAL.Info;
+
+public class CustomVmOptions {
+
+  private static final Logger log = LoggerFactory.getLogger(CustomVmOptions.class);
+
+  private static final String VM_OPTIONS_FILE_NAME = "vassal.vmoptions";
+
+  public void ensureCustomVmOptionsFileExistsInConfDir() {
+    final File confDir = Info.getConfDir();
+    final File vmOptionsFile = new File(confDir, VM_OPTIONS_FILE_NAME);
+    if (!vmOptionsFile.exists()) {
+      createInitialVmOptionsFile(confDir);
+    }
+  }
+
+  private void createInitialVmOptionsFile(File confDir) {
+    ClassLoader classLoader = getClass().getClassLoader();
+    try (InputStream is = classLoader.getResourceAsStream(VM_OPTIONS_FILE_NAME)) {
+      if (is == null) {
+        log.error("Template for custom VM options " + VM_OPTIONS_FILE_NAME + " not found in the Vassal distribution");
+        return;
+      }
+      Files.copy(is, Path.of(confDir.getAbsolutePath(), VM_OPTIONS_FILE_NAME));
+    }
+    catch (IOException e) {
+      log.error("Unable to copy " + VM_OPTIONS_FILE_NAME + " to " + confDir.getAbsolutePath(), e);
+    }
+  }
+
+  public List<String> getCustomVmOptions() {
+    try {
+      final List<String> allLines =
+        Files.readAllLines(Path.of(Info.getConfDir().getAbsolutePath(), VM_OPTIONS_FILE_NAME));
+
+      return allLines
+        .stream()
+        .filter(s -> !s.startsWith("#"))
+        .filter(StringUtils::isNotBlank)
+        .map(String::trim)
+        .collect(Collectors.toList());
+    }
+    catch (IOException e) {
+      log.error("Unable to read " + VM_OPTIONS_FILE_NAME, e);
+      return Collections.emptyList();
+    }
+  }
+}

--- a/vassal-app/src/main/java/VASSAL/launch/ModuleManager.java
+++ b/vassal-app/src/main/java/VASSAL/launch/ModuleManager.java
@@ -305,6 +305,8 @@ public class ModuleManager {
     if (SystemUtils.IS_OS_MAC_OSX) new MacOSXMenuManager();
     else new ModuleManagerMenuManager();
 
+    new CustomVmOptions().ensureCustomVmOptionsFileExistsInConfDir();
+
     SwingUtilities.invokeLater(new Runnable() {
       @Override
       public void run() {

--- a/vassal-app/src/main/resources/vassal.vmoptions
+++ b/vassal-app/src/main/resources/vassal.vmoptions
@@ -1,0 +1,9 @@
+#
+# add custom VM options here, one per line, e.g.:
+# -XX:+UseG1GC
+# -XX:MaxGCPauseMillis=200
+#
+# lines beginning with "#" and empty lines will be ignored
+#
+# delete this file to have Vassal regenerate it
+#


### PR DESCRIPTION
This is how this would work:
- a template file `vassal.vmoptions` is inside the Vassal jar
- the ModuleManager checks if `vassal.vmoptions` exists in the user's configuration directory, if it doesn't exist then the template is copied there
- when the Player or the Editor is launched, the `vassal.vmoptions` is read and it's contents appended to the launch parameters after the `-Xmx` and before the `-DVASSAL.id` parameter
- if the user messes up this file, it can be deleted and the ModuleManager will create a new one on it's next run
- the file itself is a text file with a simple syntax which is explained in the template file, it's contents are read line by line and passed through ``.filter(s -> !s.startsWith("#")).filter(StringUtils::isNotBlank).map(String::trim)`` into the launch argument list
