### PR TITLE
3.4.3(?) PieceDefiner uses BrowserHelp

### DIFF
--- a/vassal-app/src/main/java/VASSAL/counters/PieceDefiner.java
+++ b/vassal-app/src/main/java/VASSAL/counters/PieceDefiner.java
@@ -581,7 +581,7 @@ public class PieceDefiner extends JPanel implements HelpWindowExtension {
 
       if (p.getHelpFile() != null) {
         b = new JButton("Help");
-        b.addActionListener(evt -> p.getHelpFile().showWindow(Ed.this));
+        b.addActionListener(evt -> BrowserSupport.openURL(p.getHelpFile().getContents().toString()));
         add(b, "tag help");
       }
 


### PR DESCRIPTION
Apparently PieceDefiner (ONLY) was still using crappy-non-browser help windows, while all other Help buttons and Help menus were using the real browser. So that means there's no Back Button in the browser help.

This should fix it up. 

I offer you the option of merging it into 3.4.3 "because one line". OR punt it to 3.5 "because not a new bug".