### PR TITLE
13394 - Fix "1D" interpreted as "1.0" plus Beanshell test suite.

### DIFF
--- a/vassal-app/pom.xml
+++ b/vassal-app/pom.xml
@@ -156,9 +156,14 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>net.bytebuddy</groupId>
+            <artifactId>byte-buddy</artifactId>
+            <version>1.10.14</version>
+        </dependency>
+        <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
-            <version>3.5.7</version>
+            <artifactId>mockito-inline</artifactId>
+            <version>3.5.10</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/vassal-app/src/main/java/VASSAL/script/BeanShell.java
+++ b/vassal-app/src/main/java/VASSAL/script/BeanShell.java
@@ -36,13 +36,16 @@ import bsh.NameSpace;
  */
 public class BeanShell {
 
-  private static BeanShell instance = new BeanShell();
+  public static final String TRUE = "true"; // NON-NLS
+  public static final String FALSE = "false"; // NON-NLS
+
+  private static final BeanShell instance = new BeanShell();
 
   public static BeanShell getInstance() {
     return instance;
   }
 
-  protected static final String INIT_SCRIPT = "/VASSAL/script/init_script.bsh";
+  protected static final String INIT_SCRIPT = "/VASSAL/script/init_script.bsh"; // NON-NLS
 
   /*
    * An interpreter for adding script methods to the global NameSpace
@@ -93,7 +96,7 @@ public class BeanShell {
   /**
    * Execute a Script named in a component DoAction or trait DoAction.
    * Action Scripts take no parameters and return no value.
-   * @param script
+   * @param scriptName Script name
    */
   public void executeActionScript(String scriptName) {
     try {
@@ -117,17 +120,17 @@ public class BeanShell {
   /**
    * Convert a String value into a wrapped primitive object if possible.
    *
-   * @param value
+   * @param value Value to Wrap
    * @return wrapped value
    */
   public static Object wrap (String value) {
     if (value == null) {
       return "";
     }
-    else if ("true".equals(value)) {
+    else if (BeanShell.TRUE.equals(value)) {
       return Boolean.TRUE;
     }
-    else if ("false".equals(value)) {
+    else if (BeanShell.FALSE.equals(value)) {
       return Boolean.FALSE;
     }
     else {

--- a/vassal-app/src/main/java/VASSAL/script/ExpressionInterpreter.java
+++ b/vassal-app/src/main/java/VASSAL/script/ExpressionInterpreter.java
@@ -72,12 +72,12 @@ public class ExpressionInterpreter extends AbstractInterpreter implements Loopab
   private static final long serialVersionUID = 1L;
   private static final Logger logger = LoggerFactory.getLogger(ExpressionInterpreter.class);
 
-  protected static final String INIT_SCRIPT = "/VASSAL/script/init_expression.bsh";
-  protected static final String THIS = "_interp";
-  protected static final String SOURCE = "_source";
-  protected static final String MAGIC1 = "_xyzzy";
-  protected static final String MAGIC2 = "_plugh";
-  protected static final String MAGIC3 = "_plover";
+  protected static final String INIT_SCRIPT = "/VASSAL/script/init_expression.bsh"; // NON-NLS
+  protected static final String THIS = "_interp"; // NON-NLS
+  protected static final String SOURCE = "_source"; // NON-NLS
+  protected static final String MAGIC1 = "_xyzzy"; // NON-NLS
+  protected static final String MAGIC2 = "_plugh"; // NON-NLS
+  protected static final String MAGIC3 = "_plover"; // NON-NLS
 
 
   // Top-level static NameSpace shared between all ExpressionInterpreters
@@ -149,7 +149,7 @@ public class ExpressionInterpreter extends AbstractInterpreter implements Loopab
 
     // Create the Expression level namespace as a child of the
     // top level namespace
-    expressionNameSpace = new NameSpace(topLevelNameSpace, "expression");
+    expressionNameSpace = new NameSpace(topLevelNameSpace, "expression"); // NON-NLS
 
     // Get a list of any variables used in the expression. These are
     // property names that will need to be evaluated at expression
@@ -173,9 +173,9 @@ public class ExpressionInterpreter extends AbstractInterpreter implements Loopab
           if (argList.length() > 0) {
             argList.append(',');
           }
-          argList.append("String ").append(variable);
+          argList.append("String ").append(variable); // NON-NLS
         }
-        eval("String " + MAGIC2 + "(" + argList.toString() + ") { " + MAGIC3 + "=" + expression + "; return " + MAGIC3 + ".toString();}");
+        eval("String " + MAGIC2 + "(" + argList.toString() + ") { " + MAGIC3 + "=" + expression + "; return " + MAGIC3 + ".toString();}"); // NON-NLS
       }
       catch (EvalError e) {
         throw new ExpressionException(getExpression());
@@ -195,14 +195,14 @@ public class ExpressionInterpreter extends AbstractInterpreter implements Loopab
    * methods available to expressions.
    */
   protected void initialiseStatic() {
-    topLevelNameSpace = new NameSpace(null, getClassManager(), "topLevel");
+    topLevelNameSpace = new NameSpace(null, getClassManager(), "topLevel"); // NON-NLS
     setNameSpace(topLevelNameSpace);
     getNameSpace().importClass("VASSAL.build.module.properties.PropertySource");
     getNameSpace().importClass("VASSAL.script.ExpressionInterpreter");
 
     // Read the Expression initialisation script into the top level namespace
     URL ini = getClass().getResource(INIT_SCRIPT);
-    logger.info("Attempting to load " + INIT_SCRIPT + " URI generated=" + ini);
+    logger.info("Attempting to load " + INIT_SCRIPT + " URI generated=" + ini); // NON-NLS
 
     try (InputStream is = ini.openStream();
          InputStreamReader isr = new InputStreamReader(is, StandardCharsets.UTF_8);
@@ -211,12 +211,12 @@ public class ExpressionInterpreter extends AbstractInterpreter implements Loopab
         eval(in);
       }
       catch (EvalError e) {
-        logger.error("Error trying to read init script: " + ini);
+        logger.error("Error trying to read init script: " + ini); // NON-NLS
         WarningDialog.show(e, "");
       }
     }
     catch (IOException e) {
-      logger.error("Error trying to read init script: " + ini);
+      logger.error("Error trying to read init script: " + ini); // NON-NLS
       WarningDialog.show(e, "");
     }
   }
@@ -269,10 +269,10 @@ public class ExpressionInterpreter extends AbstractInterpreter implements Loopab
         if (value == null) {
           setVar(var, "");
         }
-        else if ("true".equals(value)) {
+        else if (BeanShell.TRUE.equals(value)) {
           setVar(var, true);
         }
-        else if ("false".equals(value)) {
+        else if (BeanShell.FALSE.equals(value)) {
           setVar(var, false);
         }
         else {
@@ -280,12 +280,7 @@ public class ExpressionInterpreter extends AbstractInterpreter implements Loopab
             setVar(var, Integer.parseInt(value));
           }
           catch (NumberFormatException e) {
-            try {
-              setVar(var, Float.parseFloat(value));
-            }
-            catch (NumberFormatException e1) {
-              setVar(var, value);
-            }
+            setVar(var, value);
           }
         }
       }
@@ -343,10 +338,10 @@ public class ExpressionInterpreter extends AbstractInterpreter implements Loopab
     if (value == null) {
       return "";
     }
-    else if ("true".equals(value)) {
+    else if (BeanShell.TRUE.equals(value)) {
       return Boolean.TRUE;
     }
-    else if ("false".equals(value)) {
+    else if (BeanShell.FALSE.equals(value)) {
       return Boolean.FALSE;
     }
     else {
@@ -488,8 +483,8 @@ public class ExpressionInterpreter extends AbstractInterpreter implements Loopab
    */
 
   public Object random(Object source, Object minString, Object maxString) {
-    final int min = parseInt(source, "Random", minString, 1);
-    int max = parseInt(source, "Random", maxString, 1);
+    final int min = parseInt(source, "Random", minString, 1); // NON-NLS
+    int max = parseInt(source, "Random", maxString, 1); // NON-NLS
     if (max < min) {
       max = min;
     }
@@ -501,7 +496,7 @@ public class ExpressionInterpreter extends AbstractInterpreter implements Loopab
   }
 
   public Object isRandom(Object source, Object percentString) {
-    int percent = parseInt(source, "IsRandom", percentString, 50);
+    int percent = parseInt(source, "IsRandom", percentString, 50); // NON-NLS
     if (percent < 0)
       percent = 0;
     if (percent > 100)

--- a/vassal-app/src/main/java/VASSAL/script/expression/BeanShellExpression.java
+++ b/vassal-app/src/main/java/VASSAL/script/expression/BeanShellExpression.java
@@ -17,6 +17,7 @@
  */
 package VASSAL.script.expression;
 
+import VASSAL.script.BeanShell;
 import java.util.Map;
 
 import VASSAL.build.BadDataReport;
@@ -96,7 +97,7 @@ public class BeanShellExpression extends Expression {
       catch (ExpressionException e) {
         ErrorDialog.dataWarning(new BadDataReport(Resources.getString("Error.expression_error"), "Expression=" + getExpression() + ", Error=" + e.getError(), e));
       }
-      return "true".equals(result);
+      return BeanShell.TRUE.equals(result);
     };
   }
 
@@ -112,7 +113,7 @@ public class BeanShellExpression extends Expression {
       return "";
     }
 
-    // Already a bsh exopression?
+    // Already a bsh expression?
     if (isBeanShellExpression(prop)) {
       return strip(prop);
     }
@@ -126,7 +127,7 @@ public class BeanShellExpression extends Expression {
     }
 
     // If not a Java variable, wrap it in GetProperty()
-    return ok ? prop : "GetProperty(\"" + prop + "\")";
+    return ok ? prop : "GetProperty(\"" + prop + "\")"; // NON-NLS
   }
 
   public static boolean isBeanShellExpression(String expr) {

--- a/vassal-app/src/test/java/VASSAL/script/ExpressionInterpreterTest.java
+++ b/vassal-app/src/test/java/VASSAL/script/ExpressionInterpreterTest.java
@@ -1,0 +1,380 @@
+package VASSAL.script;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import VASSAL.build.GameModule;
+import VASSAL.build.module.Map;
+import VASSAL.build.module.map.boardPicker.board.mapgrid.Zone;
+import VASSAL.build.module.properties.PropertySource;
+import VASSAL.counters.BasicPiece;
+import VASSAL.counters.GamePiece;
+import VASSAL.counters.Properties;
+import VASSAL.counters.Stack;
+import VASSAL.script.expression.ExpressionException;
+
+import java.security.SecureRandom;
+import java.util.List;
+import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+public class ExpressionInterpreterTest {
+
+  @Test
+  public void strip() {
+    assertThat(ExpressionInterpreter.strip("abc"), is(equalTo("abc")));
+    assertThat(ExpressionInterpreter.strip("{abc"), is(equalTo("{abc")));
+    assertThat(ExpressionInterpreter.strip("{abc}"), is(equalTo("abc")));
+    assertThat(ExpressionInterpreter.strip("{abc}d"), is(equalTo("{abc}d")));
+  }
+
+  @Test
+  public void getExpression() throws ExpressionException {
+    final ExpressionInterpreter interpreter = ExpressionInterpreter.createInterpreter("6 * 7");
+    final String s = interpreter.getExpression();
+    assertThat(s, is(equalTo("6 * 7")));
+  }
+
+  @Test
+  public void createInterpreter1() throws ExpressionException {
+    // Just test the interpreter is working at all. Exercise custom Vassal functions below.
+    ExpressionInterpreter interpreter = ExpressionInterpreter.createInterpreter("6 * 7");
+    final String s = interpreter.evaluate();
+    assertThat(s, is(equalTo("42")));
+  }
+
+  @Test(expected = ExpressionException.class)
+  public void createInterpreter2() throws ExpressionException {
+    // A broken expression should throw an ExpressionException
+    ExpressionInterpreter interpreter = ExpressionInterpreter.createInterpreter("6 * ");
+  }
+
+  @Test(expected = ExpressionException.class)
+  public void createInterpreter3() throws ExpressionException {
+    // Evaluating a non-existent custom function should throw an ExpressionException
+    ExpressionInterpreter interpreter = ExpressionInterpreter.createInterpreter("Blurgh()");
+    final String s = interpreter.evaluate();
+
+  }
+
+  // Check the Vassal bsh Parser extensions are included:
+  // 1. Adding null to an integer does not throw error - 2 + "" = 2
+  // 2. Adding a String to an integer converts both to Strings and does not throw error = 2 + "a" = "2a"
+  // 3. Allow comparison operators  on strings - "1" == "1" = true, "1" < "2" = true
+  // 4. =~ Regexp operator
+  // 5. !~ Regexp operator
+  @Test
+  public void checkExtensions() throws ExpressionException {
+    ExpressionInterpreter interpreter = ExpressionInterpreter.createInterpreter("2 + \"\"");
+    String s = interpreter.evaluate();
+    assertThat(s, is(equalTo("2")));
+
+    interpreter = ExpressionInterpreter.createInterpreter("2 + \"a\"");
+    s = interpreter.evaluate();
+    assertThat(s, is(equalTo("2a")));
+
+    interpreter = ExpressionInterpreter.createInterpreter("\"1\" == \"1\"");
+    s = interpreter.evaluate();
+    assertThat(s, is(equalTo("true")));
+
+    interpreter = ExpressionInterpreter.createInterpreter("\"1\" > \"2\"");
+    s = interpreter.evaluate();
+    assertThat(s, is(equalTo("false")));
+
+    interpreter = ExpressionInterpreter.createInterpreter("\"x\" =~ \"a|x|z\"");
+    s = interpreter.evaluate();
+    assertThat(s, is(equalTo("true")));
+
+    interpreter = ExpressionInterpreter.createInterpreter("\"x\" !~ \"a|x|z\"");
+    s = interpreter.evaluate();
+    assertThat(s, is(equalTo("false")));
+  }
+
+  @Test
+  public void wrap() throws ExpressionException {
+    ExpressionInterpreter interpreter = ExpressionInterpreter.createInterpreter("");
+    Object o;
+
+    // Null string should remain unchanged
+    o = interpreter.wrap("");
+    assertThat(o, is(equalTo("")));
+
+    o = interpreter.wrap("true");
+    assertThat(o, is(equalTo(Boolean.TRUE)));
+
+    o = interpreter.wrap("false");
+    assertThat(o, is(equalTo(Boolean.FALSE)));
+
+    o = interpreter.wrap("42");
+    assertThat(o, is(instanceOf(Integer.class)));
+    assertThat(o, is(equalTo(42)));
+
+    // Check no interpretation of numeric literals
+    o = interpreter.wrap("42L");
+    assertThat(o, is(instanceOf(String.class)));
+    assertThat(o, is(equalTo("42L")));
+
+    o = interpreter.wrap("42D");
+    assertThat(o, is(instanceOf(String.class)));
+    assertThat(o, is(equalTo("42D")));
+
+    // And no wrapping of Floats
+    o = interpreter.wrap("42.0");
+    assertThat(o, is(instanceOf(String.class)));
+    assertThat(o, is(equalTo("42.0")));
+
+    o = interpreter.wrap("abc");
+    assertThat(o, is(instanceOf(String.class)));
+    assertThat(o, is(equalTo("abc")));
+
+  }
+
+  private static final String GETKEY1 = "key1";
+  private static final String GETVAL1 = "prop1";
+  private static final String GETLVAL1 = "lprop1";
+  private static final String GETKEY2 = "key2";
+  private static final String GETVAL2 = "1D";
+  private static final String GETKEY3 = "key3";
+  private static final String GETVAL3 = "1F";
+  private static final String GETKEY4 = "key4";
+  private static final String GETVAL4 = "1L";
+
+  @Test
+  public void getProperty() throws ExpressionException {
+    PropertySource ps = new PropertySource() {
+      @Override
+      public Object getProperty(Object key) {
+        if (String.valueOf(key).equals(GETKEY1)) {
+          return GETVAL1;
+        }
+        else if (String.valueOf(key).equals(GETKEY2)) {
+          return GETVAL2;
+        }
+        else if (String.valueOf(key).equals(GETKEY3)) {
+          return GETVAL3;
+        }
+        else if (String.valueOf(key).equals(GETKEY4)) {
+          return GETVAL4;
+        }
+        else {
+          return null;
+        }
+      }
+      @Override
+      public Object getLocalizedProperty(Object key) {
+        if (String.valueOf(key).equals(GETKEY1)) {
+          return GETLVAL1;
+        }
+        else {
+          return null;
+        }
+      }
+    };
+
+    // Check GetProperty bsh function
+    ExpressionInterpreter interpreter = ExpressionInterpreter.createInterpreter("GetProperty(\"" + GETKEY1 + "\")");
+    String result = interpreter.evaluate(ps);
+    assertThat(result, is(equalTo(GETVAL1)));
+
+    // Check GetLocalizedProperty bsh function
+    interpreter = ExpressionInterpreter.createInterpreter("GetLocalizedProperty(\"" + GETKEY1 + "\")");
+    result = interpreter.evaluate(ps);
+    assertThat(result, is(equalTo(GETLVAL1)));
+
+    // Regression Test - Check numeric literals returned as properties do not get converted to floating point values
+    interpreter = ExpressionInterpreter.createInterpreter(GETKEY2);
+    result = interpreter.evaluate(ps);
+    assertThat(result, is(equalTo(GETVAL2)));
+
+    interpreter = ExpressionInterpreter.createInterpreter(GETKEY3);
+    result = interpreter.evaluate(ps);
+    assertThat(result, is(equalTo(GETVAL3)));
+
+    interpreter = ExpressionInterpreter.createInterpreter(GETKEY4);
+    result = interpreter.evaluate(ps);
+    assertThat(result, is(equalTo(GETVAL4)));
+  }
+
+  private static final String MAP_NAME = "myMap";
+  private static final String ZONE_NAME = "myZone";
+  private static final String ZONE_PROP = "zoneProp";
+  private static final String ZONE_VAL = "zoneVal";
+
+  @Test
+  public void getZoneProperty() throws ExpressionException {
+    Zone zone = mock(Zone.class);
+    when(zone.getProperty(ZONE_PROP)).thenReturn(ZONE_VAL);
+
+    Map map = mock(Map.class);
+    when(map.getMapName()).thenReturn(MAP_NAME);
+    when(map.findZone(ZONE_NAME)).thenReturn(zone);
+
+    GamePiece piece = mock(GamePiece.class);
+    when(piece.getMap()).thenReturn(map);
+
+    ExpressionInterpreter interpreter = ExpressionInterpreter.createInterpreter("GetZoneProperty(\"" + ZONE_PROP + "\", \"" + ZONE_NAME + "\")");
+    String result = interpreter.evaluate(piece);
+    assertThat(result, is(equalTo(ZONE_VAL)));
+
+    try (MockedStatic<Map> staticMap = Mockito.mockStatic(Map.class)) {
+      staticMap.when(Map::getMapList).thenReturn(List.of(map));
+
+      interpreter = ExpressionInterpreter.createInterpreter("GetZoneProperty(\"" + ZONE_PROP + "\", \"" + ZONE_NAME + "\", \"" + MAP_NAME + "\")");
+      result = interpreter.evaluate(piece);
+      assertThat(result, is(equalTo(ZONE_VAL)));
+
+    }
+  }
+
+  private static final String MAP_PROP = "mapProp";
+  private static final String MAP_VAL = "mapVal";
+  @Test
+  public void getMapProperty() throws ExpressionException {
+    try (MockedStatic<Map> staticMap = Mockito.mockStatic(Map.class)) {
+      Map map = mock(Map.class);
+      when(map.getMapName()).thenReturn(MAP_NAME);
+      when(map.getProperty(MAP_PROP)).thenReturn(MAP_VAL);
+      staticMap.when(Map::getMapList).thenReturn(List.of(map));
+
+      ExpressionInterpreter interpreter = ExpressionInterpreter.createInterpreter("GetMapProperty(\"" + MAP_PROP + "\", \"" + MAP_NAME + "\")");
+      String result = interpreter.evaluate();
+      assertThat(result, is(equalTo(MAP_VAL)));
+
+    }
+  }
+
+  private static final String SUM_PROP = "count";
+
+  @Test
+  public void sumStack() throws ExpressionException {
+    Stack s = new Stack();
+
+    BasicPiece bp1 = new BasicPiece();
+    bp1.setProperty(SUM_PROP, "24");
+
+    BasicPiece bp2 = new BasicPiece();
+    bp2.setProperty(SUM_PROP, "18");
+
+    s.add(bp1);
+    s.add(bp2);
+
+    ExpressionInterpreter interpreter = ExpressionInterpreter.createInterpreter("SumStack(\"" + SUM_PROP + "\")");
+    String result = interpreter.evaluate(bp1);
+    assertThat(result, is(equalTo("42")));
+
+  }
+
+  @Test
+  public void random() throws ExpressionException {
+
+    try (MockedStatic<GameModule> staticGm = Mockito.mockStatic(GameModule.class)) {
+      GameModule gm = mock(GameModule.class);
+      when(gm.getRNG()).thenReturn(new SecureRandom());
+
+      staticGm.when(GameModule::getGameModule).thenReturn(gm);
+
+      ExpressionInterpreter interpreter = ExpressionInterpreter.createInterpreter("Random(4)");
+      String result = interpreter.evaluate();
+      assertThat(result, is(greaterThanOrEqualTo("1")));
+      assertThat(result, is(lessThanOrEqualTo("4")));
+
+      interpreter = ExpressionInterpreter.createInterpreter("Random(-1, 1)");
+      result = interpreter.evaluate();
+      assertThat(result, is(greaterThanOrEqualTo("-1")));
+      assertThat(result, is(lessThanOrEqualTo("1")));
+    }
+  }
+
+  @Test
+  public void isRandom() throws ExpressionException {
+    try (MockedStatic<GameModule> staticGm = Mockito.mockStatic(GameModule.class)) {
+      GameModule gm = mock(GameModule.class);
+      when(gm.getRNG()).thenReturn(new SecureRandom());
+
+      staticGm.when(GameModule::getGameModule).thenReturn(gm);
+
+      ExpressionInterpreter interpreter = ExpressionInterpreter.createInterpreter("IsRandom()");
+      String result = interpreter.evaluate();
+
+      interpreter = ExpressionInterpreter.createInterpreter("IsRandom(0)");
+      result = interpreter.evaluate();
+      assertThat(result, is(equalTo("false")));
+
+      interpreter = ExpressionInterpreter.createInterpreter("IsRandom(100)");
+      result = interpreter.evaluate();
+      assertThat(result, is(equalTo("true")));
+    }
+  }
+
+  private static final String MATCH_PROP = "match";
+  private static final String MATCH_VAL = "pickMe";
+  private static final String MATCH_EXPR = "{match==\\\"pickMe\\\"}";
+  private static final String MAP_NAME_2 = "myMap";
+
+  @Test
+  public void sum_and_count() throws ExpressionException {
+    try (MockedStatic<Map> staticMap = Mockito.mockStatic(Map.class)) {
+      BasicPiece bp1 = new BasicPiece();
+      bp1.setProperty(SUM_PROP, "2");
+      bp1.setProperty(MATCH_PROP, MATCH_VAL);
+      bp1.setProperty(Properties.PIECE_ID, "1");
+
+      BasicPiece bp2 = new BasicPiece();
+      bp2.setProperty(SUM_PROP, "4");
+      bp2.setProperty(MATCH_PROP, "dontPickMe");
+      bp2.setProperty(Properties.PIECE_ID, "2");
+
+      BasicPiece bp3 = new BasicPiece();
+      bp3.setProperty(SUM_PROP, "8");
+      bp3.setProperty(MATCH_PROP, MATCH_VAL);
+      bp3.setProperty(Properties.PIECE_ID, "3");
+
+      BasicPiece bp4 = new BasicPiece();
+      bp4.setProperty(SUM_PROP, "16");
+      bp4.setProperty(MATCH_PROP, MATCH_VAL);
+      bp4.setProperty(Properties.PIECE_ID, "4");
+
+      Map map1 = mock(Map.class);
+      when(map1.getMapName()).thenReturn(MAP_NAME);
+      when(map1.getAllPieces()).thenReturn(new GamePiece[] {bp4});
+      Map map2 = mock(Map.class);
+      when(map2.getMapName()).thenReturn(MAP_NAME_2);
+      when(map2.getAllPieces()).thenReturn(new GamePiece[] {bp1, bp2, bp3});
+      bp1.setMap(map2);
+      bp2.setMap(map2);
+      bp3.setMap(map2);
+      bp4.setMap(map1);
+      staticMap.when(Map::getMapList).thenReturn(List.of(map1, map2));
+
+      // Sum Test 1 - No map name, should select pieces 1, 3 & 4 across both maps.
+      ExpressionInterpreter interpreter = ExpressionInterpreter.createInterpreter("Sum(\"" + SUM_PROP + "\", \"" + MATCH_EXPR + "\")");
+      String result = interpreter.evaluate(bp1);
+      assertThat("Sum properties across multiple maps", result, is(equalTo("26")));
+
+      // Sum Test 2 - Map name provided,  should select pieces 1 and 3
+      interpreter = ExpressionInterpreter.createInterpreter("Sum(\"" + SUM_PROP + "\", \"" + MATCH_EXPR + "\", \"" + MAP_NAME_2 + "\")");
+      result = interpreter.evaluate(bp1);
+      assertThat("Sum properties on named map", result, is(equalTo("10")));
+
+      // Count Test 1 - No map name, should select pieces 1, 3 & 4 across both maps.
+      interpreter = ExpressionInterpreter.createInterpreter("Count(\"" + MATCH_EXPR + "\")");
+      result = interpreter.evaluate(bp1);
+      assertThat("Count across multiple maps", result, is(equalTo("3")));
+
+      // Count Test 2 - Map name provided,  should select pieces 1 and 3
+      interpreter = ExpressionInterpreter.createInterpreter("Count(\"" + MATCH_EXPR + "\", \"" + MAP_NAME_2 + "\")");
+      result = interpreter.evaluate(bp1);
+      assertThat("Count on named map", result, is(equalTo("2")));
+    }
+  }
+
+}

--- a/vassal-app/src/test/java/VASSAL/script/expression/BeanShellExpressionTest.java
+++ b/vassal-app/src/test/java/VASSAL/script/expression/BeanShellExpressionTest.java
@@ -1,0 +1,109 @@
+package VASSAL.script.expression;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.emptyString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+
+import VASSAL.counters.BasicPiece;
+import VASSAL.counters.PieceFilter;
+import org.junit.Test;
+
+public class BeanShellExpressionTest {
+
+  private static final String EXPR1 = "abc";
+  private static final String EXPR2 = "$abc$";
+
+  @Test
+  public void constructor() {
+    BeanShellExpression e = new BeanShellExpression(EXPR1);
+    assertThat(e.getExpression(), is(equalTo("{" + EXPR1 + "}")));
+  }
+
+  @Test
+  public void strip() {
+    assertThat(BeanShellExpression.strip("abc"), is(equalTo("abc")));
+    assertThat(BeanShellExpression.strip("{abc"), is(equalTo("{abc")));
+    assertThat(BeanShellExpression.strip("{abc}"), is(equalTo("abc")));
+    assertThat(BeanShellExpression.strip("{abc}d"), is(equalTo("{abc}d")));
+  }
+
+  @Test
+  public void isDynamic() {
+    BeanShellExpression e;
+
+    e = new BeanShellExpression(EXPR1);
+    assertThat(e.isDynamic(), is(false));
+
+    e = new BeanShellExpression(EXPR2);
+    assertThat(e.isDynamic(), is(true));
+  }
+
+  @Test
+  public void getFilter() {
+    BasicPiece bp1 = new BasicPiece();
+    Expression e = BeanShellExpression.createExpression("{match==\"pickMe\"}");
+    PieceFilter f = e.getFilter();
+    bp1.setProperty("match", "pickMe");
+    assertThat(f.accept(bp1), is(true));
+    bp1.setProperty("match", "dontPickMe");
+    assertThat(f.accept(bp1), is(false));
+  }
+
+  @Test
+  public void convertProperty() {
+    assertThat(BeanShellExpression.convertProperty(""), is(emptyString()));
+    assertThat(BeanShellExpression.convertProperty("{abc}"), is(equalTo("abc")));
+    assertThat(BeanShellExpression.convertProperty("abc"), is(equalTo("abc")));
+    assertThat(BeanShellExpression.convertProperty("abc def"), is(equalTo("GetProperty(\"abc def\")")));
+  }
+
+  @Test
+  public void isBeanShellExpression() {
+    assertThat(BeanShellExpression.isBeanShellExpression("abc"), is(false));
+    assertThat(BeanShellExpression.isBeanShellExpression("{abc}d"), is(false));
+    assertThat(BeanShellExpression.isBeanShellExpression("{abc"), is(false));
+    assertThat(BeanShellExpression.isBeanShellExpression("{abc}"), is(true));
+  }
+
+  @Test
+  public void createExpression() {
+    Expression e;
+    // Null String should generate a NullExpression
+    e = BeanShellExpression.createExpression("");
+    assertThat(e, is(instanceOf(NullExpression.class)));
+    assertThat(e.getExpression(), is(emptyString()));
+
+    // An Integer should generate an IntExpression
+    e = BeanShellExpression.createExpression("42");
+    assertThat(e, is(instanceOf(IntExpression.class)));
+    assertThat(e.getExpression(), is(equalTo("42")));
+
+    // Other types of numbers should convert ot a generic BeanShell Expression
+    e = BeanShellExpression.createExpression("4.2");
+    assertThat(e, is(instanceOf(BeanShellExpression.class)));
+    assertThat(e.getExpression(), is(equalTo("{4.2}")));
+
+    e = BeanShellExpression.createExpression("abc");
+    assertThat(e, is(instanceOf(BeanShellExpression.class)));
+    assertThat(e.getExpression(), is(equalTo("{abc}")));
+
+    // Check that 1D does not get converted to 1.0
+    e = BeanShellExpression.createExpression("1D");
+    assertThat(e, is(instanceOf(BeanShellExpression.class)));
+    assertThat(e.getExpression(), is(equalTo("{1D}")));
+
+    // Check Strings get converted to StringExpressions
+    e = BeanShellExpression.createExpression("\"abc\"");
+    assertThat(e, is(instanceOf(StringExpression.class)));
+    assertThat(e.getExpression(), is(equalTo("abc")));
+
+    // Unless the alternate sig is called
+    e = BeanShellExpression.createExpression("\"abc\"", true);
+    assertThat(e, is(instanceOf(BeanShellExpression.class)));
+    assertThat(e.getExpression(), is(equalTo("{\"abc\"}")));
+
+  }
+}

--- a/vassal-app/src/test/java/VASSAL/script/expression/ExpressionTest.java
+++ b/vassal-app/src/test/java/VASSAL/script/expression/ExpressionTest.java
@@ -1,0 +1,84 @@
+package VASSAL.script.expression;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+
+import org.junit.Test;
+
+public class ExpressionTest {
+
+  /**
+   * See also Tests for {@link BeanShellExpression#createExpression(String)}
+   * See individual classes for more detailed functional tests
+   */
+  @Test
+  public void createExpression() {
+    // Check createExpression is creating the correct types of expressions
+    Expression e;
+
+    // Null Expression
+    e = Expression.createExpression("");
+    assertThat(e, is(instanceOf(NullExpression.class)));
+
+    // Int Expression
+    e = Expression.createExpression("42");
+    assertThat(e, is(instanceOf(IntExpression.class)));
+
+    // Numeric Literals should create StringExpressions, not be converted to IntExpressions
+    e = Expression.createExpression("1L");
+    assertThat(e, is(instanceOf(StringExpression.class)));
+
+    // Simple String Expression
+    e = Expression.createExpression("abc");
+    assertThat(e, is(instanceOf(StringExpression.class)));
+
+    // Beanshell Expression
+    e = Expression.createExpression("{abc}");
+    assertThat(e, is(instanceOf(BeanShellExpression.class)));
+
+    // Formatted String Expression
+    e = Expression.createExpression("Test: $abc$");
+    assertThat(e, is(instanceOf(FormattedStringExpression.class)));
+
+    // BeanShell Expression with embedded $$ varaible
+    e = Expression.createExpression("{$abc$==def}");
+    assertThat(e, is(instanceOf(BeanShellExpression.class)));
+  }
+
+  @Test
+  public void createPropertyExpression() {
+    // Check createPropertyExpression is creating the correct types of expressions
+    Expression e;
+
+    // Null Expression
+    e = Expression.createPropertyExpression("");
+    assertThat(e, is(instanceOf(NullExpression.class)));
+
+    // BeanShell Expression
+    e = Expression.createPropertyExpression("{$abc$==def}");
+    assertThat(e, is(instanceOf(BeanShellExpression.class)));
+
+    // Anything else should generate a PropertyMatchExpression
+    e = Expression.createPropertyExpression("abc==def");
+    assertThat(e, is(instanceOf(PropertyMatchExpression.class)));
+  }
+
+  @Test
+  public void createSimplePropertyExpression() {
+    // Check createSimplePropertyExpression is creating the correct types of expressions
+    Expression e;
+
+    // Null Expression
+    e = Expression.createSimplePropertyExpression("");
+    assertThat(e, is(instanceOf(NullExpression.class)));
+
+    // BeanShell Expression
+    e = Expression.createSimplePropertyExpression("{abc}");
+    assertThat(e, is(instanceOf(BeanShellExpression.class)));
+
+    // Anything else should generate a PropertyMatchExpression
+    e = Expression.createSimplePropertyExpression("abc");
+    assertThat(e, is(instanceOf(SinglePropertyExpression.class)));
+  }
+}

--- a/vassal-app/src/test/java/VASSAL/script/expression/FormattedStringExpressionTest.java
+++ b/vassal-app/src/test/java/VASSAL/script/expression/FormattedStringExpressionTest.java
@@ -1,0 +1,100 @@
+package VASSAL.script.expression;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.equalTo;
+
+import VASSAL.build.module.properties.PropertySource;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.Test;
+
+public class FormattedStringExpressionTest {
+
+  public static final String PROP1_KEY = "prop1";
+  public static final String PROP1_VALUE = "prop1val";
+  public static final String PROP1_LOCALISED_VALUE = "prop1lval";
+
+  public static final String PROP2_KEY = "prop2";
+  public static final String PROP2_VALUE = "prop2val";
+
+  public static final String TEST1_EXPR = "abc $test$ def";
+  public static final String TEST1_RESULT = "abc test def";
+
+  public static final String TEST2_EXPR = "abc $" + PROP1_KEY + "$ def";
+  public static final String TEST2_RESULT = "abc " + PROP1_VALUE + " def";
+
+  public static final String TEST3_EXPR = "abc $" + PROP1_KEY + "$ def";
+  public static final String TEST3_RESULT = "abc " + PROP1_LOCALISED_VALUE + " def";
+
+  public static final String TEST4_EXPR = "abc $" + PROP1_KEY + "$ def $" + PROP2_KEY + "$ ghi";
+  public static final String TEST4_RESULT = "abc " + PROP1_VALUE + " def " + PROP2_VALUE + " ghi";
+
+  public static final String TEST5_EXPR = "abc $" + PROP1_KEY + "$ def $" + PROP2_KEY + "$ ghi";
+  public static final String TEST5_RESULT = "abc " + PROP1_LOCALISED_VALUE + " def " + PROP2_VALUE + " ghi";
+
+  @Test
+  public void constructor() {
+    Expression e = new FormattedStringExpression(TEST1_EXPR);
+    assertThat(TEST1_EXPR, is(equalTo(e.getExpression())));
+  }
+
+  @Test
+  public void evaluate() throws ExpressionException {
+
+    Source source = new Source();
+    Map<String, String> props = new HashMap<>();
+    props.put(PROP2_KEY, PROP2_VALUE);
+
+
+    // Test 1 - Fallback behaviour Evaluation with no Property source should just strip the $'s.
+    Expression e = new FormattedStringExpression(TEST1_EXPR);
+    String s = e.evaluate();
+    assertThat ("Fallback behaviour failing", TEST1_RESULT, is(equalTo(s)));
+
+    // Test 1B - Property source supplied, Property not found
+    e = new FormattedStringExpression(TEST1_EXPR);
+    s = e.evaluate(source);
+    assertThat ("Fallback behaviour failing with Property Source", TEST1_RESULT, is(equalTo(s)));
+
+    // Test 2 - Property Source, not localised.
+    e = new FormattedStringExpression(TEST2_EXPR);
+    s = e.evaluate(source);
+    assertThat("Property Source lookup failed", TEST2_RESULT, is(equalTo(s)));
+
+    // Test 3 - Property Source, localised.
+    e = new FormattedStringExpression(TEST3_EXPR);
+    s = e.evaluate(source, true);
+    assertThat("Localised Property Source lookup failed", TEST3_RESULT, is(equalTo(s)));
+
+    // Test 4 - Property Source and Property Map, not localised
+    e = new FormattedStringExpression(TEST4_EXPR);
+    s = e.evaluate(source, props, false);
+    assertThat("Property Source plus Map lookup failed", TEST4_RESULT, is(equalTo(s)));
+
+    // Test 5 - Property Source and Property Map, localised
+    e = new FormattedStringExpression(TEST5_EXPR);
+    s = e.evaluate(source, props, true);
+    assertThat("Localised Property Source plus Map lookup failed", TEST5_RESULT, is(equalTo(s)));
+
+  }
+
+  static class Source implements PropertySource {
+
+    @Override
+    public Object getProperty(Object key) {
+      if (PROP1_KEY.equals(key)) {
+        return PROP1_VALUE;
+      }
+      return null;
+    }
+
+    @Override
+    public Object getLocalizedProperty(Object key) {
+      if (PROP1_KEY.equals(key)) {
+        return PROP1_LOCALISED_VALUE;
+      }
+      return null;
+    }
+  }
+}

--- a/vassal-app/src/test/java/VASSAL/script/expression/IntExpressionTest.java
+++ b/vassal-app/src/test/java/VASSAL/script/expression/IntExpressionTest.java
@@ -1,0 +1,40 @@
+package VASSAL.script.expression;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+
+import org.junit.Test;
+
+public class IntExpressionTest {
+
+  private static final int TEST_INT = 42;
+
+  @Test
+  public void constructor() {
+    Expression e = new IntExpression(TEST_INT);
+    assertThat(e.getExpression(), is(equalTo(String.valueOf(TEST_INT))));
+  }
+
+  @Test
+  public void evaluate() throws ExpressionException {
+    Expression e = new IntExpression (TEST_INT);
+    String s = e.evaluate();
+    assertThat(s, is(equalTo(String.valueOf(TEST_INT))));
+
+    e = new IntExpression (-TEST_INT);
+    s = e.evaluate();
+    assertThat(s, is(equalTo(String.valueOf(-TEST_INT))));
+  }
+
+  @Test
+  public void toBeanShellString() {
+    Expression e = new IntExpression (TEST_INT);
+    String s = e.toBeanShellString();
+    assertThat(s, is(equalTo(String.valueOf(TEST_INT))));
+
+    e = new IntExpression (-TEST_INT);
+    s = e.toBeanShellString();
+    assertThat(s, is(equalTo(String.valueOf(-TEST_INT))));
+  }
+}

--- a/vassal-app/src/test/java/VASSAL/script/expression/NullExpressionTest.java
+++ b/vassal-app/src/test/java/VASSAL/script/expression/NullExpressionTest.java
@@ -1,0 +1,30 @@
+package VASSAL.script.expression;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.emptyString;
+
+import org.junit.Test;
+
+public class NullExpressionTest {
+
+  @Test
+  public void constructor() {
+    Expression e = new NullExpression();
+    assertThat(e.getExpression(), is(emptyString()));
+  }
+
+  @Test
+  public void evaluate() throws ExpressionException {
+    Expression e = new NullExpression();
+    String s = e.evaluate();
+    assertThat(s, is(emptyString()));
+  }
+
+  @Test
+  public void toBeanShellString() {
+    Expression e = new NullExpression();
+    String s = e.toBeanShellString();
+    assertThat(s, is(emptyString()));
+  }
+}

--- a/vassal-app/src/test/java/VASSAL/script/expression/PropertyMatchExpressionTest.java
+++ b/vassal-app/src/test/java/VASSAL/script/expression/PropertyMatchExpressionTest.java
@@ -1,0 +1,65 @@
+package VASSAL.script.expression;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+
+import VASSAL.counters.BasicPiece;
+import VASSAL.counters.PieceFilter;
+import org.junit.Test;
+
+public class PropertyMatchExpressionTest {
+
+  private static final String PROP1 = "Army";
+  private static final String VALUE1 = "German";
+  private static final String PROP2 = "Strength";
+  private static final String PROP3 = "Hits";
+  private static final String TEST1_EXPR = PROP1 + "=" + VALUE1;
+  private static final String TEST2_EXPR = PROP2 + "=$" + PROP3 + "$";
+
+  @Test
+  public void constructor() {
+    Expression e = new PropertyMatchExpression(TEST1_EXPR);
+    assertThat(e.getExpression(), is(equalTo(TEST1_EXPR)));
+  }
+
+  @Test
+  public void getFilter() {
+
+    Expression e = new PropertyMatchExpression(TEST1_EXPR);
+    PieceFilter filter = e.getFilter();
+
+    // Test 1 - Basic expression, no $$ variables
+    BasicPiece bp = new BasicPiece();
+    bp.setProperty(PROP1, VALUE1);
+    assertThat(filter.accept(bp), is(true));
+    bp.setProperty(PROP1, VALUE1 + "xxx");
+    assertThat(filter.accept(bp), is(false));
+
+
+    // Test 2 - $$ variables
+    e = new PropertyMatchExpression(TEST2_EXPR);
+    bp = new BasicPiece();
+    bp.setProperty(PROP2, "2");
+    bp.setProperty(PROP3, "2");
+    filter = e.getFilter(bp);
+    assertThat(filter.accept(bp), is(true));
+
+    bp.setProperty(PROP2, "3");
+    assertThat(filter.accept(bp), is(false));
+
+    bp.setProperty(PROP2, "2");
+    bp.setProperty(PROP3, "3");
+    filter = e.getFilter(bp);
+    assertThat(filter.accept(bp), is(false));
+  }
+
+  @Test
+  public void isDynamic() {
+    PropertyMatchExpression e = new PropertyMatchExpression(TEST1_EXPR);
+    assertThat(e.isDynamic(), is(false));
+
+    e = new PropertyMatchExpression(TEST2_EXPR);
+    assertThat(e.isDynamic(), is(true));
+  }
+}

--- a/vassal-app/src/test/java/VASSAL/script/expression/SinglePropertyExpressionTest.java
+++ b/vassal-app/src/test/java/VASSAL/script/expression/SinglePropertyExpressionTest.java
@@ -1,0 +1,77 @@
+package VASSAL.script.expression;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.equalTo;
+
+import VASSAL.build.module.properties.PropertySource;
+import VASSAL.counters.BasicPiece;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.Test;
+
+
+public class SinglePropertyExpressionTest {
+
+  public static final String PROP1_KEY = "prop1";
+  public static final String PROP1_VALUE = "prop1val";
+  public static final String PROP1_LOCALISED_VALUE = "prop1lval";
+
+  @Test
+  public void constructor() {
+    Expression e;
+
+    e = new SinglePropertyExpression(PROP1_KEY);
+    assertThat(e.getExpression(), is(equalTo(PROP1_KEY)));
+
+    // $$ variable should converted to a straight property name
+    e = new SinglePropertyExpression("$" + PROP1_KEY + "$");
+    assertThat(e.getExpression(), is(equalTo(PROP1_KEY)));
+  }
+
+  @Test
+  public void evaluate() throws ExpressionException {
+    Expression e;
+    e = new SinglePropertyExpression(PROP1_KEY);
+
+    Source source = new Source();
+    Map<String, String> props = new HashMap<>();
+    props.put(PROP1_KEY, PROP1_VALUE);
+
+    String s;
+    // Property Source property value
+    s = e.evaluate(source, null, false);
+    assertThat(s, is(equalTo(PROP1_VALUE)));
+
+    // Property Source localised property value
+    s = e.evaluate(source, null, true);
+    assertThat(s, is(equalTo(PROP1_LOCALISED_VALUE)));
+
+    // Property Map property value
+    s = e.evaluate(null, props, false);
+    assertThat(s, is(equalTo(PROP1_VALUE)));
+
+    // No value found
+    s = e.evaluate(null, null, false);
+    assertThat(s, is(equalTo("")));
+  }
+
+  static class Source implements PropertySource {
+
+    @Override
+    public Object getProperty(Object key) {
+      if (PROP1_KEY.equals(key)) {
+        return PROP1_VALUE;
+      }
+      return null;
+    }
+
+    @Override
+    public Object getLocalizedProperty(Object key) {
+      if (PROP1_KEY.equals(key)) {
+        return PROP1_LOCALISED_VALUE;
+      }
+      return null;
+    }
+  }
+}

--- a/vassal-app/src/test/java/VASSAL/script/expression/StringExpressionTest.java
+++ b/vassal-app/src/test/java/VASSAL/script/expression/StringExpressionTest.java
@@ -1,0 +1,32 @@
+package VASSAL.script.expression;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+
+import org.junit.Test;
+
+public class StringExpressionTest {
+
+  private static final String TEST = "xyzzy";
+
+  @Test
+  public void constructor() {
+    Expression e = new StringExpression(TEST);
+    assertThat(e.getExpression(), is(equalTo(TEST)));
+  }
+
+  @Test
+  public void evaluate() throws ExpressionException {
+    Expression e = new StringExpression(TEST);
+    String s = e.evaluate();
+    assertThat(s, equalTo(TEST));
+  }
+
+  @Test
+  public void toBeanShellString() {
+    Expression e = new StringExpression(TEST);
+    String s = e.toBeanShellString();
+    assertThat(s, equalTo("\"" + TEST + "\""));
+  }
+}

--- a/vassal-app/src/test/java/bsh/BeanShellExpressionValidatorTest.java
+++ b/vassal-app/src/test/java/bsh/BeanShellExpressionValidatorTest.java
@@ -1,0 +1,33 @@
+package bsh;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.emptyString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.is;
+
+import java.util.List;
+import org.junit.Test;
+
+public class BeanShellExpressionValidatorTest {
+
+  @Test
+  public void isValid() {
+    BeanShellExpressionValidator v = new BeanShellExpressionValidator("{6 * 7}");
+    assertThat(v.isValid(), is(true));
+    assertThat(v.getError(), is(emptyString()));
+
+    v = new BeanShellExpressionValidator("{6 * }");
+    assertThat(v.isValid(), is(false));
+    assertThat(v.getError(), is(not(emptyString())));
+  }
+
+  @Test
+  public void get() {
+    BeanShellExpressionValidator v = new BeanShellExpressionValidator("{x + y + z.contains('p') + Random(6)}");
+    assertThat(v.isValid(), is(true));
+    assertThat("Find non-string variables in expression", v.getVariables(), is(equalTo(List.of("x", "y"))));
+    assertThat("Find string variables in expression", v.getStringVariables(), is(equalTo(List.of("z"))));
+    assertThat("Find method calls in expression", v.getMethods(), is(equalTo(List.of("Random"))));
+  }
+}


### PR DESCRIPTION
Also changes Mockito to 'inline' version to allow static Mocks and explicitly specified byte buddy to get correct version for inline mocks.