### PR TITLE
13427 - Allow extensions to be edited on linux/Mac

### DIFF
--- a/vassal-app/src/main/java/VASSAL/configure/ExtensionTree.java
+++ b/vassal-app/src/main/java/VASSAL/configure/ExtensionTree.java
@@ -375,16 +375,6 @@ public class ExtensionTree extends ConfigureTree {
   }
 
   @Override
-  public void mousePressed(MouseEvent e) {
-    TreePath path = getPathForLocation(e.getX(), e.getY());
-    if (path != null) {
-      if (isEditable((DefaultMutableTreeNode) path.getLastPathComponent())) {
-        super.mousePressed(e);
-      }
-    }
-  }
-
-  @Override
   protected boolean isValidParent(Configurable parent, Configurable child) {
     return super.isValidParent(parent, child) && isEditable(parent);
   }


### PR DESCRIPTION
This doesn't look like it should fix the problem, but it does. With the changes to check isPopupTrigger(), all the proper ExtensionTree mouse handling is already there. The check for isEditable() should never have been added, you always want to create a popup. The popup contents and state are handled in ExtensionTree by over-riding the buildAction methods.