### PR TITLE
3.4.6 - 12576 and 13456 - setup stack grid locations for 'any' board stacks

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/module/map/SetupStack.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/SetupStack.java
@@ -112,7 +112,6 @@ import VASSAL.tools.swing.SwingUtils;
  * This is the "At-Start Stack" component, which initializes a Map or Board with a specified stack.
  * Because it uses a regular stack, this component is better suited for limited-force-pool collections
  * of counters than a {@link DrawPile}
- *
  */
 public class SetupStack extends AbstractConfigurable implements GameComponent, UniqueIdManager.Identifyable {
   private static UniqueIdManager idMgr = new UniqueIdManager("SetupStack");
@@ -168,7 +167,7 @@ public class SetupStack extends AbstractConfigurable implements GameComponent, U
       return super.getAttributeVisibility(name);
   }
 
-  // must have a useable board with a grid
+  // must have a usable board with a grid
   protected boolean isUseGridLocation() {
     if (!useGridLocation) {
       return false;
@@ -181,7 +180,7 @@ public class SetupStack extends AbstractConfigurable implements GameComponent, U
   protected void updatePosition() {
     if (isUseGridLocation() && location != null && !location.equals("")) {
       try {
-        pos = getConfigureBoard().getGrid().getLocation(location);
+        pos = getConfigureBoard(true).getGrid().getLocation(location);
       }
       catch (BadCoords e) {
         ErrorDialog.dataWarning(new BadDataReport(this, "Error.setup_stack_position_error", location, e));
@@ -556,11 +555,12 @@ public class SetupStack extends AbstractConfigurable implements GameComponent, U
     return i.hasNext() ? i.next() : null;
   }
 
+
   /*
    * Return a board to configure the stack on.
+   * @param checkSelectedBoards If true, prefer a board the player has actually selected from the menu over simply the top one in the list.
    */
-  protected Board getConfigureBoard() {
-
+  protected Board getConfigureBoard(boolean checkSelectedBoards) {
     Board board = null;
 
     if (map != null && !OwningBoardPrompt.ANY.equals(owningBoardName)) {
@@ -568,14 +568,35 @@ public class SetupStack extends AbstractConfigurable implements GameComponent, U
     }
 
     if (board == null && map != null) {
-      String[] allBoards = map.getBoardPicker().getAllowableBoardNames();
-      if (allBoards.length > 0) {
-        board = map.getBoardPicker().getBoard(allBoards[0]);
+      //BR// If we're doing the start-of-game setup (as opposed to just configuring it), prefer a "selected" board to the first one in the list.
+      if (checkSelectedBoards) {
+        List<String> selectedBoards = map.getBoardPicker().getSelectedBoardNames();
+        for (String s : selectedBoards) {
+          board = map.getBoardByName(s);
+          if (board != null) {
+            break;
+          }
+        }
+      }
+      if (board == null) {
+        String[] allBoards = map.getBoardPicker().getAllowableBoardNames();
+        if (allBoards.length > 0) {
+          board = map.getBoardPicker().getBoard(allBoards[0]);
+        }
       }
     }
 
     return board;
   }
+
+
+  /*
+   * Return a board to configure the stack on.
+   */
+  protected Board getConfigureBoard() {
+    return getConfigureBoard(false);
+  }
+
 
   protected static final Dimension DEFAULT_SIZE = new Dimension(800, 600);
   protected static final int DELTA = 1;


### PR DESCRIPTION
I'm not sure what, if anything, the old attempted fix for this accomplished (perhaps something...) but in any event it did not touch the issue for stacks assigned a Grid Location on an "<any>" owning board at all. It was still setting the final position based on the "top board in the list" rather than based on the board picked by the player.

This PR hopefully fixes that -- I mean, it DOES "apparently fix" it for me, but please check the code carefully.

The earlier stuff in 'setAttribute()' **doesn't actually run** during the "start new game" sequence when a player picks a board -- it has already run during the load of the module in the first place. So that whole set of code kind of scares me but in any event I didn't have to interact with it to fix this.