### PR TITLE
Update GameRefresher can't refresh message

### DIFF
--- a/vassal-app/src/main/resources/VASSAL/i18n/VASSAL.properties
+++ b/vassal-app/src/main/resources/VASSAL/i18n/VASSAL.properties
@@ -395,7 +395,7 @@ GameRefresher.counters_not_found_test=%1$s Counters can not be refreshed - Not f
 GameRefresher.use_basic_name=Use counter names to identify unknown counters?
 GameRefresher.no_gpids_title=Unable to Refresh Game
 GameRefresher.no_gpids_heading=Unable to Refresh Game
-GameRefresher.no_gpids_message=The Refresher can only be used on modules and extensions saved under Vassal 3.0 or later that have GamePiece Ids allocated.
+GameRefresher.no_gpids_message=This module has GamePiece Id allocation issues that prevent games from being Refreshed. This module must be edited and then saved using Vassal 3.3.3 or later to resolve the problems.
 
 # GameState
 GameState.save_game_query=Save Game?


### PR DESCRIPTION
Update the message when game can't be refreshed due to GamePeice Id issues that require the module to be edited and saved in 3.3.3 or later. Old message was refering to Vassal 3.0 from the time when GamePiece Id's was first introduced.