### PR TITLE
3.5 13782 Layer losing track of Suffix/Prefix setting on layers

### DIFF
--- a/vassal-app/src/main/java/VASSAL/counters/Embellishment.java
+++ b/vassal-app/src/main/java/VASSAL/counters/Embellishment.java
@@ -1192,7 +1192,6 @@ public class Embellishment extends Decorator implements TranslatablePiece {
       upDownPanel.add(Box.createVerticalGlue());
       controls.add(upDownPanel, "wrap"); // NON-NLS
 
-      levelNameInput.addPropertyChangeListener(ev -> changeLevelName());
       controls.add(new JLabel(Resources.getString("Editor.Embellishment.level_name")));
       controls.add(levelNameInput.getControls(), "growx"); // NON-NLS
 


### PR DESCRIPTION
Rewrite changed order that Listeners where firing causing fields to be updated in incorrect order.