### PR TITLE
ShouldDockIntoMainWindow - turns out 'impossible' branch is the 'normal' branch when building new module

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/module/Map.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/Map.java
@@ -1950,8 +1950,8 @@ public class Map extends AbstractConfigurable implements GameComponent, MouseLis
         return false;
       }
     }
-    // should be impossible (and yet is not, if there are no maps in the module at all -- BR)
-    return false;
+    // Module isn't fully built yet, and/or no maps at all in module yet (perhaps THIS map will soon be the first one)
+    return true;
   }
 
   /**


### PR DESCRIPTION
So it turns out than when the module isn't fully "built" yet, the fabled "should be impossible" branch is actually the "normal" branch, and critical to actually getting the map set up to dock right! Argh!

So this should restore "actually having a map" behavior to Vassal. 

Anyway it's a LOT easier for ShouldDockIntoMainWindow to not know about any maps yet than we thought. As in it happens 100% of the times we load a module. Hahahahahahahahahahahahahaha.
