### PR TITLE
13820 - Ensure that the temp dir extists before trying to write to it

### DIFF
--- a/vassal-app/src/main/java/VASSAL/tools/io/ZipArchive.java
+++ b/vassal-app/src/main/java/VASSAL/tools/io/ZipArchive.java
@@ -407,6 +407,7 @@ public class ZipArchive implements FileArchive {
   private File makeTempFileFor(String path) throws IOException {
     final String base = FilenameUtils.getBaseName(path) + "_";
     final String ext = extensionOf(path);
+    Files.createDirectories(Info.getTempDir().toPath());
     return Files.createTempFile(Info.getTempDir().toPath(), base, ext).toFile();
   }
 


### PR DESCRIPTION
This should not be necessary given that we create it in StandarConfig, but somehow the directory isn't there for Windows users occasionally.