### PR TITLE
12888 - PrefsEditor - when cancelling, possibility of trying to set value of object to null (see also: BAD)

### DIFF
--- a/vassal-app/src/main/java/VASSAL/preferences/PrefsEditor.java
+++ b/vassal-app/src/main/java/VASSAL/preferences/PrefsEditor.java
@@ -191,7 +191,10 @@ public class PrefsEditor {
 
   protected synchronized void cancel() {
     for (Configurer c : options) {
-      c.setValue(savedValues.get(c));
+      Object o = savedValues.get(c);
+      if (o != null) {
+        c.setValue(o);
+      }
       c.setFrozen(false);
     }
     dialog.setVisible(false);


### PR DESCRIPTION
The actual crash was in BooleanConfigurer but it was because of this.