### PR TITLE
13363 - buildFile renamed to buildFile.xml for 3.5 and beyond

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/GameModule.java
+++ b/vassal-app/src/main/java/VASSAL/build/GameModule.java
@@ -22,6 +22,8 @@ import VASSAL.build.module.GameRefresher;
 import VASSAL.build.module.KeyNamer;
 import VASSAL.build.module.PluginsLoader;
 import VASSAL.build.module.gamepieceimage.GamePieceImageDefinitions;
+import VASSAL.build.module.metadata.AbstractMetaData;
+import VASSAL.build.module.metadata.MetaDataFactory;
 import VASSAL.build.module.properties.GlobalProperties;
 import VASSAL.chat.AddressBookServerConfigurer;
 import VASSAL.chat.ChatServerFactory;
@@ -49,6 +51,7 @@ import java.beans.PropertyChangeSupport;
 import java.io.BufferedInputStream;
 import java.io.ByteArrayInputStream;
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
@@ -167,7 +170,8 @@ public class GameModule extends AbstractConfigurable implements CommandEncoder, 
   /** The System property of this name will return a version identifier for the version of VASSAL being run */
   public static final String VASSAL_VERSION_RUNNING = "runningVassalVersion";  //$NON-NLS-1$
   public static final String NEXT_PIECESLOT_ID = "nextPieceSlotId";
-  public static final String BUILDFILE = "buildFile";
+  public static final String BUILDFILE = "buildFile.xml";
+  public static final String BUILDFILE_OLD = "buildFile";
 
   private static char COMMAND_SEPARATOR = KeyEvent.VK_ESCAPE;
 
