### PR TITLE
12986 - Stack could be getting created not-on-a-map

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/module/map/StackMetrics.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/StackMetrics.java
@@ -653,8 +653,7 @@ public class StackMetrics extends AbstractConfigurable {
           }
           else {
             fixedParent = createStack(fixed, true);
-            fixedParent.setMap(fixed.getMap());
-            comm = comm.append(fixedParent.getMap().placeAt(
+            comm = comm.append(fixed.getMap().placeAt(
               fixedParent, fixedParent.getPosition()));
             index = 1;
           }

--- a/vassal-app/src/main/java/VASSAL/build/module/map/StackMetrics.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/StackMetrics.java
@@ -653,10 +653,9 @@ public class StackMetrics extends AbstractConfigurable {
           }
           else {
             fixedParent = createStack(fixed, true);
-            if (fixedParent.getMap() != null) {
-              comm = comm.append(fixedParent.getMap().placeAt(
-                fixedParent, fixedParent.getPosition()));
-            }
+            fixedParent.setMap(fixed.getMap());
+            comm = comm.append(fixedParent.getMap().placeAt(
+              fixedParent, fixedParent.getPosition()));
             index = 1;
           }
         }

--- a/vassal-app/src/main/java/VASSAL/build/module/map/StackMetrics.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/StackMetrics.java
@@ -653,8 +653,10 @@ public class StackMetrics extends AbstractConfigurable {
           }
           else {
             fixedParent = createStack(fixed, true);
-            comm = comm.append(fixedParent.getMap().placeAt(
-              fixedParent, fixedParent.getPosition()));
+            if (fixedParent.getMap() != null) {
+              comm = comm.append(fixedParent.getMap().placeAt(
+                fixedParent, fixedParent.getPosition()));
+            }
             index = 1;
           }
         }


### PR DESCRIPTION
There is evidence elsewhere in StackMetrics.java (see line 271) that Stacks sometimes exist "not on a map". And if one is *created* not-on-a map, as tried to happen here, this line will blow up. So I put in null protection for the map.