### PR TITLE
Performance improvement of SequenceEncoder

### DIFF
--- a/vassal-app/src/main/java/VASSAL/configure/StringArrayConfigurer.java
+++ b/vassal-app/src/main/java/VASSAL/configure/StringArrayConfigurer.java
@@ -25,7 +25,9 @@ import java.awt.event.ActionListener;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import javax.swing.Box;
 import javax.swing.DefaultListModel;
@@ -184,6 +186,29 @@ public class StringArrayConfigurer extends Configurer {
     if (s == null || s.length == 0) {
       return "";
     }
+
+    final String delimiter = ",";
+
+    return Arrays
+      .stream(s)
+      .map(item -> {
+        if (item == null) {
+          return "";
+        }
+
+        if (!item.contains(",")) {
+          return item;
+        }
+
+        return item.replaceAll(delimiter, "\\\\" + delimiter);
+      })
+      .collect(Collectors.joining(delimiter));
+  }
+
+  public static String arrayToStringOld(String[] s) {
+    if (s == null || s.length == 0) {
+      return "";
+    }
     SequenceEncoder se = new SequenceEncoder(',');
     for (String item : s) {
       se.append(item != null ? item : "");
@@ -229,19 +254,4 @@ public class StringArrayConfigurer extends Configurer {
     }
   }
 
-  // TODO move test code to a manual unit test annotated with @Ignore
-  public static void main(String[] args) {
-    JFrame f = new JFrame();
-    final StringArrayConfigurer c = new StringArrayConfigurer(null, "Visible to these players:  ");
-    c.addPropertyChangeListener(new PropertyChangeListener() {
-      @Override
-      public void propertyChange(PropertyChangeEvent evt) {
-        System.err.println(c.getName() + " = " + c.getValueString());
-      }
-    });
-    c.setValue("Rack,Shack,Benny");
-    f.add(c.getControls());
-    f.pack();
-    f.setVisible(true);
-  }
 }

