### PR TITLE
13508: NPE in GamePieceOpImpl.getTileIndices()

### DIFF
--- a/vassal-app/src/main/java/VASSAL/tools/imageop/AbstractTileOpImpl.java
+++ b/vassal-app/src/main/java/VASSAL/tools/imageop/AbstractTileOpImpl.java
@@ -139,7 +139,7 @@ public abstract class AbstractTileOpImpl extends AbstractOpImpl {
   @Override
   public Point[] getTileIndices(Rectangle rect) {
     if (rect == null) throw new IllegalArgumentException();
-    return rect.intersects(new Rectangle(size)) ?
+    return rect.intersects(new Rectangle(getSize())) ?
       new Point[]{new Point(0, 0)} : new Point[0];
   }
 }


### PR DESCRIPTION
Call getSize() to ensure that size is set properly.