### PR TITLE
3.4.2 (?) - 13279 - Pivot was auto-reporting moves when auto-reporting is turned off.

### DIFF
--- a/vassal-app/src/main/java/VASSAL/counters/Pivot.java
+++ b/vassal-app/src/main/java/VASSAL/counters/Pivot.java
@@ -152,11 +152,13 @@ public class Pivot extends Decorator implements TranslatablePiece {
           getMap().placeOrMerge(outer, pos);
           c = c.append(moveTracker.getMoveCommand());
           MovementReporter r = new MovementReporter(c);
-          Command reportCommand = r.getReportCommand();
-          if (reportCommand != null) {
-            reportCommand.execute();
+          if (GlobalOptions.getInstance().autoReportEnabled()) {
+            Command reportCommand = r.getReportCommand();
+            if (reportCommand != null) {
+              reportCommand.execute();
+            }
+            c = c.append(reportCommand);
           }
-          c = c.append(reportCommand);
           c = c.append(r.markMovedPieces());
           getMap().ensureVisible(getMap().selectionBoundsOf(outer));
         }

--- a/vassal-app/src/main/java/VASSAL/counters/Pivot.java
+++ b/vassal-app/src/main/java/VASSAL/counters/Pivot.java
@@ -32,6 +32,7 @@ import javax.swing.BoxLayout;
 import javax.swing.JPanel;
 import javax.swing.KeyStroke;
 
+import VASSAL.build.module.GlobalOptions;
 import VASSAL.build.module.documentation.HelpFile;
 import VASSAL.build.module.map.MovementReporter;
 import VASSAL.command.ChangeTracker;


### PR DESCRIPTION
I set this to 3.4.2 since it's both a "super simple and obvious fix", and since it was one where the user actually went to the trouble of filing a real Bug Tracker report and providing a module for repro. But it can be moved to 3.5 if we need to based on constraints.

Pivot has apparently been ignoring the GlobalOptions auto report setting ever since it was written, in _(checks notes)_ 2004!
