### PR TITLE
13296 - Flare feature for map (call opponent's attention to a location)

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/module/GlobalOptions.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/GlobalOptions.java
@@ -257,6 +257,11 @@ public class GlobalOptions extends AbstractConfigurable {
     // Since we've changed our key mapping paradigm, we need to refresh all the keystroke listeners.
     GameModule.getGameModule().refreshKeyStrokeListeners(); 
   }
+  
+  
+  public boolean getPrefMacLegacy() {
+    return macLegacy;
+  }
  
 
   public static String getConfigureTypeName() {

--- a/vassal-app/src/main/java/VASSAL/build/module/GlobalOptions.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/GlobalOptions.java
@@ -220,7 +220,7 @@ public class GlobalOptions extends AbstractConfigurable {
 
     //CC// center_on_move_border_proximity_pct (is the pct of distance from border to center of window that triggers a recenter
     final IntConfigurer pctRecenterOn = new IntConfigurer(CENTER_ON_MOVE_SENSITIVITY,
-      Resources.getString("GlobalOptions.center_on_move_sensitivity"), 10 ); //$NON-NLS-1$
+      Resources.getString("GlobalOptions.center_on_move_sensitivity"), 10); //$NON-NLS-1$
     prefs.addOption(pctRecenterOn);
 
     validator = new SingleChildInstance(gm, getClass());

--- a/vassal-app/src/main/java/VASSAL/build/module/Map.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/Map.java
@@ -495,9 +495,9 @@ public class Map extends AbstractConfigurable implements GameComponent, MouseLis
   @Override
   public void build(Element e) {
     ActionListener al = e1 -> {
-        if (mainWindowDock == null && launchButton.isEnabled() && theMap.getTopLevelAncestor() != null) {
-          theMap.getTopLevelAncestor().setVisible(!theMap.getTopLevelAncestor().isVisible());
-        }
+      if (mainWindowDock == null && launchButton.isEnabled() && theMap.getTopLevelAncestor() != null) {
+        theMap.getTopLevelAncestor().setVisible(!theMap.getTopLevelAncestor().isVisible());
+      }
     };
     launchButton = new LaunchButton(Resources.getString("Editor.Map.map"), TOOLTIP, BUTTON_NAME, HOTKEY, ICON, al);
     launchButton.setEnabled(false);
@@ -667,11 +667,11 @@ public class Map extends AbstractConfigurable implements GameComponent, MouseLis
       new MandatoryComponent(this, StackMetrics.class)).append(idMgr);
 
     final DragGestureListener dgl = dge -> {
-        if (dragGestureListener != null &&
-            mouseListenerStack.isEmpty() &&
-            SwingUtils.isDragTrigger(dge)) {
-          dragGestureListener.dragGestureRecognized(dge);
-        }
+      if (dragGestureListener != null &&
+          mouseListenerStack.isEmpty() &&
+          SwingUtils.isDragTrigger(dge)) {
+        dragGestureListener.dragGestureRecognized(dge);
+      }
     };
 
     DragSource.getDefaultDragSource().createDefaultDragGestureRecognizer(
@@ -2270,9 +2270,9 @@ public class Map extends AbstractConfigurable implements GameComponent, MouseLis
         if (r.x + r.width > d.width) r.x = d.width - r.width;
         if (r.y + r.height > d.height) r.y = d.height - r.height;
 
-      theMap.scrollRectToVisible(r);
+        theMap.scrollRectToVisible(r);
+      }
     }
-  }
   }
 
   /**

--- a/vassal-app/src/main/java/VASSAL/build/module/Map.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/Map.java
@@ -520,7 +520,7 @@ public class Map extends AbstractConfigurable implements GameComponent, MouseLis
       addChild(new KeyBufferer());
       addChild(new ImageSaver());
       addChild(new CounterDetailViewer());
-      setMapName("Main Map"); //FIXME shouldn't this be localized?
+      setMapName(Resources.getString("Map.main_map"));
     }
     if (getComponentsOf(GlobalProperties.class).isEmpty()) {
       addChild(new GlobalProperties());

--- a/vassal-app/src/main/java/VASSAL/build/module/Map.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/Map.java
@@ -520,6 +520,7 @@ public class Map extends AbstractConfigurable implements GameComponent, MouseLis
       addChild(new KeyBufferer());
       addChild(new ImageSaver());
       addChild(new CounterDetailViewer());
+      addChild(new Flare());
       setMapName(Resources.getString("Map.main_map"));
     }
     if (getComponentsOf(GlobalProperties.class).isEmpty()) {
@@ -530,6 +531,9 @@ public class Map extends AbstractConfigurable implements GameComponent, MouseLis
     }
     if (getComponentsOf(HighlightLastMoved.class).isEmpty()) {
       addChild(new HighlightLastMoved());
+    }
+    if (getComponentsOf(Flare.class).isEmpty()) {
+      addChild(new Flare());
     }
     setup(false);
   }

--- a/vassal-app/src/main/java/VASSAL/build/module/Map.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/Map.java
@@ -92,6 +92,7 @@ import VASSAL.build.module.map.CounterDetailViewer;
 import VASSAL.build.module.map.DefaultPieceCollection;
 import VASSAL.build.module.map.DrawPile;
 import VASSAL.build.module.map.Drawable;
+import VASSAL.build.module.map.Flare;
 import VASSAL.build.module.map.ForwardToChatter;
 import VASSAL.build.module.map.ForwardToKeyBuffer;
 import VASSAL.build.module.map.GlobalMap;
@@ -179,7 +180,7 @@ import VASSAL.tools.swing.SwingUtils;
  * contained in the <code>VASSAL.build.module.map</code> package
  */
 public class Map extends AbstractConfigurable implements GameComponent, MouseListener, MouseMotionListener, DropTargetListener, Configurable,
-  UniqueIdManager.Identifyable, ToolBarComponent, MutablePropertiesContainer, PropertySource, PlayerRoster.SideChangeListener {
+    UniqueIdManager.Identifyable, ToolBarComponent, MutablePropertiesContainer, PropertySource, PlayerRoster.SideChangeListener {
   protected static boolean changeReportingEnabled = true;
   protected String mapID = ""; //$NON-NLS-1$
   protected String mapName = ""; //$NON-NLS-1$
@@ -663,8 +664,8 @@ public class Map extends AbstractConfigurable implements GameComponent, MouseLis
 
     final DragGestureListener dgl = dge -> {
       if (dragGestureListener != null &&
-        mouseListenerStack.isEmpty() &&
-        SwingUtils.isDragTrigger(dge)) {
+          mouseListenerStack.isEmpty() &&
+          SwingUtils.isDragTrigger(dge)) {
         dragGestureListener.dragGestureRecognized(dge);
       }
     };
@@ -1521,10 +1522,10 @@ public class Map extends AbstractConfigurable implements GameComponent, MouseLis
         final Rectangle vrect = scroll.getViewport().getViewRect();
 
         if ((sx == -1 && vrect.x == 0) ||
-          (sx ==  1 && vrect.x + vrect.width >= theMap.getWidth())) sx = 0;
+            (sx ==  1 && vrect.x + vrect.width >= theMap.getWidth())) sx = 0;
 
         if ((sy == -1 && vrect.y == 0) ||
-          (sy ==  1 && vrect.y + vrect.height >= theMap.getHeight())) sy = 0;
+            (sy ==  1 && vrect.y + vrect.height >= theMap.getHeight())) sy = 0;
 
         // Stop if the scroll vector is zero
         if (sx == 0 && sy == 0) scroller.stop();
