### PR TITLE
13356 game refresher does not copy marker state

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/GpIdChecker.java
+++ b/vassal-app/src/main/java/VASSAL/build/GpIdChecker.java
@@ -155,7 +155,6 @@ public class GpIdChecker {
       try {
         if (extensionsLoaded) {
           goodSlots.put(id, element);
-          System.out.println("Add Id " + id);
         }
         else {
           final int iid = Integer.parseInt(id);

--- a/vassal-app/src/main/java/VASSAL/build/GpIdChecker.java
+++ b/vassal-app/src/main/java/VASSAL/build/GpIdChecker.java
@@ -19,6 +19,7 @@ package VASSAL.build;
 
 import VASSAL.build.module.Chatter;
 import VASSAL.build.module.PrototypeDefinition;
+import VASSAL.counters.Marker;
 import java.util.ArrayList;
 import java.util.HashMap;
 
@@ -373,7 +374,8 @@ public class GpIdChecker {
           final Decorator decorator = (Decorator) p;
           final String type = decorator.myGetType();
           final String newState = findStateFromType(oldPiece, type, p.getClass());
-          if (newState != null && newState.length() > 0) {
+          // Do not copy the state of Marker traits, we want to see the new value from the new definition
+          if (newState != null && newState.length() > 0 && !(decorator instanceof Marker)) {
             decorator.mySetState(newState);
           }
           p = decorator.getInner();


### PR DESCRIPTION
Markers are essentially constants and if we change one and run the Refresher, we expected the changed value to be put into the updated piece, not the old value copied from the old piece.