### PR TITLE
13098 - Move pure Compatibility preferences to their own tab

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/module/GlobalOptions.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/GlobalOptions.java
@@ -177,7 +177,7 @@ public class GlobalOptions extends AbstractConfigurable {
          new PieceMover.DragHandler()
       ));
 
-      prefs.addOption(bug10295Conf);
+      prefs.addOption(Resources.getString("Prefs.compatibility_tab"), bug10295Conf);
     }
     
     // Move Fixed Distance trait (Translate) has been substantially re-written.
@@ -188,7 +188,7 @@ public class GlobalOptions extends AbstractConfigurable {
         Boolean.FALSE
       );
     classicMfd.addPropertyChangeListener(evt -> setUseClassicMoveFixedDistance(classicMfd.getValueBoolean()));
-    prefs.addOption(classicMfd);
+    prefs.addOption(Resources.getString("Prefs.compatibility_tab"), classicMfd);
 
     //BR// Drag Threshold
     final IntConfigurer dragThresholdConf = new IntConfigurer(
@@ -211,7 +211,7 @@ public class GlobalOptions extends AbstractConfigurable {
 
     if (!FORCE_MAC_LEGACY && SystemUtils.IS_OS_MAC_OSX) {
       // Only need to *display* this preference if we're running on a Mac.
-      prefs.addOption(macLegacyConf);
+      prefs.addOption(Resources.getString("Prefs.compatibility_tab"), macLegacyConf);
     }
     
     BooleanConfigurer config = new BooleanConfigurer(CENTER_ON_MOVE, Resources.getString("GlobalOptions.center_on_move"), Boolean.TRUE); //$NON-NLS-1$

--- a/vassal-app/src/main/java/VASSAL/build/module/Map.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/Map.java
@@ -714,7 +714,7 @@ public class Map extends AbstractConfigurable implements GameComponent, MouseLis
     );
 
     g.getPrefs().addOption(
-      Resources.getString("Prefs.general_tab"), //$NON-NLS-1$
+      Resources.getString("Prefs.compatibility_tab"), //$NON-NLS-1$
       new BooleanConfigurer(
         MOVING_STACKS_PICKUP_UNITS,
         Resources.getString("Map.moving_stacks_preference"), //$NON-NLS-1$

--- a/vassal-app/src/main/java/VASSAL/preferences/Prefs.java
+++ b/vassal-app/src/main/java/VASSAL/preferences/Prefs.java
@@ -51,7 +51,7 @@ import VASSAL.tools.ReadErrorDialog;
 public class Prefs implements Closeable {
   /** Preferences key for the directory containing modules */
   public static final String MODULES_DIR_KEY = "modulesDir"; // $NON_NLS-1$
-  public static final String DISABLE_D3D = "disableD3d";
+  public static final String DISABLE_D3D = "disableD3d"; // $NON_NLS-1$
 
   private static Prefs globalPrefs;
 
@@ -130,7 +130,7 @@ public class Prefs implements Closeable {
   }
 
   /**
-   * @param key
+   * @param key Pref Key
    * @return the value of the preferences setting stored under key
    */
   public Object getValue(String key) {
@@ -279,7 +279,7 @@ public class Prefs implements Closeable {
         Resources.getString("Prefs.disable_d3d"),
         Boolean.FALSE
       );
-      globalPrefs.addOption(d3dConf);
+      globalPrefs.addOption(Resources.getString("Prefs.compatibility_tab"), d3dConf);
     }
 
     final BooleanConfigurer wizardConf = new BooleanConfigurer(

--- a/vassal-app/src/main/resources/VASSAL/i18n/VASSAL.properties
+++ b/vassal-app/src/main/resources/VASSAL/i18n/VASSAL.properties
@@ -524,7 +524,7 @@ GlobalOptions.auto_report=Auto-report moves?
 GlobalOptions.mark_moved=Mark moved pieces?
 GlobalOptions.initial_heap=JVM initial heap (in MB):
 GlobalOptions.maximum_heap=JVM maximum heap (in MB):
-GlobalOptions.bug10295=Drag ghost bug correction?
+GlobalOptions.bug10295=Drag ghost bug correction? (Use if shadow image missing when dragging counters)
 GlobalOptions.classic_mfd=Use Classic Move Fixed Distance trait move batching?
 GlobalOptions.mouse_drag_threshold=Mouse Drag Threshold
 GlobalOptions.mac_legacy=Use Legacy Mac mouse mappings (Control for shortcuts and selection toggle, Command for context menu)
@@ -590,7 +590,7 @@ Main.new_module=New Module
 
 # Map
 Map.scroll_delay_preference=Delay scrolling when dragging at map edge (ms):  
-Map.moving_stacks_preference=Moving stacks should pick up non-moving pieces  
+Map.moving_stacks_preference=Moving stacks should pick up non-moving pieces?
 Map.piece_not_on_map=Piece is not on this map
 Map.show_hide=Show/hide %1$s window"
 Map.map=Map
@@ -722,11 +722,12 @@ Prefs.newbie=newbie
 Prefs.personal_info=Personal Info
 Prefs.password_prompt=%1$s's password
 Prefs.general_tab=General
+Prefs.compatibility_tab=Compatibility
 Prefs.personal_tab=Personal
 Prefs.sounds_tab=Sounds
 Prefs.initial_setup=Initial Setup
 Prefs.unable_to_save=Unable to save preferences.\n
-Prefs.disable_d3d=Disable DirectX D3D pipeline?
+Prefs.disable_d3d=Disable DirectX D3D pipeline? (Can resolve some graphics glitching issues)
 
 # Installation Resource Extractor
 


### PR DESCRIPTION
Move Compatibility preferences to their own preference tab.
Also added a bit of text to the bug fix compatibility prefs to give an idea of what problems they solve and hopefully make it easier for users to find themselves.