### PR TITLE
13188 - "Gentle SVG format failures" - Follow same pattern as SVGImageUtils to catch non-px format

### DIFF
--- a/vassal-app/src/main/java/VASSAL/tools/image/svg/SVGImageUtils.java
+++ b/vassal-app/src/main/java/VASSAL/tools/image/svg/SVGImageUtils.java
@@ -86,10 +86,10 @@ public class SVGImageUtils {
       synchronized (factory) {
         doc = factory.createDocument(null, in);
       }
-    } 
+    }
     catch (FileNotFoundException e) {
       throw new ImageNotFoundException(name, e);
-    } 
+    }
     catch (DOMException | IOException e) {
       throw new ImageIOException(name, e);
     }
@@ -101,7 +101,7 @@ public class SVGImageUtils {
       final int height = (int) (Float.parseFloat(root.getAttributeNS(null, "height").replaceFirst("px", "")) + 0.5);
 
       return new Dimension(width, height);
-    } 
+    }
     catch (NumberFormatException e) {
       throw new ImageIOException(name + " (Only 'px' units supported for height and width in SVG files)", e);
     }
@@ -137,7 +137,7 @@ public class SVGImageUtils {
       synchronized (factory) {
         doc = factory.createDocument(here.toString());
       }
-    } 
+    }
     catch (DOMException e) {
       throw new IOException(e);
     }
@@ -153,7 +153,7 @@ public class SVGImageUtils {
           follow.add(refpath);
           known.add(refpath);
         }
-      } 
+      }
       else {
         throw new IOException("unsupported protocol '" + url.getProtocol() + "' in xlink:href");
       }
@@ -184,7 +184,7 @@ public class SVGImageUtils {
       final Document doc = fac.createDocument(here.toString());
       relativizeElement(doc.getDocumentElement());
       DOMUtilities.writeDocument(doc, sw);
-    } 
+    }
     catch (DOMException e) {
       throw new IOException(e);
     }

--- a/vassal-app/src/main/java/VASSAL/tools/image/svg/SVGImageUtils.java
+++ b/vassal-app/src/main/java/VASSAL/tools/image/svg/SVGImageUtils.java
@@ -55,10 +55,11 @@ import VASSAL.tools.image.ImageNotFoundException;
  */
 public class SVGImageUtils {
   // NB: SAXSVGDocumentFactory isn't thread-safe, we have to synchronize on it.
-  protected static final SAXSVGDocumentFactory factory =
-    new SAXSVGDocumentFactory(XMLResourceDescriptor.getXMLParserClassName());
+  protected static final SAXSVGDocumentFactory factory = new SAXSVGDocumentFactory(
+      XMLResourceDescriptor.getXMLParserClassName());
 
-  private SVGImageUtils() { }
+  private SVGImageUtils() {
+  }
 
   /**
    * Returns the default dimensions of the SVG image.
@@ -78,18 +79,17 @@ public class SVGImageUtils {
    * @return the image dimensions
    * @throws IOException if the image cannot be read
    */
-  public static Dimension getImageSize(String name, InputStream in)
-                                                          throws IOException {
+  public static Dimension getImageSize(String name, InputStream in) throws IOException {
     // get the SVG
     final Document doc;
     try (in) {
       synchronized (factory) {
         doc = factory.createDocument(null, in);
       }
-    }
+    } 
     catch (FileNotFoundException e) {
       throw new ImageNotFoundException(name, e);
-    }
+    } 
     catch (DOMException | IOException e) {
       throw new ImageIOException(name, e);
     }
@@ -97,41 +97,37 @@ public class SVGImageUtils {
     // get the default image width and height
     final Element root = doc.getDocumentElement();
     try {
-      final int width = (int) (Float.parseFloat(
-        root.getAttributeNS(null, "width").replaceFirst("px", ""))+0.5);
-      final int height = (int) (Float.parseFloat(
-        root.getAttributeNS(null, "height").replaceFirst("px", ""))+0.5);
+      final int width = (int) (Float.parseFloat(root.getAttributeNS(null, "width").replaceFirst("px", "")) + 0.5);
+      final int height = (int) (Float.parseFloat(root.getAttributeNS(null, "height").replaceFirst("px", "")) + 0.5);
 
       return new Dimension(width, height);
-    }
+    } 
     catch (NumberFormatException e) {
-      throw new ImageIOException(name, e);
+      throw new ImageIOException(name + " (Only 'px' units supported for height and width in SVG files)", e);
     }
   }
 
   /**
-   * Conducts a recursive depth-first search for external references
-   * in the given SVG file.
+   * Conducts a recursive depth-first search for external references in the given
+   * SVG file.
    *
    * @param path the path of the file to check for external references
    */
