### PR TITLE
Add License Maven Plugin for downloading licenses of dependencies

### DIFF
--- a/developers-guide/developers-guide.adoc
+++ b/developers-guide/developers-guide.adoc
@@ -26,6 +26,7 @@ Reference: link:https://maven.apache.org/ref/3.6.3/maven-core/lifecycles.html[]
 . *package*: creates build artifacts (.jar files) in `/target`
 * javadoc
 * source: creates source code jar
+* license: downloads licenses
 . *verify*: not used
 . *install*: copies build artifacts into local maven repository
 . *site*: not used
@@ -159,6 +160,17 @@ include::{rootdir}pom.xml[lines=111..115]
 
 * Maven plugin configuration in link:{rootdir}vassal-doc/pom.xml[]
 
+===== License Maven Plugin
+
+[NOTE]
+====
+Runs goal link:https://www.mojohaus.org/license-maven-plugin/aggregate-download-licenses-mojo.html[license:aggregate-download-licenses] in *package* phase
+====
+
+* Maven plugin version in link:{rootdir}pom.xml[]
+
+* Maven plugin configuration in link:{rootdir}release-prepare/pom.xml[]
+
 ==== Build parameters
 
 ===== Version number
@@ -194,6 +206,9 @@ Each build step can be skipped by passing certain parameters.
 
 |Clirr
 |`-Dclirr.skip=true`
+
+|License Maven Plugin
+|`-Dlicense.skipAggregateDownloadLicenses=true`
 
 |===
 

--- a/pom.xml
+++ b/pom.xml
@@ -136,6 +136,11 @@
                     <artifactId>clirr-maven-plugin</artifactId>
                     <version>2.8</version>
                 </plugin>
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>license-maven-plugin</artifactId>
+                    <version>2.0.0</version>
+                </plugin>
             </plugins>
         </pluginManagement>
         <plugins>

--- a/release-prepare/pom.xml
+++ b/release-prepare/pom.xml
@@ -35,6 +35,21 @@
         <defaultGoal>package</defaultGoal>
         <plugins>
             <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>license-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>download-licenses</id>
+                        <goals>
+                            <goal>download-licenses</goal>
+                        </goals>
+                        <configuration>
+                            <licensesOutputDirectory>${vassal.jarlocation}/licenses</licensesOutputDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <artifactId>maven-dependency-plugin</artifactId>
                 <executions>
                     <execution>


### PR DESCRIPTION
```
zorro@xorro:~/dev/vassal$ ll release-prepare/target/lib/licenses/
total 208K
drwxrwxr-x 2 zorro zorro 4,0K Sep 24 01:13  ./
drwxrwxr-x 3 zorro zorro 4,0K Sep 24 01:13  ../
-rw-rw-r-- 1 zorro zorro  12K Sep 24 01:13 'apache license, version 2.0 - license-2.0.txt'
-rw-rw-r-- 1 zorro zorro  31K Sep 24 01:13 'bsd - bsd.license.html'
-rw-rw-r-- 1 zorro zorro  13K Sep 24 01:13 'eclipse public license - v 1.0 - epl-v10.html'
-rw-rw-r-- 1 zorro zorro  22K Sep 24 01:13 'gnu lesser general public license - lesser.html'
-rw-rw-r-- 1 zorro zorro  39K Sep 24 01:13 'gnu lesser general public license - lgpl-2.1.html'
-rw-rw-r-- 1 zorro zorro  39K Sep 24 01:13 'gnu lesser general public license, version 2.1 - lgpl-2.1.html'
-rw-rw-r-- 1 zorro zorro  31K Sep 24 01:13 'mit license - mit-license.html'
-rw-rw-r-- 1 zorro zorro 1,6K Sep 24 01:13 'new bsd license - license.txt'
```