### PR TITLE
3.4.3 - 13435 - Warnings with less-than sign being interpreted as HTML

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/GameModule.java
+++ b/vassal-app/src/main/java/VASSAL/build/GameModule.java
@@ -566,11 +566,14 @@ public abstract class GameModule extends AbstractConfigurable implements Command
    * Save the messages for later if the Chatter has not been initialised yet
    */
   public void warn(String s) {
+    String s2 = s;
+    s2 = s2.replaceAll("<", "&lt;")  // So < symbols in warning messages don't get misinterpreted as HTML //$NON-NLS
+           .replaceAll(">", "&gt;"); //$NON-NLS
     if (chat == null) {
-      deferredChat.add(s);
+      deferredChat.add(s2);
     }
     else {
-      chat.show(" - " + s); //$NON-NLS-1$
+      chat.show(" - " + s2); //$NON-NLS-1$
     }
   }
   


### PR DESCRIPTION
Mark on the forums pointed out a case where Bad Module Data warnings with a < sign were being misinterpreted as HTML.

This patch will clear that up.