### PR TITLE
3.4.6 - 13505 - Deck band select fix

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/module/map/KeyBufferer.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/KeyBufferer.java
@@ -104,16 +104,22 @@ public class KeyBufferer extends MouseAdapter implements Buildable, MouseMotionL
 
     final KeyBuffer kbuf = KeyBuffer.getBuffer();
 
-    GamePiece p = map.findPiece(e.getPoint(), PieceFinder.PIECE_IN_STACK);
+    GamePiece p = map.findPiece(e.getPoint(), PieceFinder.DECK_OR_PIECE_IN_STACK);
     // Don't clear the buffer until we find the clicked-on piece
     // Because selecting a piece affects its visibility
     EventFilter filter = null;
     BandSelectType bandSelect = BandSelectType.NONE;
+    Boolean isDeck = (p != null) && (p instanceof Deck);
     if (p != null) {
-      filter = (EventFilter) p.getProperty(Properties.SELECT_EVENT_FILTER);
-      if (SwingUtils.isMainMouseButtonDown(e) && Boolean.TRUE.equals(p.getProperty(Properties.NON_MOVABLE))) {
-        // Don't "eat" band-selects if unit found is non-movable
-        bandSelect = BandSelectType.SPECIAL;
+      if (isDeck) {
+        p = null;
+      }
+      else {
+        filter = (EventFilter) p.getProperty(Properties.SELECT_EVENT_FILTER);
+        if (SwingUtils.isMainMouseButtonDown(e) && Boolean.TRUE.equals(p.getProperty(Properties.NON_MOVABLE))) {
+          // Don't "eat" band-selects if unit found is non-movable
+          bandSelect = BandSelectType.SPECIAL;
+        }
       }
     }
 
@@ -175,12 +181,14 @@ public class KeyBufferer extends MouseAdapter implements Buildable, MouseMotionL
           bandSelectPiece = p;
         }
       }
-      anchor = map.mapToComponent(e.getPoint());
-      selection = new Rectangle(anchor.x, anchor.y, 0, 0);
-      if (map.getHighlighter() instanceof ColoredBorder) {
-        ColoredBorder b = (ColoredBorder) map.getHighlighter();
-        color = b.getColor();
-        thickness = b.getThickness();
+      if (!isDeck) { //BR// If started on a deck, don't do a band select
+        anchor = map.mapToComponent(e.getPoint());
+        selection = new Rectangle(anchor.x, anchor.y, 0, 0);
+        if (map.getHighlighter() instanceof ColoredBorder) {
+          ColoredBorder b = (ColoredBorder) map.getHighlighter();
+          color = b.getColor();
+          thickness = b.getThickness();
+        }
       }
     }
   }

--- a/vassal-app/src/main/java/VASSAL/build/module/map/KeyBufferer.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/KeyBufferer.java
@@ -109,7 +109,7 @@ public class KeyBufferer extends MouseAdapter implements Buildable, MouseMotionL
     // Because selecting a piece affects its visibility
     EventFilter filter = null;
     BandSelectType bandSelect = BandSelectType.NONE;
-    Boolean isDeck = (p != null) && (p instanceof Deck);
+    boolean isDeck = (p != null) && (p instanceof Deck);
     if (p != null) {
       if (isDeck) {
         p = null;

--- a/vassal-app/src/main/java/VASSAL/counters/PieceFinder.java
+++ b/vassal-app/src/main/java/VASSAL/counters/PieceFinder.java
@@ -39,6 +39,13 @@ public interface PieceFinder {
    * */
   PieceFinder PIECE_IN_STACK = new PieceInStack();
 
+  /**
+   * If a Stack overlaps the given point, return the piece containing that point if expanded,
+   * or the top piece if not expanded.
+   * If a Deck is found instead, return the deck.
+   */
+  PieceFinder DECK_OR_PIECE_IN_STACK = new DeckOrPieceInStack();
+
   /** Returns a Stack if unexpanded and overlapping the given point,
    * or a piece within that stack if expanded and overlapping the given point
    */
@@ -59,8 +66,16 @@ public interface PieceFinder {
       }
       return selected;
     }
-
   }
+
+
+  public class DeckOrPieceInStack extends PieceInStack {
+    @Override
+    public Object visitDeck(Deck d) {
+      return d;
+    }
+  }
+
 
   public class PieceInStack extends Movable {
     @Override

--- a/vassal-app/src/main/java/VASSAL/counters/PieceFinder.java
+++ b/vassal-app/src/main/java/VASSAL/counters/PieceFinder.java
@@ -72,7 +72,10 @@ public interface PieceFinder {
   public class DeckOrPieceInStack extends PieceInStack {
     @Override
     public Object visitDeck(Deck d) {
-      return d;
+      Shape s = d.getShape();
+      Point pos = d.getPosition();
+      Point p = new Point(pt.x - pos.x, pt.y - pos.y);
+      return (s.contains(p) ? d : null);
     }
   }
 


### PR DESCRIPTION
There has been a thread on the forums (http://www.vassalengine.org/forum/viewtopic.php?f=3&t=11438) where they are complaining about it doing a band-select when you drag things off a deck. 

For some reason this problem seems "worse" on Macs than on PC, but I am able to see at least some of the problem on PC. 

In any event, I this this PR should fix the problem. Doesn't allow band-selects to start on top of a deck.