### PR TITLE
Bugfix13216 - Right-clicking to add Region to Irregular Grid was 100% broken in 3.3.2

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/module/map/boardPicker/board/GridEditor.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/boardPicker/board/GridEditor.java
@@ -340,7 +340,7 @@ public abstract class GridEditor extends JDialog implements MouseListener, KeyLi
 
   @Override
   public void mouseClicked(MouseEvent e) {
-    if (setMode && SwingUtils.isMainMouseButtonDown(e)) {
+    if (setMode) {
       if (hp1 == null) {
         hp1 = e.getPoint();
       }

--- a/vassal-app/src/main/java/VASSAL/build/module/map/boardPicker/board/RegionGrid.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/boardPicker/board/RegionGrid.java
@@ -853,7 +853,6 @@ public class RegionGrid extends AbstractConfigurable implements MapGrid, Configu
     public void mouseClicked(MouseEvent e) {
       lastClick = e.getPoint(); // Also used for right clicks and stuff
       if (SwingUtils.isMainMouseButtonDown(e)) {
-
         if (lastClickedRegion != null) {
           if (e.getClickCount() >= 2) { // Double click show properties
             if (lastClickedRegion.getConfigurer() != null) {

--- a/vassal-app/src/main/java/VASSAL/build/module/map/boardPicker/board/RegionGrid.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/boardPicker/board/RegionGrid.java
@@ -851,8 +851,8 @@ public class RegionGrid extends AbstractConfigurable implements MapGrid, Configu
     // Mouse clicked, see if it is on a Region Point
     @Override
     public void mouseClicked(MouseEvent e) {
+      lastClick = e.getPoint(); // Also used for right clicks and stuff
       if (SwingUtils.isMainMouseButtonDown(e)) {
-        lastClick = e.getPoint();
 
         if (lastClickedRegion != null) {
           if (e.getClickCount() >= 2) { // Double click show properties

--- a/vassal-app/src/main/java/VASSAL/build/module/map/boardPicker/board/RegionGrid.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/boardPicker/board/RegionGrid.java
@@ -1047,16 +1047,17 @@ public class RegionGrid extends AbstractConfigurable implements MapGrid, Configu
 
     @Override
     public void mousePressed(MouseEvent e) {
+      final Point p = e.getPoint();
+      lastClick = p;                          // NB These things need assigning no matter what happens in the if blocks later. 
+      lastClickedRegion = grid.getRegion(p);
+      
       if (e.isPopupTrigger()) {
         doPopupMenu(e);
       }
       else if (SwingUtils.isMainMouseButtonDown(e)) {
-        final Point p = e.getPoint();
-        lastClick = p;
-        lastClickedRegion = grid.getRegion(p);
 
         if (!e.isShiftDown() && !SwingUtils.isSelectionToggle(e) &&
-            (lastClickedRegion==null || !lastClickedRegion.isSelected())) {
+            (lastClickedRegion == null || !lastClickedRegion.isSelected())) {
           unSelectAll();
         }
 
@@ -1110,8 +1111,8 @@ public class RegionGrid extends AbstractConfigurable implements MapGrid, Configu
       if (selectionRect != null) {
         // FIXME: inefficient, could be done with only one new Rectangle
         final Rectangle repaintRect =
-          new Rectangle(selectionRect.x-1, selectionRect.y-1,
-                        selectionRect.width+3, selectionRect.height+3);
+          new Rectangle(selectionRect.x - 1, selectionRect.y - 1,
+                        selectionRect.width + 3, selectionRect.height + 3);
 
         selectionRect.x = Math.min(e.getX(), anchor.x);
         selectionRect.y = Math.min(e.getY(), anchor.y);
@@ -1119,8 +1120,8 @@ public class RegionGrid extends AbstractConfigurable implements MapGrid, Configu
         selectionRect.height = Math.abs(e.getY() - anchor.y);
 
         repaintRect.add(
-          new Rectangle(selectionRect.x-1, selectionRect.y-1,
-                        selectionRect.width+3, selectionRect.height+3));
+          new Rectangle(selectionRect.x - 1, selectionRect.y - 1,
+                        selectionRect.width + 3, selectionRect.height + 3));
         view.repaint(repaintRect);
       }
     }


### PR DESCRIPTION
lastClick got moved inside an only-left-mouse block. 

This appeared sometime after 3.2.17.