### PR TITLE
13276 - Center-on-opponents-moves now strictly a player preference

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/module/GlobalOptions.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/GlobalOptions.java
@@ -92,7 +92,7 @@ public class GlobalOptions extends AbstractConfigurable {
 
   private String promptString = "Opponents can unmask my pieces"; //$NON-NLS-1$
   private String nonOwnerUnmaskable = NEVER;
-  private String centerOnMoves = ALWAYS;
+  private String centerOnMoves = PROMPT;
   private String autoReport = ALWAYS;
   private String markMoved = NEVER;
   private String chatterHTMLSupport = PROMPT; 
@@ -212,6 +212,9 @@ public class GlobalOptions extends AbstractConfigurable {
       prefs.addOption(macLegacyConf);
     }
     
+    BooleanConfigurer config = new BooleanConfigurer(CENTER_ON_MOVE, Resources.getString("GlobalOptions.center_on_move"), Boolean.TRUE); //$NON-NLS-1$
+    prefs.addOption(config);
+    
     validator = new SingleChildInstance(gm, getClass());
   }
 
@@ -283,7 +286,6 @@ public class GlobalOptions extends AbstractConfigurable {
     return new String[]{
       Resources.getString("Editor.GlobalOption.nonowner_unmask"), //$NON-NLS-1$
       null,
-      Resources.getString("Editor.GlobalOption.center_moves"), //$NON-NLS-1$
       Resources.getString("Editor.GlobalOption.autoreport_moves"), //$NON-NLS-1$
       Resources.getString("Editor.GlobalOption.playerid_format"), //$NON-NLS-1$
       Resources.getString("Editor.GlobalOption.chatter_html_support") //$NON-NLS-1$
@@ -296,7 +298,6 @@ public class GlobalOptions extends AbstractConfigurable {
       Arrays.asList(
         NON_OWNER_UNMASKABLE,
         PROMPT_STRING,
-        CENTER_ON_MOVE,
         AUTO_REPORT,
         PLAYER_ID_FORMAT,
         CHATTER_HTML_SUPPORT
@@ -313,7 +314,6 @@ public class GlobalOptions extends AbstractConfigurable {
     return new Class<?>[]{
       Prompt.class,
       null,
-      Prompt.class,
       Prompt.class,
       PlayerIdFormatConfig.class,
       Prompt.class
@@ -406,9 +406,6 @@ public class GlobalOptions extends AbstractConfigurable {
     else if (PROMPT_STRING.equals(key)) {
       return promptString;
     }
-    else if (CENTER_ON_MOVE.equals(key)) {
-      return centerOnMoves;
-    }
     else if (CHATTER_HTML_SUPPORT.equals(key)) {
       return chatterHTMLSupport;
     }
@@ -462,13 +459,6 @@ public class GlobalOptions extends AbstractConfigurable {
       promptString = (String) value;
       ObscurableOptions.getInstance().setPrompt(promptString);
     }
-    else if (CENTER_ON_MOVE.equals(key)) {
-      centerOnMoves = (String) value;
-      if (PROMPT.equals(centerOnMoves)) {
-        BooleanConfigurer config = new BooleanConfigurer(CENTER_ON_MOVE, Resources.getString("GlobalOptions.center_on_move")); //$NON-NLS-1$
-        GameModule.getGameModule().getPrefs().addOption(config);
-      }
-    }
     else if (CHATTER_HTML_SUPPORT.equals(key)) {
       chatterHTMLSupport = (String) value;
       if (PROMPT.equals(chatterHTMLSupport)) {
@@ -506,7 +496,7 @@ public class GlobalOptions extends AbstractConfigurable {
   }
 
   public boolean centerOnOpponentsMove() {
-    return isEnabled(centerOnMoves, CENTER_ON_MOVE);
+    return Boolean.TRUE.equals(GameModule.getGameModule().getPrefs().getValue(CENTER_ON_MOVE));
   }
   
   public boolean chatterHTMLSupport() {


### PR DESCRIPTION
Previously there has been a "GlobalOptions" setting for center on opponents' moves, allowing module designers to essentially force this preference on players, even though it's not an appropriate preference for module designers to control.

This PR:
(1) Makes the preference for "Center on opponents' moves" always appear for every module
(2) Always honors the preference regardless of any previous module setting
(3) Removes the GlobalOptions attribute