### PR TITLE
13661 - Zip fix fix fix

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/GameModule.java
+++ b/vassal-app/src/main/java/VASSAL/build/GameModule.java
@@ -30,6 +30,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.NoSuchFileException;
 import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.List;
@@ -500,7 +501,7 @@ public class GameModule extends AbstractConfigurable
         final Document doc = Builder.createDocument(in);
         build(doc.getDocumentElement());
       }
-      catch (FileNotFoundException e) {
+      catch (FileNotFoundException | NoSuchFileException e) {
         throw new IOException(
           Resources.getString("BasicModule.no_buildfile"), //$NON-NLS-1$
           e);

--- a/vassal-app/src/main/java/VASSAL/build/module/Console.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/Console.java
@@ -22,14 +22,15 @@ import VASSAL.build.GameModule;
 import VASSAL.build.module.properties.MutableProperty;
 import VASSAL.command.Logger;
 import VASSAL.tools.BugUtils;
-import org.slf4j.LoggerFactory;
 
 import java.awt.Desktop;
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.Iterator;
 import java.util.regex.Pattern;
+
+import org.slf4j.LoggerFactory;
 
 /**
  * Expandable "Console" to allow entering commands into the Chatter.
@@ -131,7 +132,7 @@ public class Console {
     else if (matches("wipe", option)) { //NON-NLS
       final File errorLog = Info.getErrorLogPath();
       try {
-        new FileOutputStream(errorLog).close();
+        Files.newOutputStream(errorLog.toPath()).close();
         show("Wiped errorlog"); //NON-NLS
       }
       catch (IOException e) {

--- a/vassal-app/src/main/java/VASSAL/build/module/GameState.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/GameState.java
@@ -22,12 +22,12 @@ import java.awt.event.ActionEvent;
 import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -748,8 +748,10 @@ public class GameState implements CommandEncoder {
 
   public void loadGameInBackground(final File f) {
     try {
-      loadGameInBackground(f.getName(),
-                           new BufferedInputStream(new FileInputStream(f)));
+      loadGameInBackground(
+        f.getName(),
+        new BufferedInputStream(Files.newInputStream(f.toPath()))
+      );
     }
     catch (IOException e) {
       ReadErrorDialog.error(e, f);
@@ -890,7 +892,7 @@ public class GameState implements CommandEncoder {
    */
   public Command decodeSavedGame(File saveFile) throws IOException {
     return decodeSavedGame(
-      new BufferedInputStream(new FileInputStream(saveFile)));
+      new BufferedInputStream(Files.newInputStream(saveFile.toPath())));
   }
 
   public Command decodeSavedGame(InputStream in) throws IOException {

--- a/vassal-app/src/main/java/VASSAL/build/module/Inventory.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/Inventory.java
@@ -28,13 +28,12 @@ import java.awt.event.KeyListener;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.awt.geom.AffineTransform;
-import java.io.BufferedWriter;
 import java.io.File;
-import java.io.FileWriter;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.Writer;
 import java.nio.charset.Charset;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -390,8 +389,7 @@ public class Inventory extends AbstractToolbarItem
   //      mapSeparator, System.getProperty("line.separator"));
 
     // Writing out a text file for the user to do whatever with. Use the native encoding.
-    try (Writer fw = new FileWriter(file, Charset.defaultCharset());
-         BufferedWriter bw = new BufferedWriter(fw);
+    try (Writer bw = Files.newBufferedWriter(file.toPath(), Charset.defaultCharset());
          PrintWriter p = new PrintWriter(bw)) {
       p.print(output);
 

--- a/vassal-app/src/main/java/VASSAL/build/module/ModuleExtension.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/ModuleExtension.java
@@ -25,6 +25,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.NoSuchFileException;
 import java.util.UUID;
 
 import javax.swing.AbstractAction;
@@ -143,7 +144,7 @@ public class ModuleExtension extends AbstractBuildable implements GameComponent,
         throw new ExtensionsLoader.LoadExtensionException(e);
       }
     }
-    catch (FileNotFoundException e) {
+    catch (FileNotFoundException | NoSuchFileException e) {
       logger.error("File {} not found in archive", fileName, e); //NON-NLS
     }
     catch (IOException e) {

--- a/vassal-app/src/main/java/VASSAL/build/module/WizardSupport.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/WizardSupport.java
@@ -31,11 +31,11 @@ import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.io.BufferedInputStream;
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
 import java.io.InputStream;
+import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -645,7 +645,7 @@ public class WizardSupport {
               // file
               processing.add(f);
               try {
-                new SavedGameLoader(controller, settings, new BufferedInputStream(new FileInputStream(f)), POST_LOAD_GAME_WIZARD) {
+                new SavedGameLoader(controller, settings, new BufferedInputStream(Files.newInputStream(f.toPath())), POST_LOAD_GAME_WIZARD) {
                   @Override
                   public void run() {
                     GameModule.getGameModule().getFileChooser().setSelectedFile(f); //BR// When loading a saved game from Wizard, put it appropriately into the "default" for the next save/load/etc.

--- a/vassal-app/src/main/java/VASSAL/build/module/documentation/BrowserPDFFile.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/documentation/BrowserPDFFile.java
@@ -36,6 +36,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 
@@ -96,7 +97,7 @@ public class BrowserPDFFile extends AbstractConfigurable {
       url = out.toUri().toURL();
       out.toFile().deleteOnExit();
     }
-    catch (FileNotFoundException e) {
+    catch (FileNotFoundException | NoSuchFileException e) {
       logger.error("File not found in data archive: {}", pdfFile, e); //NON-NLS
       url = null;
     }

--- a/vassal-app/src/main/java/VASSAL/build/module/map/TextSaver.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/TextSaver.java
@@ -18,13 +18,12 @@
 package VASSAL.build.module.map;
 
 import java.awt.event.ActionListener;
-import java.io.BufferedWriter;
 import java.io.File;
-import java.io.FileWriter;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.Writer;
 import java.nio.charset.Charset;
+import java.nio.file.Files;
 
 import javax.swing.JOptionPane;
 
@@ -107,8 +106,7 @@ public class TextSaver extends AbstractToolbarItem {
     final File file =  fc.getSelectedFile();
 
     // Writing out a text file for the user to do whatever with. Use the native encoding.
-    try (Writer fw = new FileWriter(file, Charset.defaultCharset());
-         BufferedWriter bw = new BufferedWriter(fw);
+    try (Writer bw = Files.newBufferedWriter(file.toPath(), Charset.defaultCharset());
          PrintWriter p = new PrintWriter(bw)) {
       for (final GamePiece gp : map.getPieces()) {
         final String s = gp.getName();

--- a/vassal-app/src/main/java/VASSAL/build/module/metadata/AbstractMetaData.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/metadata/AbstractMetaData.java
@@ -22,6 +22,7 @@ import java.io.FileNotFoundException;
 import java.io.InputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.file.NoSuchFileException;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
@@ -237,7 +238,7 @@ public abstract class AbstractMetaData {
          BufferedInputStream in = new BufferedInputStream(inner)) {
       archive.add(ModuleMetaData.ZIP_ENTRY_NAME, in);
     }
-    catch (final FileNotFoundException e) {
+    catch (final FileNotFoundException | NoSuchFileException e) {
       // No Metadata in source module, create a fresh copy
       new ModuleMetaData(GameModule.getGameModule()).save(archive);
     }
@@ -248,7 +249,7 @@ public abstract class AbstractMetaData {
     try (InputStream in = mda.getInputStream(ModuleMetaData.ZIP_ENTRY_NAME)) {
       zw.write(in, ModuleMetaData.ZIP_ENTRY_NAME);
     }
-    catch (final FileNotFoundException e) {
+    catch (final FileNotFoundException | NoSuchFileException e) {
       // No Metadata in source module, create a fresh copy
       new ModuleMetaData(GameModule.getGameModule()).save(zw);
     }

--- a/vassal-app/src/main/java/VASSAL/configure/SavedGameUpdaterDialog.java
+++ b/vassal-app/src/main/java/VASSAL/configure/SavedGameUpdaterDialog.java
@@ -24,13 +24,12 @@ import java.awt.HeadlessException;
 import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
 import java.io.InputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.lang.reflect.InvocationTargetException;
 import java.net.MalformedURLException;
+import java.nio.file.Files;
 import java.util.Properties;
 
 import javax.swing.Box;
@@ -196,7 +195,7 @@ public class SavedGameUpdaterDialog extends JDialog {
       p.put(MODULE_NAME_KEY, GameModule.getGameModule().getGameName());
       p.put(VERSION_KEY, GameModule.getGameModule().getGameVersion());
 
-      try (OutputStream fout = new FileOutputStream(fc.getSelectedFile());
+      try (OutputStream fout = Files.newOutputStream(fc.getSelectedFile().toPath());
            BufferedOutputStream out = new BufferedOutputStream(fout)) {
         p.store(out, null);
       }
@@ -211,7 +210,7 @@ public class SavedGameUpdaterDialog extends JDialog {
     if (JFileChooser.CANCEL_OPTION != fc.showOpenDialog(this)) {
       oldPieceInfo = new Properties();
 
-      try (InputStream fin = new FileInputStream(fc.getSelectedFile());
+      try (InputStream fin = Files.newInputStream(fc.getSelectedFile().toPath());
            BufferedInputStream in = new BufferedInputStream(fin)) {
         oldPieceInfo.load(in);
 

--- a/vassal-app/src/main/java/VASSAL/counters/Deck.java
+++ b/vassal-app/src/main/java/VASSAL/counters/Deck.java
@@ -25,15 +25,11 @@ import java.awt.Point;
 import java.awt.Rectangle;
 import java.awt.Shape;
 import java.awt.event.ActionEvent;
-import java.io.BufferedReader;
-import java.io.BufferedWriter;
 import java.io.File;
-import java.io.FileReader;
-import java.io.FileWriter;
 import java.io.IOException;
-import java.io.Reader;
 import java.io.Writer;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -54,8 +50,6 @@ import javax.swing.JOptionPane;
 import javax.swing.KeyStroke;
 import javax.swing.ListSelectionModel;
 import javax.swing.SwingUtilities;
-
-import org.apache.commons.io.IOUtils;
 
 import VASSAL.build.BadDataReport;
 import VASSAL.build.GameModule;
@@ -1499,10 +1493,9 @@ public class Deck extends Stack implements PlayerRoster.SideChangeListener {
       comm = comm.append(new AddPiece(p));
     }
 
-    try (Writer fw = new FileWriter(f, StandardCharsets.UTF_8);
-         BufferedWriter out = new BufferedWriter(fw)) {
+    try (Writer w = Files.newBufferedWriter(f.toPath(), StandardCharsets.UTF_8)) {
       gameModule.addCommandEncoder(commandEncoder);
-      out.write(gameModule.encode(comm));
+      w.write(gameModule.encode(comm));
       gameModule.removeCommandEncoder(commandEncoder);
     }
   }
@@ -1537,12 +1530,7 @@ public class Deck extends Stack implements PlayerRoster.SideChangeListener {
   }
 
   public Command loadDeck(File f) throws IOException {
-    final String ds;
-
-    try (Reader fr = new FileReader(f, StandardCharsets.UTF_8);
-         BufferedReader in = new BufferedReader(fr)) {
-      ds = IOUtils.toString(in);
-    }
+    final String ds = Files.readString(f.toPath(), StandardCharsets.UTF_8);
 
     gameModule.addCommandEncoder(commandEncoder);
     Command c = gameModule.decode(ds);

--- a/vassal-app/src/main/java/VASSAL/i18n/TranslateVassalWindow.java
+++ b/vassal-app/src/main/java/VASSAL/i18n/TranslateVassalWindow.java
@@ -23,9 +23,9 @@ import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.io.BufferedInputStream;
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
 import java.io.InputStream;
+import java.io.IOException;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Locale;
@@ -195,7 +195,7 @@ public class TranslateVassalWindow extends TranslateWindow {
       localeConfig.setValue(locale);
     }
 
-    try (InputStream fin = new FileInputStream(file);
+    try (InputStream fin = Files.newInputStream(file.toPath());
          BufferedInputStream in = new BufferedInputStream(fin)) {
       ((VassalTranslation) target).loadProperties(in);
     }

--- a/vassal-app/src/main/java/VASSAL/i18n/Translation.java
+++ b/vassal-app/src/main/java/VASSAL/i18n/Translation.java
@@ -22,6 +22,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.FileNotFoundException;
 import java.io.InputStream;
 import java.io.IOException;
+import java.nio.file.NoSuchFileException;
 import java.util.Locale;
 import java.util.Properties;
 
@@ -184,7 +185,7 @@ public class Translation extends AbstractConfigurable
            BufferedInputStream in = new BufferedInputStream(inner)) {
         localProperties.load(in);
       }
-      catch (FileNotFoundException e) {
+      catch (FileNotFoundException | NoSuchFileException e) {
         // ignore, properties have not been saved yet
         dirty = false;
         return;

--- a/vassal-app/src/main/java/VASSAL/i18n/VassalTranslation.java
+++ b/vassal-app/src/main/java/VASSAL/i18n/VassalTranslation.java
@@ -21,10 +21,10 @@ import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
 import java.io.InputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.Locale;
 import java.util.Properties;
@@ -107,7 +107,7 @@ public class VassalTranslation extends Translation {
   }
 
   public void saveProperties(File file, Locale locale) throws IOException {
-    try (OutputStream fout = new FileOutputStream(file);
+    try (OutputStream fout = Files.newOutputStream(file.toPath());
          BufferedOutputStream out = new BufferedOutputStream(fout)) {
       localProperties.store(out, locale.getDisplayName());
       dirty = false;

--- a/vassal-app/src/main/java/VASSAL/preferences/Prefs.java
+++ b/vassal-app/src/main/java/VASSAL/preferences/Prefs.java
@@ -20,8 +20,6 @@ package VASSAL.preferences;
 import java.io.BufferedInputStream;
 import java.io.Closeable;
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.InputStream;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -29,6 +27,8 @@ import java.io.RandomAccessFile;
 import java.nio.channels.Channels;
 import java.nio.channels.FileChannel;
 import java.nio.channels.FileLock;
+import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
@@ -196,12 +196,12 @@ public class Prefs implements Closeable {
   }
 
   protected void read() {
-    try (InputStream fin = new FileInputStream(file);
+    try (InputStream fin = Files.newInputStream(file.toPath());
          InputStream in = new BufferedInputStream(fin)) {
       storedValues.clear();
       storedValues.load(in);
     }
-    catch (FileNotFoundException e) {
+    catch (NoSuchFileException e) {
       // First time for this module, not an error.
     }
     catch (IOException e) {

--- a/vassal-app/src/main/java/VASSAL/preferences/ReadOnlyPrefs.java
+++ b/vassal-app/src/main/java/VASSAL/preferences/ReadOnlyPrefs.java
@@ -20,10 +20,10 @@ package VASSAL.preferences;
 
 import java.io.BufferedInputStream;
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.InputStream;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
 import java.util.Properties;
 
 import VASSAL.Info;
@@ -46,11 +46,11 @@ public class ReadOnlyPrefs {
   }
 
   protected ReadOnlyPrefs(File file) {
-    try (InputStream fin = new FileInputStream(file);
+    try (InputStream fin = Files.newInputStream(file.toPath());
          BufferedInputStream in = new BufferedInputStream(fin)) {
       storedValues.load(in);
     }
-    catch (FileNotFoundException e) {
+    catch (NoSuchFileException e) {
       // First time for this module, not an error.
     }
     catch (IOException e) {

--- a/vassal-app/src/main/java/VASSAL/tools/BugUtils.java
+++ b/vassal-app/src/main/java/VASSAL/tools/BugUtils.java
@@ -1,11 +1,11 @@
 package VASSAL.tools;
 
 import java.io.File;
-import java.io.FileReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.stream.Stream;
 
 import org.apache.commons.io.IOUtils;
@@ -81,19 +81,16 @@ public class BugUtils {
     return summary;
   }
 
-
 // FIXME: move this somewhere else?
   public static String getErrorLog() {
-    String log = null;
     final File f = Info.getErrorLogPath();
-    try (FileReader r = new FileReader(f, Charset.defaultCharset())) {
-      log = IOUtils.toString(r);
+    try {
+      return Files.readString(f.toPath(),  Charset.defaultCharset());
     }
     catch (IOException e) {
       // Don't bother logging this---if we can't read the errorLog,
       // then we probably can't write to it either.
+      return null;
     }
-
-    return log;
   }
 }

--- a/vassal-app/src/main/java/VASSAL/tools/CRCUtils.java
+++ b/vassal-app/src/main/java/VASSAL/tools/CRCUtils.java
@@ -18,9 +18,9 @@
 package VASSAL.tools;
 
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
 import java.util.List;
 import java.util.zip.CRC32;
 
@@ -62,7 +62,7 @@ public class CRCUtils {
    * @throws IOException oops
    */
   private static void buildCRC(File file, CRC32 crc, byte[] buffer) throws IOException {
-    try (InputStream in = new FileInputStream(file)) {
+    try (InputStream in = Files.newInputStream(file.toPath())) {
       buildCRC(in, crc, buffer);
     }
   }

--- a/vassal-app/src/main/java/VASSAL/tools/DataArchive.java
+++ b/vassal-app/src/main/java/VASSAL/tools/DataArchive.java
@@ -26,11 +26,12 @@ import java.awt.image.ImageFilter;
 import java.awt.image.ImageProducer;
 import java.io.Closeable;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
 import java.security.AllPermission;
 import java.security.CodeSource;
 import java.security.PermissionCollection;
@@ -152,12 +153,12 @@ public class DataArchive extends SecureClassLoader implements Closeable {
     try {
       return getInputStream(imageDir + fileName);
     }
-    catch (FileNotFoundException ignored) {
+    catch (FileNotFoundException | NoSuchFileException ignored) {
     }
     try {
       return getInputStream(imageDir + fileName + ".gif"); //NON-NLS
     }
-    catch (FileNotFoundException ignored) {
+    catch (FileNotFoundException | NoSuchFileException ignored) {
     }
 
     final InputStream in =
@@ -247,7 +248,7 @@ public class DataArchive extends SecureClassLoader implements Closeable {
       try {
         return ext.getInputStream(fileName);
       }
-      catch (FileNotFoundException ignored) {
+      catch (FileNotFoundException | NoSuchFileException ignored) {
         // not found in this extension, try the next
       }
     }
@@ -295,7 +296,7 @@ public class DataArchive extends SecureClassLoader implements Closeable {
       try {
         return ext.getURL(fileName);
       }
-      catch (FileNotFoundException e) {
+      catch (FileNotFoundException | NoSuchFileException e) {
         // not found in this extension, try the next
       }
     }
@@ -720,7 +721,7 @@ public class DataArchive extends SecureClassLoader implements Closeable {
         return zip.getInputStream(zip.getEntry(file));
       }
       else {
-        return new FileInputStream(new File(dir, file));
+        return Files.newInputStream(dir.toPath().resolve(file));
       }
     }
     catch (IOException e) {

--- a/vassal-app/src/main/java/VASSAL/tools/HTTPPostBuilder.java
+++ b/vassal-app/src/main/java/VASSAL/tools/HTTPPostBuilder.java
@@ -20,14 +20,14 @@ package VASSAL.tools;
 import java.io.BufferedWriter;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
 import java.io.InputStream;
+import java.io.IOException;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.Random;
 
 /**
@@ -80,7 +80,7 @@ public class HTTPPostBuilder {
    * @throws IOException in case of failure
    */
   public void setParameter(String name, File file) throws IOException {
-    try (FileInputStream in = new FileInputStream(file)) {
+    try (InputStream in = Files.newInputStream(file.toPath())) {
       setParameter(name, file.getPath(), in);
     }
   }

--- a/vassal-app/src/main/java/VASSAL/tools/JarArchive.java
+++ b/vassal-app/src/main/java/VASSAL/tools/JarArchive.java
@@ -21,6 +21,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
+import java.nio.file.NoSuchFileException;
 
 public class JarArchive extends DataArchive {
   protected String prefix;
@@ -43,7 +44,7 @@ public class JarArchive extends DataArchive {
       try {
         return ext.getURL(fileName);
       }
-      catch (FileNotFoundException e) {
+      catch (FileNotFoundException | NoSuchFileException e) {
         // not found in this extension, try the next
       }
     }
@@ -62,7 +63,7 @@ public class JarArchive extends DataArchive {
       try {
         return ext.getInputStream(fileName);
       }
-      catch (FileNotFoundException e) {
+      catch (FileNotFoundException | NoSuchFileException e) {
         // not found in this extension, try the next
       }
     }

--- a/vassal-app/src/main/java/VASSAL/tools/Mp3AudioClip.java
+++ b/vassal-app/src/main/java/VASSAL/tools/Mp3AudioClip.java
@@ -21,6 +21,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
+import java.nio.file.NoSuchFileException;
 
 import javazoom.jl.decoder.JavaLayerException;
 import javazoom.jl.player.Player;
@@ -53,7 +54,7 @@ public class Mp3AudioClip implements AudioClip {
         GameModule.getGameModule().getDataArchive().getInputStream(name) :
         url.openStream();
     }
-    catch (FileNotFoundException e) {
+    catch (FileNotFoundException | NoSuchFileException e) {
       ErrorDialog.dataWarning(new BadDataReport(
         Resources.getString(
           "Error.not_found", name != null ? name : url.toString()

--- a/vassal-app/src/main/java/VASSAL/tools/ReadErrorDialog.java
+++ b/vassal-app/src/main/java/VASSAL/tools/ReadErrorDialog.java
@@ -21,6 +21,7 @@ package VASSAL.tools;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.nio.file.NoSuchFileException;
 
 /**
  * Utility class for reporting an IOException reading from the local system or a resource bundled with the VASSAL engine
@@ -36,7 +37,8 @@ public class ReadErrorDialog {
    * @param filename the file which was being read
    */
   public static void error(Throwable t, IOException e, String filename) {
-    if (e instanceof FileNotFoundException) {
+    if (e instanceof FileNotFoundException ||
+        e instanceof NoSuchFileException) {
       // file is missing
       WarningDialog.showDisableable(
         t,

--- a/vassal-app/src/main/java/VASSAL/tools/ZipUpdater.java
+++ b/vassal-app/src/main/java/VASSAL/tools/ZipUpdater.java
@@ -23,12 +23,12 @@ import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.Properties;
 import java.util.jar.JarOutputStream;
 import java.util.zip.CRC32;
@@ -147,7 +147,7 @@ public class ZipUpdater implements Runnable {
       oldZipFile = ozf;
 
       final ZipOutputStream output =
-        new ZipOutputStream(new FileOutputStream(tempFile));
+        new ZipOutputStream(Files.newOutputStream(tempFile.toPath()));
       try {
         for (final String entryName : checkSums.stringPropertyNames()) {
           final long targetSum;
@@ -225,7 +225,7 @@ public class ZipUpdater implements Runnable {
       final String inputArchiveName = oldFile.getName();
 
       try (ZipFile goal = new ZipFile(newFile)) {
-        try (OutputStream fout = new FileOutputStream(updaterFile);
+        try (OutputStream fout = Files.newOutputStream(updaterFile.toPath());
              OutputStream bout = new BufferedOutputStream(fout);
              JarOutputStream out = new JarOutputStream(bout)) {
           for (final ZipEntry entry : IteratorUtils.iterate(goal.entries().asIterator())) {

--- a/vassal-app/src/main/java/VASSAL/tools/image/FileImageTypeConverter.java
+++ b/vassal-app/src/main/java/VASSAL/tools/image/FileImageTypeConverter.java
@@ -22,12 +22,11 @@ import java.awt.image.BufferedImage;
 import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
 import java.io.InputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
+import java.nio.file.Files;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
 
@@ -96,7 +95,7 @@ public class FileImageTypeConverter implements ImageTypeConverter {
 
     try {
       // write the converted image data to a file
-      try (OutputStream fout = new FileOutputStream(tmp);
+      try (OutputStream fout = Files.newOutputStream(tmp.toPath());
            OutputStream gzout = new GZIPOutputStream(fout);
            OutputStream out = new BufferedOutputStream(gzout)) {
         write(src, out);
@@ -114,7 +113,7 @@ public class FileImageTypeConverter implements ImageTypeConverter {
       final BufferedImage dst = new BufferedImage(w, h, type);
 
       // read the converted image data back
-      try (InputStream fin = new FileInputStream(tmp);
+      try (InputStream fin = Files.newInputStream(tmp.toPath());
            InputStream gzin = new GZIPInputStream(fin);
            InputStream in = new BufferedInputStream(gzin)) {
         read(in, dst);

--- a/vassal-app/src/main/java/VASSAL/tools/image/JPEGDecoder.java
+++ b/vassal-app/src/main/java/VASSAL/tools/image/JPEGDecoder.java
@@ -19,9 +19,10 @@
 package VASSAL.tools.image;
 
 import java.io.DataInputStream;
-import java.io.FileInputStream;
 import java.io.InputStream;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
 /**
  * A (partial) JPEG decoder.
@@ -106,7 +107,7 @@ class JPEGDecoder {
   }
 
   public static void main(String[] args) throws IOException {
-    try (InputStream fin = new FileInputStream(args[0]);
+    try (InputStream fin = Files.newInputStream(Path.of(args[0]));
          DataInputStream in = new DataInputStream(fin)) {
       if (!JPEGDecoder.decodeSignature(in)) {
         System.out.println("Not a JPEG"); //NON-NLS

--- a/vassal-app/src/main/java/VASSAL/tools/image/svg/SVGImageUtils.java
+++ b/vassal-app/src/main/java/VASSAL/tools/image/svg/SVGImageUtils.java
@@ -27,6 +27,7 @@ import java.io.StringWriter;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.NoSuchFileException;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -95,7 +96,7 @@ public class SVGImageUtils {
     try {
       return getImageSize(getDocument(file, in));
     }
-    catch (FileNotFoundException e) {
+    catch (FileNotFoundException | NoSuchFileException e) {
       throw new ImageNotFoundException(file, e);
     }
     catch (DOMException | IOException e) {

--- a/vassal-app/src/main/java/VASSAL/tools/image/tilecache/ImageTileDiskCache.java
+++ b/vassal-app/src/main/java/VASSAL/tools/image/tilecache/ImageTileDiskCache.java
@@ -21,9 +21,10 @@ package VASSAL.tools.image.tilecache;
 import java.awt.Dimension;
 import java.awt.image.BufferedImage;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -96,7 +97,7 @@ public class ImageTileDiskCache implements ImageTileSource, FileStore {
   /** {@inheritDoc} */
   @Override
   public InputStream getInputStream(String path) throws IOException {
-    return new FileInputStream(cpath + "/" + path);
+    return Files.newInputStream(Path.of(cpath, path));
   }
 
   /** {@inheritDoc} */

--- a/vassal-app/src/main/java/VASSAL/tools/image/tilecache/ImageToTiles.java
+++ b/vassal-app/src/main/java/VASSAL/tools/image/tilecache/ImageToTiles.java
@@ -20,7 +20,6 @@ package VASSAL.tools.image.tilecache;
 
 import java.awt.image.BufferedImage;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
@@ -79,7 +78,7 @@ public class ImageToTiles {
     final ImageLoader loader = new ImageIOImageLoader(itc);
 
     BufferedImage src = null;
-    try (InputStream in = new FileInputStream(ipath)) {
+    try (InputStream in = Files.newInputStream(Path.of(ipath))) {
       src = loader.load(
         ipath, in, BufferedImage.TYPE_INT_RGB,
         BufferedImage.TYPE_INT_ARGB_PRE, false

--- a/vassal-app/src/main/java/VASSAL/tools/image/tilecache/TileToImage.java
+++ b/vassal-app/src/main/java/VASSAL/tools/image/tilecache/TileToImage.java
@@ -20,8 +20,9 @@ package VASSAL.tools.image.tilecache;
 
 import java.awt.image.BufferedImage;
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
 import javax.imageio.ImageIO;
 
@@ -46,6 +47,6 @@ public class TileToImage {
 
     final File tfile = new File(args[0]);
     final BufferedImage img = TileUtils.read(tfile);
-    ImageIO.write(img, "PNG", new FileOutputStream(args[1])); //NON-NLS
+    ImageIO.write(img, "PNG", Files.newOutputStream(Path.of(args[1]))); //NON-NLS
   }
 }

--- a/vassal-app/src/main/java/VASSAL/tools/image/tilecache/TileUtils.java
+++ b/vassal-app/src/main/java/VASSAL/tools/image/tilecache/TileUtils.java
@@ -25,15 +25,14 @@ import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
 import java.io.ByteArrayInputStream;
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
 import java.io.InputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
 import java.nio.IntBuffer;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
 import java.util.Arrays;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
@@ -80,11 +79,11 @@ public class TileUtils {
    * @throws ImageNotFoundException if the file isn't found
    */
   public static BufferedImage read(File src) throws ImageIOException {
-    try (InputStream fin = new FileInputStream(src);
+    try (InputStream fin = Files.newInputStream(src.toPath());
          InputStream in = new BufferedInputStream(fin)) {
       return read(in);
     }
-    catch (FileNotFoundException e) {
+    catch (NoSuchFileException e) {
       throw new ImageNotFoundException(src, e);
     }
     catch (IOException e) {
@@ -204,11 +203,11 @@ public class TileUtils {
    * @throws ImageNotFoundException if the file isn't found
    */
   public static Dimension size(File src) throws ImageIOException {
-    try (InputStream in = new FileInputStream(src)) {
+    try (InputStream in = Files.newInputStream(src.toPath())) {
       // NB: We don't buffer here because we're reading only 18 bytes.
       return size(in);
     }
-    catch (FileNotFoundException e) {
+    catch (NoSuchFileException e) {
       throw new ImageNotFoundException(src, e);
     }
     catch (IOException e) {
@@ -263,7 +262,7 @@ public class TileUtils {
    */
   public static void write(BufferedImage tile, File dst)
                                                       throws ImageIOException {
-    try (OutputStream fout = new FileOutputStream(dst);
+    try (OutputStream fout = Files.newOutputStream(dst.toPath());
          OutputStream out = new BufferedOutputStream(fout)) {
       write(tile, out);
     }

--- a/vassal-app/src/main/java/VASSAL/tools/image/tilecache/TilesToImage.java
+++ b/vassal-app/src/main/java/VASSAL/tools/image/tilecache/TilesToImage.java
@@ -23,8 +23,9 @@ import java.awt.Graphics2D;
 import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.FileFilter;
-import java.io.FileOutputStream;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -112,6 +113,6 @@ public class TilesToImage {
     }
 
     // write the cobbled image
-    ImageIO.write(img, "PNG", new FileOutputStream(dpath)); //NON-NLS
+    ImageIO.write(img, "PNG", Files.newOutputStream(Path.of(dpath))); //NON-NLS
   }
 }

--- a/vassal-app/src/main/java/VASSAL/tools/imageop/RotateScaleOpSVGImpl.java
+++ b/vassal-app/src/main/java/VASSAL/tools/imageop/RotateScaleOpSVGImpl.java
@@ -24,6 +24,7 @@ import java.awt.image.BufferedImage;
 import java.io.BufferedInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.nio.file.NoSuchFileException;
 import java.util.Collections;
 import java.util.List;
 
@@ -119,7 +120,7 @@ public class RotateScaleOpSVGImpl extends AbstractTileOpImpl
 
       return renderer.render(angle, scale);
     }
-    catch (FileNotFoundException e) {
+    catch (FileNotFoundException | NoSuchFileException e) {
       throw new ImageNotFoundException(name, e);
     }
     catch (IOException e) {

--- a/vassal-app/src/main/java/VASSAL/tools/imageop/SourceOpBitmapImpl.java
+++ b/vassal-app/src/main/java/VASSAL/tools/imageop/SourceOpBitmapImpl.java
@@ -23,6 +23,7 @@ import java.awt.image.BufferedImage;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.NoSuchFileException;
 import java.util.Collections;
 import java.util.List;
 
@@ -116,7 +117,7 @@ public class SourceOpBitmapImpl extends AbstractTiledOpImpl
       // Don't wrap, just rethrow.
       throw e;
     }
-    catch (FileNotFoundException e) {
+    catch (FileNotFoundException | NoSuchFileException e) {
       throw new ImageNotFoundException(name, e);
     }
     catch (IOException e) {
@@ -144,7 +145,7 @@ public class SourceOpBitmapImpl extends AbstractTiledOpImpl
         // Don't wrap, just rethrow.
         throw e;
       }
-      catch (FileNotFoundException e) {
+      catch (FileNotFoundException | NoSuchFileException e) {
         throw new ImageNotFoundException(name, e);
       }
       catch (IOException e) {

--- a/vassal-app/src/main/java/VASSAL/tools/imageop/SourceOpSVGImpl.java
+++ b/vassal-app/src/main/java/VASSAL/tools/imageop/SourceOpSVGImpl.java
@@ -24,6 +24,7 @@ import java.io.BufferedInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.NoSuchFileException;
 import java.util.Collections;
 import java.util.List;
 
@@ -92,7 +93,7 @@ public class SourceOpSVGImpl extends AbstractTiledOpImpl
 
       return renderer.render();
     }
-    catch (FileNotFoundException e) {
+    catch (FileNotFoundException | NoSuchFileException e) {
       throw new ImageNotFoundException(name, e);
     }
     catch (IOException e) {
@@ -120,7 +121,7 @@ public class SourceOpSVGImpl extends AbstractTiledOpImpl
         // Don't wrap, just rethrow.
         throw e;
       }
-      catch (FileNotFoundException e) {
+      catch (FileNotFoundException | NoSuchFileException e) {
         throw new ImageNotFoundException(name, e);
       }
       catch (IOException e) {

--- a/vassal-app/src/main/java/VASSAL/tools/imageop/SourceTileOpSVGImpl.java
+++ b/vassal-app/src/main/java/VASSAL/tools/imageop/SourceTileOpSVGImpl.java
@@ -24,6 +24,7 @@ import java.awt.image.BufferedImage;
 import java.io.BufferedInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.nio.file.NoSuchFileException;
 import java.util.Collections;
 import java.util.List;
 
@@ -98,7 +99,7 @@ public class SourceTileOpSVGImpl extends AbstractTileOpImpl
       final Rectangle2D aoi = new Rectangle2D.Float(x0, y0, x1 - x0, y1 - y0);
       return renderer.render(0.0, 1.0, aoi);
     }
-    catch (FileNotFoundException e) {
+    catch (FileNotFoundException | NoSuchFileException e) {
       throw new ImageNotFoundException(name, e);
     }
     catch (IOException e) {

--- a/vassal-app/src/main/java/VASSAL/tools/imports/adc2/ADC2Module.java
+++ b/vassal-app/src/main/java/VASSAL/tools/imports/adc2/ADC2Module.java
@@ -38,13 +38,11 @@ import java.io.ByteArrayOutputStream;
 import java.io.DataInputStream;
 import java.io.EOFException;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.FileNotFoundException;
-import java.io.FileReader;
 import java.io.InputStream;
 import java.io.IOException;
-import java.io.Reader;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -1624,7 +1622,7 @@ public class ADC2Module extends Importer {
   protected void load(File f) throws IOException {
     super.load(f);
 
-    try (InputStream fin = new FileInputStream(f);
+    try (InputStream fin = Files.newInputStream(f.toPath());
          InputStream bin = new BufferedInputStream(fin);
          DataInputStream in = new DataInputStream(bin)) {
       name = stripExtension(f.getName());
@@ -1737,7 +1735,7 @@ public class ADC2Module extends Importer {
         new ExtensionFileFilter("Info page file (*.ipx;*.IPX)", new String[] {".ipx"}));
       if (ipx != null) {
 
-        try (InputStream fin = new FileInputStream(ipx);
+        try (InputStream fin = Files.newInputStream(ipx.toPath());
              InputStream bin = new BufferedInputStream(fin);
              DataInputStream input = new DataInputStream(bin)) {
           try {
@@ -2377,8 +2375,7 @@ public class ADC2Module extends Importer {
             final StringBuilder sb = new StringBuilder();
             sb.append("<html><body>");
 
-            try (Reader fr = new FileReader(f, StandardCharsets.US_ASCII);
-                 BufferedReader input = new BufferedReader(fr)) {
+            try (BufferedReader input = Files.newBufferedReader(f.toPath(), StandardCharsets.US_ASCII)) {
               String line;
               do {
                 line = input.readLine();
@@ -2858,7 +2855,7 @@ public class ADC2Module extends Importer {
 
   @Override
   public boolean isValidImportFile(File f) throws IOException {
-    try (InputStream fin = new FileInputStream(f);
+    try (InputStream fin = Files.newInputStream(f.toPath());
          DataInputStream in = new DataInputStream(fin)) {
       final int header = in.readByte();
       return header == -3 || header == -2;

--- a/vassal-app/src/main/java/VASSAL/tools/imports/adc2/MapBoard.java
+++ b/vassal-app/src/main/java/VASSAL/tools/imports/adc2/MapBoard.java
@@ -34,7 +34,6 @@ import java.awt.image.BufferedImage;
 import java.io.BufferedInputStream;
 import java.io.DataInputStream;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.InputStream;
 import java.io.IOException;
@@ -2272,7 +2271,7 @@ public class MapBoard extends Importer {
    */
   protected void readScannedMapLayoutFile(File f, Graphics2D g) throws IOException {
 
-    try (InputStream fin = new FileInputStream(f);
+    try (InputStream fin = Files.newInputStream(f.toPath());
          InputStream bin = new BufferedInputStream(fin);
          DataInputStream in = new DataInputStream(bin)) {
       // how many image sections
@@ -2723,7 +2722,7 @@ public class MapBoard extends Importer {
   protected void load(File f) throws IOException {
     super.load(f);
 
-    try (InputStream fin = new FileInputStream(f);
+    try (InputStream fin = Files.newInputStream(f.toPath());
          InputStream bin = new BufferedInputStream(fin);
          DataInputStream in = new DataInputStream(bin)) {
       baseName = stripExtension(f.getName());
@@ -3104,7 +3103,7 @@ public class MapBoard extends Importer {
 
   @Override
   public boolean isValidImportFile(File f) throws IOException {
-    try (InputStream fin = new FileInputStream(f);
+    try (InputStream fin = Files.newInputStream(f.toPath());
          DataInputStream in = new DataInputStream(fin)) {
       return in.readByte() == -3;
     }

--- a/vassal-app/src/main/java/VASSAL/tools/imports/adc2/SymbolSet.java
+++ b/vassal-app/src/main/java/VASSAL/tools/imports/adc2/SymbolSet.java
@@ -30,13 +30,11 @@ import java.io.ByteArrayOutputStream;
 import java.io.DataInputStream;
 import java.io.EOFException;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.FileNotFoundException;
-import java.io.FileReader;
 import java.io.InputStream;
 import java.io.IOException;
-import java.io.Reader;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
@@ -490,7 +488,7 @@ public class SymbolSet extends Importer {
   protected void load(File f) throws IOException {
     super.load(f);
 
-    try (InputStream fin = new FileInputStream(f);
+    try (InputStream fin = Files.newInputStream(f.toPath());
          InputStream bin = new BufferedInputStream(fin);
          DataInputStream in = new DataInputStream(bin)) {
       // if header is 0xFD, then mask indeces are one-byte long. Otherwise, if
@@ -587,8 +585,7 @@ public class SymbolSet extends Importer {
     sdx = action.getCaseInsensitiveFile(sdx, f, false, null);
     if (sdx != null) { // must reorder image indeces
 
-      try (Reader fr = new FileReader(sdx, StandardCharsets.US_ASCII);
-           BufferedReader input = new BufferedReader(fr)) {
+      try (BufferedReader input = Files.newBufferedReader(sdx.toPath(), StandardCharsets.US_ASCII)) {
 
         final SymbolData[] pieces = Arrays.copyOf(gamePieceData, gamePieceData.length);
 
@@ -634,7 +631,7 @@ public class SymbolSet extends Importer {
 
   @Override
   public boolean isValidImportFile(File f) throws IOException {
-    try (InputStream fin = new FileInputStream(f);
+    try (InputStream fin = Files.newInputStream(f.toPath());
          DataInputStream in = new DataInputStream(fin)) {
       return in.readUnsignedByte() >= 0xFA;
     }

--- a/vassal-app/src/main/java/VASSAL/tools/io/DeobfuscatingInputStream.java
+++ b/vassal-app/src/main/java/VASSAL/tools/io/DeobfuscatingInputStream.java
@@ -17,12 +17,13 @@
  */
 package VASSAL.tools.io;
 
-import java.io.FileInputStream;
 import java.io.FilterInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.PushbackInputStream;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
 /**
  * A {@link FilterInputStream} which converts a file created with
@@ -146,7 +147,7 @@ public class DeobfuscatingInputStream extends FilterInputStream {
 
   public static void main(String[] args) throws IOException {
     try (InputStream in = new DeobfuscatingInputStream(
-      args.length > 0 ? new FileInputStream(args[0]) : System.in)) {
+      args.length > 0 ? Files.newInputStream(Path.of(args[0])) : System.in)) {
       in.transferTo(System.out);
     }
 

--- a/vassal-app/src/main/java/VASSAL/tools/io/ObfuscatingOutputStream.java
+++ b/vassal-app/src/main/java/VASSAL/tools/io/ObfuscatingOutputStream.java
@@ -18,12 +18,13 @@
 package VASSAL.tools.io;
 
 import java.io.BufferedOutputStream;
-import java.io.FileInputStream;
 import java.io.FilterOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Random;
 
 /**
@@ -87,7 +88,7 @@ public class ObfuscatingOutputStream extends FilterOutputStream {
   }
 
   public static void main(String[] args) throws IOException {
-    try (InputStream in = args.length > 0 ? new FileInputStream(args[0]) : System.in;
+    try (InputStream in = args.length > 0 ? Files.newInputStream(Path.of(args[0])) : System.in;
          OutputStream out = new ObfuscatingOutputStream(new BufferedOutputStream(System.out))) {
       in.transferTo(out);
     }

--- a/vassal-app/src/main/java/VASSAL/tools/io/ZipArchive.java
+++ b/vassal-app/src/main/java/VASSAL/tools/io/ZipArchive.java
@@ -20,9 +20,7 @@ import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
 import java.io.ByteArrayInputStream;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
 import java.io.FilterInputStream;
 import java.io.InputStream;
 import java.io.IOException;
@@ -299,7 +297,7 @@ public class ZipArchive implements FileArchive {
       deleteEntryTempFile(old);
 
       return new ZipArchiveOutputStream(
-        new FileOutputStream(e.file), new CRC32(), e.ze
+        Files.newOutputStream(e.file.toPath()), new CRC32(), e.ze
       );
     }
     catch (IOException ex) {
@@ -317,7 +315,7 @@ public class ZipArchive implements FileArchive {
   /** {@inheritDoc} */
   @Override
   public void add(String path, File extPath) throws IOException {
-    try (FileInputStream in = new FileInputStream(extPath)) {
+    try (InputStream in = Files.newInputStream(extPath.toPath())) {
       add(path, in);
     }
   }

--- a/vassal-app/src/main/java/VASSAL/tools/io/ZipArchive.java
+++ b/vassal-app/src/main/java/VASSAL/tools/io/ZipArchive.java
@@ -62,7 +62,7 @@ import VASSAL.tools.concurrent.CountingReadWriteLock;
 public class ZipArchive implements FileArchive {
   private static final Logger logger = LoggerFactory.getLogger(ZipArchive.class);
 
-  private final Path archiveFile;
+  private final Path archive;
   private ZipFile zipFile;
 
   private boolean modified = false;
@@ -139,10 +139,10 @@ public class ZipArchive implements FileArchive {
    * @throws IOException oops
    */
   public ZipArchive(Path path, boolean truncate) throws IOException {
-    this.archiveFile = Objects.requireNonNull(path);
+    this.archive = Objects.requireNonNull(path);
 
     if (truncate) {
-      Files.deleteIfExists(archiveFile);
+      Files.deleteIfExists(archive);
     }
   }
 
@@ -194,17 +194,17 @@ public class ZipArchive implements FileArchive {
   /** {@inheritDoc} */
   @Override
   public String getName() {
-    return archiveFile.toString();
+    return archive.toString();
   }
 
   /** {@inheritDoc} */
   @Override
   public File getFile() {
-    return archiveFile.toFile();
+    return archive.toFile();
   }
 
   public Path getPath() {
-    return archiveFile;
+    return archive;
   }
 
   /** {@inheritDoc} */
@@ -457,7 +457,7 @@ public class ZipArchive implements FileArchive {
     if (zipFile == null) {
       // No existing zipfile so no old entries to copy;
       // write directly to the destination
-      try (OutputStream out = openNew(archiveFile)) {
+      try (OutputStream out = openNew(archive)) {
         writeToZip(out);
       }
     }
@@ -465,7 +465,7 @@ public class ZipArchive implements FileArchive {
       // Destination already exists, must copy old entries;
       // write to temp file first, then move to destination
       final File tmpFile = makeTempFileFor(
-        archiveFile.getFileName().toString(), archiveFile.getParent()
+        archive.getFileName().toString(), archive.getParent()
       );
       try (OutputStream out = openExisting(tmpFile.toPath())) {
         writeToZip(out);
@@ -478,7 +478,7 @@ public class ZipArchive implements FileArchive {
 
         // Replace old archive with temp archive
         Files.move(
-          tmpFile.toPath(), archiveFile,
+          tmpFile.toPath(), archive,
           StandardCopyOption.REPLACE_EXISTING
         );
       }
@@ -492,7 +492,7 @@ public class ZipArchive implements FileArchive {
         }
 
         // Reopen the original archive
-        zipFile = new ZipFile(archiveFile.toFile());
+        zipFile = new ZipFile(archive.toFile());
 
         throw e;
       }
@@ -521,7 +521,7 @@ public class ZipArchive implements FileArchive {
     }
 
     // copy unmodified entries into the archive
-    try (InputStream fin = Files.newInputStream(archiveFile);
+    try (InputStream fin = Files.newInputStream(archive);
          InputStream bin = new BufferedInputStream(fin);
          ZipInputStream in = new ZipInputStream(bin)) {
       final byte[] buf = new byte[8192];
@@ -663,8 +663,8 @@ public class ZipArchive implements FileArchive {
   private synchronized void readEntries() throws IOException {
     entries.clear();
 
-    if (Files.exists(archiveFile) && Files.size(archiveFile) > 0) {
-      zipFile = new ZipFile(archiveFile.toFile());
+    if (Files.exists(archive) && Files.size(archive) > 0) {
+      zipFile = new ZipFile(archive.toFile());
       zipFile.stream().forEach(e -> entries.put(e.getName(), new Entry(e, null)));
     }
   }

--- a/vassal-app/src/test/java/VASSAL/chat/CompressorTest.java
+++ b/vassal-app/src/test/java/VASSAL/chat/CompressorTest.java
@@ -3,10 +3,12 @@ package VASSAL.chat;
 import java.awt.Frame;
 import java.awt.TextField;
 import java.io.ByteArrayOutputStream;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
+import java.io.InputStream;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Arrays;
 
 import org.junit.Ignore;
@@ -46,7 +48,7 @@ public class CompressorTest {
     }
     else {
       final ByteArrayOutputStream byteOut = new ByteArrayOutputStream();
-      final FileInputStream file = new FileInputStream(args[0]);
+      final InputStream file = Files.newInputStream(Path.of(args[0]));
       try {
         IOUtils.copy(file, byteOut);
       }
@@ -63,8 +65,7 @@ public class CompressorTest {
       final byte[] contents = byteOut.toByteArray();
       if (contents[0] == 'P' && contents[1] == 'K') {
         final byte[] uncompressed = Compressor.decompress(contents);
-        final FileOutputStream out =
-          new FileOutputStream(args[0] + ".uncompressed"); //$NON-NLS-1$
+        final OutputStream out = Files.newOutputStream(Path.of(args[0] + ".uncompressed")); //$NON-NLS-1$
         try {
           out.write(uncompressed);
         }
@@ -86,8 +87,8 @@ public class CompressorTest {
       }
       else {
         final byte[] compressed = Compressor.compress(contents);
-        final FileOutputStream out =
-          new FileOutputStream(args[0] + ".compressed"); //$NON-NLS-1$
+        final OutputStream out =
+          Files.newOutputStream(Path.of(args[0] + ".compressed")); //$NON-NLS-1$
         try {
           out.write(compressed);
         }

--- a/vassal-app/src/test/java/VASSAL/tools/image/ImageIOImageLoaderTest.java
+++ b/vassal-app/src/test/java/VASSAL/tools/image/ImageIOImageLoaderTest.java
@@ -21,8 +21,11 @@ package VASSAL.tools.image;
 import java.awt.Dimension;
 import java.awt.image.BufferedImage;
 import java.io.File;
-import java.io.FileInputStream;
+import java.io.InputStream;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
 import javax.imageio.ImageIO;
 
 import org.junit.BeforeClass;
@@ -43,7 +46,7 @@ public class ImageIOImageLoaderTest {
 
   private BufferedImage read(ImageLoader loader, String file)
                                                            throws IOException {
-    try (FileInputStream in = new FileInputStream(file)) {
+    try (InputStream in = Files.newInputStream(Path.of(file))) {
       final BufferedImage img = loader.load(
         file, in, BufferedImage.TYPE_INT_RGB,
         BufferedImage.TYPE_INT_ARGB, false
@@ -97,7 +100,7 @@ public class ImageIOImageLoaderTest {
   }
 
   private Dimension size(ImageLoader loader, String file) throws IOException {
-    try (FileInputStream in = new FileInputStream(file)) {
+    try (InputStream in = Files.newInputStream(Path.of(file))) {
       final Dimension d = loader.size(file, in);
       return d;
     }

--- a/vassal-app/src/test/java/VASSAL/tools/image/tilecache/TileToImageTest.java
+++ b/vassal-app/src/test/java/VASSAL/tools/image/tilecache/TileToImageTest.java
@@ -19,8 +19,10 @@
 package VASSAL.tools.image.tilecache;
 
 import java.io.File;
-import java.io.FileInputStream;
+import java.io.InputStream;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
 import org.apache.commons.io.IOUtils;
 
@@ -42,8 +44,8 @@ public class TileToImageTest {
 
     TileToImage.main(new String[] { tile, out_actual });
 
-    try (FileInputStream expected = new FileInputStream(out_expected);
-         FileInputStream actual = new FileInputStream(out_actual)) {
+    try (InputStream expected = Files.newInputStream(Path.of(out_expected));
+         InputStream actual = Files.newInputStream(Path.of(out_actual))) {
       assertTrue(IOUtils.contentEquals(expected, actual));
     }
   }

--- a/vassal-app/src/test/java/VASSAL/tools/io/ZipArchiveTest.java
+++ b/vassal-app/src/test/java/VASSAL/tools/io/ZipArchiveTest.java
@@ -43,6 +43,7 @@ public class ZipArchiveTest {
   @After
   public void cleanup() throws IOException {
     Files.deleteIfExists(testArchivePath());
+    Files.deleteIfExists(Path.of(testArchivePath().toString() + ".bak"));
   }
 
   private Path testArchivePath() {

--- a/vassal-app/src/test/java/VASSAL/tools/io/ZipArchiveTest.java
+++ b/vassal-app/src/test/java/VASSAL/tools/io/ZipArchiveTest.java
@@ -22,6 +22,7 @@ import java.io.InputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Set;
@@ -85,7 +86,7 @@ public class ZipArchiveTest {
       z.getSize(name);
       fail("Expected FileNotFoundException");
     }
-    catch (FileNotFoundException e) {
+    catch (FileNotFoundException | NoSuchFileException e) {
       // expected
     }
 
@@ -93,14 +94,14 @@ public class ZipArchiveTest {
       z.getMTime(name);
       fail("Expected FileNotFoundException");
     }
-    catch (FileNotFoundException e) {
+    catch (FileNotFoundException | NoSuchFileException e) {
       // expected
     }
 
     try (InputStream in = z.getInputStream(name)) {
       fail("Expected FileNotFoundException");
     }
-    catch (FileNotFoundException e) {
+    catch (FileNotFoundException | NoSuchFileException e) {
       // expected
     }
   }

--- a/vassal-app/src/test/resources/clirr-ignored-differences.xml
+++ b/vassal-app/src/test/resources/clirr-ignored-differences.xml
@@ -21,6 +21,13 @@
         <justification>ModuleManagerWindow is never referenced by custom code</justification>
     </difference>
     <difference>
+        <className>VASSAL/launch/ModuleManager</className>
+        <differenceType>7005</differenceType>
+        <method>ModuleManager(java.net.ServerSocket, long, java.io.FileOutputStream, java.nio.channels.FileLock)</method>
+        <to>ModuleManager(java.net.ServerSocket, long, java.nio.channels.FileChannel, java.nio.channels.FileLock)</to>
+        <justification>ModuleManager is never instantiated by custom code</justification>
+    </difference>
+    <difference>
         <className>VASSAL/build/module/PieceWindow</className>
         <differenceType>6006</differenceType>
         <field>idMgr</field>

--- a/vassal-app/src/test/resources/pmd.xml
+++ b/vassal-app/src/test/resources/pmd.xml
@@ -177,6 +177,7 @@
 
   <rule ref="category/java/performance.xml/AddEmptyString" />
   <rule ref="category/java/performance.xml/AppendCharacterWithChar" />
+  <rule ref="category/java/performance.xml/AvoidFileStream" />
   <rule ref="category/java/performance.xml/BigIntegerInstantiation" />
   <rule ref="category/java/performance.xml/BooleanInstantiation" />
   <rule ref="category/java/performance.xml/ByteInstantiation" />


### PR DESCRIPTION
* Move archives to be overwritten out of the way, then write directly to the destination, without going via the temp directory. Should lead to fewer writing issues on Windows.

* Enabled PMD rule for avoiding FileInputStream, FileOutputStream, FileReader, FileWriter. Instead use the ones provided in Files which don't have finalizers.