### PR TITLE
13325: Use explicit character set

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/module/Inventory.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/Inventory.java
@@ -37,6 +37,7 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.Writer;
+import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -414,7 +415,8 @@ public class Inventory extends AbstractConfigurable
     // .substring(1).replaceAll(
   //      mapSeparator, System.getProperty("line.separator"));
 
-    try (Writer fw = new FileWriter(file);
+    // Writing out a text file for the user to do whatever with. Use the native encoding.
+    try (Writer fw = new FileWriter(file, Charset.defaultCharset());
          BufferedWriter bw = new BufferedWriter(fw);
          PrintWriter p = new PrintWriter(bw)) {
       p.print(output);

--- a/vassal-app/src/main/java/VASSAL/build/module/dice/BonesDiceServer.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/dice/BonesDiceServer.java
@@ -26,6 +26,7 @@ import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.Iterator;
 import java.util.StringTokenizer;
 import java.util.Vector;
@@ -113,7 +114,7 @@ public class BonesDiceServer extends DieServer {
     connection.connect();
 
     try (BufferedReader in = new BufferedReader(
-      new InputStreamReader(connection.getInputStream()))) {
+      new InputStreamReader(connection.getInputStream(), StandardCharsets.UTF_8))) {
 
       String line;
       while ((line = in.readLine()) != null)

--- a/vassal-app/src/main/java/VASSAL/build/module/dice/DieServer.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/dice/DieServer.java
@@ -9,6 +9,7 @@ import java.io.OutputStream;
 import java.io.PrintWriter;
 import java.net.URL;
 import java.net.URLConnection;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Vector;
 import java.util.concurrent.ExecutionException;
@@ -279,14 +280,14 @@ public abstract class DieServer {
     connection.setDoOutput(true);
 
     try (OutputStream os = connection.getOutputStream();
-         PrintWriter out = new PrintWriter(os)) {
+         PrintWriter out = new PrintWriter(os, true, StandardCharsets.UTF_8)) {
       for (String s : rollString) {
         out.println(s);
       }
     }
 
     try (InputStream is = connection.getInputStream();
-         InputStreamReader isr = new InputStreamReader(is);
+         InputStreamReader isr = new InputStreamReader(is, StandardCharsets.UTF_8);
          BufferedReader in = new BufferedReader(isr)) {
       String inputLine;
       while ((inputLine = in.readLine()) != null) {

--- a/vassal-app/src/main/java/VASSAL/build/module/map/TextSaver.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/TextSaver.java
@@ -25,6 +25,7 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.Writer;
+import java.nio.charset.Charset;
 
 import javax.swing.JOptionPane;
 
@@ -149,7 +150,9 @@ public class TextSaver extends AbstractConfigurable {
     if (fc.showSaveDialog(map.getView()) != FileChooser.APPROVE_OPTION) return;
 
     final File file =  fc.getSelectedFile();
-    try (Writer fw = new FileWriter(file);
+
+    // Writing out a text file for the user to do whatever with. Use the native encoding.
+    try (Writer fw = new FileWriter(file, Charset.defaultCharset());
          BufferedWriter bw = new BufferedWriter(fw);
          PrintWriter p = new PrintWriter(bw)) {
       for (GamePiece gp : map.getPieces()) {

--- a/vassal-app/src/main/java/VASSAL/build/module/metadata/MetaDataFactory.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/metadata/MetaDataFactory.java
@@ -22,6 +22,7 @@ import java.io.File;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipException;
 import java.util.zip.ZipFile;
@@ -84,7 +85,7 @@ public class MetaDataFactory {
 
       // read the first few lines of the buildFile
       try (InputStream zin = zip.getInputStream(buildFileEntry);
-           InputStreamReader isr = new InputStreamReader(zin);
+           InputStreamReader isr = new InputStreamReader(zin, StandardCharsets.UTF_8);
            BufferedReader br = new BufferedReader(isr)) {
         for (int i = 0; i < 10; i++) {
           final String s = br.readLine();

--- a/vassal-app/src/main/java/VASSAL/chat/Compressor.java
+++ b/vassal-app/src/main/java/VASSAL/chat/Compressor.java
@@ -24,6 +24,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
@@ -84,7 +85,7 @@ public abstract class Compressor {
             System.err.println("Input (" + s.length() + ") = " + s); //$NON-NLS-1$ //$NON-NLS-2$
             final String comp = new String(compress(s.getBytes()));
             System.err.println("Compressed (" + comp.length() + ") = " + comp); //$NON-NLS-1$ //$NON-NLS-2$
-            final String decomp = new String(decompress(comp.getBytes()));
+            final String decomp = new String(decompress(comp.getBytes(StandardCharsets.UTF_8)), StandardCharsets.UTF_8);
             System.err.println("Decompressed (" + decomp.length() + ") = " + decomp); //$NON-NLS-1$ //$NON-NLS-2$
           }
           // FIXME: review error message

--- a/vassal-app/src/main/java/VASSAL/chat/jabber/JabberClient.java
+++ b/vassal-app/src/main/java/VASSAL/chat/jabber/JabberClient.java
@@ -664,7 +664,7 @@ public class JabberClient implements LockableChatServerConnection, PacketListene
     try (FastByteArrayOutputStream ba = new FastByteArrayOutputStream();
          ObfuscatingOutputStream out = new ObfuscatingOutputStream(ba)) {
       out.write(clearText.getBytes(StandardCharsets.UTF_8));
-      return new String(ba.toByteArray());
+      return new String(ba.toByteArray(), StandardCharsets.UTF_8);
     }
     catch (IOException e) {
       e.printStackTrace();
@@ -679,7 +679,7 @@ public class JabberClient implements LockableChatServerConnection, PacketListene
    * @return decoded text
    */
   protected String decodeMessage(String encodedMessage) {
-    try (ByteArrayInputStream ba = new ByteArrayInputStream(encodedMessage.getBytes());
+    try (ByteArrayInputStream ba = new ByteArrayInputStream(encodedMessage.getBytes(StandardCharsets.UTF_8));
          DeobfuscatingInputStream in = new DeobfuscatingInputStream(ba)) {
       return IOUtils.toString(in, StandardCharsets.UTF_8);
     }

--- a/vassal-app/src/main/java/VASSAL/chat/node/Server.java
+++ b/vassal-app/src/main/java/VASSAL/chat/node/Server.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.ServerSocket;
 import java.net.Socket;
+import java.nio.charset.Charset;
 import java.util.Properties;
 
 import VASSAL.tools.ArgsParser;
@@ -84,8 +85,9 @@ public class Server extends Thread {
       handler.start();
       handler.writeLine(Protocol.encodeRegisterCommand("rk", "test/Main Room", "")); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
 
+      // open stdin, use native encoding.
       final BufferedReader reader =
-        new BufferedReader(new InputStreamReader(System.in));
+        new BufferedReader(new InputStreamReader(System.in, Charset.defaultCharset()));
       try {
         String line;
         while ((line = reader.readLine()) != null) {

--- a/vassal-app/src/main/java/VASSAL/counters/Deck.java
+++ b/vassal-app/src/main/java/VASSAL/counters/Deck.java
@@ -34,6 +34,7 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.io.Reader;
 import java.io.Writer;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -1394,7 +1395,7 @@ public class Deck extends Stack implements PlayerRoster.SideChangeListener {
       comm = comm.append(new AddPiece(p));
     }
 
-    try (Writer fw = new FileWriter(f);
+    try (Writer fw = new FileWriter(f, StandardCharsets.UTF_8);
          BufferedWriter out = new BufferedWriter(fw)) {
       gameModule.addCommandEncoder(commandEncoder);
       out.write(gameModule.encode(comm));
@@ -1434,7 +1435,7 @@ public class Deck extends Stack implements PlayerRoster.SideChangeListener {
   public Command loadDeck(File f) throws IOException {
     String ds;
 
-    try (Reader fr = new FileReader(f);
+    try (Reader fr = new FileReader(f, StandardCharsets.UTF_8);
          BufferedReader in = new BufferedReader(fr)) {
       ds = IOUtils.toString(in);
     }

--- a/vassal-app/src/main/java/VASSAL/launch/Launcher.java
+++ b/vassal-app/src/main/java/VASSAL/launch/Launcher.java
@@ -24,6 +24,7 @@ import java.io.PrintStream;
 import java.lang.reflect.InvocationTargetException;
 import java.net.InetAddress;
 import java.net.Socket;
+import java.nio.charset.Charset;
 
 import javax.swing.SwingUtilities;
 
@@ -107,7 +108,7 @@ public abstract class Launcher {
     start.startErrorLog();
 
     // log everything which comes across our stderr
-    System.setErr(new PrintStream(new LoggedOutputStream(), true));
+    System.setErr(new PrintStream(new LoggedOutputStream(), true, Charset.defaultCharset()));
 
     logger.info(getClass().getSimpleName());
     Thread.setDefaultUncaughtExceptionHandler(new ExceptionHandler());

--- a/vassal-app/src/main/java/VASSAL/launch/ModuleManager.java
+++ b/vassal-app/src/main/java/VASSAL/launch/ModuleManager.java
@@ -35,6 +35,8 @@ import java.net.Socket;
 import java.net.UnknownHostException;
 import java.nio.channels.FileLock;
 import java.nio.channels.OverlappingFileLockException;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 import javax.swing.JFrame;
 import javax.swing.JMenuBar;
@@ -261,7 +263,7 @@ public class ModuleManager {
     start.startErrorLog();
 
     // log everything which comes across our stderr
-    System.setErr(new PrintStream(new LoggedOutputStream(), true));
+    System.setErr(new PrintStream(new LoggedOutputStream(), true, Charset.defaultCharset()));
 
     Thread.setDefaultUncaughtExceptionHandler(new ExceptionHandler());
 
@@ -395,7 +397,7 @@ public class ModuleManager {
             if (message == null || clientSocket.isClosed()) continue;
 
             try (PrintStream out = new PrintStream(
-              new BufferedOutputStream(clientSocket.getOutputStream()))) {
+              new BufferedOutputStream(clientSocket.getOutputStream()), true, StandardCharsets.UTF_8)) {
 
               out.println(message);
             }

--- a/vassal-app/src/main/java/VASSAL/launch/TileProgressPumpStateMachine.java
+++ b/vassal-app/src/main/java/VASSAL/launch/TileProgressPumpStateMachine.java
@@ -18,6 +18,8 @@
 
 package VASSAL.launch;
 
+import java.nio.charset.StandardCharsets;
+
 import VASSAL.tools.concurrent.listener.EventListener;
 import VASSAL.tools.image.tilecache.ZipFileImageTiler;
 
@@ -52,7 +54,7 @@ class TileProgressPumpStateMachine {
   public static final int DONE    = 5;
 
   protected void appendName(StringBuilder sb, byte[] buf, int beg, int end) {
-    sb.append(new String(buf, beg, end - beg));
+    sb.append(new String(buf, beg, end - beg, StandardCharsets.UTF_8));
   }
 
   protected boolean hasName(StringBuilder sb) {

--- a/vassal-app/src/main/java/VASSAL/launch/TilingHandler.java
+++ b/vassal-app/src/main/java/VASSAL/launch/TilingHandler.java
@@ -31,6 +31,7 @@ import java.io.PrintWriter;
 import java.net.InetAddress;
 import java.net.ServerSocket;
 import java.net.Socket;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -201,7 +202,7 @@ public class TilingHandler {
     );
 
     // write the image paths to child's stdin, one per line
-    try (PrintWriter stdin = new PrintWriter(proc.stdin)) {
+    try (PrintWriter stdin = new PrintWriter(proc.stdin, true, StandardCharsets.UTF_8)) {
       multi.forEach(stdin::println);
     }
 

--- a/vassal-app/src/main/java/VASSAL/script/BeanShell.java
+++ b/vassal-app/src/main/java/VASSAL/script/BeanShell.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 
 import VASSAL.tools.WarningDialog;
 import bsh.BeanShellExpressionValidator;
@@ -56,29 +57,17 @@ public class BeanShell {
   public void init() {
     // Read in the Vassal Script init script
     URL ini = instance.getClass().getResource(INIT_SCRIPT);
-    BufferedReader in = null;
-    try {
-      in = new BufferedReader(
-        new InputStreamReader(
-        ini.openStream()));
+    try (BufferedReader in = new BufferedReader(
+      new InputStreamReader(ini.openStream(), StandardCharsets.UTF_8))) {
+
       CompileResult result = compile(in);
-      if (! result.isSuccess()) {
+      if (!result.isSuccess()) {
         result.printStackTrace();
       }
     }
     catch (IOException e) {
       //FIXME: Error message
       WarningDialog.show(e, "");
-    }
-    finally {
-      if (in != null) {
-        try {
-          in.close();
-        }
-        catch (IOException e) {
-          //
-        }
-      }
     }
   }
 

--- a/vassal-app/src/main/java/VASSAL/script/ExpressionInterpreter.java
+++ b/vassal-app/src/main/java/VASSAL/script/ExpressionInterpreter.java
@@ -31,6 +31,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.IOException;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -189,7 +190,7 @@ public class ExpressionInterpreter extends AbstractInterpreter {
     logger.info("Attempting to load " + INIT_SCRIPT + " URI generated=" + ini);
 
     try (InputStream is = ini.openStream();
-         InputStreamReader isr = new InputStreamReader(is);
+         InputStreamReader isr = new InputStreamReader(is, StandardCharsets.UTF_8);
          BufferedReader in = new BufferedReader(isr)) {
       try {
         eval(in);

--- a/vassal-app/src/main/java/VASSAL/tools/BugUtils.java
+++ b/vassal-app/src/main/java/VASSAL/tools/BugUtils.java
@@ -5,6 +5,7 @@ import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 
 import VASSAL.Info;
@@ -84,7 +85,7 @@ public class BugUtils {
   public static String getErrorLog() {
     String log = null;
     final File f = new File(Info.getConfDir(), "errorLog");
-    try (FileReader r = new FileReader(f)) {
+    try (FileReader r = new FileReader(f, Charset.defaultCharset())) {
       log = IOUtils.toString(r);
     }
     catch (IOException e) {

--- a/vassal-app/src/main/java/VASSAL/tools/HTTPPostBuilder.java
+++ b/vassal-app/src/main/java/VASSAL/tools/HTTPPostBuilder.java
@@ -27,6 +27,7 @@ import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.Random;
 
 import VASSAL.tools.io.IOUtils;
@@ -40,7 +41,7 @@ import VASSAL.tools.io.IOUtils;
 public class HTTPPostBuilder {
   private final ByteArrayOutputStream bytes = new ByteArrayOutputStream();
   private final BufferedWriter bw =
-    new BufferedWriter(new OutputStreamWriter(bytes));
+    new BufferedWriter(new OutputStreamWriter(bytes, StandardCharsets.UTF_8));
 
   private final String boundary = "---------------------------" +
     randomString() + randomString() + randomString();

--- a/vassal-app/src/main/java/VASSAL/tools/ZipUpdater.java
+++ b/vassal-app/src/main/java/VASSAL/tools/ZipUpdater.java
@@ -52,7 +52,10 @@ import VASSAL.tools.io.IOUtils;
  * the new archive.
  * User: rkinney
  * Date: Oct 23, 2003
+ *
+ * @deprecated removed without replacement
  */
+@Deprecated
 public class ZipUpdater implements Runnable {
   private static final Logger logger =
     LoggerFactory.getLogger(ZipUpdater.class);
@@ -341,7 +344,7 @@ public class ZipUpdater implements Runnable {
 
         try {
           r = new BufferedReader(new InputStreamReader(
-            ZipUpdater.class.getResourceAsStream("/" + UPDATED_ARCHIVE_NAME)));
+            ZipUpdater.class.getResourceAsStream("/" + UPDATED_ARCHIVE_NAME), StandardCharsets.UTF_8));
           final String newArchiveName = r.readLine();
           final ZipUpdater updater = new ZipUpdater(new File(oldArchiveName));
           updater.write(new File(newArchiveName));

--- a/vassal-app/src/main/java/VASSAL/tools/icon/IconFactory.java
+++ b/vassal-app/src/main/java/VASSAL/tools/icon/IconFactory.java
@@ -24,6 +24,7 @@ import java.io.InputStreamReader;
 import java.io.IOException;
 import java.net.JarURLConnection;
 import java.net.URL;
+import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Enumeration;
@@ -317,7 +318,7 @@ public final class IconFactory {
     final URL sizeURL = jar.getURL(path);
 
     try (InputStream in = sizeURL.openStream();
-         InputStreamReader isr = new InputStreamReader(in);
+         InputStreamReader isr = new InputStreamReader(in, Charset.defaultCharset());
          BufferedReader br = new BufferedReader(isr)) {
       String imageName = ""; //$NON-NLS-1$
       while (imageName != null) {
@@ -347,7 +348,7 @@ public final class IconFactory {
     final URL url = jar.getURL(scalablePath);
 
     try (InputStream in = url.openStream();
-         InputStreamReader isr = new InputStreamReader(in);
+         InputStreamReader isr = new InputStreamReader(in, Charset.defaultCharset());
          BufferedReader br = new BufferedReader(isr)) {
       String imageName = ""; //$NON-NLS-1$
       while (imageName != null) {

--- a/vassal-app/src/main/java/VASSAL/tools/image/svg/SVGImageUtils.java
+++ b/vassal-app/src/main/java/VASSAL/tools/image/svg/SVGImageUtils.java
@@ -26,6 +26,7 @@ import java.io.InputStream;
 import java.io.StringWriter;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -285,7 +286,7 @@ public class SVGImageUtils {
     }
 
     sw.flush();
-    return sw.toString().getBytes();
+    return sw.toString().getBytes(StandardCharsets.UTF_8);
   }
 
   protected static void relativizeElement(Element e) {

--- a/vassal-app/src/main/java/VASSAL/tools/image/tilecache/TileUtils.java
+++ b/vassal-app/src/main/java/VASSAL/tools/image/tilecache/TileUtils.java
@@ -33,6 +33,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
 import java.nio.IntBuffer;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
@@ -173,9 +174,9 @@ public class TileUtils {
    * @throws IOException if the byte array is not the tile signature
    */
   static void checkSignature(byte[] sig) throws IOException {
-    if (!Arrays.equals(sig, "VASSAL".getBytes())) {
+    if (!Arrays.equals(sig, "VASSAL".getBytes(StandardCharsets.UTF_8))) {
       throw new IOException(
-        "bad signature: got \"" + new String(sig) +
+        "bad signature: got \"" + new String(sig, StandardCharsets.UTF_8) +
         "\", expected \"VASSAL\""
       );
     }
@@ -288,7 +289,7 @@ public class TileUtils {
     // write the header
     bb = ByteBuffer.allocate(18);
 
-    bb.put("VASSAL".getBytes())
+    bb.put("VASSAL".getBytes(StandardCharsets.UTF_8))
       .putInt(tile.getWidth())
       .putInt(tile.getHeight())
       .putInt(tile.getType());

--- a/vassal-app/src/main/java/VASSAL/tools/image/tilecache/ZipFileImageTiler.java
+++ b/vassal-app/src/main/java/VASSAL/tools/image/tilecache/ZipFileImageTiler.java
@@ -31,6 +31,7 @@ import java.io.OutputStream;
 import java.net.InetAddress;
 import java.net.Socket;
 import java.net.UnknownHostException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
@@ -85,7 +86,7 @@ public class ZipFileImageTiler {
 
       // Get the image paths from stdin, one per line
       final List<String> pl = new ArrayList<>();
-      try (BufferedReader stdin = new BufferedReader(new InputStreamReader(System.in))) {
+      try (BufferedReader stdin = new BufferedReader(new InputStreamReader(System.in, StandardCharsets.UTF_8))) {
         String s;
         while ((s = stdin.readLine()) != null) {
           pl.add(s);

--- a/vassal-app/src/main/java/VASSAL/tools/imports/adc2/SymbolSet.java
+++ b/vassal-app/src/main/java/VASSAL/tools/imports/adc2/SymbolSet.java
@@ -36,6 +36,7 @@ import java.io.FileReader;
 import java.io.InputStream;
 import java.io.IOException;
 import java.io.Reader;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
@@ -586,7 +587,7 @@ public class SymbolSet extends Importer {
     sdx = action.getCaseInsensitiveFile(sdx, f, false, null);
     if (sdx != null) { // must reorder image indeces
 
-      try (Reader fr = new FileReader(sdx);
+      try (Reader fr = new FileReader(sdx, StandardCharsets.US_ASCII);
            BufferedReader input = new BufferedReader(fr)) {
 
         final SymbolData[] pieces = Arrays.copyOf(gamePieceData, gamePieceData.length);

--- a/vassal-app/src/main/java/VASSAL/tools/logging/LoggedOutputStream.java
+++ b/vassal-app/src/main/java/VASSAL/tools/logging/LoggedOutputStream.java
@@ -20,6 +20,7 @@ package VASSAL.tools.logging;
 
 import java.io.ByteArrayOutputStream;
 import java.io.OutputStream;
+import java.nio.charset.Charset;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -74,7 +75,7 @@ public class LoggedOutputStream extends OutputStream {
   @Override
   public synchronized void flush() {
     if (buf.size() > 0) {
-      logger.warn(new String(buf.toByteArray()));
+      logger.warn(new String(buf.toByteArray(), Charset.defaultCharset()));
       buf.reset();
     }
   }

--- a/vassal-app/src/main/java/VASSAL/tools/version/GitProperties.java
+++ b/vassal-app/src/main/java/VASSAL/tools/version/GitProperties.java
@@ -7,6 +7,7 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.util.Properties;
 
 /**
@@ -42,7 +43,7 @@ public class GitProperties {
         return;
       }
 
-      try (BufferedReader reader = new BufferedReader(new InputStreamReader(is))) {
+      try (BufferedReader reader = new BufferedReader(new InputStreamReader(is, StandardCharsets.UTF_8))) {
         gitProperties.load(reader);
       }
 


### PR DESCRIPTION
Prevents the application from behaving differently on platforms with different default character encoding.

Explanation is here: https://spotbugs.readthedocs.io/en/stable/bugDescriptions.html#dm-reliance-on-default-encoding-dm-default-encoding

And also in the javadoc of the Java API calls that were changed, e.g. here: https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/io/InputStreamReader.html, quote "The charset that it uses may be specified by name or may be given explicitly, or the platform's default charset may be accepted.".