### PR TITLE
3.5 - 13495 - loading saved game from wizard remembers default name appropriately

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/module/WizardSupport.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/WizardSupport.java
@@ -653,6 +653,7 @@ public class WizardSupport {
                 new SavedGameLoader(controller, settings, new BufferedInputStream(new FileInputStream(f)), POST_LOAD_GAME_WIZARD) {
                   @Override
                   public void run() {
+                    GameModule.getGameModule().getFileChooser().setSelectedFile(f); //BR// When loading a saved game from Wizard, put it appropriately into the "default" for the next save/load/etc.
                     super.run();
                     processing.remove(f);
                   }


### PR DESCRIPTION
Fixes the following issue:

When a saved game is loaded "normally" (through the file menu), the most recent filename loaded is remembered as the default for the next save/load operation.

However when the initial file is loaded via the Wizard, this information is lost and so attempting to save the game leaves you with no "default" and possibly not even in the right directory.