### PR TITLE
3.4.3 - 13436 - Module Managers for multiple versions of VASSAL can coexist

### DIFF
--- a/vassal-app/src/main/java/VASSAL/Info.java
+++ b/vassal-app/src/main/java/VASSAL/Info.java
@@ -148,7 +148,7 @@ public final class Info {
    * @return a version-specific name for the errorlog
    */
   public static String getErrorLogName() {
-    final String v = "errorLog" + getReportableVersion().replaceAll("\\.", "_");
+    final String v = "errorLog_" + getReportableVersion().replaceAll("\\.", "_");
     return v;
   }
 

--- a/vassal-app/src/main/java/VASSAL/Info.java
+++ b/vassal-app/src/main/java/VASSAL/Info.java
@@ -145,12 +145,12 @@ public final class Info {
 
 
   /**
-   * @return a version-specific name for the errorlog
+   * @return a version-specific errorLog path
    */
-  public static String getErrorLogName() {
-    final String v = "errorLog-" + getReportableVersion();
-    return v;
+  public static File getErrorLogPath() {
+    return new File (getHomeDir(), "errorLog-" + getReportableVersion());
   }
+
 
 
   private static final int instanceID;

--- a/vassal-app/src/main/java/VASSAL/Info.java
+++ b/vassal-app/src/main/java/VASSAL/Info.java
@@ -148,7 +148,7 @@ public final class Info {
    * @return a version-specific name for the errorlog
    */
   public static String getErrorLogName() {
-    final String v = "errorLog_" + getReportableVersion().replaceAll("\\.", "_");
+    final String v = "errorLog-" + getReportableVersion();
     return v;
   }
 

--- a/vassal-app/src/main/java/VASSAL/Info.java
+++ b/vassal-app/src/main/java/VASSAL/Info.java
@@ -143,6 +143,16 @@ public final class Info {
     return v.contains("-") ?  v.substring(0, v.indexOf('-')) : v;
   }
 
+
+  /**
+   * @return a version-specific name for the errorlog
+   */
+  public static String getErrorLogName() {
+    final String v = "errorLog" + getReportableVersion().replaceAll("\\.", "_");
+    return v;
+  }
+
+
   private static final int instanceID;
 
   /**

--- a/vassal-app/src/main/java/VASSAL/launch/ModuleManager.java
+++ b/vassal-app/src/main/java/VASSAL/launch/ModuleManager.java
@@ -136,10 +136,9 @@ public class ModuleManager {
 
     // Different versions of VASSAL can all co-exist, each with own Module Manager
     String ver = Info.getReportableVersion();
-    ver = ver.replaceAll("\\.", "_");
 
-    final File keyfile = new File(Info.getConfDir(), "key_" + ver);
-    final File lockfile = new File(Info.getConfDir(), "lock_" + ver);
+    final File keyfile = new File(Info.getConfDir(), "key-" + ver);
+    final File lockfile = new File(Info.getConfDir(), "lock-" + ver);
 
     int port = 0;
     long key = 0;

--- a/vassal-app/src/main/java/VASSAL/launch/ModuleManager.java
+++ b/vassal-app/src/main/java/VASSAL/launch/ModuleManager.java
@@ -136,7 +136,7 @@ public class ModuleManager {
 
     // Different versions of VASSAL can all co-exist, each with own Module Manager
     String ver = Info.getReportableVersion();
-    ver = ver.replaceAll(".", "_");
+    ver = ver.replaceAll("\\.", "_");
 
     final File keyfile = new File(Info.getConfDir(), "key" + ver);
     final File lockfile = new File(Info.getConfDir(), "lock" + ver);
@@ -258,7 +258,7 @@ public class ModuleManager {
     this.lock = lock;
 
     // truncate the errorLog
-    final File errorLog = new File(Info.getHomeDir(), "errorLog");
+    final File errorLog = new File(Info.getHomeDir(), Info.getErrorLogName());
     new FileOutputStream(errorLog).close();
 
     final StartUp start = SystemUtils.IS_OS_MAC_OSX ?

--- a/vassal-app/src/main/java/VASSAL/launch/ModuleManager.java
+++ b/vassal-app/src/main/java/VASSAL/launch/ModuleManager.java
@@ -134,8 +134,12 @@ public class ModuleManager {
     // (2) No port collisions, because we don't use a predetermined port.
     //
 
-    final File keyfile = new File(Info.getConfDir(), "key");
-    final File lockfile = new File(Info.getConfDir(), "lock");
+    // Different versions of VASSAL can all co-exist, each with own Module Manager
+    String ver = Info.getReportableVersion();
+    ver = ver.replaceAll(".", "_");
+
+    final File keyfile = new File(Info.getConfDir(), "key" + ver);
+    final File lockfile = new File(Info.getConfDir(), "lock" + ver);
 
     int port = 0;
     long key = 0;

--- a/vassal-app/src/main/java/VASSAL/launch/ModuleManager.java
+++ b/vassal-app/src/main/java/VASSAL/launch/ModuleManager.java
@@ -138,8 +138,8 @@ public class ModuleManager {
     String ver = Info.getReportableVersion();
     ver = ver.replaceAll("\\.", "_");
 
-    final File keyfile = new File(Info.getConfDir(), "key" + ver);
-    final File lockfile = new File(Info.getConfDir(), "lock" + ver);
+    final File keyfile = new File(Info.getConfDir(), "key_" + ver);
+    final File lockfile = new File(Info.getConfDir(), "lock_" + ver);
 
     int port = 0;
     long key = 0;

--- a/vassal-app/src/main/java/VASSAL/launch/ModuleManager.java
+++ b/vassal-app/src/main/java/VASSAL/launch/ModuleManager.java
@@ -257,7 +257,7 @@ public class ModuleManager {
     this.lock = lock;
 
     // truncate the errorLog
-    final File errorLog = new File(Info.getHomeDir(), Info.getErrorLogName());
+    final File errorLog = Info.getErrorLogPath();
     new FileOutputStream(errorLog).close();
 
     final StartUp start = SystemUtils.IS_OS_MAC_OSX ?

--- a/vassal-app/src/main/java/VASSAL/launch/ModuleManagerWindow.java
+++ b/vassal-app/src/main/java/VASSAL/launch/ModuleManagerWindow.java
@@ -1935,7 +1935,7 @@ public class ModuleManagerWindow extends JFrame {
     @Override
     public void actionPerformed(ActionEvent e) {
 // FIXME: don't create a new one each time!
-      final File logfile = new File(Info.getHomeDir(), "errorLog");
+      final File logfile = new File(Info.getHomeDir(), Info.getErrorLogName());
       final LogPane lp = new LogPane(logfile);
 
 // FIXME: this should have its own key. Probably keys should be renamed

--- a/vassal-app/src/main/java/VASSAL/launch/ModuleManagerWindow.java
+++ b/vassal-app/src/main/java/VASSAL/launch/ModuleManagerWindow.java
@@ -1935,7 +1935,7 @@ public class ModuleManagerWindow extends JFrame {
     @Override
     public void actionPerformed(ActionEvent e) {
 // FIXME: don't create a new one each time!
-      final File logfile = new File(Info.getHomeDir(), Info.getErrorLogName());
+      final File logfile = Info.getErrorLogPath();
       final LogPane lp = new LogPane(logfile);
 
 // FIXME: this should have its own key. Probably keys should be renamed

--- a/vassal-app/src/main/java/VASSAL/launch/ModuleManagerWindow.java
+++ b/vassal-app/src/main/java/VASSAL/launch/ModuleManagerWindow.java
@@ -175,7 +175,7 @@ public class ModuleManagerWindow extends JFrame {
   private static final ModuleManagerWindow instance = new ModuleManagerWindow();
 
   public ModuleManagerWindow() {
-    setTitle("VASSAL");
+    setTitle("VASSAL " + Info.getVersion());
     setLayout(new BoxLayout(getContentPane(), BoxLayout.X_AXIS));
 
     ApplicationIcons.setFor(this);

--- a/vassal-app/src/main/java/VASSAL/tools/BugDialog.java
+++ b/vassal-app/src/main/java/VASSAL/tools/BugDialog.java
@@ -309,7 +309,7 @@ public class BugDialog extends JDialog {
 
   private Component buildConnectionFailedPanel() {
     final String errorLogPath =
-      new File(Info.getConfDir(), "errorLog").getAbsolutePath();
+      new File(Info.getConfDir(), Info.getErrorLogName()).getAbsolutePath();
 
     final FlowLabel label = new FlowLabel(Resources.getString(
       "BugDialog.connection_failed_instructions", errorLogPath));

--- a/vassal-app/src/main/java/VASSAL/tools/BugDialog.java
+++ b/vassal-app/src/main/java/VASSAL/tools/BugDialog.java
@@ -308,8 +308,7 @@ public class BugDialog extends JDialog {
   }
 
   private Component buildConnectionFailedPanel() {
-    final String errorLogPath =
-      new File(Info.getConfDir(), Info.getErrorLogName()).getAbsolutePath();
+    final String errorLogPath = Info.getErrorLogPath().getAbsolutePath();
 
     final FlowLabel label = new FlowLabel(Resources.getString(
       "BugDialog.connection_failed_instructions", errorLogPath));

--- a/vassal-app/src/main/java/VASSAL/tools/BugUtils.java
+++ b/vassal-app/src/main/java/VASSAL/tools/BugUtils.java
@@ -25,7 +25,7 @@ public class BugUtils {
     pb.setParameter("email", email);
     pb.setParameter("summary", getSummary(t));
     pb.setParameter("description", getDescription(description, errorLog));
-    pb.setParameter("log", Info.getErrorLogName(), errorLog);
+    pb.setParameter("log", Info.getErrorLogPath().getName(), errorLog);
 
     try (InputStream in = pb.post(url)) {
       final String result = IOUtils.toString(in, StandardCharsets.UTF_8);
@@ -84,7 +84,7 @@ public class BugUtils {
 // FIXME: move this somewhere else?
   public static String getErrorLog() {
     String log = null;
-    final File f = new File(Info.getConfDir(), Info.getErrorLogName());
+    final File f = Info.getErrorLogPath();
     try (FileReader r = new FileReader(f, Charset.defaultCharset())) {
       log = IOUtils.toString(r);
     }

--- a/vassal-app/src/main/java/VASSAL/tools/BugUtils.java
+++ b/vassal-app/src/main/java/VASSAL/tools/BugUtils.java
@@ -25,7 +25,7 @@ public class BugUtils {
     pb.setParameter("email", email);
     pb.setParameter("summary", getSummary(t));
     pb.setParameter("description", getDescription(description, errorLog));
-    pb.setParameter("log", "errorLog", errorLog);
+    pb.setParameter("log", Info.getErrorLogName(), errorLog);
 
     try (InputStream in = pb.post(url)) {
       final String result = IOUtils.toString(in, StandardCharsets.UTF_8);
@@ -84,7 +84,7 @@ public class BugUtils {
 // FIXME: move this somewhere else?
   public static String getErrorLog() {
     String log = null;
-    final File f = new File(Info.getConfDir(), "errorLog");
+    final File f = new File(Info.getConfDir(), Info.getErrorLogName());
     try (FileReader r = new FileReader(f, Charset.defaultCharset())) {
       log = IOUtils.toString(r);
     }


### PR DESCRIPTION
Up until now Vassal could only have one Module Manager running at the same time. Now, each VERSION of Vassal can only have one Module Manager running at the same time. 

This should help people who need/want to run multiple versions of Vassal because of different modules (and module maintainers) having different requirements.