### PR TITLE
3.5 - Default logfile prompt to on

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/module/BasicLogger.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/BasicLogger.java
@@ -72,8 +72,8 @@ public class BasicLogger implements Logger, Buildable, GameComponent, CommandEnc
   public static final String END = "end_log";  //$NON-NLS-1$
   public static final String LOG = "LOG\t";  //$NON-NLS-1$
   public static final String PROMPT_NEW_LOG = "PromptNewLog";  //$NON-NLS-1$
-  public static final String PROMPT_NEW_LOG_START = "PromptNewLogStart";  //$NON-NLS-1$
-  public static final String PROMPT_NEW_LOG_END = "PromptNewLogEnd";  //$NON-NLS-1$
+  public static final String PROMPT_NEW_LOG_START = "PromptNewLogAtStart"; //$NON-NLS-1$
+  public static final String PROMPT_NEW_LOG_END = "PromptNewLogAtEnd"; //$NON-NLS-1$
   public static final String PROMPT_LOG_COMMENT = "promptLogComment";  //$NON-NLS-1$
   protected static final String STEP_ICON = "/images/StepForward16.gif";  //$NON-NLS-1$
   protected static final String UNDO_ICON = "/images/Undo16.gif";  //$NON-NLS-1$
@@ -177,7 +177,7 @@ public class BasicLogger implements Logger, Buildable, GameComponent, CommandEnc
     });
     undoKeyConfig.fireUpdate();
 
-    BooleanConfigurer logOptionStart = new BooleanConfigurer(PROMPT_NEW_LOG_START, Resources.getString("BasicLogger.prompt_new_log_before"), Boolean.FALSE);  //$NON-NLS-1$
+    BooleanConfigurer logOptionStart = new BooleanConfigurer(PROMPT_NEW_LOG_START, Resources.getString("BasicLogger.prompt_new_log_before"), Boolean.TRUE);  //$NON-NLS-1$
     mod.getPrefs().addOption(Resources.getString("Prefs.general_tab"), logOptionStart); //$NON-NLS-1$
 
     BooleanConfigurer logOptionEnd = new BooleanConfigurer(PROMPT_NEW_LOG_END, Resources.getString("BasicLogger.prompt_new_log_after"), Boolean.TRUE);  //$NON-NLS-1$

--- a/vassal-app/src/main/java/VASSAL/build/module/BasicLogger.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/BasicLogger.java
@@ -73,7 +73,7 @@ public class BasicLogger implements Logger, Buildable, GameComponent, CommandEnc
   public static final String LOG = "LOG\t";  //$NON-NLS-1$
   public static final String PROMPT_NEW_LOG = "PromptNewLog";  //$NON-NLS-1$
   public static final String PROMPT_NEW_LOG_START = "PromptNewLogAtStart"; //$NON-NLS-1$
-  public static final String PROMPT_NEW_LOG_END = "PromptNewLogAtEnd"; //$NON-NLS-1$
+  public static final String PROMPT_NEW_LOG_END = "PromptNewLogEnd"; //$NON-NLS-1$
   public static final String PROMPT_LOG_COMMENT = "promptLogComment";  //$NON-NLS-1$
   protected static final String STEP_ICON = "/images/StepForward16.gif";  //$NON-NLS-1$
   protected static final String UNDO_ICON = "/images/Undo16.gif";  //$NON-NLS-1$


### PR DESCRIPTION
3.5 has a much better & more comprehensible "reminder-to-start-logfile" flow. 

At the time I did it, I didn't realize quite how big of an issue this was in the community (or I'd have done it for 3.4 back when there was time), but ALSO because of that lack of realization, I didn't default the preference to on (and I just used the old preference which everyone already HAD defaulted to off anyway). 

So now this defaults those logfile preferences to "on", and uses a new key so that with 3.5 it will start "defaulted on" for everyone including players upgrading. And it has a "don't ask again" button on the box so the people that don't want it will just click that and everything will be fine.

But for all the PBEM people it will now remind them not only when they finish a log file, but ALSO when they load a saved game or start a new game or whatever.
