### PR TITLE
13319: Multiline HTML labels breaks toolbar button alignment

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/module/Chatter.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/Chatter.java
@@ -352,8 +352,6 @@ public class Chatter extends JPanel implements CommandEncoder, Buildable {
         f = myFont;
       }
     }
-    addStyle("body",    f, gameMsg,   "",     0);
-    addStyle("p",       f, gameMsg,   "",     0);
     addStyle(".msg",    f, gameMsg,   "",     0);
     addStyle(".msg2",   f, gameMsg2,  "",     0);
     addStyle(".msg3",   f, gameMsg3,  "",     0);

--- a/vassal-app/src/main/java/VASSAL/build/module/Map.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/Map.java
@@ -240,7 +240,7 @@ public class Map extends AbstractConfigurable implements GameComponent, MouseLis
     theMap.addMouseListener(this);
     if (shouldDockIntoMainWindow()) {
       final String constraints =
-        (SystemUtils.IS_OS_MAC_OSX ? "ins 0 0 1 0" : "ins 0") +
+        (SystemUtils.IS_OS_MAC_OSX ? "ins 1 0 1 0" : "ins 0") +
         ",gapx 0,hidemode 3";
       toolBar.setLayout(new MigLayout(constraints));
     }

--- a/vassal-app/src/main/java/VASSAL/build/module/Map.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/Map.java
@@ -73,6 +73,8 @@ import javax.swing.WindowConstants;
 
 import net.miginfocom.swing.MigLayout;
 
+import org.apache.commons.lang3.SystemUtils;
+
 import org.jdesktop.animation.timing.Animator;
 import org.jdesktop.animation.timing.TimingTargetAdapter;
 import org.w3c.dom.Element;
@@ -237,7 +239,10 @@ public class Map extends AbstractConfigurable implements GameComponent, MouseLis
     getView();
     theMap.addMouseListener(this);
     if (shouldDockIntoMainWindow()) {
-      toolBar.setLayout(new MigLayout("ins 0,gapx 0,hidemode 3"));
+      final String constraints =
+        (SystemUtils.IS_OS_MAC_OSX ? "ins 0 0 1 0" : "ins 0") +
+        ",gapx 0,hidemode 3,debug";
+      toolBar.setLayout(new MigLayout(constraints));
     }
     else {
       toolBar.setLayout(new WrapLayout(WrapLayout.LEFT, 0, 0));

--- a/vassal-app/src/main/java/VASSAL/build/module/Map.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/Map.java
@@ -241,7 +241,7 @@ public class Map extends AbstractConfigurable implements GameComponent, MouseLis
     if (shouldDockIntoMainWindow()) {
       final String constraints =
         (SystemUtils.IS_OS_MAC_OSX ? "ins 0 0 1 0" : "ins 0") +
-        ",gapx 0,hidemode 3,debug";
+        ",gapx 0,hidemode 3";
       toolBar.setLayout(new MigLayout(constraints));
     }
     else {

--- a/vassal-app/src/main/java/VASSAL/launch/PlayerWindow.java
+++ b/vassal-app/src/main/java/VASSAL/launch/PlayerWindow.java
@@ -21,7 +21,6 @@ import java.awt.BorderLayout;
 import java.awt.Component;
 import java.awt.Container;
 import java.awt.Dimension;
-import java.awt.FlowLayout;
 import java.io.File;
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -170,7 +169,7 @@ public class PlayerWindow extends JFrame {
   }
 
   private void buildToolbar() {
-    toolBar.setLayout(new WrapLayout(FlowLayout.LEFT, 0, 0));
+    toolBar.setLayout(new WrapLayout(WrapLayout.LEFT, 0, 0));
     toolBar.setAlignmentX(0.0f);
     toolBar.setFloatable(false);
     add(toolBar, BorderLayout.NORTH);

--- a/vassal-app/src/main/java/VASSAL/tools/LaunchButton.java
+++ b/vassal-app/src/main/java/VASSAL/tools/LaunchButton.java
@@ -83,6 +83,15 @@ public class LaunchButton extends JButton {
     checkVisibility();
   }
 
+  @Override
+  public int getBaseline(int width, int height) {
+    // Without this, buttons with no text, buttons with single line HTML text,
+    // and buttons with multiline HTML text end up having different baselines.
+    // LaunchButtons go into toolbars only, so there should be no allignment
+    // issues caused by indicating that the baseline is non-applicable.
+    return -1;
+  }
+
   public String getNameAttribute() {
     return nameAtt;
   }


### PR DESCRIPTION
Stop setting a baseline for LaunchButtons; what's reported by the underlying Swing machinery doesn't match up neatly when the labels are a mix of nothing, HTML, and HTML having multiple lines.