### PR TITLE
13275 - Ctrl+MouseWheel will zoom in and out (Command + Mousewheel on Mac, of course)

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/module/Map.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/Map.java
@@ -245,6 +245,12 @@ public class Map extends AbstractConfigurable implements GameComponent, MouseLis
     toolBar.setAlignmentX(0.0F);
     toolBar.setFloatable(false);
   }
+  
+  
+  public Component getComponent() {
+    return theMap;
+  }
+
 
   // Global Change Reporting control
   public static void setChangeReportingEnabled(boolean b) {

--- a/vassal-app/src/main/java/VASSAL/build/module/map/Zoomer.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/Zoomer.java
@@ -671,7 +671,7 @@ public class Zoomer extends AbstractConfigurable implements GameComponent {
     listener = new MouseWheelListener() {
       @Override
       public void mouseWheelMoved(MouseWheelEvent e) {
-        if ((e.getScrollAmount() == 0) || !map.getComponent().hasFocus()) {
+        if (e.getScrollAmount() == 0) {
           return;
         }
         
@@ -686,6 +686,8 @@ public class Zoomer extends AbstractConfigurable implements GameComponent {
             zoomOut();
           }
         }
+        
+        map.getComponent().getParent().dispatchEvent(e); // So that the scrollbars can still find our event.
       }
     };
     

--- a/vassal-app/src/main/java/VASSAL/build/module/map/Zoomer.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/Zoomer.java
@@ -689,10 +689,8 @@ public class Zoomer extends AbstractConfigurable implements GameComponent {
         map.getComponent().getParent().dispatchEvent(e); // So that the scrollbars can still find our event.
       }
     };
-    
-    if (listener != null) {
-      map.getComponent().addMouseWheelListener(listener);
-    }
+        
+    map.getComponent().addMouseWheelListener(listener);
   }
   
   

--- a/vassal-app/src/main/java/VASSAL/build/module/map/Zoomer.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/Zoomer.java
@@ -28,6 +28,8 @@ import java.awt.Point;
 import java.awt.Rectangle;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
+import java.awt.event.MouseWheelEvent;
+import java.awt.event.MouseWheelListener;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -48,6 +50,7 @@ import javax.swing.JMenuItem;
 import javax.swing.JPanel;
 import javax.swing.JPopupMenu;
 import javax.swing.JRadioButtonMenuItem;
+import javax.swing.JScrollBar;
 import javax.swing.JScrollPane;
 import javax.swing.JSpinner;
 import javax.swing.JSplitPane;
@@ -80,6 +83,7 @@ import VASSAL.i18n.Resources;
 import VASSAL.tools.ErrorDialog;
 import VASSAL.tools.LaunchButton;
 import VASSAL.tools.NamedKeyStroke;
