### PR TITLE
13326 - Saving a module will default to .VMOD, an extension to .VEXT

### DIFF
--- a/vassal-app/src/main/java/VASSAL/launch/CreateModuleAction.java
+++ b/vassal-app/src/main/java/VASSAL/launch/CreateModuleAction.java
@@ -37,7 +37,7 @@ public class CreateModuleAction extends GameModuleAction {
 
   @Override
   public void performAction(ActionEvent e) throws IOException {
-    GameModule.init(new BasicModule(new ArchiveWriter((String) null)));
+    GameModule.init(new BasicModule(new ArchiveWriter((String) null, ".vmod")));
     JFrame frame = GameModule.getGameModule().getPlayerWindow();
     frame.setVisible(true);
     ModuleEditorWindow w = new ModuleEditorWindow(GameModule.getGameModule());

--- a/vassal-app/src/main/java/VASSAL/launch/EditExtensionAction.java
+++ b/vassal-app/src/main/java/VASSAL/launch/EditExtensionAction.java
@@ -52,7 +52,7 @@ public class EditExtensionAction extends LoadModuleAction {
   @Override
   protected void loadModule(File f) throws IOException {
     final ModuleExtension ext =
-      new ModuleExtension(new ArchiveWriter(new ZipArchive(f)));
+      new ModuleExtension(new ArchiveWriter(new ZipArchive(f), ".vext"));
     ext.build();
     final JFrame frame = GameModule.getGameModule().getPlayerWindow();
     final ExtensionEditorWindow w =

--- a/vassal-app/src/main/java/VASSAL/launch/EditModuleAction.java
+++ b/vassal-app/src/main/java/VASSAL/launch/EditModuleAction.java
@@ -45,7 +45,7 @@ public class EditModuleAction extends LoadModuleAction {
 
   @Override
   protected void loadModule(File f) throws IOException {
-    GameModule.init(new BasicModule(new ArchiveWriter(new ZipArchive(f))));
+    GameModule.init(new BasicModule(new ArchiveWriter(new ZipArchive(f), ".vmod")));
 
 // FIXME: really hide the MM?
 //    ModuleManagerWindow.getInstance().setVisible(false);

--- a/vassal-app/src/main/java/VASSAL/launch/NewExtensionAction.java
+++ b/vassal-app/src/main/java/VASSAL/launch/NewExtensionAction.java
@@ -41,7 +41,7 @@ public class NewExtensionAction extends GameModuleAction {
 
   @Override
   public void performAction(ActionEvent e) {
-    ModuleExtension ext = new ModuleExtension(new ArchiveWriter((String) null));
+    ModuleExtension ext = new ModuleExtension(new ArchiveWriter((String) null, ".vext"));
     ext.build();
     JFrame frame = GameModule.getGameModule().getPlayerWindow();
     ExtensionEditorWindow w = new ExtensionEditorWindow(GameModule.getGameModule(), ext);

--- a/vassal-app/src/main/java/VASSAL/tools/ArchiveWriter.java
+++ b/vassal-app/src/main/java/VASSAL/tools/ArchiveWriter.java
@@ -243,7 +243,7 @@ public class ArchiveWriter extends DataArchive {
   }
 
   /**
-   * Saves the archive, prompting for a name only if none has ever been provide.
+   * Saves the archive, prompting for a name only if none has ever been provided.
    * @throws IOException IOException
    */
   public void save() throws IOException {
@@ -251,7 +251,7 @@ public class ArchiveWriter extends DataArchive {
   }
 
   /**
-   * Saves the archive, prompting for a name only if none has ever been provide.
+   * Saves the archive, prompting for a name only if none has ever been provided.
    * @param notifyModuleManager If true, notifies Module Manager that the save has occurred
    * @throws IOException IOException
    */
@@ -299,12 +299,7 @@ public class ArchiveWriter extends DataArchive {
     String filename = fc.getSelectedFile().getPath();
 
     if (!StringUtils.isEmpty(defaultExtension) && (filename.lastIndexOf('.') < 0)) {
-      if (defaultExtension.indexOf('.') >= 0) {
-        filename = filename + defaultExtension;
-      }
-      else {
-        filename = filename + "." + defaultExtension;
-      }
+      filename = filename + defaultExtension;
       if (new File(filename).exists() && JOptionPane.NO_OPTION == JOptionPane.showConfirmDialog(GameModule.getGameModule().getPlayerWindow(), "Overwrite " + filename + "?", "File Exists", JOptionPane.YES_NO_OPTION)) {
         return;
       }


### PR DESCRIPTION
Up until now, if you make a new module, tell it to "save" or "save as", and type in "Name", you get a module named literally "Name", with no extension. 

This fix corrects that, adding ".vmod" to module saves if no fileext has been added, and ".vext" to a module extension missing a fileext.