### PR TITLE
(3.3.3) Be sure to show HTML-Enable pref even if reading a pre-3.3.3 module that doesn't have a GlobalOptions setting written in yet

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/module/Chatter.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/Chatter.java
@@ -45,6 +45,7 @@ import VASSAL.build.Buildable;
 import VASSAL.build.GameModule;
 import VASSAL.command.Command;
 import VASSAL.command.CommandEncoder;
+import VASSAL.configure.BooleanConfigurer;
 import VASSAL.configure.ColorConfigurer;
 import VASSAL.configure.FontConfigurer;
 import VASSAL.i18n.Resources;
@@ -528,6 +529,12 @@ public class Chatter extends JPanel implements CommandEncoder, Buildable {
 
     globalPrefs.addOption( Resources.getString("Chatter.chat_window"), otherChatColor );      
     otherChat = (Color) globalPrefs.getValue(OTHER_CHAT_COLOR);
+    
+    // Put up the HTML Enable/Disable checkbox if we're supposed to have it.
+    if (GlobalOptions.PROMPT.equals(GlobalOptions.getInstance().chatterHTMLSetting())) {
+      BooleanConfigurer config2 = new BooleanConfigurer(GlobalOptions.CHATTER_HTML_SUPPORT, Resources.getString("GlobalOptions.chatter_html_support")); //$NON-NLS-1$
+      globalPrefs.addOption(Resources.getString("Chatter.chat_window"), config2);        
+    }
 
     makeStyleSheet(myFont);
   }

--- a/vassal-app/src/main/java/VASSAL/build/module/GlobalOptions.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/GlobalOptions.java
@@ -111,7 +111,7 @@ public class GlobalOptions extends AbstractConfigurable {
   private boolean useSingleWindow;
   
   private boolean useClassicMoveFixedDistance = false;
-  private BooleanConfigurer classicMfd;
+  private BooleanConfigurer classicMfd;  
 
   private static void setInstance(GlobalOptions go) {
     instance = go;
@@ -214,7 +214,7 @@ public class GlobalOptions extends AbstractConfigurable {
     
     BooleanConfigurer config = new BooleanConfigurer(CENTER_ON_MOVE, Resources.getString("GlobalOptions.center_on_move"), Boolean.TRUE); //$NON-NLS-1$
     prefs.addOption(config);
-    
+       
     validator = new SingleChildInstance(gm, getClass());
   }
 
@@ -497,6 +497,10 @@ public class GlobalOptions extends AbstractConfigurable {
 
   public boolean centerOnOpponentsMove() {
     return Boolean.TRUE.equals(GameModule.getGameModule().getPrefs().getValue(CENTER_ON_MOVE));
+  }
+  
+  public String chatterHTMLSetting() {
+    return chatterHTMLSupport;
   }
   
   public boolean chatterHTMLSupport() {


### PR DESCRIPTION
Our new GlobalOptions attribute that controls the "Enable HTML" situation for a module isn't yet written into modules written by pre-3.3.3. So it wasn't displaying the preference in the Chat tab in that case, because GlobalOptions was never getting a "setAttribute" for that property, and displaying the preference depended on receiving the setAttribute (rathern than merely on the attribute currently having the right value). This now makes sure the preference gets created. Had to force the preference during Chatter (rather than during GlobalOptions addTo, where I first tried), because otherwise the preference ended up at a variable location on the tab.