### PR TITLE
Bug13539-GameRefresher resets entered Text Labels

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/GpIdChecker.java
+++ b/vassal-app/src/main/java/VASSAL/build/GpIdChecker.java
@@ -19,7 +19,6 @@ package VASSAL.build;
 
 import VASSAL.build.module.Chatter;
 import VASSAL.build.module.PrototypeDefinition;
-import VASSAL.counters.Marker;
 import java.util.ArrayList;
 import java.util.HashMap;
 
@@ -30,6 +29,8 @@ import VASSAL.counters.GamePiece;
 import VASSAL.counters.PieceCloner;
 import VASSAL.counters.PlaceMarker;
 import VASSAL.counters.Properties;
+import VASSAL.counters.Marker;
+import VASSAL.counters.Labeler;
 import VASSAL.i18n.Resources;
 
 /**
@@ -402,6 +403,10 @@ public class GpIdChecker {
             if (d.myGetType().equals(typeToFind)) {
               return d.myGetState();
             }
+            else if (d instanceof Labeler) {
+              return d.myGetState();
+            }
+
           }
           p = d.getInner();
         }


### PR DESCRIPTION
Bug13539-GameRefresher resets entered Text Labels when trait properties are modified