### PR TITLE
Do not log anything below log level INFO

### DIFF
--- a/vassal-app/src/main/resources/logback.xml
+++ b/vassal-app/src/main/resources/logback.xml
@@ -23,7 +23,7 @@
     <prudent>true</prudent>
   </appender>
 
-  <root level="ALL">
+  <root level="info">
     <appender-ref ref="FILE" />
   </root>
 </configuration>


### PR DESCRIPTION
If log levels DEBUG or TRACE are needed for development, a `/vassal-app/src/test/resources/logback.xml` can be added and will override the `logback.xml` for the production environment.