### PR TITLE
3.4.0(!!) - Move Trails fix - shouldn't be forcing in new keystroke mappings

### DIFF
--- a/vassal-app/src/main/java/VASSAL/counters/Footprint.java
+++ b/vassal-app/src/main/java/VASSAL/counters/Footprint.java
@@ -190,9 +190,9 @@ public class Footprint extends MovementMarkable {
     edgePointBuffer = st.nextInt(DEFAULT_EDGE_POINT_BUFFER);
     edgeDisplayBuffer = st.nextInt(DEFAULT_EDGE_DISPLAY_BUFFER);
     lineWidth = st.nextDouble(LINE_WIDTH);
-    trailKeyOn = st.nextNamedKeyStroke(NamedKeyStroke.getNamedKeyStroke(DEFAULT_TRAIL_KEY, InputEvent.CTRL_MASK + InputEvent.SHIFT_MASK));
-    trailKeyOff = st.nextNamedKeyStroke(NamedKeyStroke.getNamedKeyStroke(DEFAULT_TRAIL_KEY, InputEvent.CTRL_MASK + InputEvent.ALT_MASK));
-    trailKeyClear = st.nextNamedKeyStroke(NamedKeyStroke.getNamedKeyStroke(DEFAULT_TRAIL_KEY, InputEvent.CTRL_MASK + InputEvent.SHIFT_MASK + InputEvent.ALT_MASK));
+    trailKeyOn = st.nextNamedKeyStroke(null);
+    trailKeyOff = st.nextNamedKeyStroke(null);
+    trailKeyClear = st.nextNamedKeyStroke(null);
 
     commands = null;
     showTrailCommand = null;


### PR DESCRIPTION
I was auto-mapping new keystrokes when really it would be better to just leave them empty until someone wants them.