### PR TITLE
2705 - NPE Fix - FreeRotator - protect from NPE if piece got moved off map by e.g. GKC.

### DIFF
--- a/vassal-app/src/main/java/VASSAL/counters/FreeRotator.java
+++ b/vassal-app/src/main/java/VASSAL/counters/FreeRotator.java
@@ -622,11 +622,11 @@ public class FreeRotator extends Decorator
 
   @Override
   public void mouseDragged(MouseEvent e) {
-    if (SwingUtils.isMainMouseButtonDown(e)) {
+    if (SwingUtils.isMainMouseButtonDown(e) && !hasPieceMoved()) { // hasPieceMoved() protects from NPE if gone from map
       if (drawGhost) {
         final Point mousePos = getMap().componentToMap(e.getPoint());
         final double myAngle = getRelativeAngle(mousePos, pivot);
-        tempAngle = getAngle() - (myAngle - startAngle)/PI_180;
+        tempAngle = getAngle() - (myAngle - startAngle) / PI_180;
       }
       getMap().repaint();
     }
@@ -635,7 +635,7 @@ public class FreeRotator extends Decorator
   private double getRelativeAngle(Point p, Point origin) {
     double myAngle;
     if (p.y == origin.y) {
-      myAngle = p.x < origin.x ? -Math.PI/2.0 : Math.PI/2.0;
+      myAngle = p.x < origin.x ? -Math.PI / 2.0 : Math.PI / 2.0;
     }
     else {
       myAngle = Math.atan((double)(p.x - origin.x) / (origin.y - p.y));


### PR DESCRIPTION
All other paths in this trait have explicit NPE protect for "the piece might no longer be on a map", but this path had no protection, so it will NPE any time the piece gets GKC'ed off a map during its interactive free rotating thinger.