### PR TITLE
3.5 - Allow full-translated strings into TranslatedStringEnum/TranslatingStringEnumConfigurer family as CTOR option

### DIFF
--- a/vassal-app/src/main/java/VASSAL/configure/AutoConfigurer.java
+++ b/vassal-app/src/main/java/VASSAL/configure/AutoConfigurer.java
@@ -59,12 +59,9 @@ public class AutoConfigurer extends Configurer
 
     target = c;
     setValue(target);
-    target.addPropertyChangeListener(new PropertyChangeListener() {
-      @Override
-      public void propertyChange(final PropertyChangeEvent evt) {
-        if (Configurable.NAME_PROPERTY.equals(evt.getPropertyName())) {
-          setName((String) evt.getNewValue());
-        }
+    target.addPropertyChangeListener(evt -> {
+      if (Configurable.NAME_PROPERTY.equals(evt.getPropertyName())) {
+        setName((String) evt.getNewValue());
       }
     });
 
@@ -153,6 +150,7 @@ public class AutoConfigurer extends Configurer
         final String[] validValues = se.getValidValues(target);
         final String[] i18nKeys = se.getI18nKeys(target);
         config = new TranslatingStringEnumConfigurer(key, prompt, validValues, i18nKeys);
+        ((TranslatingStringEnumConfigurer)config).setDisplayNames(se.isDisplayNames());
       }
     }
     else if (StringEnum.class.isAssignableFrom(type)) {
@@ -243,7 +241,7 @@ public class AutoConfigurer extends Configurer
           }
         }
       }
-      // Only repack the configurer if an item visiblity has changed.
+      // Only repack the configurer if an item visibility has changed.
       if (visChanged && p.getTopLevelAncestor() instanceof Window) {
         ((Window) p.getTopLevelAncestor()).pack();
       }

--- a/vassal-app/src/main/java/VASSAL/configure/AutoConfigurer.java
+++ b/vassal-app/src/main/java/VASSAL/configure/AutoConfigurer.java
@@ -149,8 +149,7 @@ public class AutoConfigurer extends Configurer
       if (se != null) {
         final String[] validValues = se.getValidValues(target);
         final String[] i18nKeys = se.getI18nKeys(target);
-        config = new TranslatingStringEnumConfigurer(key, prompt, validValues, i18nKeys);
-        ((TranslatingStringEnumConfigurer)config).setDisplayNames(se.isDisplayNames());
+        config = new TranslatingStringEnumConfigurer(key, prompt, validValues, i18nKeys, se.isDisplayNames());
       }
     }
     else if (StringEnum.class.isAssignableFrom(type)) {

--- a/vassal-app/src/main/java/VASSAL/configure/TranslatableStringEnum.java
+++ b/vassal-app/src/main/java/VASSAL/configure/TranslatableStringEnum.java
@@ -27,4 +27,11 @@ public abstract class TranslatableStringEnum extends StringEnum {
     super();
   }
   public abstract String[] getI18nKeys(AutoConfigurable target);
+
+  /**
+   * @return true if names have already been translated; false means keys will be passed to Resources.getString()
+   */
+  public boolean isDisplayNames() {
+    return false;
+  }
 }

