### PR TITLE
3.4.1 - 13381 - Ignore numeric literals when returning Beanshell Values

### DIFF
--- a/vassal-app/src/main/java/VASSAL/script/BeanShell.java
+++ b/vassal-app/src/main/java/VASSAL/script/BeanShell.java
@@ -36,13 +36,16 @@ import bsh.NameSpace;
  */
 public class BeanShell {
 
-  private static BeanShell instance = new BeanShell();
+  public static final String TRUE = "true"; // NON-NLS
+  public static final String FALSE = "false"; // NON-NLS
+
+  private static final BeanShell instance = new BeanShell();
 
   public static BeanShell getInstance() {
     return instance;
   }
 
-  protected static final String INIT_SCRIPT = "/VASSAL/script/init_script.bsh";
+  protected static final String INIT_SCRIPT = "/VASSAL/script/init_script.bsh"; // NON-NLS
 
   /*
    * An interpreter for adding script methods to the global NameSpace
@@ -93,7 +96,7 @@ public class BeanShell {
   /**
    * Execute a Script named in a component DoAction or trait DoAction.
    * Action Scripts take no parameters and return no value.
-   * @param script
+   * @param scriptName Script name
    */
   public void executeActionScript(String scriptName) {
     try {
@@ -117,18 +120,22 @@ public class BeanShell {
   /**
    * Convert a String value into a wrapped primitive object if possible.
    *
-   * @param value
+   * @param value Value to wrap
    * @return wrapped value
    */
   public static Object wrap (String value) {
     if (value == null) {
       return "";
     }
-    else if ("true".equals(value)) {
+    else if (TRUE.equals(value)) {
       return Boolean.TRUE;
     }
-    else if ("false".equals(value)) {
+    else if (FALSE.equals(value)) {
       return Boolean.FALSE;
+    }
+    // Treat apparent numeric literals as Strings
+    else if ("dDfFlL".indexOf(value.charAt(value.length() - 1)) >= 0) { // NON-NLS
+      return value;
     }
     else {
       try {

--- a/vassal-app/src/main/java/VASSAL/script/ExpressionInterpreter.java
+++ b/vassal-app/src/main/java/VASSAL/script/ExpressionInterpreter.java
@@ -72,12 +72,12 @@ public class ExpressionInterpreter extends AbstractInterpreter implements Loopab
   private static final long serialVersionUID = 1L;
   private static final Logger logger = LoggerFactory.getLogger(ExpressionInterpreter.class);
 
-  protected static final String INIT_SCRIPT = "/VASSAL/script/init_expression.bsh";
-  protected static final String THIS = "_interp";
-  protected static final String SOURCE = "_source";
-  protected static final String MAGIC1 = "_xyzzy";
-  protected static final String MAGIC2 = "_plugh";
-  protected static final String MAGIC3 = "_plover";
+  protected static final String INIT_SCRIPT = "/VASSAL/script/init_expression.bsh"; // NON-NLS
+  protected static final String THIS = "_interp"; // NON-NLS
+  protected static final String SOURCE = "_source"; // NON-NLS
+  protected static final String MAGIC1 = "_xyzzy"; // NON-NLS
+  protected static final String MAGIC2 = "_plugh"; // NON-NLS
+  protected static final String MAGIC3 = "_plover"; // NON-NLS
 
 
   // Top-level static NameSpace shared between all ExpressionInterpreters
@@ -149,7 +149,7 @@ public class ExpressionInterpreter extends AbstractInterpreter implements Loopab
 
     // Create the Expression level namespace as a child of the
     // top level namespace
-    expressionNameSpace = new NameSpace(topLevelNameSpace, "expression");
+    expressionNameSpace = new NameSpace(topLevelNameSpace, "expression"); // NON-NLS
 
     // Get a list of any variables used in the expression. These are
     // property names that will need to be evaluated at expression
@@ -173,9 +173,9 @@ public class ExpressionInterpreter extends AbstractInterpreter implements Loopab
           if (argList.length() > 0) {
             argList.append(',');
           }
-          argList.append("String ").append(variable);
+          argList.append("String ").append(variable); // NON-NLS
         }
-        eval("String " + MAGIC2 + "(" + argList.toString() + ") { " + MAGIC3 + "=" + expression + "; return " + MAGIC3 + ".toString();}");
+        eval("String " + MAGIC2 + "(" + argList.toString() + ") { " + MAGIC3 + "=" + expression + "; return " + MAGIC3 + ".toString();}"); // NON-NLS
       }
       catch (EvalError e) {
         throw new ExpressionException(getExpression());
@@ -195,14 +195,14 @@ public class ExpressionInterpreter extends AbstractInterpreter implements Loopab
    * methods available to expressions.
    */
   protected void initialiseStatic() {
-    topLevelNameSpace = new NameSpace(null, getClassManager(), "topLevel");
+    topLevelNameSpace = new NameSpace(null, getClassManager(), "topLevel"); // NON-NLS
     setNameSpace(topLevelNameSpace);
     getNameSpace().importClass("VASSAL.build.module.properties.PropertySource");
     getNameSpace().importClass("VASSAL.script.ExpressionInterpreter");
 
     // Read the Expression initialisation script into the top level namespace
     URL ini = getClass().getResource(INIT_SCRIPT);
-    logger.info("Attempting to load " + INIT_SCRIPT + " URI generated=" + ini);
+    logger.info("Attempting to load " + INIT_SCRIPT + " URI generated=" + ini); // NON-NLS
 
     try (InputStream is = ini.openStream();
          InputStreamReader isr = new InputStreamReader(is, StandardCharsets.UTF_8);
@@ -211,12 +211,12 @@ public class ExpressionInterpreter extends AbstractInterpreter implements Loopab
         eval(in);
       }
       catch (EvalError e) {
-        logger.error("Error trying to read init script: " + ini);
+        logger.error("Error trying to read init script: " + ini); // NON-NLS
         WarningDialog.show(e, "");
       }
     }
     catch (IOException e) {
-      logger.error("Error trying to read init script: " + ini);
+      logger.error("Error trying to read init script: " + ini); // NON-NLS
       WarningDialog.show(e, "");
     }
   }
@@ -269,11 +269,15 @@ public class ExpressionInterpreter extends AbstractInterpreter implements Loopab
         if (value == null) {
           setVar(var, "");
         }
-        else if ("true".equals(value)) {
+        else if (BeanShell.TRUE.equals(value)) {
           setVar(var, true);
         }
-        else if ("false".equals(value)) {
+        else if (BeanShell.FALSE.equals(value)) {
           setVar(var, false);
+        }
+        // Treat apparent numeric literals as Strings
+        else if ("dDfFlL".indexOf(value.charAt(value.length() - 1)) >= 0) { // NON-NLS
+          setVar(var, value);
         }
         else {
           try {
@@ -343,11 +347,15 @@ public class ExpressionInterpreter extends AbstractInterpreter implements Loopab
     if (value == null) {
       return "";
     }
-    else if ("true".equals(value)) {
+    else if (BeanShell.TRUE.equals(value)) {
       return Boolean.TRUE;
     }
-    else if ("false".equals(value)) {
+    else if (BeanShell.FALSE.equals(value)) {
       return Boolean.FALSE;
+    }
+    // Treat apparent numeric literals as Strings
+    else if ("dDfFlL".indexOf(value.charAt(value.length() - 1)) >= 0) { // NON-NLS
+      return value;
     }
     else {
       try {
@@ -488,8 +496,8 @@ public class ExpressionInterpreter extends AbstractInterpreter implements Loopab
    */
 
   public Object random(Object source, Object minString, Object maxString) {
-    final int min = parseInt(source, "Random", minString, 1);
-    int max = parseInt(source, "Random", maxString, 1);
+    final int min = parseInt(source, "Random", minString, 1); // NON-NLS
+    int max = parseInt(source, "Random", maxString, 1); // NON-NLS
     if (max < min) {
       max = min;
     }
@@ -501,7 +509,7 @@ public class ExpressionInterpreter extends AbstractInterpreter implements Loopab
   }
 
   public Object isRandom(Object source, Object percentString) {
-    int percent = parseInt(source, "IsRandom", percentString, 50);
+    int percent = parseInt(source, "IsRandom", percentString, 50); // NON-NLS
     if (percent < 0)
       percent = 0;
     if (percent > 100)

--- a/vassal-app/src/main/java/VASSAL/script/expression/BeanShellExpression.java
+++ b/vassal-app/src/main/java/VASSAL/script/expression/BeanShellExpression.java
@@ -17,6 +17,7 @@
  */
 package VASSAL.script.expression;
 
+import VASSAL.script.BeanShell;
 import java.util.Map;
 
 import VASSAL.build.BadDataReport;
@@ -96,7 +97,7 @@ public class BeanShellExpression extends Expression {
       catch (ExpressionException e) {
         ErrorDialog.dataWarning(new BadDataReport(Resources.getString("Error.expression_error"), "Expression=" + getExpression() + ", Error=" + e.getError(), e));
       }
-      return "true".equals(result);
+      return BeanShell.TRUE.equals(result);
     };
   }
 
@@ -126,7 +127,7 @@ public class BeanShellExpression extends Expression {
     }
 
     // If not a Java variable, wrap it in GetProperty()
-    return ok ? prop : "GetProperty(\"" + prop + "\")";
+    return ok ? prop : "GetProperty(\"" + prop + "\")"; // NON-NLS
   }
 
   public static boolean isBeanShellExpression(String expr) {


### PR DESCRIPTION
Prevent values like "1D", "3F", "2L" being converted to numbers. While this is technically correct, Vassal does not implement Double, Float or Long types and no Developer will ever want this to happen.