### PR TITLE
3.4.2(!!) 13398 - Fix piece drag so that pieces can be moved a few pixels

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/module/map/PieceMover.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/PieceMover.java
@@ -200,6 +200,7 @@ public class PieceMover extends AbstractBuildable
         if (this.map.getStackMetrics().isStackingEnabled() &&
             this.map.getPieceCollection().canMerge(dragging, s) &&
             !DragBuffer.getBuffer().contains(s) &&
+            !DragBuffer.getBuffer().containsAllMembers(s) &&  //BR// Don't merge back into a stack we are in the act of emptying
             s.topPiece() != null) {
           if (this.map.isLocationRestricted(pt) && !s.isExpanded()) {
             if (s.getPosition().equals(this.map.snapTo(pt))) {
@@ -590,6 +591,12 @@ public class PieceMover extends AbstractBuildable
           final Stack parent = map.getStackMetrics().createStack(dragging);
           if (parent != null) {
             comm = comm.append(map.placeAt(parent, p));
+
+            //BR// We've made a new stack, so put it on the list of merge targets, in case more pieces land here too
+            mergeCandidates = new ArrayList<>();
+            mergeCandidates.add(dragging);
+            mergeCandidates.add(parent);
+            mergeTargets.put(p, mergeCandidates);
           }
         }
       }

--- a/vassal-app/src/main/java/VASSAL/counters/DragBuffer.java
+++ b/vassal-app/src/main/java/VASSAL/counters/DragBuffer.java
@@ -141,6 +141,20 @@ public class DragBuffer {
   }
 
   /**
+   * @return true if the DragBuffer contains all members of Stack s
+   * @param s Stack to test.
+   */
+  public boolean containsAllMembers (Stack s) {
+    List<GamePiece> members = s.asList();
+    for (GamePiece p : members) {
+      if (!contains(p)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /**
    * @return an unmodifiable {@link List} of {@link GamePiece}s contained in
    * this {@link DragBuffer}
    */


### PR DESCRIPTION
The "Undo bug" fix changed starting-a-drag behavior by no longer adding the actual Stack object to the DragBuffer (instead we are just holding the pieces that were inside it). And so now that is affecting the behavior at the other end when we are dropping the pieces.

The bad behavior we were seeing is pieces still seeing their "old stack" sitting there on the board "within merge range", and so they'd merge back into it and end up back in their same old location instead of at their new adjusted location.

So first part of this is a new special case is when we encounter a stack we might want to drop onto -- if DragBuffer already contains all current members of the potential target stack, then it is a stack we are in the process of emptying out, and we don't want to merge back into it. I've added a method to DragBuffer to help check for this.

The second part of the fix is that now when we drop a piece and therefore end up creating a stack, we need to add that new stack to our list of "merge targets", so that any other pieces also dropped onto the space will also "find" the new stack. I was actually surprised that new stacks weren't already being added into the list, as it seems like this could have caused bad behavior, but I guess if under the "old behavior" we always brought the whole "stack object" along with us, then cases where that would matter would be rare, or were masked, or something like that.

So far this seems to work with my testing. I don't have any modules that use "snap to" maps though, so it would be nice if somebody tested on those and made sure it isn't creating "extra stacks" or something. But I think it should be cleaning the old stacks up automatically as it is moving pieces out one-at-a-time in this process.