### PR TITLE
3215 - Don't rebuild whole BasicModule after properties window cancel

### DIFF
--- a/vassal-app/src/main/java/VASSAL/configure/PropertiesWindow.java
+++ b/vassal-app/src/main/java/VASSAL/configure/PropertiesWindow.java
@@ -39,6 +39,7 @@ import VASSAL.build.Builder;
 import VASSAL.build.Configurable;
 import VASSAL.build.GameModule;
 import VASSAL.build.module.documentation.HelpWindow;
+import VASSAL.launch.BasicModule;
 import VASSAL.tools.ErrorDialog;
 
 /**
@@ -134,7 +135,14 @@ public class PropertiesWindow extends JDialog {
   }
 
   public void cancel() {
-    target.build(originalState);
+    if (target instanceof BasicModule) { // Modules we don't want to do the full scary rebuild, just put the text fields back.
+      target.setAttribute(GameModule.MODULE_NAME,    originalState.getAttribute(BasicModule.MODULE_NAME));
+      target.setAttribute(GameModule.MODULE_VERSION, originalState.getAttribute(BasicModule.MODULE_VERSION));
+      target.setAttribute(GameModule.DESCRIPTION,    originalState.getAttribute(BasicModule.DESCRIPTION));
+    }
+    else {
+      target.build(originalState);
+    }
     dispose();
   }
 


### PR DESCRIPTION
We were rebuilding BasicModule (!) whenever we cancelled. Really just needed to copy the original data in the three text fields back over.