--- a/vassal-app/src/main/java/VASSAL/configure/TranslatingStringEnumConfigurer.java
+++ b/vassal-app/src/main/java/VASSAL/configure/TranslatingStringEnumConfigurer.java
@@ -58,11 +58,43 @@ public class TranslatingStringEnumConfigurer extends Configurer {
    *
    * @param key Configurer Key
    * @param name Configurer Name
+   * @param validValues Array of values to maintain
+   * @param i18nKeys Array of Translation Keys used to describe the list of values
+   * @param isDisplayNames True if we have already been given full translated strings; false if they are "keys" for Resources.getString()
+   */
+  public TranslatingStringEnumConfigurer(String key, String name, String[] validValues, String[] i18nKeys, boolean isDisplayNames) {
+    super(key, name, validValues);
+    this.validValues = validValues;
+    this.i18nKeys = i18nKeys;
+    this.isDisplayNames = isDisplayNames;
+  }
+
+
+  /**
+   * Create a drop-list of localised display values that allows you to select a value from an
+   * underlying list of 'internal' untranslated values.
+   *
+   * @param key Configurer Key
+   * @param name Configurer Name
    * @param validValues List of values to maintain
    * @param i18nKeys List of Translation Keys used to describe the list of values
    */
   public TranslatingStringEnumConfigurer(String key, String name, List<String> validValues, List<String> i18nKeys) {
     this (key, name, validValues.toArray(new String[0]), i18nKeys.toArray(new String[0]));
+  }
+
+  /**
+   * Create a drop-list of localised display values that allows you to select a value from an
+   * underlying list of 'internal' untranslated values.
+   *
+   * @param key Configurer Key
+   * @param name Configurer Name
+   * @param validValues List of values to maintain
+   * @param i18nKeys List of Translation Keys used to describe the list of values
+   * @param isDisplayNames True if we have already been given full translated strings; false if they are "keys" for Resources.getString()
+   */
+  public TranslatingStringEnumConfigurer(String key, String name, List<String> validValues, List<String> i18nKeys, boolean isDisplayNames) {
+    this (key, name, validValues.toArray(new String[0]), i18nKeys.toArray(new String[0]), isDisplayNames);
   }
 
   /**
@@ -86,12 +118,44 @@ public class TranslatingStringEnumConfigurer extends Configurer {
    *
    * @param key Configurer Key
    * @param name Configurer Name
+   * @param validValues Array of values to maintain
+   * @param i18nKeys Array of Translation Keys used to describe the list of values
+   * @param initialValue Initial Value to set in the Configurer.
+   * @param isDisplayNames True if we have already been given full translated strings; false if they are "keys" for Resources.getString()
+   */
+  public TranslatingStringEnumConfigurer(String key, String name, String[] validValues, String[] i18nKeys, String initialValue, boolean isDisplayNames) {
+    this (key, name, validValues, i18nKeys, isDisplayNames);
+    setValue(initialValue);
+  }
+
+  /**
+   * Create a drop-list of localised display values that allows you to select a value from an
+   * underlying list of 'internal' untranslated values.
+   *
+   * @param key Configurer Key
+   * @param name Configurer Name
    * @param validValues List of values to maintain
    * @param i18nKeys List of Translation Keys used to describe the list of values
    * @param initialValue Initial Value to set in the Configurer.
    */
   public TranslatingStringEnumConfigurer(String key, String name, List<String> validValues, List<String> i18nKeys, String initialValue) {
     this (key, name, validValues, i18nKeys);
+    setValue(initialValue);
+  }
+
+  /**
+   * Create a drop-list of localised display values that allows you to select a value from an
+   * underlying list of 'internal' untranslated values.
+   *
+   * @param key Configurer Key
+   * @param name Configurer Name
+   * @param validValues List of values to maintain
+   * @param i18nKeys List of Translation Keys used to describe the list of values
+   * @param initialValue Initial Value to set in the Configurer.
+   * @param isDisplayNames True if we have already been given full translated strings; false if they are "keys" for Resources.getString()
+   */
+  public TranslatingStringEnumConfigurer(String key, String name, List<String> validValues, List<String> i18nKeys, String initialValue, boolean isDisplayNames) {
+    this (key, name, validValues, i18nKeys, isDisplayNames);
     setValue(initialValue);
   }
 

--- a/vassal-app/src/main/java/VASSAL/configure/TranslatingStringEnumConfigurer.java
+++ b/vassal-app/src/main/java/VASSAL/configure/TranslatingStringEnumConfigurer.java
@@ -50,6 +50,7 @@ public class TranslatingStringEnumConfigurer extends Configurer {
     super(key, name, validValues);
     this.validValues = validValues;
     this.i18nKeys = i18nKeys;
+    this.isDisplayNames = false;
   }
 
   /**

--- a/vassal-app/src/main/java/VASSAL/configure/TranslatingStringEnumConfigurer.java
+++ b/vassal-app/src/main/java/VASSAL/configure/TranslatingStringEnumConfigurer.java
@@ -35,6 +35,7 @@ public class TranslatingStringEnumConfigurer extends Configurer {
   private final String[] i18nKeys;
   private JComboBox<String> box;
   private Box panel;
+  private boolean isDisplayNames;
 
   /**
    * Create a drop-list of localised display values that allows you to select a value from an
@@ -95,6 +96,20 @@ public class TranslatingStringEnumConfigurer extends Configurer {
   }
 
   /**
+   * @return true if our "keys" are actually already translated strings; false if they are really keys
+   */
+  public boolean isDisplayNames() {
+    return isDisplayNames;
+  }
+
+  /**
+   * @param isDisplayNames true if our "keys" are actually already translated strings; false if they are really keys
+   */
+  public void setDisplayNames(boolean isDisplayNames) {
+    this.isDisplayNames = isDisplayNames;
+  }
+
+  /**
    * Get the Controls that make up this Configurer
    * @return A swing Component that holds all of the Configurer controls
    */
@@ -105,7 +120,7 @@ public class TranslatingStringEnumConfigurer extends Configurer {
       // Translate the keys based on the current locale
       final String[] displayValues = new String[i18nKeys.length];
       for (int i = 0; i < i18nKeys.length; i++) {
-        displayValues[i] = Resources.getString(i18nKeys[i]);
+        displayValues[i] = isDisplayNames() ? i18nKeys[i] : Resources.getString(i18nKeys[i]);
       }
 
       panel = Box.createHorizontalBox();


### PR DESCRIPTION
Default is still to pass "keys". Adding extra constructor boolean parameter allows telling it we are sending pre-translated strings so it shouldn't run Resources.get() again on them.

This should give us the flexibility to navigate past situations where translated strings are available but "keys" are not.