### PR TITLE
3.4.3 - 13342 - a much less scary fix version

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/module/BasicLogger.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/BasicLogger.java
@@ -206,8 +206,7 @@ public class BasicLogger implements Logger, Buildable, GameComponent, CommandEnc
       logOutput.clear();
       nextInput = 0;
       nextUndo = -1;
-      beginningState =
-        GameModule.getGameModule().getGameState().getRestoreCommand();
+      beginningState = null; // Will create one when we actually start a log
     }
     else {
       if (endLogAction.isEnabled()) {


### PR DESCRIPTION
Just don't have BasicLogger create a save string during its setup() method. It will create one anyway when a logfile is actually started.