### PR TITLE
Reactivate checkstyle and javadoc

### DIFF
--- a/vassal-app/pom.xml
+++ b/vassal-app/pom.xml
@@ -253,7 +253,7 @@
                     <consoleOutput>true</consoleOutput>
                     <failOnViolation>true</failOnViolation>
                     <linkXRef>true</linkXRef>
-                    <skip>true</skip>
+                    <skip>false</skip>
                 </configuration>
                 <executions>
                     <execution>
@@ -309,7 +309,7 @@
                     </bottom>
                     <additionalJOption>--allow-script-in-comments</additionalJOption>
                     <doclint>none</doclint>
-                    <skip>true</skip>
+                    <skip>false</skip>
                 </configuration>
                 <executions>
                     <execution>


### PR DESCRIPTION
Oops. I deactivated these while setting up the spotbugs plugin.