### PR TITLE
Fix MarkTB's Text Label problem -- apparently was using same style sheet as BasicHTML

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/module/Chatter.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/Chatter.java
@@ -367,8 +367,6 @@ public class Chatter extends JPanel implements CommandEncoder, Buildable {
         f = myFont;
       }
     }
-    addStyle("body",    f, gameMsg,   "",     0);
-    addStyle("p",       f, gameMsg,   "",     0);
     addStyle(".msg",    f, gameMsg,   "",     0);
     addStyle(".msg2",   f, gameMsg2,  "",     0);
     addStyle(".msg3",   f, gameMsg3,  "",     0);


### PR DESCRIPTION
Always nice to fix something by *removing* two lines!