### PR TITLE
13358 - Prevent units in Zones setting OldLocationName incorrectly

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/module/Map.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/Map.java
@@ -798,8 +798,9 @@ public class Map extends AbstractConfigurable implements GameComponent, MouseLis
       MapGrid grid = b.getGrid();
       if (grid instanceof ZonedGrid) {
         Rectangle r = b.bounds();
-        p.translate(-r.x, -r.y);  // Translate to Board co-ords
-        return ((ZonedGrid) grid).findZone(p);
+        Point pos = new Point(p);
+        pos.translate(-r.x, -r.y);  // Translate to Board co-ords
+        return ((ZonedGrid) grid).findZone(pos);
       }
     }
     return null;


### PR DESCRIPTION
This is the fix for the flare problem. 

I checked all other usages of Map.findZone(p) in Vassal (8) and all pass a throw-away point to findZone except for Decorator.setOldProperties() which had the potential to corrupt the setting of OldLocationName to based on Board co-ords instead of Map co-ords.

