### PR TITLE
3.4.2 (!!) - 13425 - MouseoverStackViewer legacy expression matching was broken by a code cleanup

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/module/Chatter.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/Chatter.java
@@ -46,7 +46,6 @@ import VASSAL.build.Buildable;
 import VASSAL.build.GameModule;
 import VASSAL.command.Command;
 import VASSAL.command.CommandEncoder;
-import VASSAL.configure.BooleanConfigurer;
 import VASSAL.configure.ColorConfigurer;
 import VASSAL.configure.FontConfigurer;
 import VASSAL.i18n.Resources;

--- a/vassal-app/src/main/java/VASSAL/counters/PropertiesPieceFilter.java
+++ b/vassal-app/src/main/java/VASSAL/counters/PropertiesPieceFilter.java
@@ -141,7 +141,7 @@ public class PropertiesPieceFilter {
   private abstract static class ComparisonFilter implements PieceFilter {
     protected String name;
     protected String value;
-    protected Boolean alternate;
+    protected Object alternate;
 
     public ComparisonFilter(String name, String value) {
       this.name = name;
@@ -192,7 +192,7 @@ public class PropertiesPieceFilter {
       String property = String.valueOf(piece.getProperty(name));
       boolean retVal = value.equals(property);
       if (alternate != null) {
-        retVal = retVal || alternate.equals(Boolean.parseBoolean(property));
+        retVal = retVal || alternate.equals(property);
       }
       return retVal;
     }
@@ -218,7 +218,7 @@ public class PropertiesPieceFilter {
       String property = String.valueOf(piece.getProperty(name));
       boolean retVal = !value.equals(property);
       if (alternate != null) {
-        retVal = retVal && !alternate.equals(Boolean.parseBoolean(property));
+        retVal = retVal && !alternate.equals(property);
       }
       return retVal;
     }

--- a/vassal-app/src/main/java/VASSAL/counters/PropertiesPieceFilter.java
+++ b/vassal-app/src/main/java/VASSAL/counters/PropertiesPieceFilter.java
@@ -141,7 +141,7 @@ public class PropertiesPieceFilter {
   private abstract static class ComparisonFilter implements PieceFilter {
     protected String name;
     protected String value;
-    protected Object alternate;
+    protected Object alternate; //BR// NB - 3.4.2 - reverted from Boolean because of 13425
 
     public ComparisonFilter(String name, String value) {
       this.name = name;
@@ -192,7 +192,7 @@ public class PropertiesPieceFilter {
       String property = String.valueOf(piece.getProperty(name));
       boolean retVal = value.equals(property);
       if (alternate != null) {
-        retVal = retVal || alternate.equals(property);
+        retVal = retVal || alternate.equals(property); //BR// NB - 3.4.2 - reverted from Boolean because of 13425
       }
       return retVal;
     }
@@ -218,7 +218,7 @@ public class PropertiesPieceFilter {
       String property = String.valueOf(piece.getProperty(name));
       boolean retVal = !value.equals(property);
       if (alternate != null) {
-        retVal = retVal && !alternate.equals(property);
+        retVal = retVal && !alternate.equals(property); //BR// NB - 3.4.2 - reverted from Boolean because of 13425
       }
       return retVal;
     }


### PR DESCRIPTION
Did some Big Boy Bisecting and we found a Broken Thing. Reverted it, and the problem went away. Yay! 

Marked with comments So We Will Know.