### PR TITLE
Issue 13250 - Add implementation of Missing !~ Beanshell operator

### DIFF
--- a/vassal-app/src/main/java/bsh/Primitive.java
+++ b/vassal-app/src/main/java/bsh/Primitive.java
@@ -473,7 +473,10 @@ public final class Primitive implements ParserConstants, java.io.Serializable
                 
             case MATCH:
                 return Boolean.valueOf(Pattern.matches(rhs, lhs));
-                
+
+            case NMATCH:
+                return ! Boolean.valueOf(Pattern.matches(rhs, lhs));
+
             default:
                 throw new InterpreterError(
           "Unimplemented binary String operator");

--- a/vassal-app/src/main/java/bsh/bsh.jjt
+++ b/vassal-app/src/main/java/bsh/bsh.jjt
@@ -462,6 +462,8 @@ TOKEN : /* OPERATORS */
 | < LEX: "@lteq" >
 | < GE: ">=" >
 | < GEX: "@gteq" >
+| < MATCH: "=~" >
+| < NMATCH: "!~" >
 | < NE: "!=" >
 | < BOOL_OR: "||" >
 | < BOOL_ORX: "@or" >


### PR DESCRIPTION
Missed the implementation of the !~ beanshell function. The Parser recognises it, but Beanshell doesn't implement it.