@@ -337,18 +341,29 @@ public class GameModule extends AbstractConfigurable implements CommandEncoder, 
       build(null);
     }
     else {
+      final AbstractMetaData data = MetaDataFactory.buildMetaData(f);
+      final String properBuildFileName = (VersionUtils.compareVersions(data.getVassalVersion(), "3.4.999") < 0) ? BUILDFILE_OLD : BUILDFILE;
+
+      if (!(data instanceof ModuleMetaData)) {
+        throw new IOException(
+          Resources.getString("BasicModule.not_a_module"), //$NON-NLS-1$
+          null);
+      }
+
       // existing module
-      try (InputStream inner = darch.getInputStream(BUILDFILE);
+      try (InputStream inner = darch.getInputStream(properBuildFileName);
            BufferedInputStream in = new BufferedInputStream(inner)) {
         final Document doc = Builder.createDocument(in);
         build(doc.getDocumentElement());
       }
-      catch (IOException e) {
-        // FIXME: review error message
-        // FIXME: this should be more specific, to separate the case where
-        // we have failed I/O from when we read ok but have no module
+      catch (FileNotFoundException e) {
         throw new IOException(
-          Resources.getString("BasicModule.not_a_module"), //$NON-NLS-1$
+          Resources.getString("BasicModule.no_buildfile"), //$NON-NLS-1$
+          e);
+      }
+      catch (IOException e) {
+        throw new IOException(
+          Resources.getString("BasicModule.io_error_reading_archive"), //$NON-NLS-1$
           e);
       }
     }
@@ -1571,6 +1586,8 @@ public class GameModule extends AbstractConfigurable implements CommandEncoder, 
       final String save = buildString();
       writer.addFile(BUILDFILE,
         new ByteArrayInputStream(save.getBytes(StandardCharsets.UTF_8)));
+
+      writer.removeFile(BUILDFILE_OLD); // Don't leave old non-extension buildfile around if we successfully write the new one.     
 
       if (saveAs) writer.saveAs(true);
       else writer.save(true);

--- a/vassal-app/src/main/java/VASSAL/build/GameModule.java
+++ b/vassal-app/src/main/java/VASSAL/build/GameModule.java
@@ -342,7 +342,7 @@ public class GameModule extends AbstractConfigurable implements CommandEncoder, 
     }
     else {
       final AbstractMetaData data = MetaDataFactory.buildMetaData(f);
-      final String properBuildFileName = (VersionUtils.compareVersions(data.getVassalVersion(), "3.4.999") < 0) ? BUILDFILE_OLD : BUILDFILE;
+      final String properBuildFileName = (VersionUtils.compareVersions(VersionUtils.truncateToMinorVersion(data.getVassalVersion()), "3.5") < 0) ? BUILDFILE_OLD : BUILDFILE;
 
       if (!(data instanceof ModuleMetaData)) {
         throw new IOException(

--- a/vassal-app/src/main/java/VASSAL/build/module/ModuleExtension.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/ModuleExtension.java
@@ -120,7 +120,7 @@ public class ModuleExtension extends AbstractBuildable implements GameComponent,
   public void build() {
 
     final AbstractMetaData data = MetaDataFactory.buildMetaData(archive.getArchive().getFile());
-    final String fileName = (VersionUtils.compareVersions(data.getVassalVersion(), "3.4.999") < 0) ? GameModule.BUILDFILE_OLD : GameModule.BUILDFILE;
+    final String fileName = (VersionUtils.compareVersions(VersionUtils.truncateToMinorVersion(data.getVassalVersion()), "3.5") < 0) ? GameModule.BUILDFILE_OLD : GameModule.BUILDFILE;
 
     if (!(data instanceof ExtensionMetaData)) {
       logger.error("Not an extension file {}", fileName, null);

--- a/vassal-app/src/main/java/VASSAL/build/module/metadata/ExtensionMetaData.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/metadata/ExtensionMetaData.java
@@ -136,7 +136,7 @@ public class ExtensionMetaData extends AbstractMetaData {
 
       ZipEntry data = zip.getEntry(getZipEntryName());
       if (data == null) {
-        data = zip.getEntry(GameModule.BUILDFILE);
+        data = zip.getEntry(GameModule.BUILDFILE_OLD);
         handler = new ExtensionBuildFileXMLHandler();
       }
       else {

--- a/vassal-app/src/main/java/VASSAL/build/module/metadata/MetaDataFactory.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/metadata/MetaDataFactory.java
@@ -69,7 +69,10 @@ public class MetaDataFactory {
       // Check if it has a buildFile
       ZipEntry buildFileEntry = zip.getEntry(GameModule.BUILDFILE);
       if (buildFileEntry == null) {
-        return null;
+        buildFileEntry = zip.getEntry(GameModule.BUILDFILE_OLD);
+        if (buildFileEntry == null) {
+          return null;
+        }
       }
 
       // It's either a module or an Extension, check for existence of metadata

--- a/vassal-app/src/main/java/VASSAL/build/module/metadata/ModuleMetaData.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/metadata/ModuleMetaData.java
@@ -120,7 +120,7 @@ public class ModuleMetaData extends AbstractMetaData {
 
       ZipEntry data = zip.getEntry(ZIP_ENTRY_NAME);
       if (data == null) {
-        data = zip.getEntry(GameModule.BUILDFILE);
+        data = zip.getEntry(GameModule.BUILDFILE_OLD);
         if (data == null) return;
 
         handler = new ModuleBuildFileXMLHandler();

--- a/vassal-app/src/main/java/VASSAL/tools/ArchiveWriter.java
+++ b/vassal-app/src/main/java/VASSAL/tools/ArchiveWriter.java
@@ -188,6 +188,7 @@ public class ArchiveWriter extends DataArchive {
 
   public void removeImage(String name) {
     removeFile(imageDir + name);
+    localImages = null;
   }
 
   /**

--- a/vassal-app/src/main/java/VASSAL/tools/ArchiveWriter.java
+++ b/vassal-app/src/main/java/VASSAL/tools/ArchiveWriter.java
@@ -187,14 +187,7 @@ public class ArchiveWriter extends DataArchive {
   }
 
   public void removeImage(String name) {
-    try {
-      archive.remove(imageDir + name);
-    }
-    catch (IOException e) {
-      WriteErrorDialog.error(e, archive.getName());
-    }
-
-    localImages = null;
+    removeFile(imageDir + name);
   }
 
   /**

--- a/vassal-app/src/main/java/VASSAL/tools/ArchiveWriter.java
+++ b/vassal-app/src/main/java/VASSAL/tools/ArchiveWriter.java
@@ -198,6 +198,20 @@ public class ArchiveWriter extends DataArchive {
   }
 
   /**
+   * Removes a file in the archive
+   * @param name file in the archive to be removed
+   */
+  public void removeFile(String name) {
+    try {
+      archive.remove (name);
+    }
+    catch (IOException e) {
+      WriteErrorDialog.error(e, archive.getName());
+    }
+  }
+
+
+  /**
    * Copy a file from the user's filesystem to the archive.
    *
    * @param path the full path of the file on the user's filesystem

--- a/vassal-app/src/main/resources/VASSAL/i18n/VASSAL.properties
+++ b/vassal-app/src/main/resources/VASSAL/i18n/VASSAL.properties
@@ -288,6 +288,8 @@ BasicLogger.enable_comments=Prompt for log file comments
 # BasicModule
 BasicModule.version_message=%1$s version %2$s
 BasicModule.not_a_module=Not a VASSAL module
+BasicModule.no_buildfile=Could not find buildFile in module file
+BasicModule.io_error_reading_archive=I/O error reading module file
 
 # BoardPicker
 BoardPicker.choose_boards=Choose Boards


### PR DESCRIPTION
Now featuring a file extension for Extra Sanity!

* Looks for "buildFile" for all versions 3.4.999 and earlier. 
* Looks for "buildFile.xml" for all versions after that
* Writes buildFile.xml
* And then removes old "buildFile" instances lingering in the archive