+import VASSAL.tools.swing.SwingUtils;
 
 /**
  * Controls the zooming in/out of a {@link Map} window.
@@ -99,6 +103,8 @@ public class Zoomer extends AbstractConfigurable implements GameComponent {
   protected LaunchButton zoomPickButton;
   protected LaunchButton zoomOutButton;
   protected ZoomMenu zoomMenu;
+
+  protected MouseWheelListener listener;
 
   protected State state;
 
@@ -660,8 +666,35 @@ public class Zoomer extends AbstractConfigurable implements GameComponent {
     map.getToolBar().add(zoomInButton);
     map.getToolBar().add(zoomPickButton);
     map.getToolBar().add(zoomOutButton);
-  }
 
+    // Ctrl+Mousewheel to zoom in/out.
+    listener = new MouseWheelListener() {
+      @Override
+      public void mouseWheelMoved(MouseWheelEvent e) {
+        if ((e.getScrollAmount() == 0) || !map.getComponent().hasFocus()) {
+          return;
+        }
+        
+        if ((e.getScrollType() == MouseWheelEvent.WHEEL_UNIT_SCROLL) && SwingUtils.isSelectionToggle(e)) {
+          int units = e.getUnitsToScroll();
+          
+          if ((units < 0) && state.hasHigherLevel()) {
+            zoomIn();
+          }
+          
+          if ((units > 0) && state.hasLowerLevel()) {
+            zoomOut();
+          }
+        }
+      }
+    };
+    
+    if (listener != null) {
+      map.getComponent().addMouseWheelListener(listener);
+    }
+  }
+  
+  
   @Override
   public String getAttributeValueString(String key) {
     if (ZOOM_START.equals(key)) {
@@ -808,6 +841,11 @@ public class Zoomer extends AbstractConfigurable implements GameComponent {
     map.getToolBar().remove(zoomInButton);
     map.getToolBar().remove(zoomPickButton);
     map.getToolBar().remove(zoomOutButton);
+    
+    if (listener != null) {
+      map.getComponent().removeMouseWheelListener(listener);
+      listener = null;
+    }
   }
 
   public double getZoomFactor() {

--- a/vassal-app/src/main/java/VASSAL/build/module/map/Zoomer.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/Zoomer.java
@@ -681,8 +681,7 @@ public class Zoomer extends AbstractConfigurable implements GameComponent {
           if ((units < 0) && state.hasHigherLevel()) {
             zoomIn();
           }
-          
-          if ((units > 0) && state.hasLowerLevel()) {
+          else if ((units > 0) && state.hasLowerLevel()) {
             zoomOut();
           }
         }

--- a/vassal-app/src/main/java/VASSAL/build/module/map/Zoomer.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/Zoomer.java
@@ -668,28 +668,25 @@ public class Zoomer extends AbstractConfigurable implements GameComponent {
     map.getToolBar().add(zoomOutButton);
 
     // Ctrl+Mousewheel to zoom in/out.
-    listener = new MouseWheelListener() {
-      @Override
-      public void mouseWheelMoved(MouseWheelEvent e) {
-        if (e.getScrollAmount() == 0) {
-          return;
-        }
-        
-        if ((e.getScrollType() == MouseWheelEvent.WHEEL_UNIT_SCROLL) && SwingUtils.isSelectionToggle(e)) {
-          int units = e.getUnitsToScroll();
-          
-          if ((units < 0) && state.hasHigherLevel()) {
-            zoomIn();
-          }
-          else if ((units > 0) && state.hasLowerLevel()) {
-            zoomOut();
-          }
-        }
-        
-        map.getComponent().getParent().dispatchEvent(e); // So that the scrollbars can still find our event.
+    listener = e -> {
+      if (e.getScrollAmount() == 0) {
+        return;
       }
+
+      if ((e.getScrollType() == MouseWheelEvent.WHEEL_UNIT_SCROLL) && SwingUtils.isSelectionToggle(e)) {
+        int units = e.getUnitsToScroll();
+
+        if ((units < 0) && state.hasHigherLevel()) {
+          zoomIn();
+        }
+        else if ((units > 0) && state.hasLowerLevel()) {
+          zoomOut();
+        }
+      }
+
+      map.getComponent().getParent().dispatchEvent(e); // So that the scrollbars can still find our event.
     };
-        
+       
     map.getComponent().addMouseWheelListener(listener);
   }
   

--- a/vassal-app/src/main/java/VASSAL/tools/ScrollPane.java
+++ b/vassal-app/src/main/java/VASSAL/tools/ScrollPane.java
@@ -23,6 +23,7 @@ import java.awt.event.MouseWheelListener;
 
 import javax.swing.JScrollBar;
 import javax.swing.JScrollPane;
+import VASSAL.tools.swing.SwingUtils;
 
 /**
  ScrollPane extends JScrollPane to have complete mouse-wheel functionality.
@@ -110,7 +111,7 @@ public class ScrollPane extends JScrollPane {
       public void mouseWheelMoved(MouseWheelEvent e) {
         if (e.getScrollAmount() == 0) return;
 
-        if (e.getScrollType() == MouseWheelEvent.WHEEL_UNIT_SCROLL) {
+        if ((e.getScrollType() == MouseWheelEvent.WHEEL_UNIT_SCROLL) && !e.isAltDown() && !SwingUtils.isSelectionToggle(e)) {
           final JScrollBar bar = e.isShiftDown() ?
             horizontalScrollBar : verticalScrollBar;
           if (bar == null || !bar.isVisible()) return;


### PR DESCRIPTION
This is actually pretty sweet, works a LOT better than I was expecting. And of course module designer has control of exactly what "zoom stops" are provided.

I don't think there's any need to provide a preference to e.g. turn this on and off, because realistically who does "ctrl + mousewheel" when they don't "mean it" anyway.