### PR TITLE
3.5 - Belatedly make GKC's use AbstractToolbarItem now that we've come to a more stable point.

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/AbstractToolbarItem.java
+++ b/vassal-app/src/main/java/VASSAL/build/AbstractToolbarItem.java
@@ -103,6 +103,14 @@ public abstract class AbstractToolbarItem extends AbstractConfigurable {
   }
 
   /**
+   * Sets launch button for this toolbar item
+   * @param launch - launch button
+   */
+  protected void setLaunchButton(LaunchButton launch) {
+    this.launch = launch;
+  }
+
+  /**
    * This getAttributeNames() will return the items specific to the Toolbar Button - classes extending this should
    * add their own items as well. If the "nameKey" is blank, then no "name" configure entry will be generated.
    * Extending classes can use ArrayUtils.addAll(super.getAttributeNames(), key1, ..., keyN), or supply their own

--- a/vassal-app/src/main/java/VASSAL/build/module/map/DeckGlobalKeyCommand.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/DeckGlobalKeyCommand.java
@@ -25,6 +25,7 @@ import java.util.List;
 
 import javax.swing.KeyStroke;
 
+import VASSAL.build.AbstractToolbarItem;
 import VASSAL.configure.GlobalCommandTargetConfigurer;
 import VASSAL.counters.CounterGlobalKeyCommand;
 import VASSAL.counters.GlobalCommandTarget;
@@ -165,7 +166,6 @@ public class DeckGlobalKeyCommand extends MassKeyCommand {
     setAttribute(REPORT_FORMAT, sd.nextToken(""));
     localizedName = sd.nextToken(getConfigureName());
     setAttribute(TARGET, sd.nextToken(""));
-
   }
 
   @Override
@@ -185,7 +185,7 @@ public class DeckGlobalKeyCommand extends MassKeyCommand {
   @Override
   public String[] getAttributeNames() {
     return new String[]{
-      NAME,
+      AbstractToolbarItem.NAME,
       KEY_COMMAND,
 
       TARGET,             // Fast Match parameters (disabled for this variant)

--- a/vassal-app/src/main/java/VASSAL/build/module/map/LOS_Thread.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/LOS_Thread.java
@@ -985,6 +985,7 @@ public class LOS_Thread extends AbstractToolbarItem implements
    */
   @Override
   public void addLocalImageNames(Collection<String> s) {
+    super.addLocalImageNames(s);
     final HTMLImageFinder h = new HTMLImageFinder(reportFormat.getFormat());
     h.addImageNames(s);
   }

--- a/vassal-app/src/main/java/VASSAL/build/module/map/MassKeyCommand.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/MassKeyCommand.java
@@ -19,6 +19,7 @@ package VASSAL.build.module.map;
 
 import VASSAL.build.AbstractToolbarItem;
 import VASSAL.configure.GlobalCommandTargetConfigurer;
+import VASSAL.configure.IconConfigurer;
 import VASSAL.configure.TranslatableStringEnum;
 import VASSAL.configure.TranslatingStringEnumConfigurer;
 import VASSAL.counters.CounterGlobalKeyCommand;
@@ -57,6 +58,7 @@ import VASSAL.counters.PieceFilter;
 import VASSAL.i18n.Resources;
 import VASSAL.i18n.TranslatableConfigurerFactory;
 import VASSAL.tools.FormattedString;
+import VASSAL.tools.LaunchButton;
 import VASSAL.tools.NamedKeyStroke;
 import VASSAL.tools.RecursionLimiter;
 import VASSAL.tools.ToolBarComponent;
@@ -103,6 +105,7 @@ public class MassKeyCommand extends AbstractToolbarItem
   @Deprecated (since = "2020-10-21", forRemoval = true) public static final String ICON = "icon"; // NON-NLS
   @Deprecated (since = "2020-10-21", forRemoval = true) public static final String TOOLTIP = "tooltip"; // NON-NLS
 
+  protected LaunchButton launch;
   protected NamedKeyStroke stroke = new NamedKeyStroke();
   protected String[] names = new String[0];
   protected String condition;
@@ -134,10 +137,15 @@ public class MassKeyCommand extends AbstractToolbarItem
     setButtonTextKey(BUTTON_TEXT);
     setHotKeyKey(HOTKEY);
 
-    makeLaunchButton(Resources.getString("Editor.GlobalKeyCommand.button_name"),
-                     Resources.getString("Editor.GlobalKeyCommand.button_name"),
-              "", //Default art exists, but is a little weird, and wasn't actually being defaulted to before --> "/images/keyCommand.gif", //NON-NLS
-                     al);
+    launch = makeLaunchButton(Resources.getString("Editor.GlobalKeyCommand.button_name"),
+                              Resources.getString("Editor.GlobalKeyCommand.button_name"),
+                      "", //Default art exists, but is a little weird, and wasn't actually being defaulted to before --> "/images/keyCommand.gif", //NON-NLS
+                             al);
+  }
+
+  @Override
+  public LaunchButton getLaunchButton() {
+    return launch;
   }
 
   @Override
@@ -278,6 +286,14 @@ public class MassKeyCommand extends AbstractToolbarItem
         ReportFormatConfig.class,
         Prompt.class
       );
+    }
+  }
+
+  @Deprecated(since = "2020-10-01", forRemoval = true)
+  public static class IconConfig implements ConfigurerFactory {
+    @Override
+    public Configurer getConfigurer(AutoConfigurable c, String key, String name) {
+      return new IconConfigurer(key, name, "/images/keyCommand.gif"); //NON-NLS
     }
   }
 


### PR DESCRIPTION
Earlier during 3.5 process I made AbstractToolbarItem to handle the common case of "Configurables that run from a Toolbar launch button". I left MassKeyCommand out because we had that ginormous GKC project going at the time -- so now that we got that all merged I have come back to clean up this little detail. 
