### PR TITLE
3.4.4-13458-Allow floats to be compared in Beanshell. (Regression). 

### DIFF
--- a/vassal-app/src/main/java/VASSAL/script/ExpressionInterpreter.java
+++ b/vassal-app/src/main/java/VASSAL/script/ExpressionInterpreter.java
@@ -276,8 +276,7 @@ public class ExpressionInterpreter extends AbstractInterpreter implements Loopab
         else if (BeanShell.FALSE.equals(value)) {
           setVar(var, false);
         }
-        // Do not attempt to convert int or float Numeric Literals, return them as Strings.
-        else if (StringUtils.containsAny(value, "dDfFlL")) { // NON-NLS
+        else if (! StringUtils.containsOnly(value, "+-.0123456789")) { // NON-NLS
           setVar(var, value);
         }
         else {

--- a/vassal-app/src/main/java/VASSAL/script/ExpressionInterpreter.java
+++ b/vassal-app/src/main/java/VASSAL/script/ExpressionInterpreter.java
@@ -40,6 +40,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -275,12 +276,22 @@ public class ExpressionInterpreter extends AbstractInterpreter implements Loopab
         else if (BeanShell.FALSE.equals(value)) {
           setVar(var, false);
         }
+        // Do not attempt to convert int or float Numeric Literals, return them as Strings.
+        else if (StringUtils.containsAny(value, "dDfFlL")) { // NON-NLS
+          setVar(var, value);
+        }
         else {
           try {
             setVar(var, Integer.parseInt(value));
           }
-          catch (NumberFormatException e) {
-            setVar(var, value);
+          catch (NumberFormatException ex1) {
+
+            try {
+              setVar(var, Float.parseFloat(value));
+            }
+            catch (NumberFormatException ex2) {
+              setVar(var, value);
+            }
           }
         }
       }

--- a/vassal-app/src/test/java/VASSAL/script/expression/PropertyMatchExpressionTest.java
+++ b/vassal-app/src/test/java/VASSAL/script/expression/PropertyMatchExpressionTest.java
@@ -62,4 +62,32 @@ public class PropertyMatchExpressionTest {
     e = new PropertyMatchExpression(TEST2_EXPR);
     assertThat(e.isDynamic(), is(true));
   }
+
+  /*
+   * Bug 13458 Regression test
+   * Check boolean int and float values are correctly converted to types in expressions
+   */
+  @Test
+  public void test_type_conversion() throws ExpressionException {
+    BasicPiece bp = new BasicPiece();
+    bp.setProperty("boolProp", "true");
+    bp.setProperty("intProp", "42");
+    bp.setProperty("floatProp", ".75");
+
+
+    // Check boolean conversion
+    Expression e = Expression.createExpression("{boolProp}");
+    assertThat("Auto convert boolean string to boolean type", e.evaluate(bp), is(equalTo("true")));
+    e = Expression.createExpression("{boolProp==true}");
+    assertThat("Auto convert boolean string to boolean type", e.evaluate(bp), is(equalTo("true")));
+
+    // Check Int conversion
+    e = Expression.createExpression("{intProp==42}");
+    assertThat("Auto convert int string to int type", e.evaluate(bp), is(equalTo("true")));
+
+    // Check Float conversion
+    e = Expression.createExpression("{floatProp==.75}");
+    assertThat("Auto convert float string to float type", e.evaluate(bp), is(equalTo("true")));
+
+  }
 }


### PR DESCRIPTION
Caused by overly aggressive fix for bug 13381.
Replace Float conversion but check for and exclude numeric literals first.
Added Regression test.