### PR TITLE
Bug 13373: Bad imageName array size

### DIFF
--- a/vassal-app/src/main/java/VASSAL/counters/Embellishment.java
+++ b/vassal-app/src/main/java/VASSAL/counters/Embellishment.java
@@ -201,8 +201,16 @@ public class Embellishment extends Decorator implements TranslatablePiece {
       drawUnderneathWhenSelected = st.nextBoolean(false);
       xOff = st.nextInt(0);
       yOff = st.nextInt(0);
+
       imageName = st.nextStringArray(0);
       commonName = st.nextStringArray(imageName.length);
+      if (commonName.length == 1 && imageName.length == 0) {
+        // This happens if imageName contains a single empty string, since
+        // the sequence language can't distinguish that from a zero-length
+        // array.
+        imageName = new String[]{""};
+      }
+
       loopLevels = st.nextBoolean(true);
       name = st.nextToken("");
 


### PR DESCRIPTION
The sequence langauge can't distinguish a single-element String array containing an empty string from a zero-element array, so in the case of Embellishment we have to help it out.