### PR TITLE
13677, 13679 - Ensure AbstractTiledOpImpl.fixTileSize() is atomic

### DIFF
--- a/vassal-app/src/main/java/VASSAL/counters/Labeler.java
+++ b/vassal-app/src/main/java/VASSAL/counters/Labeler.java
@@ -552,11 +552,13 @@ public class Labeler extends Decorator implements TranslatablePiece, Loopable {
     @Override
     protected void fixSize() {
       if ((size = getSizeFromCache()) == null) {
-        buildDimensions();
+        synchronized (this) {
+          buildDimensions();
 
-        // ensure that our area is nonempty
-        if (size.width <= 0 || size.height <= 0) {
-          size.width = size.height = 1;
+          // ensure that our area is nonempty
+          if (size.width <= 0 || size.height <= 0) {
+            size.width = size.height = 1;
+          }
         }
       }
     }

--- a/vassal-app/src/main/java/VASSAL/counters/Labeler.java
+++ b/vassal-app/src/main/java/VASSAL/counters/Labeler.java
@@ -34,6 +34,7 @@ import java.awt.image.BufferedImage;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.function.DoubleConsumer;
 
 import javax.swing.Box;
@@ -569,10 +570,10 @@ public class Labeler extends Decorator implements TranslatablePiece, Loopable {
       if (!(o instanceof LabelOp)) return false;
 
       final LabelOp lop = (LabelOp) o;
-      return (txt == null ? lop.txt == null : txt.equals(lop.txt)) &&
-             (font == null ? lop.font == null : font.equals(lop.font)) &&
-             (fg == null ? lop.fg == null : fg.equals(lop.fg)) &&
-             (bg == null ? lop.bg == null : bg.equals(lop.bg));
+      return Objects.equals(txt, lop.txt) &&
+             Objects.equals(font, lop.font) &&
+             Objects.equals(fg, lop.fg) &&
+             Objects.equals(bg, lop.bg);
     }
 
     @Override
@@ -621,6 +622,7 @@ public class Labeler extends Decorator implements TranslatablePiece, Loopable {
       return im;
     }
 
+    @Override
     protected JLabel buildDimensions() {
       // Build a JLabel to render HTML
       final JLabel l = new JLabel(txt);

--- a/vassal-app/src/main/java/VASSAL/counters/Labeler.java
+++ b/vassal-app/src/main/java/VASSAL/counters/Labeler.java
@@ -506,7 +506,7 @@ public class Labeler extends Decorator implements TranslatablePiece, Loopable {
     @Override
     public BufferedImage eval() throws Exception {
       // fix our size
-      buildDimensions();
+      if (size == null) fixSize();
 
       // draw nothing if our size is zero
       if (size.width <= 0 || size.height <= 0) return ImageUtils.NULL_IMAGE;
@@ -542,25 +542,23 @@ public class Labeler extends Decorator implements TranslatablePiece, Loopable {
       return im;
     }
 
-    protected JLabel buildDimensions() {
+    protected Dimension buildDimensions() {
       final Graphics2D g = ImageUtils.NULL_IMAGE.createGraphics();
       final FontMetrics fm = g.getFontMetrics(font);
-      size = new Dimension(fm.stringWidth(txt), fm.getHeight());
+      final Dimension s = new Dimension(fm.stringWidth(txt), fm.getHeight());
       g.dispose();
-      return null;
+      return s;
     }
 
     @Override
     protected void fixSize() {
       if ((size = getSizeFromCache()) == null) {
-        synchronized (this) {
-          buildDimensions();
-
-          // ensure that our area is nonempty
-          if (size.width <= 0 || size.height <= 0) {
-            size.width = size.height = 1;
-          }
+        final Dimension s = buildDimensions();
+        // ensure that our area is nonempty
+        if (s.width <= 0 || s.height <= 0) {
+          s.width = s.height = 1;
         }
+        size = s;
       }
     }
 
@@ -589,8 +587,8 @@ public class Labeler extends Decorator implements TranslatablePiece, Loopable {
 
     @Override
     public BufferedImage eval() throws Exception {
-      // determine whether we are HTML and fix our size
-      final JLabel l = buildDimensions();
+      // fix our size
+      if (size == null) fixSize();
 
       // draw nothing if our size is zero
       if (size.width <= 0 || size.height <= 0) return ImageUtils.NULL_IMAGE;
@@ -615,6 +613,7 @@ public class Labeler extends Decorator implements TranslatablePiece, Loopable {
 
       // paint the foreground
       if (fg != null) {
+        final JLabel l = makeLabel();
         l.paint(g);
       }
 
@@ -622,15 +621,18 @@ public class Labeler extends Decorator implements TranslatablePiece, Loopable {
       return im;
     }
 
-    @Override
-    protected JLabel buildDimensions() {
+    protected JLabel makeLabel() {
       // Build a JLabel to render HTML
       final JLabel l = new JLabel(txt);
       l.setForeground(fg);
       l.setFont(font);
-      size = l.getPreferredSize();
-      l.setSize(size);
+      l.setSize(l.getPreferredSize());
       return l;
+    }
+
+    @Override
+    protected Dimension buildDimensions() {
+      return makeLabel().getSize();
     }
   }
 

--- a/vassal-app/src/main/java/VASSAL/tools/imageop/AbstractTiledOpImpl.java
+++ b/vassal-app/src/main/java/VASSAL/tools/imageop/AbstractTiledOpImpl.java
@@ -53,15 +53,17 @@ public abstract class AbstractTiledOpImpl extends AbstractOpImpl {
    * {@link #getNumYTiles}, and all other tile methods.
    */
   protected void fixTileSize() {
-    if (size == null) fixSize();
-
     synchronized (this) {
-      tileSize = DEFAULT_TILE_SIZE;
+      if (size == null) fixSize();
 
-      numXTiles = (int) Math.ceil((double)size.width / tileSize.width);
-      numYTiles = (int) Math.ceil((double)size.height / tileSize.height);
-
-      tiles = new ImageOp[numXTiles * numYTiles];
+      if (tileSize == null) {
+        // We do not touch tileSize until last here, as the check for
+        // whether fileTileSize() will run is on the nullity of tileSize.
+        numXTiles = (int) Math.ceil((double)size.width / DEFAULT_TILE_SIZE.width);
+        numYTiles = (int) Math.ceil((double)size.height / DEFAULT_TILE_SIZE.height);
+        tiles = new ImageOp[numXTiles * numYTiles];
+        tileSize = DEFAULT_TILE_SIZE;
+      }
     }
   }
 

--- a/vassal-app/src/main/java/VASSAL/tools/imageop/AbstractTiledOpImpl.java
+++ b/vassal-app/src/main/java/VASSAL/tools/imageop/AbstractTiledOpImpl.java
@@ -55,12 +55,14 @@ public abstract class AbstractTiledOpImpl extends AbstractOpImpl {
   protected void fixTileSize() {
     if (size == null) fixSize();
 
-    tileSize = DEFAULT_TILE_SIZE;
+    synchronized (this) {
+      tileSize = DEFAULT_TILE_SIZE;
 
-    numXTiles = (int) Math.ceil((double)size.width / tileSize.width);
-    numYTiles = (int) Math.ceil((double)size.height / tileSize.height);
+      numXTiles = (int) Math.ceil((double)size.width / tileSize.width);
+      numYTiles = (int) Math.ceil((double)size.height / tileSize.height);
 
-    tiles = new ImageOp[numXTiles * numYTiles];
+      tiles = new ImageOp[numXTiles * numYTiles];
+    }
   }
 
   /** {@inheritDoc} */

--- a/vassal-app/src/main/java/VASSAL/tools/imageop/GamePieceOpImpl.java
+++ b/vassal-app/src/main/java/VASSAL/tools/imageop/GamePieceOpImpl.java
@@ -18,6 +18,7 @@
 
 package VASSAL.tools.imageop;
 
+import java.awt.Dimension;
 import java.awt.Graphics2D;
 import java.awt.Rectangle;
 import java.awt.image.BufferedImage;

--- a/vassal-app/src/main/java/VASSAL/tools/imageop/GamePieceOpImpl.java
+++ b/vassal-app/src/main/java/VASSAL/tools/imageop/GamePieceOpImpl.java
@@ -100,11 +100,10 @@ public class GamePieceOpImpl extends AbstractTileOpImpl implements GamePieceOp {
   /** {@inheritDoc} */
   @Override
   protected void fixSize() {
-    synchronized (this) {
-      size = piece.boundingBox().getSize();
-      if (size.width < 1) size.width = 1;
-      if (size.height < 1) size.height = 1;
-    }
+    final Dimension s = piece.boundingBox().getSize();
+    if (s.width < 1) s.width = 1;
+    if (s.height < 1) s.height = 1;
+    size = s;
   }
 
   /**

--- a/vassal-app/src/main/java/VASSAL/tools/imageop/GamePieceOpImpl.java
+++ b/vassal-app/src/main/java/VASSAL/tools/imageop/GamePieceOpImpl.java
@@ -103,6 +103,7 @@ public class GamePieceOpImpl extends AbstractTileOpImpl implements GamePieceOp {
     final Dimension s = piece.boundingBox().getSize();
     if (s.width < 1) s.width = 1;
     if (s.height < 1) s.height = 1;
+    // assinging to size is atomic
     size = s;
   }
 

--- a/vassal-app/src/main/java/VASSAL/tools/imageop/GamePieceOpImpl.java
+++ b/vassal-app/src/main/java/VASSAL/tools/imageop/GamePieceOpImpl.java
@@ -100,9 +100,11 @@ public class GamePieceOpImpl extends AbstractTileOpImpl implements GamePieceOp {
   /** {@inheritDoc} */
   @Override
   protected void fixSize() {
-    size = piece.boundingBox().getSize();
-    if (size.width < 1) size.width = 1;
-    if (size.height < 1) size.height = 1;
+    synchronized (this) {
+      size = piece.boundingBox().getSize();
+      if (size.width < 1) size.width = 1;
+      if (size.height < 1) size.height = 1;
+    }
   }
 
   /**

--- a/vassal-app/src/main/java/VASSAL/tools/imageop/OrthoRotateOpBitmapImpl.java
+++ b/vassal-app/src/main/java/VASSAL/tools/imageop/OrthoRotateOpBitmapImpl.java
@@ -82,6 +82,7 @@ public class OrthoRotateOpBitmapImpl extends AbstractTiledOpImpl
         // transpose dimensions for 90- and 270-degree rotations
         s.setSize(s.height, s.width);
       }
+      // assigning to size is atomic
       size = s;
     }
   }

--- a/vassal-app/src/main/java/VASSAL/tools/imageop/OrthoRotateOpBitmapImpl.java
+++ b/vassal-app/src/main/java/VASSAL/tools/imageop/OrthoRotateOpBitmapImpl.java
@@ -77,14 +77,12 @@ public class OrthoRotateOpBitmapImpl extends AbstractTiledOpImpl
   @Override
   protected void fixSize() {
     if ((size = getSizeFromCache()) == null) {
-      synchronized (this) {
-        size = sop.getSize();
-
+      final Dimension s = sop.getSize();
+      if (angle == 1 || angle == 3) {
         // transpose dimensions for 90- and 270-degree rotations
-        if (angle == 1 || angle == 3) {
-          size.setSize(size.height, size.width);
-        }
+        s.setSize(s.height, s.width);
       }
+      size = s;
     }
   }
 

--- a/vassal-app/src/main/java/VASSAL/tools/imageop/OrthoRotateOpBitmapImpl.java
+++ b/vassal-app/src/main/java/VASSAL/tools/imageop/OrthoRotateOpBitmapImpl.java
@@ -77,11 +77,14 @@ public class OrthoRotateOpBitmapImpl extends AbstractTiledOpImpl
   @Override
   protected void fixSize() {
     if ((size = getSizeFromCache()) == null) {
-      size = sop.getSize();
+      synchronized (this) {
+        size = sop.getSize();
 
-      // transpose dimensions for 90- and 270-degree rotations
-      if (angle == 1 || angle == 3)
-        size.setSize(size.height, size.width);
+        // transpose dimensions for 90- and 270-degree rotations
+        if (angle == 1 || angle == 3) {
+          size.setSize(size.height, size.width);
+        }
+      }
     }
   }
 


### PR DESCRIPTION
When fixSize() and fixTileSize() are not atomic (in this case, that means they do more than assign the correct value to one variable as a single assignment---a single assignment need not be synchronized because size computation is idempotent, so it doesn't matter which thread wins the race), then the part containing the computation must be synchronized.