### PR TITLE
13808 - Don't prompt to create new logfile before current one is done

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/module/GameState.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/GameState.java
@@ -381,10 +381,15 @@ public class GameState implements CommandEncoder {
 
     if (gameStarted) {
       if (gameStarting) {
+        // If we're starting a new session, prompt to create a new logfile.
+        // But NOT if we're starting a session by *replaying* a logfile -- in that case we'd get the reminder at the
+        // end of the logfile.
         SwingUtilities.invokeLater(() -> {
           final Logger logger = GameModule.getGameModule().getLogger();
           if (logger instanceof BasicLogger) {
-            ((BasicLogger)logger).queryNewLogFile(true);
+            if (!((BasicLogger)logger).isReplaying()) {
+              ((BasicLogger) logger).queryNewLogFile(true);
+            }
           }
         });
       }


### PR DESCRIPTION
I noticed that when I load a new logfile in (planning to replay it), I'm getting *immediately* prompted to start a new logfile. Which seems wrong -- because since I'm replaying one I will get a prompt at the END of the replay. 

So this little fix patches that.

If it wanted to get cherrypicked to 3.4.12 that could happen to, or I could probably re-poot this PR to that.