### PR TITLE
Bug 10414: SVG with non-px dimensions throws ImageIOException

### DIFF
--- a/vassal-app/src/main/java/VASSAL/tools/image/svg/SVGImageUtils.java
+++ b/vassal-app/src/main/java/VASSAL/tools/image/svg/SVGImageUtils.java
@@ -110,7 +110,7 @@ public class SVGImageUtils {
     final String vbs = root.getAttributeNS(null, SVGConstants.SVG_VIEW_BOX_ATTRIBUTE);
 
     final BridgeContext bctx = new BridgeContext(new UserAgentAdapter());
-    final UnitProcessor.Context uctx = UnitProcessor.createContext(bctx, root); 
+    final UnitProcessor.Context uctx = UnitProcessor.createContext(bctx, root);
 
     float w = -1.0f;
     float h = -1.0f;

--- a/vassal-app/src/main/java/VASSAL/tools/image/svg/SVGImageUtils.java
+++ b/vassal-app/src/main/java/VASSAL/tools/image/svg/SVGImageUtils.java
@@ -31,11 +31,18 @@ import java.util.HashSet;
 import java.util.List;
 
 import org.apache.batik.anim.dom.SAXSVGDocumentFactory;
+import org.apache.batik.bridge.BridgeContext;
+import org.apache.batik.bridge.BridgeException;
+import org.apache.batik.bridge.UnitProcessor;
+import org.apache.batik.bridge.UserAgent;
+import org.apache.batik.bridge.UserAgentAdapter;
+import org.apache.batik.bridge.ViewBox;
 import org.apache.batik.dom.GenericDOMImplementation;
 import org.apache.batik.dom.util.DOMUtilities;
 import org.apache.batik.dom.util.SAXDocumentFactory;
 import org.apache.batik.dom.util.XLinkSupport;
 import org.apache.batik.dom.util.XMLSupport;
+import org.apache.batik.util.SVGConstants;
 import org.apache.batik.util.XMLResourceDescriptor;
 
 import org.w3c.dom.Document;
@@ -43,6 +50,8 @@ import org.w3c.dom.DOMException;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
+import org.w3c.dom.svg.SVGDocument;
+import org.w3c.dom.svg.SVGSVGElement;
 
 import VASSAL.tools.image.ImageIOException;
 import VASSAL.tools.image.ImageNotFoundException;
@@ -54,20 +63,24 @@ import VASSAL.tools.image.ImageNotFoundException;
  * @since 3.1.0
  */
 public class SVGImageUtils {
-  // NB: SAXSVGDocumentFactory isn't thread-safe, we have to synchronize on it.
-  protected static final SAXSVGDocumentFactory factory =
-    new SAXSVGDocumentFactory(XMLResourceDescriptor.getXMLParserClassName());
-
   private SVGImageUtils() { }
 
-  /**
-   * Returns the default dimensions of the SVG image.
-   *
-   * @return the image dimensions
-   * @throws IOException if the image cannot be read
-   */
-  public static Dimension getImageSize(InputStream in) throws IOException {
-    return getImageSize("", in);
+  // NB: SAXSVGDocumentFactory isn't thread-safe, we have to synchronize on it.
+  private static final SAXSVGDocumentFactory FACTORY =
+    new SAXSVGDocumentFactory(XMLResourceDescriptor.getXMLParserClassName());
+
+  public static SVGDocument getDocument(String file, InputStream in) throws IOException {
+    try (in) {
+      // We synchronize on FACTORY becuase it does internal caching
+      // of the Documents it produces. This ensures that a Document is
+      // being modified on one thread only.
+      synchronized (FACTORY) {
+        return FACTORY.createSVGDocument(file, in);
+      }
+    }
+    catch (DOMException e) {
+      throw new IOException(e);
+    }
   }
 
   /**
@@ -78,35 +91,108 @@ public class SVGImageUtils {
    * @return the image dimensions
    * @throws IOException if the image cannot be read
    */
-  public static Dimension getImageSize(String name, InputStream in)
-                                                          throws IOException {
-    // get the SVG
-    final Document doc;
-    try (in) {
-      synchronized (factory) {
-        doc = factory.createDocument(null, in);
-      }
+  public static Dimension getImageSize(String file, InputStream in) throws IOException {
+    try {
+      return getImageSize(getDocument(file, in));
     }
     catch (FileNotFoundException e) {
-      throw new ImageNotFoundException(name, e);
+      throw new ImageNotFoundException(file, e);
     }
     catch (DOMException | IOException e) {
-      throw new ImageIOException(name, e);
+      throw new ImageIOException(file, e);
+    }
+  }
+
+  public static Dimension getImageSize(SVGDocument doc) throws IOException {
+    final SVGSVGElement root = doc.getRootElement();
+    final String ws = root.getAttributeNS(null, SVGConstants.SVG_WIDTH_ATTRIBUTE);
+    final String hs = root.getAttributeNS(null, SVGConstants.SVG_HEIGHT_ATTRIBUTE);
+    final String vbs = root.getAttributeNS(null, SVGConstants.SVG_VIEW_BOX_ATTRIBUTE);
+
+    final BridgeContext bctx = new BridgeContext(new UserAgentAdapter());
+    final UnitProcessor.Context uctx = UnitProcessor.createContext(bctx, root); 
+
+    float w = -1.0f;
+    float h = -1.0f;
+    float[] vb = null;
+
+    // try to parse the width
+    if (!ws.isEmpty()) {
+      try {
+        w = UnitProcessor.svgHorizontalLengthToUserSpace(ws, SVGConstants.SVG_WIDTH_ATTRIBUTE, uctx);
+      }
+      catch (BridgeException e) {
+        // the width was invalid
+        throw new IOException(e);
+      }
     }
 
-    // get the default image width and height
-    final Element root = doc.getDocumentElement();
-    try {
-      final int width = (int) (Float.parseFloat(
-        root.getAttributeNS(null, "width").replaceFirst("px", "")) + 0.5);
-      final int height = (int) (Float.parseFloat(
-        root.getAttributeNS(null, "height").replaceFirst("px", "")) + 0.5);
+    // try to parse the height
+    if (!hs.isEmpty()) {
+      try {
+        h = UnitProcessor.svgVerticalLengthToUserSpace(hs, SVGConstants.SVG_HEIGHT_ATTRIBUTE, uctx);
+      }
+      catch (BridgeException e) {
+        // the height was invalid
+        throw new IOException(e);
+      }
+    }
 
-      return new Dimension(width, height);
+    // try to parse the viewBox
+    if (!vbs.isEmpty()) {
+      try {
+        vb = ViewBox.parseViewBoxAttribute(root, vbs, bctx);
+      }
+      catch (BridgeException e) {
+        // the viewBox was invalid
+        throw new IOException(e);
+      }
     }
-    catch (NumberFormatException e) {
-      throw new ImageIOException(name, e);
+
+    if (w < 0.0f || h < 0.0f) {
+      if (!vbs.isEmpty()) {
+        // the viewBox array will be null if it had 0 height or width
+        if (vb != null) {
+          // we have a nonempty viewBox
+          if (w < 0.0f) {
+            // no width given; use the width of the viewBox
+            w = vb[2];
+          }
+
+          if (h < 0.0f) {
+            // no height given; use the height of the viewBox
+            h = vb[3];
+          }
+        }
+      }
+      else {
+        // no viewBox
+        if (h >= 0.0f) {
+          // height but no width; make it square
+          w = h;
+        }
+        else if (w >= 0.0f) {
+          // width but no height; make it square
+          h = w;
+        }
+        else {
+          // no dimensions specified
+          w = h = 0;
+        }
+      }
     }
+
+    return new Dimension((int)(w + 0.5f), (int)(h + 0.5f));
+  }
+
+  /**
+   * Returns the default dimensions of the SVG image.
+   *
+   * @return the image dimensions
+   * @throws IOException if the image cannot be read
+   */
+  public static Dimension getImageSize(InputStream in) throws IOException {
+    return getImageSize("", in);
   }
 
   /**
@@ -138,8 +224,8 @@ public class SVGImageUtils {
 
     Document doc = null;
     try {
-      synchronized (factory) {
-        doc = factory.createDocument(here.toString());
+      synchronized (FACTORY) {
+        doc = FACTORY.createDocument(here.toString());
       }
     }
     catch (DOMException e) {
@@ -183,7 +269,8 @@ public class SVGImageUtils {
     // SVGDOMImplementation adds unwanted attributes to SVG elements
     final SAXDocumentFactory fac = new SAXDocumentFactory(
       new GenericDOMImplementation(),
-      XMLResourceDescriptor.getXMLParserClassName());
+      XMLResourceDescriptor.getXMLParserClassName()
+    );
 
     final URL here = new URL("file", null, new File(path).getCanonicalPath());
     final StringWriter sw = new StringWriter();

--- a/vassal-app/src/test/java/VASSAL/tools/image/svg/SVGImageUtilsTest.java
+++ b/vassal-app/src/test/java/VASSAL/tools/image/svg/SVGImageUtilsTest.java
@@ -1,0 +1,176 @@
+package VASSAL.tools.image.svg;
+
+import java.awt.Dimension;
+import java.io.ByteArrayInputStream;
+import java.io.FileInputStream;
+import java.io.InputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Stream;
+
+import org.apache.commons.io.IOUtils;
+
+import VASSAL.tools.image.ImageIOException;
+import VASSAL.tools.lang.Pair;
+
+import static org.junit.Assert.*;
+import org.junit.Test;
+import org.junit.experimental.runners.Enclosed;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+@RunWith(Enclosed.class)
+public class SVGImageUtilsTest {
+
+  public static class GetSizeBadInputTest {
+    @Test(expected = ImageIOException.class)
+    public void testGarbage() throws IOException {
+      final ByteArrayInputStream in = new ByteArrayInputStream(
+        "bogus".getBytes(StandardCharsets.UTF_8)
+      );
+      SVGImageUtils.getImageSize("test.svg", in);
+    }
+  }
+
+  @RunWith(Parameterized.class)
+  public static class GetSizeUnitsTest {
+    private final String aw;
+    private final String ah;
+    private final int ew;
+    private final int eh;
+
+    public GetSizeUnitsTest(String aw, int ew, String ah, int eh) {
+      this.aw = aw;
+      this.ah = ah;
+      this.ew = ew;
+      this.eh = eh;
+    }
+
+    private static final String WH = "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"%s\" height=\"%s\"></svg>";
+
+    @Test
+    public void testGetSize() throws IOException {
+      final String svg = String.format(WH, aw, ah);
+      final ByteArrayInputStream in = new ByteArrayInputStream(
+        svg.getBytes(StandardCharsets.UTF_8)
+      );
+
+      assertEquals(
+        new Dimension(ew, eh),
+        SVGImageUtils.getImageSize("test.svg", in)
+      );
+    }
+
+    @Parameters
+    public static Iterable<Object[]> data() {
+      final List<Pair<String, Integer>> lengths = List.of(
+        Pair.of("87",     87),
+        Pair.of("87px",   87),
+        Pair.of("190",   190),
+        Pair.of("190px", 190),
+        Pair.of("1in",    96),
+        Pair.of("72pt",   96),
+        Pair.of("72pt",   96),
+        Pair.of("6pc",    96),
+        Pair.of("2.54cm", 96),
+        Pair.of("25.4mm", 96),
+        Pair.of("98.6",   99),
+        Pair.of("98.4",   98)
+      );
+
+      // make the cartesian product as a stream
+      final Stream<Object[]> op = lengths.stream().flatMap(
+        a -> lengths.stream().map(
+          b -> new Object[]{a.first, a.second, b.first, b.second}
+        )
+      );
+
+      return (Iterable<Object[]>) op::iterator;
+    }
+  }
+
+  @RunWith(Parameterized.class)
+  public static class GetSizeTest {
+    private final String w;
+    private final String h;
+    private final String vb;
+    private final Object exp;
+
+    public GetSizeTest(String w, String h, String vb, Object exp) {
+      this.w = w;
+      this.h = h;
+      this.vb = vb;
+      this.exp = exp;
+    }
+
+    private static final String SVG = "<svg xmlns=\"http://www.w3.org/2000/svg\" %s %s %s></svg>";
+
+    @Test
+    public void testGetSize() throws IOException {
+      final String svg = String.format(
+        SVG,
+        w == null ? "" : "width=\"" + w + "\"",
+        h == null ? "" : "height=\"" + h + "\"",
+        vb == null ? "" : "viewBox=\"" + vb + "\""
+      );
+      final ByteArrayInputStream in = new ByteArrayInputStream(
+        svg.getBytes(StandardCharsets.UTF_8)
+      );
+
+      if (exp instanceof Throwable) {
+        try {
+          SVGImageUtils.getImageSize("test.svg", in);
+          fail("Expected " + exp);
+        }
+        catch (Throwable t) {
+          assertTrue(exp.getClass().isAssignableFrom(t.getClass()));
+        }
+      }
+      else {
+        assertEquals(
+          exp,
+          SVGImageUtils.getImageSize("test.svg", in)
+        );
+      }
+    }
+
+    @Parameters
+    public static Iterable<Object[]> data() {
+      return Arrays.asList(new Object[][]{
+        { null,  null,  "0 0 100 200",     new Dimension(100, 200) },
+        { null,  null,  "0 0 100.1 200.5", new Dimension(100, 201) },
+        { null,  null,  "3 8 100 200",     new Dimension(100, 200) },
+        { "20",  "30",  "0 0 0 0",         new Dimension(20, 30)   },
+        { "1",   "2",   null,              new Dimension(1, 2)     },
+        // missing width, height and empty view box gives empty image
+        { null,  null,  "0 0 0 0",         new Dimension(0, 0)     },
+        { null,  null,  "0 0 1 0",         new Dimension(0, 0)     },
+        { null,  null,  "0 0 0 1",         new Dimension(0, 0)     },
+        // missing dimension picked up from viewBox
+        { "30",  null,  "0 0 50 60",       new Dimension(30, 60)   },
+        { null,  "30",  "0 0 50 60",       new Dimension(50, 30)   },
+        { "30",  null,  "0 0 0 0",         new Dimension(30, 0)    },
+        { null,  "30",  "0 0 0 0",         new Dimension(0, 30)    },
+        // given width, height always used
+        { "0",   "0",   null,              new Dimension(0, 0)     },
+        { "1",   "0",   "0 0 50 60",       new Dimension(1, 0)     },
+        { "0",   "1",   "0 0 50 60",       new Dimension(0, 1)     },
+        // missing one dimension results in a square
+        { "30",  null,  null,              new Dimension(30, 30)   },
+        { null,  "30",  null,              new Dimension(30, 30)   },
+        // missing all dimensions gives empty image
+        { null,  null,  null,              new Dimension(0, 0)     },
+        // any bogus value throws
+        { "bob", "1",   null,              new IOException()       },
+        { "1",   "bob", null,              new IOException()       },
+        { "1",   "2",   "bob",             new IOException()       },
+        { null,  null,  "bob",             new IOException()       },
+        { null,  null,  "0 0 13 bob",      new IOException()       },
+        { null,  null,  "0 0 -1 0",        new IOException()       },
+      });
+    }
+  }
+}


### PR DESCRIPTION
CSS 2.1 defined 96px = 1in, so we can now fix dimensions for all SVG which doesn't use font-relative sizes. This should prevent all reasonable SVG from throwing exceptions due to dimensions.