### PR TITLE
13467, 13469: HTML img elements refering to images in module hold it open

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/module/Chatter.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/Chatter.java
@@ -102,7 +102,6 @@ public class Chatter extends JPanel implements CommandEncoder, Buildable {
     //BR// Conversation is now a JTextPane w/ HTMLEditorKit to process HTML, which gives us HTML support "for free".
     conversationPane = new JTextPane();
     conversationPane.setContentType("text/html"); //NON-NLS
-//    kit = (HTMLEditorKit) conversationPane.getEditorKit();
     kit = new DataArchiveHTMLEditorKit(GameModule.getGameModule().getDataArchive());
     conversationPane.setEditorKit(kit);
 

--- a/vassal-app/src/main/java/VASSAL/build/widget/HtmlChart.java
+++ b/vassal-app/src/main/java/VASSAL/build/widget/HtmlChart.java
@@ -54,10 +54,11 @@ import VASSAL.tools.DataArchive;
 import VASSAL.tools.ErrorDialog;
 import VASSAL.tools.ReadErrorDialog;
 import VASSAL.tools.ScrollPane;
+import VASSAL.tools.io.IOUtils;
 import VASSAL.tools.imageop.Op;
 import VASSAL.tools.imageop.OpIcon;
 import VASSAL.tools.imageop.SourceOp;
-import VASSAL.tools.io.IOUtils;
+import VASSAL.tools.swing.DataArchiveHTMLEditorKit;
 
 /**
  * An HtmlChart is used for displaying html information for the module. The
@@ -113,15 +114,14 @@ public class HtmlChart extends Widget implements MouseListener {
   // playing a module, but is unacceptable for editors; they can only save
   // their work to a new file. Therefore, we read the entire file instead
   // of simply using:
-  //    GameModule.getGameModule().getDataArchive().getURL( fileName );
+  //    GameModule.getGameModule().getDataArchive().getURL(fileName);
   @Override
   public Component getComponent() {
     if (htmlWin == null) {
       htmlWin = new JEditorPane();
       htmlWin.setEditable(false);
       htmlWin.setContentType("text/html");
-      XTMLEditorKit myHTMLEditorKit = new XTMLEditorKit();
-      htmlWin.setEditorKit(myHTMLEditorKit);
+      htmlWin.setEditorKit(new DataArchiveHTMLEditorKit(GameModule.getGameModule().getDataArchive()));
 
       htmlWin.addHyperlinkListener(new HtmlChartHyperlinkListener());
       htmlWin.addMouseListener(this);
@@ -299,7 +299,10 @@ public class HtmlChart extends Widget implements MouseListener {
    * The image is placed on a label and returned as a ComponentView. An
    * ImageView cannot be used as the standard Java HTML Renderer can only
    * display Images from an external URL.
+   *
+   * @deprecated Use {@link VASSAL.tools.swing.DataArchiveHTMLEditorKit} instead.
    */
+  @Deprecated(since = "2020-10-10", forRemoval = true)
   public static class XTMLEditorKit extends HTMLEditorKit {
     private static final long serialVersionUID = 1L;
 

--- a/vassal-app/src/main/java/VASSAL/tools/swing/DataArchiveHTMLEditorKit.java
+++ b/vassal-app/src/main/java/VASSAL/tools/swing/DataArchiveHTMLEditorKit.java
@@ -1,0 +1,91 @@
+package VASSAL.tools.swing;
+
+import java.net.URL;
+import java.io.File;
+import java.io.InputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import javax.swing.text.AttributeSet;
+import javax.swing.text.Element;
+import javax.swing.text.StyleConstants;
+import javax.swing.text.View;
+import javax.swing.text.ViewFactory;
+import javax.swing.text.html.HTML;
+import javax.swing.text.html.HTMLEditorKit;
+import javax.swing.text.html.ImageView;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import VASSAL.Info;
+import VASSAL.tools.DataArchive;
+
+/**
+ * Extended HTML Editor kit to let the <src> tag display images from the
+ * module DataArchive where no pathname is included in the image name.
+ */
+public class DataArchiveHTMLEditorKit extends HTMLEditorKit {
+  private static final long serialVersionUID = 1L;
+
+  private static final Logger logger = LoggerFactory.getLogger(DataArchiveHTMLEditorKit.class);
+
+  private final DataArchive arch;
+
+  public DataArchiveHTMLEditorKit(DataArchive arch) {
+    this.arch = arch;
+  }
+
+  @Override
+  public ViewFactory getViewFactory() {
+    return new DataArchiveHTMLFactory();
+  }
+
+  private class DataArchiveImageView extends ImageView {
+    public DataArchiveImageView(Element e) {
+      super(e);
+    }
+
+    @Override
+    public URL getImageURL() {
+      final String src = (String) getElement().getAttributes().getAttribute(HTML.Attribute.SRC);
+
+      URL url = null;
+      Path out = Info.getTempDir().toPath().resolve(src);
+
+      try {
+        if (!Files.exists(out)) {
+          try (InputStream in = arch.getInputStream("images/" + src)) {
+            Files.copy(in, out);
+          }
+          out.toFile().deleteOnExit();
+        }
+
+        url = out.toUri().toURL();
+      }
+      catch (IOException e) {
+        logger.error("Failed to load {}", src, e);
+      }
+
+      return url;
+    }
+  }
+
+  private class DataArchiveHTMLFactory extends HTMLFactory {
+    @Override
+    public View create(Element e) {
+      final AttributeSet attrs = e.getAttributes();
+      final HTML.Tag kind = (HTML.Tag) (attrs.getAttribute(StyleConstants.NameAttribute));
+
+      if (kind == HTML.Tag.IMG) {
+        final String file = (String) attrs.getAttribute(HTML.Attribute.SRC);
+        if (!file.isBlank() && !file.contains("/")) {
+          return new DataArchiveImageView(e);
+        }
+      }
+
+      return super.create(e);
+    }
+  }
+}

--- a/vassal-app/src/main/java/VASSAL/tools/swing/HTMLWindowHelper.java
+++ b/vassal-app/src/main/java/VASSAL/tools/swing/HTMLWindowHelper.java
@@ -31,9 +31,10 @@ import javax.swing.JLabel;
 import javax.swing.event.HyperlinkEvent;
 import javax.swing.event.HyperlinkListener;
 
-import VASSAL.build.widget.HtmlChart;
+import VASSAL.build.GameModule;
 import VASSAL.tools.ReadErrorDialog;
 import VASSAL.tools.ScrollPane;
+import VASSAL.tools.swing.DataArchiveHTMLEditorKit;
 
 public class HTMLWindowHelper implements HyperlinkListener {
   private JEditorPane pane = new JEditorPane();
@@ -46,7 +47,7 @@ public class HTMLWindowHelper implements HyperlinkListener {
      * Allow <src> tag to display images from the module DataArchive
      * where no pathname included in the image name.
      */
-    pane.setEditorKit(new HtmlChart.XTMLEditorKit());
+    pane.setEditorKit(new DataArchiveHTMLEditorKit(GameModule.getGameModule().getDataArchive()));
     pane.addHyperlinkListener(this);
   }
 


### PR DESCRIPTION
Our old HTMLEditorKit replacement doesn't handle attributes properly; the JDK's HTMLEditorKit holds open the module file with no way to close it properly. This fixes both.