--- a/vassal-app/src/main/java/VASSAL/tools/SequenceEncoder.java
+++ b/vassal-app/src/main/java/VASSAL/tools/SequenceEncoder.java
@@ -70,13 +70,7 @@ public class SequenceEncoder {
   }
 
   public SequenceEncoder append(String s) {
-    // start the buffer, or add delimiter after previous token
-    if (buffer == null) {
-      buffer = new StringBuilder();
-    }
-    else {
-      buffer.append(delimit);
-    }
+    startBufferOrAddDelimiter();
 
     if (s != null) {
       if (s.endsWith("\\") || (s.startsWith("'") && s.endsWith("'"))) {
@@ -97,19 +91,27 @@ public class SequenceEncoder {
   }
 
   public SequenceEncoder append(int i) {
-    return append(String.valueOf(i));
+    startBufferOrAddDelimiter();
+    buffer.append(i);
+    return this;
   }
 
   public SequenceEncoder append(long l) {
-    return append(String.valueOf(l));
+    startBufferOrAddDelimiter();
+    buffer.append(l);
+    return this;
   }
 
   public SequenceEncoder append(double d) {
-    return append(String.valueOf(d));
+    startBufferOrAddDelimiter();
+    buffer.append(d);
+    return this;
   }
 
   public SequenceEncoder append(boolean b) {
-    return append(String.valueOf(b));
+    startBufferOrAddDelimiter();
+    buffer.append(b);
+    return this;
   }
 
   public SequenceEncoder append(KeyStroke stroke) {
@@ -132,6 +134,18 @@ public class SequenceEncoder {
     return append(p.getExpression());
   }
 
+  /**
+   * start the buffer, or add delimiter after previous token
+   */
+  private void startBufferOrAddDelimiter() {
+    if (buffer == null) {
+      buffer = new StringBuilder();
+    }
+    else {
+      buffer.append(delimit);
+    }
+  }
+
   public String getValue() {
     return buffer != null ? buffer.toString() : null;
   }
@@ -141,7 +155,7 @@ public class SequenceEncoder {
     int end = s.indexOf(delimit);
 
     while (begin <= end) {
-      buffer.append(s.substring(begin, end)).append('\\');
+      buffer.append(s, begin, end).append('\\');
       begin = end;
       end = s.indexOf(delimit, end + 1);
     }
@@ -365,15 +379,4 @@ public class SequenceEncoder {
     }
   }
 
-  public static void main(String[] args) {
-    SequenceEncoder se = new SequenceEncoder(',');
-    for (String arg : args) {
-      se.append(arg);
-    }
-    System.out.println(se.getValue());
-    SequenceEncoder.Decoder st = new SequenceEncoder.Decoder(se.getValue(), ',');
-    while (st.hasMoreTokens()) {
-      System.out.println(st.nextToken());
-    }
-  }
 }

--- a/vassal-app/src/test/java/VASSAL/configure/StringArrayConfigurerTest.java
+++ b/vassal-app/src/test/java/VASSAL/configure/StringArrayConfigurerTest.java
@@ -1,0 +1,68 @@
+package VASSAL.configure;
+
+import javax.swing.JFrame;
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
+import java.util.stream.IntStream;
+
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.BlockJUnit4ClassRunner;
+
+@RunWith(BlockJUnit4ClassRunner.class)
+public class StringArrayConfigurerTest {
+
+  @Test
+  public void compareStringArrayToStringPerformance() {
+    final String[] input = IntStream
+      .range(0, 1000)
+      .mapToObj(value -> "string" + value)
+      .toArray(String[]::new);
+
+    // warm up VM
+    IntStream
+      .range(0, 100000)
+      .forEach(value -> {
+        final String sOld = StringArrayConfigurer.arrayToStringOld(input);
+        final String sNew = StringArrayConfigurer.arrayToString(input);
+      });
+
+    // measure old
+    final long oldStart = System.currentTimeMillis();
+    IntStream
+      .range(0, 100000)
+      .forEach(value -> {
+        final String s = StringArrayConfigurer.arrayToStringOld(input);
+      });
+    final long oldDuration = System.currentTimeMillis() - oldStart;
+
+    // measure new
+    final long newStart = System.currentTimeMillis();
+    IntStream
+      .range(0, 100000)
+      .forEach(value -> {
+        final String s = StringArrayConfigurer.arrayToString(input);
+      });
+    final long newDuration = System.currentTimeMillis() - newStart;
+
+    System.out.println("old method duration: " + oldDuration + "\nnew method duration: " + newDuration);
+  }
+
+  @Ignore
+  @Test
+  public void manualTest() {
+    JFrame f = new JFrame();
+    final StringArrayConfigurer c = new StringArrayConfigurer(null, "Visible to these players:  ");
+    c.addPropertyChangeListener(new PropertyChangeListener() {
+      @Override
+      public void propertyChange(PropertyChangeEvent evt) {
+        System.err.println(c.getName() + " = " + c.getValueString());
+      }
+    });
+    c.setValue("Rack,Shack,Benny");
+    f.add(c.getControls());
+    f.pack();
+    f.setVisible(true);
+  }
+}

--- a/vassal-app/src/test/java/VASSAL/tools/SequenceEncoderTest.java
+++ b/vassal-app/src/test/java/VASSAL/tools/SequenceEncoderTest.java
@@ -24,6 +24,7 @@ import javax.swing.KeyStroke;
 
 import VASSAL.configure.PropertyExpression;
 
+import org.junit.Ignore;
 import org.junit.Test;
 
 import static org.junit.Assert.*;
@@ -214,5 +215,20 @@ public class SequenceEncoderTest {
 
     assertEquals("", sd.nextToken());
     assertEquals(value2, sd.nextToken());
+  }
+
+  @Ignore
+  @Test
+  public void manualTest() {
+    final String[] args = new String[] { "foo", "bar", "baz"};
+    SequenceEncoder se = new SequenceEncoder(',');
+    for (String arg : args) {
+      se.append(arg);
+    }
+    System.out.println(se.getValue());
+    SequenceEncoder.Decoder st = new SequenceEncoder.Decoder(se.getValue(), ',');
+    while (st.hasMoreTokens()) {
+      System.out.println(st.nextToken());
+    }
   }
 }


### PR DESCRIPTION
A first try at improving performance of SequenceEncoder.

One open question is, how to detect whether the primitives need escaping due to the escape character being in `[0-9truefalse.-]`.

Possible solution (pseudocode):
```
class SequenceEncoder {
  boolean dangerousDelimiter = false;

  SequenceEncoder(String delimiter) {
    if (delimiter.matches("[0-9truefalse.-]")) dangerousDelimiter = true;
  }

  void append(int i) {
    if (dangerousDelimiter)
      possiblyEscapeAndAppend(i);
    else
      fastAppend(i);
  }
}
```