### PR TITLE
10314 - NPE Fix - GameRefresher - dialog can be null if the dialog box is closed quickly while test is running

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/module/GameRefresher.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/GameRefresher.java
@@ -184,12 +184,14 @@ public final class GameRefresher implements GameComponent {
     }
 
     if (isTestMode()) {
-      dialog.addMessage(Resources.getString("GameRefresher.counters_refreshed_test", updatedCount));
-      if (notOwnedCount > 0) {
-        dialog.addMessage(Resources.getString("GameRefresher.counters_not_owned_test", notOwnedCount));
-      }
-      if (notFoundCount > 0) {
-        dialog.addMessage(Resources.getString("GameRefresher.counters_not_found_test", notFoundCount));
+      if (dialog != null) { // Could be null if dialog box got closed while we were still running - see start() method above
+        dialog.addMessage(Resources.getString("GameRefresher.counters_refreshed_test", updatedCount));
+        if (notOwnedCount > 0) {
+          dialog.addMessage(Resources.getString("GameRefresher.counters_not_owned_test", notOwnedCount));
+        }
+        if (notFoundCount > 0) {
+          dialog.addMessage(Resources.getString("GameRefresher.counters_not_found_test", notFoundCount));
+        }
       }
     }
     else {


### PR DESCRIPTION
see start() method for a picture of how that happens