### PR TITLE
3.4.2 (!) - Remove 'Preference' option from HTML-related stuff

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/module/Chatter.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/Chatter.java
@@ -546,12 +546,6 @@ public class Chatter extends JPanel implements CommandEncoder, Buildable {
     globalPrefs.addOption(Resources.getString("Chatter.chat_window"), otherChatColor);
     otherChat = (Color) globalPrefs.getValue(OTHER_CHAT_COLOR);
     
-    // Put up the HTML Enable/Disable checkbox if we're supposed to have it.
-    if (GlobalOptions.PROMPT.equals(GlobalOptions.getInstance().chatterHTMLSetting())) {
-      BooleanConfigurer config2 = new BooleanConfigurer(GlobalOptions.CHATTER_HTML_SUPPORT, Resources.getString("GlobalOptions.chatter_html_support")); //$NON-NLS-1$
-      globalPrefs.addOption(Resources.getString("Chatter.chat_window"), config2);        
-    }
-
     makeStyleSheet(myFont);
   }
 

--- a/vassal-app/src/main/java/VASSAL/build/module/GlobalOptions.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/GlobalOptions.java
@@ -264,6 +264,13 @@ public class GlobalOptions extends AbstractConfigurable {
     }
   }
 
+  public static class PromptOnOff extends StringEnum {
+    @Override
+    public String[] getValidValues(AutoConfigurable target) {
+      return new String[]{ALWAYS, NEVER};
+    }
+  }
+
   public static class PlayerIdFormatConfig implements ConfigurerFactory {
     @Override
     public Configurer getConfigurer(AutoConfigurable c, String key, String name) {
@@ -318,7 +325,7 @@ public class GlobalOptions extends AbstractConfigurable {
       null,
       Prompt.class,
       PlayerIdFormatConfig.class,
-      Prompt.class
+      PromptOnOff.class
     };
   }
 
@@ -409,6 +416,9 @@ public class GlobalOptions extends AbstractConfigurable {
       return promptString;
     }
     else if (CHATTER_HTML_SUPPORT.equals(key)) {
+      if (PROMPT.equals(chatterHTMLSupport)) {
+        return NEVER; //BR// So peeps with the old/bad "preference" option will get a safe result.
+      }
       return chatterHTMLSupport;
     }
     else if (AUTO_REPORT.equals(key)) {
@@ -463,10 +473,6 @@ public class GlobalOptions extends AbstractConfigurable {
     }
     else if (CHATTER_HTML_SUPPORT.equals(key)) {
       chatterHTMLSupport = (String) value;
-      if (PROMPT.equals(chatterHTMLSupport)) {
-        BooleanConfigurer config = new BooleanConfigurer(CHATTER_HTML_SUPPORT, Resources.getString("GlobalOptions.chatter_html_support")); //$NON-NLS-1$
-        GameModule.getGameModule().getPrefs().addOption(Resources.getString("Chatter.chat_window"), config);        
-      }
     }
     else if (AUTO_REPORT.equals(key)) {
       autoReport = (String) value;
@@ -501,10 +507,6 @@ public class GlobalOptions extends AbstractConfigurable {
     return Boolean.TRUE.equals(GameModule.getGameModule().getPrefs().getValue(CENTER_ON_MOVE));
   }
   
-  public String chatterHTMLSetting() {
-    return chatterHTMLSupport;
-  }
-  
   public boolean chatterHTMLSupport() {
     return isEnabled(chatterHTMLSupport, CHATTER_HTML_SUPPORT);
   }
@@ -527,7 +529,7 @@ public class GlobalOptions extends AbstractConfigurable {
     if (ALWAYS.equals(attValue)) {
       return true;
     }
-    else if (NEVER.equals(attValue)) {
+    else if (NEVER.equals(attValue) || CHATTER_HTML_SUPPORT.equals(prefsPrompt)) {
       return false;
     }
     else {


### PR DESCRIPTION
The GlobalOptions default "Prompt" class has a "use user preference" option which is not a good one for "Enable HTML in Chat Log" to have. This change fixes it to ONLY accept "Always" or "Never" for the HTML-in-chat-log. 

Mostly cleanup because the preference thing was quasi-harmless, but it already caused confusion tonight so now it can DIE! DIE! DIE!