@@ -2024,7 +2025,7 @@ public class Map extends AbstractConfigurable implements GameComponent, MouseLis
       if (mainWindowDock != null) {
         if (mainWindowDock.getHideableComponent().isShowing()) {
           Prefs.getGlobalPrefs().getOption(MAIN_WINDOW_HEIGHT)
-            .setValue(mainWindowDock.getTopLevelAncestor().getHeight());
+               .setValue(mainWindowDock.getTopLevelAncestor().getHeight());
         }
         mainWindowDock.hideComponent();
         toolBar.setVisible(false);
@@ -2143,7 +2144,7 @@ public class Map extends AbstractConfigurable implements GameComponent, MouseLis
       // If no piece at destination and this is a stacking piece, create
       // a new Stack containing the piece
       if (!(p instanceof Stack) &&
-        !Boolean.TRUE.equals(p.getProperty(Properties.NO_STACK))) {
+          !Boolean.TRUE.equals(p.getProperty(Properties.NO_STACK))) {
         final Stack parent = getStackMetrics().createStack(p);
         if (parent != null) {
           c = c.append(placeAt(parent, pt));
@@ -2265,9 +2266,9 @@ public class Map extends AbstractConfigurable implements GameComponent, MouseLis
         if (r.x + r.width > d.width) r.x = d.width - r.width;
         if (r.y + r.height > d.height) r.y = d.height - r.height;
 
-        theMap.scrollRectToVisible(r);
-      }
+      theMap.scrollRectToVisible(r);
     }
+  }
   }
 
   /**
@@ -2494,7 +2495,7 @@ public class Map extends AbstractConfigurable implements GameComponent, MouseLis
   public Class<?>[] getAllowableConfigureComponents() {
     return new Class<?>[]{ GlobalMap.class, LOS_Thread.class, ToolbarMenu.class, MultiActionButton.class, HidePiecesButton.class, Zoomer.class,
       CounterDetailViewer.class, HighlightLastMoved.class, LayeredPieceCollection.class, ImageSaver.class, TextSaver.class, DrawPile.class, SetupStack.class,
-      MassKeyCommand.class, MapShader.class, PieceRecenterer.class };
+      MassKeyCommand.class, MapShader.class, PieceRecenterer.class, Flare.class };
   }
 
   @Override
@@ -2699,7 +2700,7 @@ public class Map extends AbstractConfigurable implements GameComponent, MouseLis
     @Override
     public Object visitStack(Stack s) {
       if (s.getPosition().equals(pt) && map.getStackMetrics().isStackingEnabled() && !Boolean.TRUE.equals(p.getProperty(Properties.NO_STACK))
-        && s.topPiece() != null && map.getPieceCollection().canMerge(s, p)) {
+          && s.topPiece() != null && map.getPieceCollection().canMerge(s, p)) {
         return map.getStackMetrics().merge(s, p);
       }
       else {
@@ -2710,8 +2711,8 @@ public class Map extends AbstractConfigurable implements GameComponent, MouseLis
     @Override
     public Object visitDefault(GamePiece piece) {
       if (piece.getPosition().equals(pt) && map.getStackMetrics().isStackingEnabled() && !Boolean.TRUE.equals(p.getProperty(Properties.NO_STACK))
-        && !Boolean.TRUE.equals(piece.getProperty(Properties.INVISIBLE_TO_ME)) && !Boolean.TRUE.equals(piece.getProperty(Properties.NO_STACK))
-        && map.getPieceCollection().canMerge(piece, p)) {
+          && !Boolean.TRUE.equals(piece.getProperty(Properties.INVISIBLE_TO_ME)) && !Boolean.TRUE.equals(piece.getProperty(Properties.NO_STACK))
+          && map.getPieceCollection().canMerge(piece, p)) {
         return map.getStackMetrics().merge(piece, p);
       }
       else {

--- a/vassal-app/src/main/java/VASSAL/build/module/Map.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/Map.java
@@ -495,9 +495,9 @@ public class Map extends AbstractConfigurable implements GameComponent, MouseLis
   @Override
   public void build(Element e) {
     ActionListener al = e1 -> {
-      if (mainWindowDock == null && launchButton.isEnabled() && theMap.getTopLevelAncestor() != null) {
-        theMap.getTopLevelAncestor().setVisible(!theMap.getTopLevelAncestor().isVisible());
-      }
+        if (mainWindowDock == null && launchButton.isEnabled() && theMap.getTopLevelAncestor() != null) {
+          theMap.getTopLevelAncestor().setVisible(!theMap.getTopLevelAncestor().isVisible());
+        }
     };
     launchButton = new LaunchButton(Resources.getString("Editor.Map.map"), TOOLTIP, BUTTON_NAME, HOTKEY, ICON, al);
     launchButton.setEnabled(false);
@@ -520,7 +520,7 @@ public class Map extends AbstractConfigurable implements GameComponent, MouseLis
       addChild(new KeyBufferer());
       addChild(new ImageSaver());
       addChild(new CounterDetailViewer());
-      setMapName("Main Map");
+      setMapName("Main Map"); //FIXME shouldn't this be localized?
     }
     if (getComponentsOf(GlobalProperties.class).isEmpty()) {
       addChild(new GlobalProperties());
@@ -663,11 +663,11 @@ public class Map extends AbstractConfigurable implements GameComponent, MouseLis
       new MandatoryComponent(this, StackMetrics.class)).append(idMgr);
 
     final DragGestureListener dgl = dge -> {
-      if (dragGestureListener != null &&
-          mouseListenerStack.isEmpty() &&
-          SwingUtils.isDragTrigger(dge)) {
-        dragGestureListener.dragGestureRecognized(dge);
-      }
+        if (dragGestureListener != null &&
+            mouseListenerStack.isEmpty() &&
+            SwingUtils.isDragTrigger(dge)) {
+          dragGestureListener.dragGestureRecognized(dge);
+        }
     };
 
     DragSource.getDefaultDragSource().createDefaultDragGestureRecognizer(

--- a/vassal-app/src/main/java/VASSAL/build/module/map/Flare.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/Flare.java
@@ -17,7 +17,12 @@
 
 package VASSAL.build.module.map;
 
-import java.awt.*;
+import java.awt.Color;
+import java.awt.Point;
+import java.awt.Graphics;
+import java.awt.Graphics2D;
+import java.awt.RenderingHints;
+import java.awt.BasicStroke;
 import java.awt.event.MouseListener;
 import java.awt.event.ActionListener;
 import java.awt.event.MouseEvent;

--- a/vassal-app/src/main/java/VASSAL/build/module/map/Flare.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/Flare.java
@@ -17,29 +17,25 @@
 
 package VASSAL.build.module.map;
 
+import java.awt.*;
+import java.awt.event.MouseListener;
+import java.awt.event.ActionListener;
 import java.awt.event.MouseEvent;
 import java.awt.event.ActionEvent;
-import VASSAL.build.module.documentation.HelpFile;
-import VASSAL.command.Command;
-import java.awt.BasicStroke;
-import java.awt.Color;
-import java.awt.Graphics2D;
-import java.awt.Graphics;
-import VASSAL.build.GameModule;
-import VASSAL.build.Buildable;
 import javax.swing.Timer;
 
 import org.apache.commons.lang3.SystemUtils;
 
-import java.awt.Point;
-import VASSAL.build.module.Map;
-import java.awt.event.MouseListener;
-import java.awt.event.ActionListener;
-import VASSAL.build.module.GameComponent;
-import VASSAL.build.module.GlobalOptions;
-import VASSAL.command.CommandEncoder;
 import VASSAL.build.AbstractConfigurable;
 import VASSAL.build.AutoConfigurable;
+import VASSAL.build.Buildable;
+import VASSAL.build.GameModule;
+import VASSAL.build.module.documentation.HelpFile;
+import VASSAL.build.module.GameComponent;
+import VASSAL.build.module.GlobalOptions;
+import VASSAL.build.module.Map;
+import VASSAL.command.Command;
+import VASSAL.command.CommandEncoder;
 import VASSAL.command.FlareCommand;
 import VASSAL.configure.ColorConfigurer;
 import VASSAL.configure.StringEnum;
@@ -59,8 +55,8 @@ public class Flare extends AbstractConfigurable
   private int framesPerPulse;
   private String flareKey;
   private Color color;
-  private static int CIRCLE_RATE    = 33; // 33ms for approx 30 frames/sec
-  private static int DEFAULT_FRAMES = 60; // 2 sec for basic "no animation" pulse
+  private static final int CIRCLE_RATE    = 33; // 33ms for approx 30 frames/sec
+  private static final int DEFAULT_FRAMES = 60; // 2 sec for basic "no animation" pulse
   private Point clickPoint;
   private Boolean active;
   private Timer timer;
@@ -80,12 +76,12 @@ public class Flare extends AbstractConfigurable
 
 
   public Flare() {
-    this.circleSize = 100;
-    this.color = Color.RED;
-    this.active = false;
-    this.flareKey = FLARE_ALT;
-    this.pulses       = 6;
-    this.pulsesPerSec = 3;
+    circleSize   = 100;
+    color        = Color.RED;
+    active       = false;
+    flareKey     = FLARE_ALT;
+    pulses       = 6;
+    pulsesPerSec = 3;
   }
 
   public String getDescription() {
@@ -97,7 +93,7 @@ public class Flare extends AbstractConfigurable
   }
 
   public Class<?>[] getAttributeTypes() {
-    return (Class<?>[]) new Class[] { FlareKeyConfig.class, Integer.class, Color.class, Integer.class, Integer.class };
+    return new Class[] { FlareKeyConfig.class, Integer.class, Color.class, Integer.class, Integer.class };
   }
 
   public String[] getAttributeNames() {
@@ -114,19 +110,19 @@ public class Flare extends AbstractConfigurable
 
   public String getAttributeValueString(final String key) {
     if (FLARE_KEY.equals(key)) {
-      return new StringBuilder().append(this.flareKey).toString();
+      return flareKey;
     }
     else if (CIRCLE_SIZE.equals(key)) {
-      return new StringBuilder().append(this.circleSize).toString();
+      return String.valueOf(this.circleSize);
     }
     else if (CIRCLE_COLOR.equals(key)) {
-      return new StringBuilder().append(ColorConfigurer.colorToString(this.color)).toString();
+      return ColorConfigurer.colorToString(this.color);
     }
     else if (PULSES.equals(key)) {
-      return new StringBuilder().append(this.pulses).toString();
+      return String.valueOf(this.pulses);
     }
     else if (PULSES_PER_SEC.equals(key)) {
-      return new StringBuilder().append(this.pulsesPerSec).toString();
+      return String.valueOf(this.pulsesPerSec);
     }
     return null;
   }
@@ -135,43 +131,43 @@ public class Flare extends AbstractConfigurable
   public void setAttribute(String key, Object value) {
     if (FLARE_KEY.equals(key)) {
       if (FLARE_ALT_LOCAL.equals(value)) {
-        this.flareKey = FLARE_ALT;
+        flareKey = FLARE_ALT;
       } 
       else if (FLARE_COMMAND_LOCAL.equals(value) || FLARE_CTRL_LOCAL.equals(value)) {
-        this.flareKey = FLARE_CTRL;
+        flareKey = FLARE_CTRL;
       } 
       else {
-        this.flareKey = (String) value;
+        flareKey = (String) value;
       }
     }
     else if (CIRCLE_SIZE.equals(key)) {
       if (value instanceof String) {
-        this.circleSize = Integer.parseInt((String) value); 
+        circleSize = Integer.parseInt((String) value);
       } 
       else if (value instanceof Integer) {
-        this.circleSize = (Integer) value;
+        circleSize = (Integer) value;
       }
     } 
     else if (CIRCLE_COLOR.equals(key)) {
       if (value instanceof String) {
         value = ColorConfigurer.stringToColor((String) value);
       }
-      this.color = (Color)value;
+      color = (Color)value;
     }
     else if (PULSES.equals(key)) {
       if (value instanceof String) {
-        this.pulses = Integer.parseInt((String) value);
+        pulses = Integer.parseInt((String) value);
       } 
       else {
-        this.pulses = (Integer) value;
+        pulses = (Integer) value;
       }
     }
     else if (PULSES_PER_SEC.equals(key)) {
       if (value instanceof String) {
-        this.pulsesPerSec = Integer.parseInt((String) value);
+        pulsesPerSec = Integer.parseInt((String) value);
       } 
       else {
-        this.pulsesPerSec = (Integer) value;
+        pulsesPerSec = (Integer) value;
       }
     }
   }
@@ -185,49 +181,49 @@ public class Flare extends AbstractConfigurable
 
   public void addTo(final Buildable parent) {
     if (parent instanceof Map) {
-      this.map = (Map) parent;
-      GameModule.getGameModule().addCommandEncoder((CommandEncoder) this);
-      this.map.addDrawComponent((Drawable) this);
-      this.map.addLocalMouseListener((MouseListener) this);
-      this.timer  = new Timer(CIRCLE_RATE, this);
-      this.frame  = 0;
+      map = (Map) parent;
+      GameModule.getGameModule().addCommandEncoder(this);
+      map.addDrawComponent(this);
+      map.addLocalMouseListener(this);
+      timer  = new Timer(CIRCLE_RATE, this);
+      frame  = 0;
     }
   }
   
   public void removeFrom(final Buildable parent) {
     if (parent instanceof Map) {
-      GameModule.getGameModule().removeCommandEncoder((CommandEncoder) this);
+      GameModule.getGameModule().removeCommandEncoder(this);
     }
   }
 
 
   public void startAnimation(final boolean isLocal) {
     if (!isLocal) {
-      this.map.centerAt(this.clickPoint);
+      map.centerAt(this.clickPoint);
     }
-    this.active = true;
-    this.timer.restart();
-    this.frame = 0;
+    active = true;
+    timer.restart();
+    frame = 0;
     
-    this.animate = ((this.pulses > 0) && (this.pulsesPerSec > 0));
-    if (this.animate) {
-      this.framesPerPulse = 30 / this.pulsesPerSec;
-      if (this.framesPerPulse < 1) this.framesPerPulse = 1;
-      this.frames = this.pulses * framesPerPulse;
+    animate = ((pulses > 0) && (pulsesPerSec > 0));
+    if (animate) {
+      framesPerPulse = 30 / pulsesPerSec;
+      if (framesPerPulse < 1) framesPerPulse = 1;
+      frames = pulses * framesPerPulse;
     } 
     else {
-      this.frames = DEFAULT_FRAMES;
+      frames = DEFAULT_FRAMES;
     }
     
-    this.map.getView().repaint();
+    map.getView().repaint();
   }
 
   public void draw(final Graphics g, final Map map) {
-    if (this.active && this.clickPoint != null) {                 
+    if (active && clickPoint != null) {
       final Graphics2D g2d = (Graphics2D) g;
       final double os_scale = g2d.getDeviceConfiguration().getDefaultTransform().getScaleX();
       
-      int diameter = (int)(map.getZoom() * os_scale * this.circleSize);
+      int diameter = (int)(map.getZoom() * os_scale * circleSize);
       if (animate) {
         diameter = diameter * (framesPerPulse - (frame % framesPerPulse)) / framesPerPulse;
       }
@@ -236,11 +232,13 @@ public class Flare extends AbstractConfigurable
       }
 
       // translate the piece center for current zoom
-      final Point p = map.mapToDrawing(clickPoint, os_scale);                             
+      final Point p = map.mapToDrawing(clickPoint, os_scale);
       
       // draw a circle around the selected point
       g2d.setColor(color);
       g2d.setStroke(new BasicStroke((float)(3 * os_scale)));
+      g2d.setRenderingHint(RenderingHints.KEY_ANTIALIASING,
+                           RenderingHints.VALUE_ANTIALIAS_ON);
       g2d.drawOval(p.x - diameter / 2, p.y - diameter / 2, diameter, diameter); 
     }
   }
@@ -260,8 +258,8 @@ public class Flare extends AbstractConfigurable
     if (s.startsWith(COMMAND_PREFIX)) {
       final int x = Integer.parseInt(s.substring(s.indexOf(":") + 1, s.indexOf(",")));
       final int y = Integer.parseInt(s.substring(s.indexOf(",") + 1));
-      this.clickPoint = new Point(x, y);
-      return (Command) new FlareCommand(this);
+      clickPoint = new Point(x, y);
+      return new FlareCommand(this);
     }
     return null;
   }
@@ -271,13 +269,13 @@ public class Flare extends AbstractConfigurable
   }
 
   public void actionPerformed(final ActionEvent e) {
-    this.frame++;
-    if (this.frame >= this.frames) {
-      this.active = false;
-      this.timer.stop();
+    frame++;
+    if (frame >= frames) {
+      active = false;
+      timer.stop();
     }
-    if (!this.active || this.animate) {
-      this.map.repaint();  
+    if (!active || animate) {
+      map.repaint();
     }    
   }
 
@@ -298,11 +296,11 @@ public class Flare extends AbstractConfigurable
         return;
       }
     }
-    this.clickPoint = new Point(e.getX(), e.getY());
+    clickPoint = new Point(e.getX(), e.getY());
     final GameModule mod = GameModule.getGameModule();
-    final Command c = (Command) new FlareCommand(this);
+    final Command c = new FlareCommand(this);
     mod.sendAndLog(c);
-    this.startAnimation(true);
+    startAnimation(true);
   }
 
   public void mouseReleased(final MouseEvent e) {
@@ -322,11 +320,11 @@ public class Flare extends AbstractConfigurable
   }
 
   public void setClickPoint(final Point p) {
-    this.clickPoint = p;
+    clickPoint = p;
   }
 
   public Point getClickPoint() {
-    return this.clickPoint;
+    return clickPoint;
   }
   
   

--- a/vassal-app/src/main/java/VASSAL/build/module/map/Flare.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/Flare.java
@@ -68,7 +68,7 @@ import VASSAL.tools.swing.SwingUtils;
  */
 public class Flare extends AbstractConfigurable
         implements CommandEncoder, GameComponent, Drawable, MouseListener {
-  public static final String COMMAND_PREFIX = "FLARE:";
+  public static final String COMMAND_PREFIX = "FLARE\t";
 
   // Attributes
   private int circleSize;       // Maximum circle size in pixels
@@ -435,7 +435,7 @@ public class Flare extends AbstractConfigurable
    */
   public String encode(final Command c) {
     if (c instanceof FlareCommand) {
-      return COMMAND_PREFIX + ((FlareCommand) c).getClickPoint().x + "," + ((FlareCommand) c).getClickPoint().y + "," + ((FlareCommand) c).getMapId();
+      return COMMAND_PREFIX + ((FlareCommand) c).getMapId() + "\t" + ((FlareCommand) c).getClickPoint().x + "\t" + ((FlareCommand) c).getClickPoint().y;
     }
     return null;
   }
@@ -446,14 +446,14 @@ public class Flare extends AbstractConfigurable
    * @return Flare Command object
    */
   public Command decode(final String s) {
-    if (s.startsWith(COMMAND_PREFIX)) {
-      SequenceEncoder.Decoder sd = new SequenceEncoder.Decoder(s, ',');
-
+    if (s.startsWith(COMMAND_PREFIX + getMap().getId())) {
+      SequenceEncoder.Decoder sd = new SequenceEncoder.Decoder(s, '\t');
+      sd.nextToken(); // Skip over the Command Prefix
+      sd.nextToken(); // Skip over the Id
       final int x = sd.nextInt(0);
       final int y = sd.nextInt(0);
-      final String id = sd.nextToken("");
       clickPoint = new Point(x, y);
-      return new FlareCommand(this, id);
+      return new FlareCommand(this);
     }
     return null;
   }

--- a/vassal-app/src/main/java/VASSAL/build/module/map/Flare.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/Flare.java
@@ -30,7 +30,6 @@ import java.awt.event.MouseEvent;
 import VASSAL.build.BadDataReport;
 import VASSAL.build.module.Chatter;
 import VASSAL.build.module.map.boardPicker.board.mapgrid.Zone;
-import VASSAL.build.module.properties.PropertySource;
 import VASSAL.command.NullCommand;
 import VASSAL.configure.Configurer;
 import VASSAL.i18n.TranslatableConfigurerFactory;
@@ -72,7 +71,6 @@ public class Flare extends AbstractConfigurable
   private Point clickPoint;
   private FormattedString reportFormat = new FormattedString();
   private volatile boolean active;
-  private PropertySource propertySource;
 
   public static final String CIRCLE_SIZE  = "circleSize";
   public static final String CIRCLE_SCALE = "circleScale";
@@ -251,8 +249,6 @@ public class Flare extends AbstractConfigurable
       GameModule.getGameModule().addCommandEncoder(this);
       map.addDrawComponent(this);
       map.addLocalMouseListener(this);
-
-      propertySource = (PropertySource) parent;
     }
     else {
       ErrorDialog.dataWarning(new BadDataReport("Flare - can only be added to a Map. ", reportFormat.getFormat()));
@@ -417,12 +413,7 @@ public class Flare extends AbstractConfigurable
     final Zone z = map.findZone(clickPoint);
     reportFormat.setProperty(FLARE_ZONE, (z != null) ? z.getName() : "");
     reportFormat.setProperty(FLARE_MAP, map.getMapName());
-    reportFormat.setProperty(GlobalOptions.PLAYER_NAME, (String) mod.getProperty(GlobalOptions.PLAYER_NAME));
-    reportFormat.setProperty(GlobalOptions.PLAYER_NAME_ALT, (String) mod.getProperty(GlobalOptions.PLAYER_NAME_ALT));
-    reportFormat.setProperty(GlobalOptions.PLAYER_SIDE, (String) mod.getProperty(GlobalOptions.PLAYER_SIDE));
-    reportFormat.setProperty(GlobalOptions.PLAYER_SIDE_ALT, (String) mod.getProperty(GlobalOptions.PLAYER_SIDE_ALT));
-    reportFormat.setProperty(GlobalOptions.PLAYER_ID,   (String) mod.getProperty(GlobalOptions.PLAYER_ID));
-    String reportText = reportFormat.getLocalizedText(propertySource);
+    String reportText = reportFormat.getLocalizedText(map);
     if (reportText.trim().length() > 0) {
       c = new Chatter.DisplayText(mod.getChatter(), "* " + reportText);
       c.execute();

--- a/vassal-app/src/main/java/VASSAL/build/module/map/Flare.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/Flare.java
@@ -68,12 +68,23 @@ public class Flare extends AbstractConfigurable
   public static final String PULSES       = "flarePulses";
   public static final String PULSES_PER_SEC = "flarePulsesPerSec";
 
-  public static final String FLARE_ALT_LOCAL     = Resources.getString("Editor.Flare.flare_key_desc", Resources.getString("Keys.alt"));
-  public static final String FLARE_CTRL_LOCAL    = Resources.getString("Editor.Flare.flare_key_desc", Resources.getString("Keys.ctrl"));
-  public static final String FLARE_COMMAND_LOCAL = Resources.getString("Editor.Flare.flare_key_desc", Resources.getString("Keys.meta"));
+  public static final String FLARE_ALT_LOCAL       = Resources.getString("Editor.Flare.flare_key_desc", Resources.getString("Keys.alt"));
+  public static final String FLARE_CTRL_LOCAL      = Resources.getString("Editor.Flare.flare_key_desc", Resources.getString("Keys.ctrl"));
+  public static final String FLARE_COMMAND_LOCAL   = Resources.getString("Editor.Flare.flare_key_desc", Resources.getString("Keys.meta"));
+  public static final String FLARE_ALT_SHIFT_LOCAL = Resources.getString("Editor.Flare.flare_key_desc", Resources.getString("Keys.alt_shift"));
+  public static final String FLARE_SHIFT_COMMAND_LOCAL = Resources.getString("Editor.Flare.flare_key_desc", Resources.getString("Keys.shift_command"));
+  public static final String FLARE_CTRL_SHIFT_LOCAL = Resources.getString("Editor.Flare.flare_key_desc", Resources.getString("Keys.ctrl_shift"));
+  public static final String FLARE_ALT_COMMAND_LOCAL = Resources.getString("Editor.Flare.flare_key_desc", Resources.getString("Keys.alt_command"));
+  public static final String FLARE_CTRL_ALT_LOCAL = Resources.getString("Editor.Flare.flare_key_desc", Resources.getString("Keys.ctrl_alt"));
+  public static final String FLARE_ALT_SHIFT_COMMAND_LOCAL = Resources.getString("Editor.Flare.flare_key_desc", Resources.getString("Keys.alt_shift_command"));
+  public static final String FLARE_CTRL_ALT_SHIFT_LOCAL = Resources.getString("Editor.Flare.flare_key_desc", Resources.getString("Keys.ctrl_alt_shift"));
 
-  public static final String FLARE_ALT = "keyAlt";
-  public static final String FLARE_CTRL = "keyCtrl";
+  public static final String FLARE_ALT            = "keyAlt";
+  public static final String FLARE_CTRL           = "keyCtrl";
+  public static final String FLARE_ALT_SHIFT      = "keyAltShift";
+  public static final String FLARE_CTRL_SHIFT     = "keyCtrlShift";
+  public static final String FLARE_CTRL_ALT       = "keyCtrlAlt";
+  public static final String FLARE_CTRL_ALT_SHIFT = "keyCtrlAltShift";
 
   private static final int STROKE = 3;
 
@@ -88,11 +99,11 @@ public class Flare extends AbstractConfigurable
   }
 
   public String getDescription() {
-    return Resources.getString("Map Flare");
+    return Resources.getString("Editor.Flare.desc");
   }
 
   public static String getConfigureTypeName() {
-    return Resources.getString("Map Flare");
+    return Resources.getString("Editor.Flare.configure");
   }
 
   public Class<?>[] getAttributeTypes() {
@@ -142,6 +153,18 @@ public class Flare extends AbstractConfigurable
       }
       else if (FLARE_COMMAND_LOCAL.equals(value) || FLARE_CTRL_LOCAL.equals(value)) {
         flareKey = FLARE_CTRL;
+      }
+      else if (FLARE_ALT_SHIFT_LOCAL.equals(value)) {
+        flareKey = FLARE_ALT_SHIFT;
+      }
+      else if (FLARE_SHIFT_COMMAND_LOCAL.equals(value) || FLARE_CTRL_SHIFT_LOCAL.equals(value)) {
+        flareKey = FLARE_CTRL_SHIFT;
+      }
+      else if (FLARE_ALT_COMMAND_LOCAL.equals(value) || FLARE_CTRL_ALT_LOCAL.equals(value)) {
+        flareKey = FLARE_CTRL_ALT;
+      }
+      else if (FLARE_ALT_SHIFT_COMMAND_LOCAL.equals(value) || FLARE_CTRL_ALT_SHIFT_LOCAL.equals(value)) {
+        flareKey = FLARE_CTRL_ALT_SHIFT;
       }
       else {
         flareKey = (String) value;
@@ -321,12 +344,32 @@ public class Flare extends AbstractConfigurable
       return;
     }
     if (FLARE_CTRL.equals(flareKey)) {
-      if (!SwingUtils.isSelectionToggle(e)) {
+      if (!SwingUtils.isSelectionToggle(e) || e.isAltDown() || e.isShiftDown()) {
         return;
       }
     }
-    else {
-      if (!e.isAltDown()) {
+    else if (FLARE_ALT.equals(flareKey)) {
+      if (!e.isAltDown() || e.isShiftDown() || SwingUtils.isSelectionToggle(e)) {
+        return;
+      }
+    }
+    else if (FLARE_ALT_SHIFT.equals(flareKey)) {
+      if (!e.isAltDown() || !e.isShiftDown() || SwingUtils.isSelectionToggle(e)) {
+        return;
+      }
+    }
+    else if (FLARE_CTRL_SHIFT.equals(flareKey)) {
+      if (!e.isShiftDown() || !SwingUtils.isSelectionToggle(e) || e.isAltDown()) {
+        return;
+      }
+    }
+    else if (FLARE_CTRL_ALT.equals(flareKey)) {
+      if (!e.isAltDown() || !SwingUtils.isSelectionToggle(e) || e.isShiftDown()) {
+        return;
+      }
+    }
+    else if (FLARE_CTRL_ALT_SHIFT.equals(flareKey)) {
+      if (!e.isAltDown() || !e.isShiftDown() || !SwingUtils.isSelectionToggle(e)) {
         return;
       }
     }
@@ -367,7 +410,11 @@ public class Flare extends AbstractConfigurable
     public String[] getValidValues(AutoConfigurable target) {
       return new String[] {
         FLARE_ALT_LOCAL,
-        SystemUtils.IS_OS_MAC_OSX && !GlobalOptions.getInstance().getPrefMacLegacy() ? FLARE_COMMAND_LOCAL : FLARE_CTRL_LOCAL
+        SystemUtils.IS_OS_MAC_OSX && !GlobalOptions.getInstance().getPrefMacLegacy() ? FLARE_COMMAND_LOCAL : FLARE_CTRL_LOCAL,
+        FLARE_ALT_SHIFT_LOCAL,
+        SystemUtils.IS_OS_MAC_OSX && !GlobalOptions.getInstance().getPrefMacLegacy() ? FLARE_SHIFT_COMMAND_LOCAL : FLARE_CTRL_SHIFT_LOCAL,
+        SystemUtils.IS_OS_MAC_OSX && !GlobalOptions.getInstance().getPrefMacLegacy() ? FLARE_ALT_COMMAND_LOCAL : FLARE_CTRL_ALT_LOCAL,
+        SystemUtils.IS_OS_MAC_OSX && !GlobalOptions.getInstance().getPrefMacLegacy() ? FLARE_ALT_SHIFT_COMMAND_LOCAL : FLARE_CTRL_ALT_SHIFT_LOCAL,
       };
     }
   }

--- a/vassal-app/src/main/java/VASSAL/build/module/map/Flare.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/Flare.java
@@ -62,17 +62,14 @@ public class Flare extends AbstractConfigurable
     this.colorBlue = 0;
     this.active = false;
   }
-  
-  @Override
+
   public String getDescription() {
     return Resources.getString("Map Flare");
   }
   
-  @Override
   public static String getConfigureTypeName() {
     return Resources.getString("Map Flare");
   }
-
 
   public Class<?>[] getAttributeTypes() {
     return (Class<?>[]) new Class[] { Integer.class, Integer.class, Integer.class, Integer.class };

--- a/vassal-app/src/main/java/VASSAL/build/module/map/Flare.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/Flare.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020 Vassalengine.org   Brian Reynolds
+ * Inspired by VASL piece finder by David Sullivan
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public

--- a/vassal-app/src/main/java/VASSAL/build/module/map/Flare.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/Flare.java
@@ -57,29 +57,42 @@ import VASSAL.configure.FlareFormattedStringConfigurer;
 import VASSAL.i18n.Resources;
 import VASSAL.tools.swing.SwingUtils;
 
+/**
+ * Allows a player to ping a location ("send up a flare") by clicking on a map with the correct modifier key
+ * combination held down (default: Alt+LeftClick). Can be shown as an animated colored circle, or a plain one.
+ * If reportFormat field is provided, a message is also displayed in the chat log.
+ *
+ * Flare will work with both online play and PBEM play.
+ */
 public class Flare extends AbstractConfigurable
         implements CommandEncoder, GameComponent, Drawable, MouseListener {
   public static final String COMMAND_PREFIX = "FLARE:";
-  private Map map;
-  private int circleSize;
-  private boolean circleScale;
-  private int pulses;
-  private int pulsesPerSec;
-  private boolean animate;
-  private String flareKey;
-  private Color color;
-  private Point clickPoint;
-  private FormattedString reportFormat = new FormattedString();
-  private volatile boolean active;
 
-  public static final String CIRCLE_SIZE  = "circleSize";
-  public static final String CIRCLE_SCALE = "circleScale";
-  public static final String CIRCLE_COLOR = "circleColor";
-  public static final String FLARE_KEY    = "flareKey";
-  public static final String PULSES       = "flarePulses";
+  // Attributes
+  private int circleSize;       // Maximum circle size in pixels
+  private boolean circleScale;  // If true, scale circle to map zoom
+  private int pulses;           // How many total "pulses" to animate, or 0 for steady w/o animation
+  private int pulsesPerSec;     // How many pulses per second, or 0 for steady w/o animation
+  private String flareKey;      // Configures which set of modifier keys and click will produce the flare
+  private Color color;          // Color for the flare circle
+  private FormattedString reportFormat = new FormattedString(); // Report format for reporting the flare to the chat log
+
+  // Internal properties
+  private Map map;                  // The map for this Flare
+  private Point clickPoint;         // Clicked point where this Flare is to appear
+  private boolean animate;          // Internal flag if we should be animating
+  private volatile boolean active;  // Internal flag if we're currently active
+
+  // Attribute names
+  public static final String CIRCLE_SIZE    = "circleSize";
+  public static final String CIRCLE_SCALE   = "circleScale";
+  public static final String CIRCLE_COLOR   = "circleColor";
+  public static final String FLARE_KEY      = "flareKey";
+  public static final String PULSES         = "flarePulses";
   public static final String PULSES_PER_SEC = "flarePulsesPerSec";
-  public static final String REPORT_FORMAT = "reportFormat";
+  public static final String REPORT_FORMAT  = "reportFormat";
 
+  // Friendly (localizable) names for modifier key combinations
   public static final String FLARE_ALT_LOCAL       = Resources.getString("Editor.Flare.flare_key_desc", Resources.getString("Keys.alt"));
   public static final String FLARE_CTRL_LOCAL      = Resources.getString("Editor.Flare.flare_key_desc", Resources.getString("Keys.ctrl"));
   public static final String FLARE_COMMAND_LOCAL   = Resources.getString("Editor.Flare.flare_key_desc", Resources.getString("Keys.meta"));
@@ -91,6 +104,7 @@ public class Flare extends AbstractConfigurable
   public static final String FLARE_ALT_SHIFT_COMMAND_LOCAL = Resources.getString("Editor.Flare.flare_key_desc", Resources.getString("Keys.alt_shift_command"));
   public static final String FLARE_CTRL_ALT_SHIFT_LOCAL = Resources.getString("Editor.Flare.flare_key_desc", Resources.getString("Keys.ctrl_alt_shift"));
 
+  // The modifier key codes we actually store
   public static final String FLARE_ALT            = "keyAlt";
   public static final String FLARE_CTRL           = "keyCtrl";
   public static final String FLARE_ALT_SHIFT      = "keyAltShift";
@@ -98,6 +112,7 @@ public class Flare extends AbstractConfigurable
   public static final String FLARE_CTRL_ALT       = "keyCtrlAlt";
   public static final String FLARE_CTRL_ALT_SHIFT = "keyCtrlAltShift";
 
+  // Special properties for our FormattedString reportFormat
   public static final String FLARE_LOCATION       = "FlareLocation";
   public static final String FLARE_ZONE           = "FlareZone";
   public static final String FLARE_MAP            = "FlareMap";
@@ -114,22 +129,40 @@ public class Flare extends AbstractConfigurable
     pulsesPerSec = 3;
   }
 
+  /**
+   * @return String description of this component, displayed in Editor.
+   */
   public String getDescription() {
     return Resources.getString("Editor.Flare.desc");
   }
 
+  /**
+   * @return String name of component class. The part in [..] in the Editor.
+   */
   public static String getConfigureTypeName() {
     return Resources.getString("Editor.Flare.configure");
   }
 
+  /**
+   * Attribute types for this component's buildFile (xml) entry. These launch the proper configurers when the component is edited in the Editor.
+   * @return list of classes for attributes
+   */
   public Class<?>[] getAttributeTypes() {
     return new Class[] { FlareKeyConfig.class, Integer.class, Color.class, Boolean.class, Integer.class, Integer.class, ReportFormatConfig.class };
   }
 
+  /**
+   * Attribute names for this component's buildFile (xml) entry.
+   * @return list of names for attributes
+   */
   public String[] getAttributeNames() {
     return new String[] { FLARE_KEY, CIRCLE_SIZE, CIRCLE_COLOR, CIRCLE_SCALE, PULSES, PULSES_PER_SEC, REPORT_FORMAT };
   }
 
+  /**
+   * Attribute names for this component's buildFile (xml) entry. These show up in the Editor next to the configurers for each attribute.
+   * @return list of names for attributes
+   */
   public String[] getAttributeDescriptions() {
     return new String[] { Resources.getString("Editor.Flare.flare_key"),
             Resources.getString("Editor.Flare.circle_size"),
@@ -140,6 +173,13 @@ public class Flare extends AbstractConfigurable
             Resources.getString("Editor.report_format")};
   }
 
+  /**
+   * Gets current attribute value in string form.
+   *
+   * @param key - attribute name
+   *
+   * @return current the value of one of this component's attributes, in string form.
+   */
   public String getAttributeValueString(final String key) {
     if (FLARE_KEY.equals(key)) {
       return flareKey;
@@ -165,7 +205,13 @@ public class Flare extends AbstractConfigurable
     return null;
   }
 
-
+  /**
+   * Sets the value of one of this component's attributes.
+   *
+   * @param key the name of the attribute
+   *
+   * @param value new value for attribute. Can pass either the Object itself or the String version.
+   */
   public void setAttribute(String key, Object value) {
     if (FLARE_KEY.equals(key)) {
       if (FLARE_ALT_LOCAL.equals(value)) {
@@ -237,12 +283,18 @@ public class Flare extends AbstractConfigurable
   }
 
 
+  /**
+   * @return Help file for this component, accessed when "Help" button in Editor is clicked while configuring component.
+   */
   @Override
   public HelpFile getHelpFile() {
     return HelpFile.getReferenceManualPage("Flare.htm");  //$NON-NLS-1$
   }
 
-
+  /**
+   * Adds this component to a Buildable component. In this case, a Map.
+   * @param parent - the Map to add the Flare to.
+   */
   public void addTo(final Buildable parent) {
     if (parent instanceof Map) {
       map = (Map) parent;
@@ -255,6 +307,10 @@ public class Flare extends AbstractConfigurable
     }
   }
 
+  /**
+   * Removes this component from a Buildable parent.
+   * @param parent - the Map to remove the Flare from.
+   */
   public void removeFrom(final Buildable parent) {
     if (parent instanceof Map) {
       GameModule.getGameModule().removeCommandEncoder(this);
@@ -274,6 +330,9 @@ public class Flare extends AbstractConfigurable
     ));
   }
 
+  /**
+   * Animator to loop the Flare animation. Use the LOOP behavior so that it's always shrinking bullseye rings.
+   */
   private final Animator animator = new Animator(0, 1, Animator.RepeatBehavior.LOOP, new TimingTargetAdapter() {
     @Override
     public void begin() {
@@ -295,6 +354,11 @@ public class Flare extends AbstractConfigurable
     }
   });
 
+  /**
+   * Start the Flare animation.
+   * @param isLocal - true if this Flare was launched on this client (i.e. by this player). Otherwise, center on
+   *                  the ping location if user preferences are set for centering on opponent moves.
+   */
   public void startAnimation(final boolean isLocal) {
     if (!isLocal) {
       if (GlobalOptions.getInstance().centerOnOpponentsMove()) {
@@ -309,6 +373,11 @@ public class Flare extends AbstractConfigurable
     animator.start();
   }
 
+  /**
+   * Draw the Flare at current animation frame
+   * @param g - Graphics
+   * @param map - Map component
+   */
   public void draw(final Graphics g, final Map map) {
     if (active && clickPoint != null) {
       final Graphics2D g2d = (Graphics2D) g;
@@ -346,6 +415,11 @@ public class Flare extends AbstractConfigurable
     return true;
   }
 
+  /**
+   * Encodes Flare commands into string form.
+   * @param c Command
+   * @return String version of Flare Command, or null if not a Flare Command.
+   */
   public String encode(final Command c) {
     if (c instanceof FlareCommand) {
       return COMMAND_PREFIX + ((FlareCommand) c).getClickPoint().x + "," + ((FlareCommand) c).getClickPoint().y;
@@ -353,6 +427,11 @@ public class Flare extends AbstractConfigurable
     return null;
   }
 
+  /**
+   * Decodes string command info into a Flare Command.
+   * @param s String for a Flare Command
+   * @return Flare Command object
+   */
   public Command decode(final String s) {
     if (s.startsWith(COMMAND_PREFIX)) {
       final int x = Integer.parseInt(s.substring(s.indexOf(":") + 1, s.indexOf(",")));
@@ -370,6 +449,11 @@ public class Flare extends AbstractConfigurable
   public void mouseClicked(final MouseEvent e) {
   }
 
+  /**
+   * Check for our modifier key, and if so launch a Flare sequence on our map, and send a command to other players' along
+   * with a Chat Log message if a Report Format has been specified in the component.
+   * @param e - a MouseEvent
+   */
   public void mousePressed(final MouseEvent e) {
     if (!SwingUtils.isMainMouseButtonDown(e)) {
       return;
@@ -409,18 +493,23 @@ public class Flare extends AbstractConfigurable
     final GameModule mod = GameModule.getGameModule();
 
     Command c = new NullCommand();
+
+    // Set special properties for our reportFormat to use ($FlareLocation$, $FlareZone$, $FlareMap$)
     reportFormat.setProperty(FLARE_LOCATION, map.locationName(clickPoint));
     final Zone z = map.findZone(clickPoint);
     reportFormat.setProperty(FLARE_ZONE, (z != null) ? z.getName() : "");
     reportFormat.setProperty(FLARE_MAP, map.getMapName());
-    String reportText = reportFormat.getLocalizedText(map);
+    String reportText = reportFormat.getLocalizedText(map); // Map and global properties also available (e.g. PlayerName, PlayerSide)
     if (reportText.trim().length() > 0) {
       c = new Chatter.DisplayText(mod.getChatter(), "* " + reportText);
       c.execute();
     }
 
+    // Send to other players
     c = c.append(new FlareCommand(this));
     mod.sendAndLog(c);
+
+    // Start animation on our own client
     startAnimation(true);
   }
 
@@ -448,7 +537,9 @@ public class Flare extends AbstractConfigurable
     return clickPoint;
   }
 
-
+  /**
+   * A configurer for different combinations of modifier key
+   */
   public static class FlareKeyConfig extends StringEnum {
     @Override
     public String[] getValidValues(AutoConfigurable target) {
@@ -463,6 +554,10 @@ public class Flare extends AbstractConfigurable
     }
   }
 
+  /**
+   * A configurer for our reportFormat, which includes the unique $FlareLocation$, $FlareZone$, $FlareMap$ properties as
+   * well as $PlayerName$ and $PlayerSide$ in the "Insert" pulldown.
+   */
   public static class ReportFormatConfig implements TranslatableConfigurerFactory {
     @Override
     public Configurer getConfigurer(AutoConfigurable c, String key, String name) {

--- a/vassal-app/src/main/java/VASSAL/build/module/map/Flare.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/Flare.java
@@ -210,7 +210,6 @@ public class Flare extends AbstractConfigurable
   private double os_scale = 1.0;
 
   private volatile float animfrac;
-  private volatile boolean goingUp;
 
   private void repaintArea() {
     map.repaint(new Rectangle(
@@ -221,18 +220,16 @@ public class Flare extends AbstractConfigurable
     ));
   }
 
-  private final Animator animator = new Animator(0, new TimingTargetAdapter() {
+  private final Animator animator = new Animator(0, 1, Animator.RepeatBehavior.LOOP, new TimingTargetAdapter() {
     @Override
     public void begin() {
       active = true;
       animfrac = 0.0f;
-      goingUp  = true;
       repaintArea();
     }
 
     @Override
     public void timingEvent(float fraction) {
-      goingUp = (fraction >= animfrac);
       animfrac = fraction;
       repaintArea();
     }
@@ -265,7 +262,7 @@ public class Flare extends AbstractConfigurable
 
       double diameter = (circleScale ? map.getZoom() : 1.0) * os_scale * circleSize;
       if (animate) {
-        diameter *= goingUp ? (1.0 - animfrac) : animfrac; //BR// Always ping "down"
+        diameter *= (1.0 - animfrac); //BR// Always ping "down"
       }
 
       if (diameter <= 0.0) {

--- a/vassal-app/src/main/java/VASSAL/build/module/map/Flare.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/Flare.java
@@ -1,0 +1,257 @@
+/*
+ * Copyright (c) 2020 Vassalengine.org   Brian Reynolds
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License (LGPL) as published by the Free Software Foundation.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public
+ * License along with this library; if not, copies are available
+ * at http://www.opensource.org.
+ */
+
+package VASSAL.build.module.map;
+
+import java.awt.event.MouseEvent;
+import java.awt.event.ActionEvent;
+import VASSAL.build.module.documentation.HelpFile;
+import VASSAL.command.Command;
+import java.awt.BasicStroke;
+import java.awt.Color;
+import java.awt.Graphics2D;
+import java.awt.Graphics;
+import VASSAL.build.GameModule;
+import VASSAL.build.Buildable;
+import javax.swing.Timer;
+import java.awt.Point;
+import VASSAL.build.module.Map;
+import java.awt.event.MouseListener;
+import java.awt.event.ActionListener;
+import VASSAL.build.module.GameComponent;
+import VASSAL.command.CommandEncoder;
+import VASSAL.build.AbstractConfigurable;
+import VASSAL.command.FlareCommand;
+import VASSAL.i18n.Resources;
+
+public class Flare extends AbstractConfigurable
+    implements CommandEncoder, GameComponent, Drawable, ActionListener, MouseListener {
+  public static final String COMMAND_PREFIX = "FLARE:";
+  private Map map;
+  private int circleSize;
+  private int colorRed;
+  private int colorGreen;
+  private int colorBlue;
+  private static final int CIRCLE_DURATION = 2000;
+  private Point clickPoint;
+  private Boolean active;
+  private Timer timer;
+  public static final String CIRCLESIZE = "circlesize";
+  public static final String COLORRED = "colorred";
+  public static final String COLORGREEN = "colorgreen";
+  public static final String COLORBLUE = "colorblue";
+
+  public Flare() {
+    this.circleSize = 100;
+    this.colorRed = 255;
+    this.colorGreen = 0;
+    this.colorBlue = 0;
+    this.active = false;
+  }
+  
+  @Override
+  public String getDescription() {
+    return Resources.getString("Map Flare");
+  }
+  
+  @Override
+  public static String getConfigureTypeName() {
+    return Resources.getString("Map Flare");
+  }
+
+
+  public Class<?>[] getAttributeTypes() {
+    return (Class<?>[]) new Class[] { Integer.class, Integer.class, Integer.class, Integer.class };
+  }
+
+  public String[] getAttributeNames() {
+    return new String[] { "circlesize", "colorred", "colorgreen", "colorblue" };
+  }
+
+  public String[] getAttributeDescriptions() {
+    return new String[] { "Circle Size", "Red", "Green", "Blue" };
+  }
+
+  public String getAttributeValueString(final String key) {
+    if ("circlesize".equals(key)) {
+      return new StringBuilder().append(this.circleSize).toString();
+    }
+    if ("colorred".equals(key)) {
+      return new StringBuilder().append(this.colorRed).toString();
+    }
+    if ("colorgreen".equals(key)) {
+      return new StringBuilder().append(this.colorGreen).toString();
+    }
+    if ("colorblue".equals(key)) {
+      return new StringBuilder().append(this.colorBlue).toString();
+    }
+    return null;
+  }
+
+  public void setAttribute(final String key, final Object value) {
+    if ("circlesize".equals(key)) {
+      if (value instanceof String) {
+        this.circleSize = Integer.parseInt((String) value); 
+      } 
+      else if (value instanceof Integer) {
+        this.circleSize = (Integer) value;
+      }
+    } 
+    else if ("colorred".equals(key)) {
+      if (value instanceof String) {
+        this.colorRed = Integer.parseInt((String) value);
+      } 
+      else if (value instanceof Integer) {
+        this.colorRed = (Integer) value;
+      }
+    } 
+    else if ("colorgreen".equals(key)) {
+      if (value instanceof String) {
+        this.colorGreen = Integer.parseInt((String) value);
+      } 
+      else if (value instanceof Integer) {
+        this.colorGreen = (Integer) value;
+      }
+    } 
+    else if ("colorblue".equals(key)) {
+      if (value instanceof String) {
+        this.colorBlue = Integer.parseInt((String) value);
+      } 
+      else if (value instanceof Integer) {
+        this.colorBlue = (Integer) value;
+      }
+    }
+  }
+
+  public void addTo(final Buildable parent) {
+    if (parent instanceof Map) {
+      this.map = (Map) parent;
+      GameModule.getGameModule().addCommandEncoder((CommandEncoder) this);
+      this.map.addDrawComponent((Drawable) this);
+      this.map.addLocalMouseListener((MouseListener) this);
+      this.timer = new Timer(CIRCLE_DURATION, this);
+    }
+  }
+  
+  public void removeFrom(final Buildable parent) {
+    if (parent instanceof Map) {
+      GameModule.getGameModule().removeCommandEncoder((CommandEncoder) this);
+    }
+  }
+
+
+  public void startAnimation(final boolean isLocal) {
+    if (!isLocal) {
+      this.map.centerAt(this.clickPoint);
+    }
+    this.active = true;
+    this.timer.restart();
+    this.map.getView().repaint();
+  }
+
+  public void draw(final Graphics g, final Map map) {
+    if (this.active && this.clickPoint != null) {                 
+      final Graphics2D g2d = (Graphics2D) g;
+      final double os_scale = g2d.getDeviceConfiguration().getDefaultTransform().getScaleX();
+      final int diameter = (int)(map.getZoom() * os_scale * this.circleSize);
+
+      // translate the piece center for current zoom
+      
+      final Point p = map.mapToDrawing(clickPoint, os_scale);                             
+      
+      // draw a circle around the selected point
+      g2d.setColor(Color.RED);
+      final Color drawColor = new Color(this.colorRed, this.colorGreen, this.colorBlue);
+      g.setColor(drawColor);
+      g2d.setStroke(new BasicStroke((float)(3 * os_scale)));
+      
+      g2d.drawOval(p.x - diameter / 2, p.y - diameter / 2, diameter, diameter); 
+    }
+  }
+
+  public boolean drawAboveCounters() {
+    return true;
+  }
+
+  public String encode(final Command c) {
+    if (c instanceof FlareCommand) {
+      return COMMAND_PREFIX + ((FlareCommand) c).getClickPoint().x + "," + ((FlareCommand) c).getClickPoint().y;
+    }
+    return null;
+  }
+
+  public Command decode(final String s) {
+    if (s.startsWith(COMMAND_PREFIX)) {
+      final int x = Integer.parseInt(s.substring(s.indexOf(":") + 1, s.indexOf(",")));
+      final int y = Integer.parseInt(s.substring(s.indexOf(",") + 1));
+      this.clickPoint = new Point(x, y);
+      return (Command) new FlareCommand(this);
+    }
+    return null;
+  }
+
+  public HelpFile getHelpFile() {
+    return null;
+  }
+
+  public Class[] getAllowableConfigureComponents() {
+    return new Class[0];
+  }
+
+  public void actionPerformed(final ActionEvent e) {
+    this.active = false;
+    this.timer.stop();
+    this.map.repaint();
+  }
+
+  public void mouseClicked(final MouseEvent e) {
+  }
+
+  public void mousePressed(final MouseEvent e) {
+    if (e.isAltDown()) {
+      this.clickPoint = new Point(e.getX(), e.getY());
+      final GameModule mod = GameModule.getGameModule();
+      final Command c = (Command) new FlareCommand(this);
+      mod.sendAndLog(c);
+      this.startAnimation(true);
+    }
+  }
+
+  public void mouseReleased(final MouseEvent e) {
+  }
+
+  public void mouseEntered(final MouseEvent e) {
+  }
+
+  public void mouseExited(final MouseEvent e) {
+  }
+
+  public void setup(final boolean gameStarting) {
+  }
+
+  public Command getRestoreCommand() {
+    return null;
+  }
+
+  public void setClickPoint(final Point p) {
+    this.clickPoint = p;
+  }
+
+  public Point getClickPoint() {
+    return this.clickPoint;
+  }
+}

--- a/vassal-app/src/main/java/VASSAL/build/module/map/Flare.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/Flare.java
@@ -262,14 +262,14 @@ public class Flare extends AbstractConfigurable
 
       double diameter = (circleScale ? map.getZoom() : 1.0) * os_scale * circleSize;
       if (animate) {
-        diameter *= (1.0 - animfrac); //BR// Always ping "down"
+        diameter *= (1.0 - animfrac);
       }
 
       if (diameter <= 0.0) {
         return;
       }
 
-      // translate the piece center for current zoom
+      // translate the click location for current zoom
       final Point p = map.mapToDrawing(clickPoint, os_scale);
       g2d.setRenderingHint(RenderingHints.KEY_ANTIALIASING,
               RenderingHints.VALUE_ANTIALIAS_ON);
@@ -365,10 +365,10 @@ public class Flare extends AbstractConfigurable
   public static class FlareKeyConfig extends StringEnum {
     @Override
     public String[] getValidValues(AutoConfigurable target) {
-      String[] values = new String[2];
-      values[0] = FLARE_ALT_LOCAL;
-      values[1] = (SystemUtils.IS_OS_MAC_OSX && !GlobalOptions.getInstance().getPrefMacLegacy()) ? FLARE_COMMAND_LOCAL : FLARE_CTRL_LOCAL; // Show proper Mac "Ctrl" key
-      return values;
+      return new String[] {
+        FLARE_ALT_LOCAL,
+        SystemUtils.IS_OS_MAC_OSX && !GlobalOptions.getInstance().getPrefMacLegacy() ? FLARE_COMMAND_LOCAL : FLARE_CTRL_LOCAL
+      };
     }
   }
 

--- a/vassal-app/src/main/java/VASSAL/build/module/map/Flare.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/Flare.java
@@ -466,7 +466,12 @@ public class Flare extends AbstractConfigurable
    */
   public String encode(final Command c) {
     if (c instanceof FlareCommand) {
-      return COMMAND_PREFIX + ((FlareCommand) c).getId() + DELIMITER + ((FlareCommand) c).getClickPoint().x + DELIMITER + ((FlareCommand) c).getClickPoint().y;
+      SequenceEncoder se = new SequenceEncoder(DELIMITER);
+      se
+        .append(((FlareCommand)c).getId())
+        .append(((FlareCommand)c).getClickPoint().x)
+        .append(((FlareCommand)c).getClickPoint().y);
+      return COMMAND_PREFIX + se.getValue();
     }
     return null;
   }

--- a/vassal-app/src/main/java/VASSAL/build/module/map/Flare.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/Flare.java
@@ -552,7 +552,8 @@ public class Flare extends AbstractConfigurable
     // Set special properties for our reportFormat to use ($FlareLocation$, $FlareZone$, $FlareMap$)
     reportFormat.setProperty(FLARE_NAME, getAttributeValueString(NAME));
     reportFormat.setProperty(FLARE_LOCATION, map.locationName(clickPoint));
-    final Zone z = map.findZone(clickPoint);
+    Point sacrificialPoint = new Point(clickPoint); // findZone murderously writes back into the point it is passed, so we will pass it a sacrificialPoint rather than our precious one.
+    final Zone z = map.findZone(sacrificialPoint);
     reportFormat.setProperty(FLARE_ZONE, (z != null) ? z.getName() : "");
     reportFormat.setProperty(FLARE_MAP, map.getMapName());
     String reportText = reportFormat.getLocalizedText(map); // Map and global properties also available (e.g. PlayerName, PlayerSide)

--- a/vassal-app/src/main/java/VASSAL/build/module/map/Flare.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/Flare.java
@@ -33,6 +33,7 @@ import VASSAL.build.module.Chatter;
 import VASSAL.build.module.map.boardPicker.board.mapgrid.Zone;
 import VASSAL.command.NullCommand;
 import VASSAL.configure.Configurer;
+import VASSAL.configure.TranslatableStringEnum;
 import VASSAL.i18n.TranslatableConfigurerFactory;
 import VASSAL.tools.ErrorDialog;
 import VASSAL.tools.FormattedString;
@@ -586,9 +587,23 @@ public class Flare extends AbstractConfigurable
   /**
    * A configurer for different combinations of modifier key
    */
-  public static class FlareKeyConfig extends StringEnum {
+  public static class FlareKeyConfig extends TranslatableStringEnum {
     @Override
+
+
+
     public String[] getValidValues(AutoConfigurable target) {
+      return new String[] {
+        FLARE_ALT,
+        FLARE_CTRL,
+        FLARE_ALT_SHIFT,
+        FLARE_CTRL_SHIFT,
+        FLARE_CTRL_ALT,
+        FLARE_CTRL_ALT_SHIFT
+      };
+    }
+
+    public String[] getI18nKeys(AutoConfigurable target) {
       return new String[] {
         FLARE_ALT_LOCAL,
         SystemUtils.IS_OS_MAC_OSX && !GlobalOptions.getInstance().getPrefMacLegacy() ? FLARE_COMMAND_LOCAL : FLARE_CTRL_LOCAL,

--- a/vassal-app/src/main/java/VASSAL/build/module/map/Flare.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/Flare.java
@@ -73,6 +73,7 @@ public class Flare extends AbstractConfigurable
   public  static final String COMMAND_PREFIX = "FLARE" + DELIMITER; //$NON-NLS-1$
 
   protected static final UniqueIdManager idMgr = new UniqueIdManager("Flare"); //$NON-NLS-1$
+  protected String id = "";     // Our unique ID
 
   // Attributes
   private int circleSize;       // Maximum circle size in pixels
@@ -442,7 +443,7 @@ public class Flare extends AbstractConfigurable
    */
   public String encode(final Command c) {
     if (c instanceof FlareCommand) {
-      return COMMAND_PREFIX + ((FlareCommand) c).getMapId() + DELIMITER + ((FlareCommand) c).getClickPoint().x + DELIMITER + ((FlareCommand) c).getClickPoint().y;
+      return COMMAND_PREFIX + ((FlareCommand) c).getId() + DELIMITER + ((FlareCommand) c).getClickPoint().x + DELIMITER + ((FlareCommand) c).getClickPoint().y;
     }
     return null;
   }
@@ -453,7 +454,7 @@ public class Flare extends AbstractConfigurable
    * @return Flare Command object
    */
   public Command decode(final String s) {
-    if (s.startsWith(COMMAND_PREFIX + getMap().getId())) { // Make sure this command is heading to our map
+    if (s.startsWith(COMMAND_PREFIX + getId())) { // Make sure this command is for this flare
       SequenceEncoder.Decoder sd = new SequenceEncoder.Decoder(s, DELIMITER);
       sd.nextToken(); // Skip over the Command Prefix
       sd.nextToken(); // Skip over the Id
@@ -562,12 +563,12 @@ public class Flare extends AbstractConfigurable
 
   @Override
   public void setId(String id) {
-
+    this.id = id;
   }
 
   @Override
   public String getId() {
-    return null;
+    return id;
   }
 
   /**

--- a/vassal-app/src/main/java/VASSAL/build/module/map/Flare.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/Flare.java
@@ -552,8 +552,7 @@ public class Flare extends AbstractConfigurable
     // Set special properties for our reportFormat to use ($FlareLocation$, $FlareZone$, $FlareMap$)
     reportFormat.setProperty(FLARE_NAME, getAttributeValueString(NAME));
     reportFormat.setProperty(FLARE_LOCATION, map.locationName(clickPoint));
-    Point sacrificialPoint = new Point(clickPoint); // findZone murderously writes back into the point it is passed, so we will pass it a sacrificialPoint rather than our precious one.
-    final Zone z = map.findZone(sacrificialPoint);
+    final Zone z = map.findZone(clickPoint);
     reportFormat.setProperty(FLARE_ZONE, (z != null) ? z.getName() : "");
     reportFormat.setProperty(FLARE_MAP, map.getMapName());
     String reportText = reportFormat.getLocalizedText(map); // Map and global properties also available (e.g. PlayerName, PlayerSide)

--- a/vassal-app/src/main/java/VASSAL/build/module/map/Flare.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/Flare.java
@@ -37,6 +37,7 @@ import VASSAL.i18n.TranslatableConfigurerFactory;
 import VASSAL.tools.ErrorDialog;
 import VASSAL.tools.FormattedString;
 import VASSAL.tools.SequenceEncoder;
+import VASSAL.tools.UniqueIdManager;
 import org.jdesktop.animation.timing.Animator;
 import org.jdesktop.animation.timing.TimingTargetAdapter;
 
@@ -67,8 +68,11 @@ import VASSAL.tools.swing.SwingUtils;
  * Flare will work with both online play and PBEM play.
  */
 public class Flare extends AbstractConfigurable
-        implements CommandEncoder, GameComponent, Drawable, MouseListener {
-  public static final String COMMAND_PREFIX = "FLARE\t";
+        implements CommandEncoder, GameComponent, Drawable, MouseListener, UniqueIdManager.Identifyable {
+  private static final String DELIMITER = "\t"; //$NON-NLS-1$
+  public  static final String COMMAND_PREFIX = "FLARE" + DELIMITER; //$NON-NLS-1$
+
+  protected static final UniqueIdManager idMgr = new UniqueIdManager("Flare"); //$NON-NLS-1$
 
   // Attributes
   private int circleSize;       // Maximum circle size in pixels
@@ -86,38 +90,38 @@ public class Flare extends AbstractConfigurable
   private volatile boolean active;  // Internal flag if we're currently active
 
   // Attribute names
-  public static final String CIRCLE_SIZE    = "circleSize";
-  public static final String CIRCLE_SCALE   = "circleScale";
-  public static final String CIRCLE_COLOR   = "circleColor";
-  public static final String FLARE_KEY      = "flareKey";
-  public static final String PULSES         = "flarePulses";
-  public static final String PULSES_PER_SEC = "flarePulsesPerSec";
-  public static final String REPORT_FORMAT  = "reportFormat";
+  public static final String CIRCLE_SIZE    = "circleSize";         //$NON-NLS-1$
+  public static final String CIRCLE_SCALE   = "circleScale";        //$NON-NLS-1$
+  public static final String CIRCLE_COLOR   = "circleColor";        //$NON-NLS-1$
+  public static final String FLARE_KEY      = "flareKey";           //$NON-NLS-1$
+  public static final String PULSES         = "flarePulses";        //$NON-NLS-1$
+  public static final String PULSES_PER_SEC = "flarePulsesPerSec";  //$NON-NLS-1$
+  public static final String REPORT_FORMAT  = "reportFormat";       //$NON-NLS-1$
 
   // Friendly (localizable) names for modifier key combinations
-  public static final String FLARE_ALT_LOCAL       = Resources.getString("Editor.Flare.flare_key_desc", Resources.getString("Keys.alt"));
-  public static final String FLARE_CTRL_LOCAL      = Resources.getString("Editor.Flare.flare_key_desc", Resources.getString("Keys.ctrl"));
-  public static final String FLARE_COMMAND_LOCAL   = Resources.getString("Editor.Flare.flare_key_desc", Resources.getString("Keys.meta"));
-  public static final String FLARE_ALT_SHIFT_LOCAL = Resources.getString("Editor.Flare.flare_key_desc", Resources.getString("Keys.alt_shift"));
-  public static final String FLARE_SHIFT_COMMAND_LOCAL = Resources.getString("Editor.Flare.flare_key_desc", Resources.getString("Keys.shift_command"));
-  public static final String FLARE_CTRL_SHIFT_LOCAL = Resources.getString("Editor.Flare.flare_key_desc", Resources.getString("Keys.ctrl_shift"));
-  public static final String FLARE_ALT_COMMAND_LOCAL = Resources.getString("Editor.Flare.flare_key_desc", Resources.getString("Keys.alt_command"));
-  public static final String FLARE_CTRL_ALT_LOCAL = Resources.getString("Editor.Flare.flare_key_desc", Resources.getString("Keys.ctrl_alt"));
-  public static final String FLARE_ALT_SHIFT_COMMAND_LOCAL = Resources.getString("Editor.Flare.flare_key_desc", Resources.getString("Keys.alt_shift_command"));
-  public static final String FLARE_CTRL_ALT_SHIFT_LOCAL = Resources.getString("Editor.Flare.flare_key_desc", Resources.getString("Keys.ctrl_alt_shift"));
+  public static final String FLARE_ALT_LOCAL       = Resources.getString("Editor.Flare.flare_key_desc", Resources.getString("Keys.alt"));                       //$NON-NLS-1$ //$NON-NLS-2$
+  public static final String FLARE_CTRL_LOCAL      = Resources.getString("Editor.Flare.flare_key_desc", Resources.getString("Keys.ctrl"));                      //$NON-NLS-1$ //$NON-NLS-2$
+  public static final String FLARE_COMMAND_LOCAL   = Resources.getString("Editor.Flare.flare_key_desc", Resources.getString("Keys.meta"));                      //$NON-NLS-1$ //$NON-NLS-2$
+  public static final String FLARE_ALT_SHIFT_LOCAL = Resources.getString("Editor.Flare.flare_key_desc", Resources.getString("Keys.alt_shift"));                 //$NON-NLS-1$ //$NON-NLS-2$
+  public static final String FLARE_SHIFT_COMMAND_LOCAL = Resources.getString("Editor.Flare.flare_key_desc", Resources.getString("Keys.shift_command"));         //$NON-NLS-1$ //$NON-NLS-2$
+  public static final String FLARE_CTRL_SHIFT_LOCAL = Resources.getString("Editor.Flare.flare_key_desc", Resources.getString("Keys.ctrl_shift"));               //$NON-NLS-1$ //$NON-NLS-2$
+  public static final String FLARE_ALT_COMMAND_LOCAL = Resources.getString("Editor.Flare.flare_key_desc", Resources.getString("Keys.alt_command"));             //$NON-NLS-1$ //$NON-NLS-2$
+  public static final String FLARE_CTRL_ALT_LOCAL = Resources.getString("Editor.Flare.flare_key_desc", Resources.getString("Keys.ctrl_alt"));                   //$NON-NLS-1$ //$NON-NLS-2$
+  public static final String FLARE_ALT_SHIFT_COMMAND_LOCAL = Resources.getString("Editor.Flare.flare_key_desc", Resources.getString("Keys.alt_shift_command")); //$NON-NLS-1$ //$NON-NLS-2$
+  public static final String FLARE_CTRL_ALT_SHIFT_LOCAL = Resources.getString("Editor.Flare.flare_key_desc", Resources.getString("Keys.ctrl_alt_shift"));       //$NON-NLS-1$ //$NON-NLS-2$
 
   // The modifier key codes we actually store
-  public static final String FLARE_ALT            = "keyAlt";
-  public static final String FLARE_CTRL           = "keyCtrl";
-  public static final String FLARE_ALT_SHIFT      = "keyAltShift";
-  public static final String FLARE_CTRL_SHIFT     = "keyCtrlShift";
-  public static final String FLARE_CTRL_ALT       = "keyCtrlAlt";
-  public static final String FLARE_CTRL_ALT_SHIFT = "keyCtrlAltShift";
+  public static final String FLARE_ALT            = "keyAlt";          //$NON-NLS-1$
+  public static final String FLARE_CTRL           = "keyCtrl";         //$NON-NLS-1$
+  public static final String FLARE_ALT_SHIFT      = "keyAltShift";     //$NON-NLS-1$
+  public static final String FLARE_CTRL_SHIFT     = "keyCtrlShift";    //$NON-NLS-1$
+  public static final String FLARE_CTRL_ALT       = "keyCtrlAlt";      //$NON-NLS-1$
+  public static final String FLARE_CTRL_ALT_SHIFT = "keyCtrlAltShift"; //$NON-NLS-1$
 
   // Special properties for our FormattedString reportFormat
-  public static final String FLARE_LOCATION       = "FlareLocation";
-  public static final String FLARE_ZONE           = "FlareZone";
-  public static final String FLARE_MAP            = "FlareMap";
+  public static final String FLARE_LOCATION       = "FlareLocation";   //$NON-NLS-1$
+  public static final String FLARE_ZONE           = "FlareZone";       //$NON-NLS-1$
+  public static final String FLARE_MAP            = "FlareMap";        //$NON-NLS-1$
 
   private static final int STROKE = 3;
 
@@ -135,14 +139,14 @@ public class Flare extends AbstractConfigurable
    * @return String description of this component, displayed in Editor.
    */
   public String getDescription() {
-    return Resources.getString("Editor.Flare.desc");
+    return Resources.getString("Editor.Flare.desc"); //$NON-NLS-1$
   }
 
   /**
    * @return String name of component class. The part in [..] in the Editor.
    */
   public static String getConfigureTypeName() {
-    return Resources.getString("Editor.Flare.configure");
+    return Resources.getString("Editor.Flare.configure"); //$NON-NLS-1$
   }
 
   /**
@@ -173,13 +177,13 @@ public class Flare extends AbstractConfigurable
    * @return list of names for attributes
    */
   public String[] getAttributeDescriptions() {
-    return new String[] { Resources.getString("Editor.Flare.flare_key"),
-            Resources.getString("Editor.Flare.circle_size"),
-            Resources.getString("Editor.Flare.circle_color"),
-            Resources.getString("Editor.Flare.circle_scale"),
-            Resources.getString("Editor.Flare.pulses"),
-            Resources.getString("Editor.Flare.pulses_per_sec"),
-            Resources.getString("Editor.report_format")};
+    return new String[] { Resources.getString("Editor.Flare.flare_key"), //$NON-NLS-1$
+            Resources.getString("Editor.Flare.circle_size"), //$NON-NLS-1$
+            Resources.getString("Editor.Flare.circle_color"), //$NON-NLS-1$
+            Resources.getString("Editor.Flare.circle_scale"), //$NON-NLS-1$
+            Resources.getString("Editor.Flare.pulses"), //$NON-NLS-1$
+            Resources.getString("Editor.Flare.pulses_per_sec"), //$NON-NLS-1$
+            Resources.getString("Editor.report_format")}; //$NON-NLS-1$
   }
 
   /**
@@ -305,6 +309,7 @@ public class Flare extends AbstractConfigurable
    * @param parent - the Map to add the Flare to.
    */
   public void addTo(final Buildable parent) {
+    idMgr.add(this);
     if (parent instanceof Map) {
       map = (Map) parent;
       GameModule.getGameModule().addCommandEncoder(this);
@@ -324,6 +329,7 @@ public class Flare extends AbstractConfigurable
     if (parent instanceof Map) {
       GameModule.getGameModule().removeCommandEncoder(this);
     }
+    idMgr.remove(this);
   }
 
   private double os_scale = 1.0;
@@ -392,36 +398,37 @@ public class Flare extends AbstractConfigurable
    * @param map - Map component
    */
   public void draw(final Graphics g, final Map map) {
-    if (active && clickPoint != null) {
-      final Graphics2D g2d = (Graphics2D) g;
-      os_scale = g2d.getDeviceConfiguration().getDefaultTransform().getScaleX();
-
-      double diameter = (circleScale ? map.getZoom() : 1.0) * os_scale * circleSize;
-      if (animate) {
-        diameter *= (1.0 - animfrac);
-      }
-
-      if (diameter <= 0.0) {
-        return;
-      }
-
-      // translate the click location for current zoom
-      final Point p = map.mapToDrawing(clickPoint, os_scale);
-      g2d.setRenderingHint(RenderingHints.KEY_ANTIALIASING,
-              RenderingHints.VALUE_ANTIALIAS_ON);
-
-      // draw a circle around the selected point
-      g2d.setColor(color);
-      g2d.setStroke(new BasicStroke((float)(STROKE * os_scale)));
-      g2d.setRenderingHint(RenderingHints.KEY_ANTIALIASING,
-              RenderingHints.VALUE_ANTIALIAS_ON);
-      g2d.drawOval(
-              (int)(p.x - diameter / 2.0),
-              (int)(p.y - diameter / 2.0),
-              (int)(diameter + 0.5),
-              (int)(diameter + 0.5)
-      );
+    if (!active || (clickPoint == null)) {
+      return;
     }
+    final Graphics2D g2d = (Graphics2D) g;
+    os_scale = g2d.getDeviceConfiguration().getDefaultTransform().getScaleX();
+
+    double diameter = (circleScale ? map.getZoom() : 1.0) * os_scale * circleSize;
+    if (animate) {
+      diameter *= (1.0 - animfrac);
+    }
+
+    if (diameter <= 0.0) {
+      return;
+    }
+
+    // translate the click location for current zoom
+    final Point p = map.mapToDrawing(clickPoint, os_scale);
+    g2d.setRenderingHint(RenderingHints.KEY_ANTIALIASING,
+            RenderingHints.VALUE_ANTIALIAS_ON);
+
+    // draw a circle around the selected point
+    g2d.setColor(color);
+    g2d.setStroke(new BasicStroke((float)(STROKE * os_scale)));
+    g2d.setRenderingHint(RenderingHints.KEY_ANTIALIASING,
+            RenderingHints.VALUE_ANTIALIAS_ON);
+    g2d.drawOval(
+            (int)(p.x - diameter / 2.0),
+            (int)(p.y - diameter / 2.0),
+            (int)(diameter + 0.5),
+            (int)(diameter + 0.5)
+    );
   }
 
   public boolean drawAboveCounters() {
@@ -435,7 +442,7 @@ public class Flare extends AbstractConfigurable
    */
   public String encode(final Command c) {
     if (c instanceof FlareCommand) {
-      return COMMAND_PREFIX + ((FlareCommand) c).getMapId() + "\t" + ((FlareCommand) c).getClickPoint().x + "\t" + ((FlareCommand) c).getClickPoint().y;
+      return COMMAND_PREFIX + ((FlareCommand) c).getMapId() + DELIMITER + ((FlareCommand) c).getClickPoint().x + DELIMITER + ((FlareCommand) c).getClickPoint().y;
     }
     return null;
   }
@@ -446,8 +453,8 @@ public class Flare extends AbstractConfigurable
    * @return Flare Command object
    */
   public Command decode(final String s) {
-    if (s.startsWith(COMMAND_PREFIX + getMap().getId())) {
-      SequenceEncoder.Decoder sd = new SequenceEncoder.Decoder(s, '\t');
+    if (s.startsWith(COMMAND_PREFIX + getMap().getId())) { // Make sure this command is heading to our map
+      SequenceEncoder.Decoder sd = new SequenceEncoder.Decoder(s, DELIMITER);
       sd.nextToken(); // Skip over the Command Prefix
       sd.nextToken(); // Skip over the Id
       final int x = sd.nextInt(0);
@@ -551,6 +558,16 @@ public class Flare extends AbstractConfigurable
 
   public Point getClickPoint() {
     return clickPoint;
+  }
+
+  @Override
+  public void setId(String id) {
+
+  }
+
+  @Override
+  public String getId() {
+    return null;
   }
 
   /**

--- a/vassal-app/src/main/java/VASSAL/build/module/map/Flare.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/Flare.java
@@ -349,6 +349,9 @@ public class Flare extends AbstractConfigurable
 
   private volatile float animfrac;
 
+  /**
+   * Repaint only the necessary area
+   */
   private void repaintArea() {
     map.repaint(new Rectangle(
             (int)(clickPoint.x - circleSize / 2.0 - 2 * STROKE * os_scale),
@@ -369,12 +372,19 @@ public class Flare extends AbstractConfigurable
       repaintArea();
     }
 
+    /**
+     * Animator tells us when to update the image.
+     * @param fraction Animator lets us know how far we are through our cycle
+     */
     @Override
     public void timingEvent(float fraction) {
       animfrac = fraction;
       repaintArea();
     }
 
+    /**
+     * Animator tells us we're done.
+     */
     @Override
     public void end() {
       active = false;
@@ -444,12 +454,16 @@ public class Flare extends AbstractConfigurable
     );
   }
 
+  /**
+   * Flare is always drawn above counters
+   * @return true
+   */
   public boolean drawAboveCounters() {
     return true;
   }
 
   /**
-   * Encodes Flare commands into string form.
+   * Serializes Flare commands into string form.
    * @param c Command
    * @return String version of Flare Command, or null if not a Flare Command.
    */
@@ -461,7 +475,7 @@ public class Flare extends AbstractConfigurable
   }
 
   /**
-   * Decodes string command info into a Flare Command.
+   * Deserializes string command info into a Flare Command.
    * @param s String for a Flare Command
    * @return Flare Command object
    */
@@ -482,6 +496,9 @@ public class Flare extends AbstractConfigurable
     return new Class[0];
   }
 
+  /**
+   * @param e MouseEvent
+   */
   public void mouseClicked(final MouseEvent e) {
   }
 
@@ -550,35 +567,66 @@ public class Flare extends AbstractConfigurable
     startAnimation(true);
   }
 
+  /**
+   * @param e MouseEvent
+   */
   public void mouseReleased(final MouseEvent e) {
   }
 
+  /**
+   * @param e MouseEvent
+   */
   public void mouseEntered(final MouseEvent e) {
   }
 
+  /**
+   * @param e MouseEvent
+   */
   public void mouseExited(final MouseEvent e) {
   }
 
+  /**
+   * @param e MouseEvent
+   */
   public void setup(final boolean gameStarting) {
   }
 
+  /**
+   * @return Theoretically returns the command to "restore" this from a saved game or when adding a new player, but of
+   * course Flare doesn't need to be "restored", so null.
+   */
   public Command getRestoreCommand() {
     return null;
   }
 
+  /**
+   * Record our clicked point on the map
+   * @param p - point where player clicked and where flare should be shown
+   */
   public void setClickPoint(final Point p) {
     clickPoint = p;
   }
 
+  /**
+   * @return point where player clicked and where flare should be shown
+   */
   public Point getClickPoint() {
     return clickPoint;
   }
 
+  /**
+   * Sets our unique ID (among Flares), so that multiple Flares don't inadvertently start each other when we
+   * send commands to other clients.
+   * @param id Sets our unique ID
+   */
   @Override
   public void setId(String id) {
     this.id = id;
   }
 
+  /**
+   * @return unique ID of this flare, for purposes of distinguishing between Flare commands
+   */
   @Override
   public String getId() {
     return id;
@@ -589,8 +637,6 @@ public class Flare extends AbstractConfigurable
    */
   public static class FlareKeyConfig extends TranslatableStringEnum {
     @Override
-
-
 
     public String[] getValidValues(AutoConfigurable target) {
       return new String[] {

--- a/vassal-app/src/main/java/VASSAL/build/module/map/Flare.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/Flare.java
@@ -98,6 +98,7 @@ public class Flare extends AbstractConfigurable
   public static final String PULSES         = "flarePulses";        //$NON-NLS-1$
   public static final String PULSES_PER_SEC = "flarePulsesPerSec";  //$NON-NLS-1$
   public static final String REPORT_FORMAT  = "reportFormat";       //$NON-NLS-1$
+  public static final String NAME           = "flareName";          //$NON-NLS-1$
 
   // Friendly (localizable) names for modifier key combinations
   public static final String FLARE_ALT_LOCAL       = Resources.getString("Editor.Flare.flare_key_desc", Resources.getString("Keys.alt"));                       //$NON-NLS-1$ //$NON-NLS-2$
@@ -120,6 +121,7 @@ public class Flare extends AbstractConfigurable
   public static final String FLARE_CTRL_ALT_SHIFT = "keyCtrlAltShift"; //$NON-NLS-1$
 
   // Special properties for our FormattedString reportFormat
+  public static final String FLARE_NAME           = "FlareName";       //$NON-NLS-1$
   public static final String FLARE_LOCATION       = "FlareLocation";   //$NON-NLS-1$
   public static final String FLARE_ZONE           = "FlareZone";       //$NON-NLS-1$
   public static final String FLARE_MAP            = "FlareMap";        //$NON-NLS-1$
@@ -134,6 +136,7 @@ public class Flare extends AbstractConfigurable
     flareKey     = FLARE_ALT;
     pulses       = 6;
     pulsesPerSec = 3;
+    setConfigureName(Resources.getString("Editor.Flare.desc"));
   }
 
   /**
@@ -162,7 +165,7 @@ public class Flare extends AbstractConfigurable
    * @return list of classes for attributes
    */
   public Class<?>[] getAttributeTypes() {
-    return new Class[] { FlareKeyConfig.class, Integer.class, Color.class, Boolean.class, Integer.class, Integer.class, ReportFormatConfig.class };
+    return new Class[] { String.class, FlareKeyConfig.class, Integer.class, Color.class, Boolean.class, Integer.class, Integer.class, ReportFormatConfig.class };
   }
 
   /**
@@ -170,7 +173,7 @@ public class Flare extends AbstractConfigurable
    * @return list of names for attributes
    */
   public String[] getAttributeNames() {
-    return new String[] { FLARE_KEY, CIRCLE_SIZE, CIRCLE_COLOR, CIRCLE_SCALE, PULSES, PULSES_PER_SEC, REPORT_FORMAT };
+    return new String[] { NAME, FLARE_KEY, CIRCLE_SIZE, CIRCLE_COLOR, CIRCLE_SCALE, PULSES, PULSES_PER_SEC, REPORT_FORMAT };
   }
 
   /**
@@ -178,7 +181,9 @@ public class Flare extends AbstractConfigurable
    * @return list of names for attributes
    */
   public String[] getAttributeDescriptions() {
-    return new String[] { Resources.getString("Editor.Flare.flare_key"), //$NON-NLS-1$
+    return new String[] {
+            Resources.getString("Editor.name_label"), //$NON-NLS-1$
+            Resources.getString("Editor.Flare.flare_key"), //$NON-NLS-1$
             Resources.getString("Editor.Flare.circle_size"), //$NON-NLS-1$
             Resources.getString("Editor.Flare.circle_color"), //$NON-NLS-1$
             Resources.getString("Editor.Flare.circle_scale"), //$NON-NLS-1$
@@ -195,7 +200,10 @@ public class Flare extends AbstractConfigurable
    * @return current the value of one of this component's attributes, in string form.
    */
   public String getAttributeValueString(final String key) {
-    if (FLARE_KEY.equals(key)) {
+    if (NAME.equals(key)) {
+      return getConfigureName();
+    }
+    else if (FLARE_KEY.equals(key)) {
       return flareKey;
     }
     else if (CIRCLE_SIZE.equals(key)) {
@@ -227,7 +235,10 @@ public class Flare extends AbstractConfigurable
    * @param value new value for attribute. Can pass either the Object itself or the String version.
    */
   public void setAttribute(String key, Object value) {
-    if (FLARE_KEY.equals(key)) {
+    if (NAME.equals(key)) {
+      setConfigureName((String) value);
+    }
+    else if (FLARE_KEY.equals(key)) {
       if (FLARE_ALT_LOCAL.equals(value)) {
         flareKey = FLARE_ALT;
       }
@@ -519,6 +530,7 @@ public class Flare extends AbstractConfigurable
     Command c = new NullCommand();
 
     // Set special properties for our reportFormat to use ($FlareLocation$, $FlareZone$, $FlareMap$)
+    reportFormat.setProperty(FLARE_NAME, getAttributeValueString(NAME));
     reportFormat.setProperty(FLARE_LOCATION, map.locationName(clickPoint));
     final Zone z = map.findZone(clickPoint);
     reportFormat.setProperty(FLARE_ZONE, (z != null) ? z.getName() : "");

--- a/vassal-app/src/main/java/VASSAL/build/module/map/Flare.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/Flare.java
@@ -56,7 +56,6 @@ import VASSAL.command.Command;
 import VASSAL.command.CommandEncoder;
 import VASSAL.command.FlareCommand;
 import VASSAL.configure.ColorConfigurer;
-import VASSAL.configure.StringEnum;
 import VASSAL.configure.FlareFormattedStringConfigurer;
 import VASSAL.i18n.Resources;
 import VASSAL.tools.swing.SwingUtils;
@@ -70,7 +69,7 @@ import VASSAL.tools.swing.SwingUtils;
  */
 public class Flare extends AbstractConfigurable
         implements CommandEncoder, GameComponent, Drawable, MouseListener, UniqueIdManager.Identifyable {
-  private static final String DELIMITER = "\t"; //$NON-NLS-1$
+  private static final char DELIMITER = '\t'; //$NON-NLS-1$
   public  static final String COMMAND_PREFIX = "FLARE" + DELIMITER; //$NON-NLS-1$
 
   protected static final UniqueIdManager idMgr = new UniqueIdManager("Flare"); //$NON-NLS-1$
@@ -584,7 +583,7 @@ public class Flare extends AbstractConfigurable
   }
 
   /**
-   * @param e MouseEvent
+   * @param gameStarting
    */
   public void setup(final boolean gameStarting) {
   }

--- a/vassal-app/src/main/java/VASSAL/build/module/map/Flare.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/Flare.java
@@ -438,8 +438,6 @@ public class Flare extends AbstractConfigurable
 
     // translate the click location for current zoom
     final Point p = map.mapToDrawing(clickPoint, os_scale);
-    g2d.setRenderingHint(RenderingHints.KEY_ANTIALIASING,
-            RenderingHints.VALUE_ANTIALIAS_ON);
 
     // draw a circle around the selected point
     g2d.setColor(color);
@@ -650,13 +648,14 @@ public class Flare extends AbstractConfigurable
     }
 
     public String[] getI18nKeys(AutoConfigurable target) {
+      boolean macLegacy = GlobalOptions.getInstance().getPrefMacLegacy();
       return new String[] {
         FLARE_ALT_LOCAL,
-        SystemUtils.IS_OS_MAC_OSX && !GlobalOptions.getInstance().getPrefMacLegacy() ? FLARE_COMMAND_LOCAL : FLARE_CTRL_LOCAL,
+        SystemUtils.IS_OS_MAC_OSX && !macLegacy ? FLARE_COMMAND_LOCAL : FLARE_CTRL_LOCAL,
         FLARE_ALT_SHIFT_LOCAL,
-        SystemUtils.IS_OS_MAC_OSX && !GlobalOptions.getInstance().getPrefMacLegacy() ? FLARE_SHIFT_COMMAND_LOCAL : FLARE_CTRL_SHIFT_LOCAL,
-        SystemUtils.IS_OS_MAC_OSX && !GlobalOptions.getInstance().getPrefMacLegacy() ? FLARE_ALT_COMMAND_LOCAL : FLARE_CTRL_ALT_LOCAL,
-        SystemUtils.IS_OS_MAC_OSX && !GlobalOptions.getInstance().getPrefMacLegacy() ? FLARE_ALT_SHIFT_COMMAND_LOCAL : FLARE_CTRL_ALT_SHIFT_LOCAL,
+        SystemUtils.IS_OS_MAC_OSX && !macLegacy ? FLARE_SHIFT_COMMAND_LOCAL : FLARE_CTRL_SHIFT_LOCAL,
+        SystemUtils.IS_OS_MAC_OSX && !macLegacy ? FLARE_ALT_COMMAND_LOCAL : FLARE_CTRL_ALT_LOCAL,
+        SystemUtils.IS_OS_MAC_OSX && !macLegacy ? FLARE_ALT_SHIFT_COMMAND_LOCAL : FLARE_CTRL_ALT_SHIFT_LOCAL,
       };
     }
   }

--- a/vassal-app/src/main/java/VASSAL/command/FlareCommand.java
+++ b/vassal-app/src/main/java/VASSAL/command/FlareCommand.java
@@ -22,17 +22,17 @@ import java.awt.Point;
 import VASSAL.build.module.map.Flare;
 
 public class FlareCommand extends Command {
-  private final Flare finder;
+  private final Flare flare;
   private final Point clickPoint;
     
-  public FlareCommand(final Flare finder) {
-    clickPoint = new Point(finder.getClickPoint());
-    this.finder = finder;
+  public FlareCommand(final Flare flare) {
+    clickPoint = new Point(flare.getClickPoint());
+    this.flare = flare;
   }
     
   protected void executeCommand() {
-    finder.setClickPoint(clickPoint);
-    finder.startAnimation(false);
+    flare.setClickPoint(clickPoint);
+    flare.startAnimation(false);
   }
     
   protected Command myUndoCommand() {

--- a/vassal-app/src/main/java/VASSAL/command/FlareCommand.java
+++ b/vassal-app/src/main/java/VASSAL/command/FlareCommand.java
@@ -22,17 +22,17 @@ import java.awt.Point;
 import VASSAL.build.module.map.Flare;
 
 public class FlareCommand extends Command {
-  private Flare finder;
-  private Point clickPoint;
+  private final Flare finder;
+  private final Point clickPoint;
     
   public FlareCommand(final Flare finder) {
-    this.clickPoint = new Point(finder.getClickPoint());
+    clickPoint = new Point(finder.getClickPoint());
     this.finder = finder;
   }
     
   protected void executeCommand() {
-    this.finder.setClickPoint(this.clickPoint);
-    this.finder.startAnimation(false);
+    finder.setClickPoint(clickPoint);
+    finder.startAnimation(false);
   }
     
   protected Command myUndoCommand() {
@@ -44,6 +44,6 @@ public class FlareCommand extends Command {
   }
     
   public Point getClickPoint() {
-    return this.clickPoint;
+    return clickPoint;
   }
 }

--- a/vassal-app/src/main/java/VASSAL/command/FlareCommand.java
+++ b/vassal-app/src/main/java/VASSAL/command/FlareCommand.java
@@ -1,0 +1,49 @@
+
+/*
+ * Copyright (c) 2020 Vassalengine.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License (LGPL) as published by the Free Software Foundation.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public
+ * License along with this library; if not, copies are available
+ * at http://www.opensource.org.
+ */
+package VASSAL.command;
+
+import java.awt.Point;
+
+import VASSAL.build.module.map.Flare;
+
+public class FlareCommand extends Command {
+  private Flare finder;
+  private Point clickPoint;
+    
+  public FlareCommand(final Flare finder) {
+    this.clickPoint = new Point(finder.getClickPoint());
+    this.finder = finder;
+  }
+    
+  protected void executeCommand() {
+    this.finder.setClickPoint(this.clickPoint);
+    this.finder.startAnimation(false);
+  }
+    
+  protected Command myUndoCommand() {
+    return null;
+  }
+    
+  public int getValue() {
+    return 0;
+  }
+    
+  public Point getClickPoint() {
+    return this.clickPoint;
+  }
+}

--- a/vassal-app/src/main/java/VASSAL/command/FlareCommand.java
+++ b/vassal-app/src/main/java/VASSAL/command/FlareCommand.java
@@ -24,15 +24,26 @@ import VASSAL.build.module.map.Flare;
 public class FlareCommand extends Command {
   private final Flare flare;
   private final Point clickPoint;
+  private final String id;
     
   public FlareCommand(final Flare flare) {
     clickPoint = new Point(flare.getClickPoint());
     this.flare = flare;
+    id = flare.getMap().getId();
   }
-    
+
+  public FlareCommand(final Flare flare, final String id) {
+    clickPoint = new Point(flare.getClickPoint());
+    this.flare = flare;
+    this.id    = id;
+  }
+
+
   protected void executeCommand() {
-    flare.setClickPoint(clickPoint);
-    flare.startAnimation(false);
+    if (id.equals(flare.getMap().getId())) {
+      flare.setClickPoint(clickPoint);
+      flare.startAnimation(false);
+    }
   }
     
   protected Command myUndoCommand() {
@@ -45,5 +56,9 @@ public class FlareCommand extends Command {
     
   public Point getClickPoint() {
     return clickPoint;
+  }
+
+  public String getMapId() {
+    return id;
   }
 }

--- a/vassal-app/src/main/java/VASSAL/command/FlareCommand.java
+++ b/vassal-app/src/main/java/VASSAL/command/FlareCommand.java
@@ -24,28 +24,17 @@ import VASSAL.build.module.map.Flare;
 public class FlareCommand extends Command {
   private final Flare flare;
   private final Point clickPoint;
-  private final String id;
     
   public FlareCommand(final Flare flare) {
     clickPoint = new Point(flare.getClickPoint());
     this.flare = flare;
-    id = flare.getMap().getId();
   }
-
-  public FlareCommand(final Flare flare, final String id) {
-    clickPoint = new Point(flare.getClickPoint());
-    this.flare = flare;
-    this.id    = id;
-  }
-
 
   protected void executeCommand() {
-    if (id.equals(flare.getMap().getId())) {
-      flare.setClickPoint(clickPoint);
-      flare.startAnimation(false);
-    }
+    flare.setClickPoint(clickPoint);
+    flare.startAnimation(false);
   }
-    
+
   protected Command myUndoCommand() {
     return null;
   }
@@ -59,6 +48,6 @@ public class FlareCommand extends Command {
   }
 
   public String getMapId() {
-    return id;
+    return flare.getMap().getId();
   }
 }

--- a/vassal-app/src/main/java/VASSAL/command/FlareCommand.java
+++ b/vassal-app/src/main/java/VASSAL/command/FlareCommand.java
@@ -47,7 +47,7 @@ public class FlareCommand extends Command {
     return clickPoint;
   }
 
-  public String getMapId() {
-    return flare.getMap().getId();
+  public String getId() {
+    return flare.getId();
   }
 }

--- a/vassal-app/src/main/java/VASSAL/configure/FlareFormattedStringConfigurer.java
+++ b/vassal-app/src/main/java/VASSAL/configure/FlareFormattedStringConfigurer.java
@@ -1,0 +1,41 @@
+/*
+ *
+ * Copyright (c) 2004 by Rodney Kinney
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License (LGPL) as published by the Free Software Foundation.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public
+ * License along with this library; if not, copies are available
+ * at http://www.opensource.org.
+ */
+package VASSAL.configure;
+
+import VASSAL.build.module.GlobalOptions;
+import org.apache.commons.lang3.ArrayUtils;
+
+/** Utility subclass of {@link FormattedStringConfigurer} which includes variable
+ * keys for player name, side, and id
+ */
+public class FlareFormattedStringConfigurer extends FormattedStringConfigurer {
+  public FlareFormattedStringConfigurer(String key, String name, String[] options) {
+    super(key, name);
+
+    final String[] allOptions = ArrayUtils.addAll(
+      new String[]{
+        GlobalOptions.PLAYER_NAME,
+        GlobalOptions.PLAYER_SIDE,
+        GlobalOptions.PLAYER_ID
+      },
+      options
+    );
+
+    setOptions(allOptions);
+  }
+}

--- a/vassal-app/src/main/java/VASSAL/configure/FlareFormattedStringConfigurer.java
+++ b/vassal-app/src/main/java/VASSAL/configure/FlareFormattedStringConfigurer.java
@@ -18,6 +18,7 @@
 package VASSAL.configure;
 
 import VASSAL.build.module.GlobalOptions;
+import VASSAL.build.module.map.Flare;
 import org.apache.commons.lang3.ArrayUtils;
 
 /** Utility subclass of {@link FormattedStringConfigurer} which includes variable
@@ -31,7 +32,10 @@ public class FlareFormattedStringConfigurer extends FormattedStringConfigurer {
       new String[]{
         GlobalOptions.PLAYER_NAME,
         GlobalOptions.PLAYER_SIDE,
-        GlobalOptions.PLAYER_ID
+        GlobalOptions.PLAYER_ID,
+        Flare.FLARE_LOCATION,
+        Flare.FLARE_ZONE,
+        Flare.FLARE_MAP
       },
       options
     );

--- a/vassal-app/src/main/java/VASSAL/configure/FlareFormattedStringConfigurer.java
+++ b/vassal-app/src/main/java/VASSAL/configure/FlareFormattedStringConfigurer.java
@@ -33,6 +33,7 @@ public class FlareFormattedStringConfigurer extends FormattedStringConfigurer {
         GlobalOptions.PLAYER_NAME,
         GlobalOptions.PLAYER_SIDE,
         GlobalOptions.PLAYER_ID,
+        Flare.FLARE_NAME,
         Flare.FLARE_LOCATION,
         Flare.FLARE_ZONE,
         Flare.FLARE_MAP

--- a/vassal-app/src/main/java/VASSAL/tools/SequenceEncoder.java
+++ b/vassal-app/src/main/java/VASSAL/tools/SequenceEncoder.java
@@ -60,7 +60,7 @@ public class SequenceEncoder {
   private StringBuilder buffer;
   private final char delim;
 
-  // Ugly delimiters: The characters in UGLY can ocucr in what's returned
+  // Ugly delimiters: The characters in UGLY can occur in what's returned
   // by String.valueOf() for boolean, int, long, and double---that is,
   // anything which looks like a number (possibly in scientific notation,
   // e.g., 1E-6) but also true, false, Infinity, and NaN. When the delimiter
@@ -323,7 +323,7 @@ public class SequenceEncoder {
     /**
      * Parse the next token into an integer
      * @param defaultValue Return this value if no more tokens, or next token doesn't parse to an integer
-     * @return
+     * @return next token as an integer, or defaultValue if it didn't exist or didn't parse
      */
     public int nextInt(int defaultValue) {
       if (val != null) {
@@ -331,6 +331,7 @@ public class SequenceEncoder {
           defaultValue = Integer.parseInt(nextToken());
         }
         catch (NumberFormatException e) {
+          // no action
         }
       }
       return defaultValue;
@@ -342,6 +343,7 @@ public class SequenceEncoder {
           defaultValue = Long.parseLong(nextToken());
         }
         catch (NumberFormatException e) {
+          // no action
         }
       }
       return defaultValue;
@@ -353,6 +355,7 @@ public class SequenceEncoder {
           defaultValue = Double.parseDouble(nextToken());
         }
         catch (NumberFormatException e) {
+          // no action
         }
       }
       return defaultValue;
@@ -365,7 +368,7 @@ public class SequenceEncoder {
     /**
      * Return the first character of the next token
      * @param defaultValue Return this value if no more tokens, or if next token has zero length
-     * @return
+     * @return next token if a character is available, or defaultValue if no more tokens or the token has zero length
      */
     public char nextChar(char defaultValue) {
       if (val != null) {
@@ -436,8 +439,8 @@ public class SequenceEncoder {
 
     /**
      * Return the next token, or the default value if there are no more tokens
-     * @param defaultValue
-     * @return
+     * @param defaultValue default value in case there are no more tokens
+     * @return next token, or the default value if no more tokens
      */
     public String nextToken(String defaultValue) {
       return val != null ? nextToken() : defaultValue;

--- a/vassal-app/src/main/resources/VASSAL/i18n/Editor.properties
+++ b/vassal-app/src/main/resources/VASSAL/i18n/Editor.properties
@@ -543,8 +543,12 @@ Editor.TriggerAction.looping_ends=Loop until condition is true:
 Editor.TriggerAction.looping_continues=Loop while condition is true:
 
 # Flare
-Editor.Flare.flare_key=Flare Key/Mouse Combination
+Editor.Flare.flare_key=Flare Key/Mouse Combination:  
 Editor.Flare.flare_key_desc=%1$s + Main Mouse Button
-Editor.Flare.circle_size=Diameter of Flare Circle in Pixels
-Editor.Flare.circle_color=Color of Flare Circle
+Editor.Flare.circle_size=Diameter of Flare Circle in Pixels:  
+Editor.Flare.circle_color=Color of Flare Circle:  
 Editor.Flare.circle_scale=Scale to Map Zoom Level
+Editor.Flare.desc=Map Flare
+Editor.Flare.configure=Map Flare
+Editor.Flare.pulses=Pulses (0 for no animation):  
+Editor.Flare.pulses_per_sec=Pulses per Second (0 for no animation):  

--- a/vassal-app/src/main/resources/VASSAL/i18n/Editor.properties
+++ b/vassal-app/src/main/resources/VASSAL/i18n/Editor.properties
@@ -541,3 +541,9 @@ Editor.TriggerAction.watch_for=Watch for these Keystrokes:
 Editor.TriggerAction.repeat_this=Repeat this set of KeyStrokes (Loop)?
 Editor.TriggerAction.looping_ends=Loop until condition is true:
 Editor.TriggerAction.looping_continues=Loop while condition is true:
+
+# Flare
+Editor.Flare.flare_key=Flare Key/Mouse Combination
+Editor.Flare.flare_key_desc=%1$s + Main Mouse Button
+Editor.Flare.circle_size=Diameter of Flare Circle in Pixels
+Editor.Flare.circle_color=Color of Flare Circle

--- a/vassal-app/src/main/resources/VASSAL/i18n/Editor.properties
+++ b/vassal-app/src/main/resources/VASSAL/i18n/Editor.properties
@@ -547,3 +547,4 @@ Editor.Flare.flare_key=Flare Key/Mouse Combination
 Editor.Flare.flare_key_desc=%1$s + Main Mouse Button
 Editor.Flare.circle_size=Diameter of Flare Circle in Pixels
 Editor.Flare.circle_color=Color of Flare Circle
+Editor.Flare.circle_scale=Scale to Map Zoom Level

--- a/vassal-app/src/main/resources/VASSAL/i18n/VASSAL.properties
+++ b/vassal-app/src/main/resources/VASSAL/i18n/VASSAL.properties
@@ -599,6 +599,7 @@ Map.map=Map
 Map.offboard=offboard
 Map.mark_unmoved=Mark all pieces on this map as not moved
 Map.window_title=%1$s map
+Map.main_map=Main Map
 
 # Module Extension
 ModuleExtension.cannot_remove=Cannot remove Extension

--- a/vassal-app/src/main/resources/VASSAL/i18n/VASSAL.properties
+++ b/vassal-app/src/main/resources/VASSAL/i18n/VASSAL.properties
@@ -517,6 +517,13 @@ Keys.pgup=PgUp
 Keys.pgdn=PgDn
 Keys.bropen=[
 Keys.brclose=]
+Keys.alt_shift=Alt + Shift
+Keys.shift_command=Shift + Cmd
+Keys.ctrl_shift=Ctrl + Shift
+Keys.alt_command=Alt + Cmd
+Keys.ctrl_alt=Ctrl + Alt
+Keys.alt_shift_command=Alt + Shift + Cmd
+Keys.ctrl_alt_shift=Ctrl + Alt + Shift
 
 # GlobalOptions
 GlobalOptions.use_combined=Use combined application window (requires restart)?


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/3742246/90534065-4aacfd00-e147-11ea-896e-276699e9eb11.png)

VASL has had a feature like this for a long time, and I actually had a random person come along and "insert it" into PoG as a custom class. Neither version is as good as This Awesome Feature (of course). It has also come up recently in the forums w/ various people asking for it. 

This version adds:
* Default of Alt+Click to send the ping. Ctrl+Click (an inherently terrible idea of course) is included because it was the VASL (and derivative custom class) keystroke, and so the usual bring-the-old-guys-along reasons. Possibly I could include things like other mouse buttons entirely (e.g. mousebuttons 3, 4, 5), though I want to think about it a bit since this is currently a module designer setting and not everybody would have those buttons (or want to be forced to use them). 
* Can configure the color & size of the circle
* Can choose an unanimated circle (this is the only option for the old VASL etc classes)
* But can also do a cool animated pingy-thing, w/ control of speed of animation, etc.
* Yay features!!!!!!!!!!!!!!!!!!!!!!1!1111!!!!!!!!!!!