-  public static List<String> getExternalReferences(String path)
-                                                           throws IOException {
+  public static List<String> getExternalReferences(String path) throws IOException {
     final ArrayList<String> reflist = new ArrayList<>();
     reflist.add(path);
     return getExternalReferences(path, reflist);
   }
 
   /**
-   * Conducts a recursive depth-first search for external references
-   * in the SVG file named by path. This is a helper function for
+   * Conducts a recursive depth-first search for external references in the SVG
+   * file named by path. This is a helper function for
    * {@link #getExternalReferences}.
    *
-   * @param path the path of the file to check for external references
+   * @param path  the path of the file to check for external references
    * @param known the list of references already found
    */
-  protected static List<String> getExternalReferences(
-                          String path, List<String> known) throws IOException {
+  protected static List<String> getExternalReferences(String path, List<String> known) throws IOException {
 
     final HashSet<String> follow = new HashSet<>();
     final URL here = new URL("file", null, new File(path).getCanonicalPath());
@@ -141,7 +137,7 @@ public class SVGImageUtils {
       synchronized (factory) {
         doc = factory.createDocument(here.toString());
       }
-    }
+    } 
     catch (DOMException e) {
       throw new IOException(e);
     }
@@ -149,8 +145,7 @@ public class SVGImageUtils {
     final NodeList usenodes = doc.getElementsByTagName("use");
     for (int i = 0; i < usenodes.getLength(); ++i) {
       final Element e = (Element) usenodes.item(i);
-      final URL url = new URL(new URL(e.getBaseURI()),
-                              XLinkSupport.getXLinkHref(e));
+      final URL url = new URL(new URL(e.getBaseURI()), XLinkSupport.getXLinkHref(e));
       // balk (for now) unless file is available on our filesystem
       if (url.getProtocol().equals("file")) {
         final String refpath = url.getPath();
@@ -158,10 +153,9 @@ public class SVGImageUtils {
           follow.add(refpath);
           known.add(refpath);
         }
-      }
+      } 
       else {
-        throw new IOException("unsupported protocol '" +
-                              url.getProtocol() + "' in xlink:href");
+        throw new IOException("unsupported protocol '" + url.getProtocol() + "' in xlink:href");
       }
     }
 
@@ -177,13 +171,11 @@ public class SVGImageUtils {
    *
    * @param path the path of the file to be processed
    */
-  public static byte[] relativizeExternalReferences(String path)
-                                                           throws IOException {
+  public static byte[] relativizeExternalReferences(String path) throws IOException {
     // use the GenericDOMImplementation here because
     // SVGDOMImplementation adds unwanted attributes to SVG elements
-    final SAXDocumentFactory fac = new SAXDocumentFactory(
-      new GenericDOMImplementation(),
-      XMLResourceDescriptor.getXMLParserClassName());
+    final SAXDocumentFactory fac = new SAXDocumentFactory(new GenericDOMImplementation(),
+        XMLResourceDescriptor.getXMLParserClassName());
 
     final URL here = new URL("file", null, new File(path).getCanonicalPath());
     final StringWriter sw = new StringWriter();
@@ -192,7 +184,7 @@ public class SVGImageUtils {
       final Document doc = fac.createDocument(here.toString());
       relativizeElement(doc.getDocumentElement());
       DOMUtilities.writeDocument(doc, sw);
-    }
+    } 
     catch (DOMException e) {
       throw new IOException(e);
     }
@@ -213,8 +205,7 @@ public class SVGImageUtils {
     // relativize the xlink:href attribute if there is one
     if (e.hasAttributeNS(XLinkSupport.XLINK_NAMESPACE_URI, "href")) {
       try {
-        final URL url = new URL(new URL(e.getBaseURI()),
-                                XLinkSupport.getXLinkHref(e));
+        final URL url = new URL(new URL(e.getBaseURI()), XLinkSupport.getXLinkHref(e));
         final String anchor = url.getRef();
         final String name = new File(url.getPath()).getName();
         XLinkSupport.setXLinkHref(e, name + '#' + anchor);

--- a/vassal-app/src/main/java/VASSAL/tools/image/svg/SVGRenderer.java
+++ b/vassal-app/src/main/java/VASSAL/tools/image/svg/SVGRenderer.java
@@ -64,6 +64,7 @@ import org.w3c.dom.Node;
 
 import VASSAL.build.GameModule;
 import VASSAL.tools.DataArchive;
+import VASSAL.tools.image.ImageIOException;
 import VASSAL.tools.image.ImageUtils;
 
 /**
@@ -98,7 +99,7 @@ public class SVGRenderer {
   public SVGRenderer(String file, InputStream in) throws IOException {
     // load the SVG
     try (in) {
-      // We synchronize on docFactory becuase it does internal caching
+      // We synchronize on docFactory because it does internal caching
       // of the Documents it produces. This ensures that a Document is
       // being modified on one thread only.
       synchronized (docFactory) {
@@ -112,13 +113,18 @@ public class SVGRenderer {
     // get the default image size
     final Element root = doc.getDocumentElement();
 
-    defaultW = Float.parseFloat(
-      root.getAttributeNS(null, "width").replaceFirst("px", ""));
-    defaultH = Float.parseFloat(
-      root.getAttributeNS(null, "height").replaceFirst("px", ""));
+    try {
+      defaultW = Float.parseFloat(
+        root.getAttributeNS(null, "width").replaceFirst("px", ""));
+      defaultH = Float.parseFloat(
+        root.getAttributeNS(null, "height").replaceFirst("px", ""));
+    }
+    catch (NumberFormatException e) { // This follows the pattern in SVGImageUtils for the same situation.
+      throw new ImageIOException(file + " (Only 'px' units supported for height and width in SVG files)", e);
+    }
   }
 
-  private static final double DEGTORAD = Math.PI/180.0;
+  private static final double DEGTORAD = Math.PI / 180.0;
 
   public BufferedImage render() {
     return render(0.0, 1.0);
@@ -128,7 +134,7 @@ public class SVGRenderer {
     // The renderer needs the bounds unscaled---scaling comes from the
     // width and height hints.
     AffineTransform px = AffineTransform.getRotateInstance(
-      angle*DEGTORAD, defaultW/2.0, defaultH/2.0);
+      angle * DEGTORAD, defaultW / 2.0, defaultH / 2.0);
     r.setTransform(px);
 
     px = new AffineTransform(px);
@@ -156,7 +162,7 @@ public class SVGRenderer {
     // The renderer needs the bounds unscaled---scaling comes from the
     // width and height hints.
     AffineTransform px = AffineTransform.getRotateInstance(
-      angle*DEGTORAD, defaultW/2.0, defaultH/2.0);
+      angle * DEGTORAD, defaultW / 2.0, defaultH / 2.0);
     r.setTransform(px);
 
     px = new AffineTransform(px);
@@ -237,8 +243,8 @@ public class SVGRenderer {
       super.transcode(document, uri, output);
 
        // prepare the image to be painted
-      int w = (int)(width+0.5);
-      int h = (int)(height+0.5);
+      int w = (int)(width + 0.5);
+      int h = (int)(height + 0.5);
 
       // paint the SVG document using the bridge package
       // create the appropriate renderer


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/3742246/89812735-955ac380-db0e-11ea-89e5-fb6843881661.png)

Much cleaner fail, and now provides a bit of guidance.

We can come back and try to support other formats later, if we want, but in any event this should help with the bug reports.