### PR TITLE
Deprecation cleanup

### DIFF
--- a/vassal-app/src/main/java/VASSAL/Info.java
+++ b/vassal-app/src/main/java/VASSAL/Info.java
@@ -73,6 +73,7 @@ public final class Info {
    * @deprecated If you need the minor version number, get it from
    * a {@link VersionTokenizer}.
    */
+  @SuppressWarnings("removal")
   @Deprecated(since = "2020-08-06", forRemoval = true)
   public static String getMinorVersion() {
     ProblemDialog.showDeprecated("2020-08-06");

--- a/vassal-app/src/main/java/VASSAL/build/module/InternetDiceButton.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/InternetDiceButton.java
@@ -73,6 +73,7 @@ public class InternetDiceButton extends DiceButton implements GameComponent, Com
   /**
    * Ask the die manager to do our roll!
    */
+  @SuppressWarnings("removal")
   @Override
   protected void DR() {
     reportFormat.setProperty(NAME, getLocalizedConfigureName());

--- a/vassal-app/src/main/java/VASSAL/build/module/Map.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/Map.java
@@ -173,7 +173,6 @@ import VASSAL.preferences.PositionOption;
 import VASSAL.preferences.Prefs;
 import VASSAL.search.HTMLImageFinder;
 import VASSAL.tools.AdjustableSpeedScrollPane;
-import VASSAL.tools.ComponentSplitter;
 import VASSAL.tools.KeyStrokeSource;
 import VASSAL.tools.LaunchButton;
 import VASSAL.tools.NamedKeyStroke;
@@ -220,8 +219,9 @@ public class Map extends AbstractToolbarItem implements GameComponent, MouseList
   protected JLayeredPane layeredPane = new JLayeredPane();
   protected JScrollPane scroll;
 
+  @SuppressWarnings("removal")
   @Deprecated(since = "2020-11-05", forRemoval = true)
-  protected ComponentSplitter.SplitPane mainWindowDock;
+  protected VASSAL.tools.ComponentSplitter.SplitPane mainWindowDock;
 
   protected SplitPane splitPane;
 

--- a/vassal-app/src/main/java/VASSAL/build/module/PieceWindow.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/PieceWindow.java
@@ -49,7 +49,6 @@ import VASSAL.counters.GamePiece;
 import VASSAL.i18n.Resources;
 import VASSAL.preferences.PositionOption;
 import VASSAL.preferences.VisibilityOption;
-import VASSAL.tools.ComponentSplitter;
 import VASSAL.tools.LaunchButton;
 import VASSAL.tools.NamedKeyStroke;
 import VASSAL.tools.UniqueIdManager;
@@ -79,8 +78,9 @@ public class PieceWindow extends Widget implements UniqueIdManager.Identifyable 
   protected String tooltip = ""; //$NON-NLS-1$
   protected double scale;
 
+  @SuppressWarnings({"deprecation", "removal"})
   @Deprecated(since = "2020-11-15", forRemoval = true)
-  protected ComponentSplitter.SplitPane mainWindowDock;
+  protected VASSAL.tools.ComponentSplitter.SplitPane mainWindowDock;
 
   protected SplitPane splitPane;
 

--- a/vassal-app/src/main/java/VASSAL/build/module/PrivateMap.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/PrivateMap.java
@@ -253,6 +253,7 @@ public class PrivateMap extends Map {
   }
 
   /** @deprecated Use {@link #setBoards(Collection)} instead. */
+  @SuppressWarnings("removal")
   @Deprecated(since = "2020-08-06", forRemoval = true)
   @Override
   public void setBoards(Enumeration<Board> boardList) {

--- a/vassal-app/src/main/java/VASSAL/build/module/RandomTextButton.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/RandomTextButton.java
@@ -51,6 +51,7 @@ public class RandomTextButton extends DiceButton {
   public static final String FACES = "faces"; //$NON-NLS-1$
   public static final String NUMERIC = "numeric"; //$NON-NLS-1$
 
+  @SuppressWarnings("removal")
   public RandomTextButton() {
     super();
     final ActionListener ranAction = e -> {

--- a/vassal-app/src/main/java/VASSAL/build/module/StartupGlobalKeyCommand.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/StartupGlobalKeyCommand.java
@@ -41,6 +41,7 @@ import java.util.List;
  *
  */
 public class StartupGlobalKeyCommand extends GlobalKeyCommand implements GameComponent {
+  @SuppressWarnings("removal")
   public StartupGlobalKeyCommand() {
     super();
     /* These four fields pertaining to the physical representation of the
@@ -68,6 +69,7 @@ public class StartupGlobalKeyCommand extends GlobalKeyCommand implements GameCom
     return HelpFile.getReferenceManualPage("Map.html", "StartupGlobalKeyCommand"); //NON-NLS
   }
 
+  @SuppressWarnings("removal")
   @Override
   public VisibilityCondition getAttributeVisibility(String key) {
     if (List.of(BUTTON_TEXT, TOOLTIP, ICON, HOTKEY).contains(key)) {

--- a/vassal-app/src/main/java/VASSAL/build/module/map/MassKeyCommand.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/MassKeyCommand.java
@@ -101,6 +101,8 @@ public class MassKeyCommand extends AbstractToolbarItem
   public static final String CHECK_VALUE = "propValue"; // NON-NLS
   public static final String SINGLE_MAP = "singleMap"; // NON-NLS
 
+  // TODO: When these are removed, look for all of the "removal" warning
+  // suppressions we added for them, and remove those.
   // These 3 identical to AbstractToolbarItem and here for clirr purposes only
   @Deprecated (since = "2020-10-21", forRemoval = true) public static final String NAME = "name"; // NON-NLS
   @Deprecated (since = "2020-10-21", forRemoval = true) public static final String ICON = "icon"; // NON-NLS

--- a/vassal-app/src/main/java/VASSAL/build/module/map/boardPicker/Board.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/boardPicker/Board.java
@@ -714,8 +714,8 @@ public class Board extends AbstractConfigurable implements GridContainer {
    * @deprecated Board images are removed automatically now, when under
    * memory pressure.
    */
+  @SuppressWarnings("removal")
   @Deprecated(since = "2020-08-06", forRemoval = true)
-  @SuppressWarnings("all")
   public void cleanUp() {
     ProblemDialog.showDeprecated("2020-08-06");
     if (imageFile != null) {

--- a/vassal-app/src/main/java/VASSAL/chat/PrivateChatter.java
+++ b/vassal-app/src/main/java/VASSAL/chat/PrivateChatter.java
@@ -37,8 +37,9 @@ public class PrivateChatter extends Chatter {
   }
 
   /** @deprecated Use {@link GlobalOptions#getInstance()#getPlayerId} */
-  @Override
+  @SuppressWarnings("removal")
   @Deprecated(since = "2020-08-06", forRemoval = true)
+  @Override
   public String getHandle() {
     ProblemDialog.showDeprecated("2020-08-06");
     return GlobalOptions.getInstance().getPlayerId();

--- a/vassal-app/src/main/java/VASSAL/chat/ui/ChatServerControls.java
+++ b/vassal-app/src/main/java/VASSAL/chat/ui/ChatServerControls.java
@@ -55,7 +55,6 @@ import VASSAL.configure.NamedHotKeyConfigurer;
 import VASSAL.i18n.Resources;
 import VASSAL.preferences.PositionOption;
 import VASSAL.preferences.VisibilityOption;
-import VASSAL.tools.ComponentSplitter;
 import VASSAL.tools.NamedKeyStroke;
 import VASSAL.tools.NamedKeyStrokeListener;
 import VASSAL.tools.menu.MenuManager;
@@ -81,8 +80,9 @@ public class ChatServerControls extends AbstractBuildable {
   protected JButton configServerButton;
   protected String configServerText;
 
+  @SuppressWarnings("removal")
   @Deprecated(since = "2020-11-15", forRemoval = true)
-  protected ComponentSplitter.SplitPane splitter;
+  protected VASSAL.tools.ComponentSplitter.SplitPane splitter;
 
   protected SplitPane splitPane;
 

--- a/vassal-app/src/main/java/VASSAL/configure/ModuleUpdaterDialog.java
+++ b/vassal-app/src/main/java/VASSAL/configure/ModuleUpdaterDialog.java
@@ -36,9 +36,11 @@ import VASSAL.tools.ErrorDialog;
 import VASSAL.tools.ZipUpdater;
 import VASSAL.tools.filechooser.FileChooser;
 
+@Deprecated(since = "2020-08-05", forRemoval = true)
 public class ModuleUpdaterDialog extends JDialog {
   private static final long serialVersionUID = 1L;
 
+  @SuppressWarnings("removal")
   public ModuleUpdaterDialog(Frame owner) throws HeadlessException {
     super(owner, false);
     setTitle(Resources.getString("Editor.ModuleUpdaterDialog.title"));

--- a/vassal-app/src/main/java/VASSAL/launch/EditorWindow.java
+++ b/vassal-app/src/main/java/VASSAL/launch/EditorWindow.java
@@ -44,7 +44,6 @@ import VASSAL.build.GameModule;
 import VASSAL.build.module.Documentation;
 import VASSAL.build.module.documentation.HelpWindow;
 import VASSAL.configure.ConfigureTree;
-import VASSAL.configure.ModuleUpdaterDialog;
 import VASSAL.configure.RemoveUnusedImagesDialog;
 import VASSAL.configure.SaveAction;
 import VASSAL.configure.SaveAsAction;
@@ -71,7 +70,6 @@ public abstract class EditorWindow extends JFrame {
   protected SaveAction saveAction;
   protected SaveAsAction saveAsAction;
   protected JMenuItem componentHelpItem;
-  protected Action createUpdater;
 
   protected final HelpWindow helpWindow = new HelpWindow(Resources.getString("Editor.ModuleEditor.reference_manual"), //$NON-NLS-1$
       null);
@@ -222,17 +220,6 @@ public abstract class EditorWindow extends JFrame {
     mm.addAction("General.quit", new ShutDownAction());
 // FXIME: mnemonics should be language-dependant
 //    mm.getAction("General.quit").setMnemonic('Q');
-
-    createUpdater = new AbstractAction("Create " + getEditorType() + " updater") {
-      private static final long serialVersionUID = 1L;
-
-      @Override
-      public void actionPerformed(ActionEvent e) {
-        new ModuleUpdaterDialog(EditorWindow.this).setVisible(true);
-      }
-    };
-    createUpdater.setEnabled(false);
-    mm.addAction("create_module_updater", createUpdater);  //NON-NLS
 
     mm.addAction("Editor.UnusedImages.remove_unused_images", new AbstractAction("Remove Unused Images") {  //NON-NLS
       private static final long serialVersionUID = 1L;

--- a/vassal-app/src/main/java/VASSAL/launch/ExtensionEditorWindow.java
+++ b/vassal-app/src/main/java/VASSAL/launch/ExtensionEditorWindow.java
@@ -57,7 +57,6 @@ public class ExtensionEditorWindow extends EditorWindow {
 
     saveAction.setEnabled(true);
     saveAsAction.setEnabled(true);
-    createUpdater.setEnabled(true);
 
     pack();
   }

--- a/vassal-app/src/main/java/VASSAL/launch/ModuleEditorWindow.java
+++ b/vassal-app/src/main/java/VASSAL/launch/ModuleEditorWindow.java
@@ -76,7 +76,6 @@ public class ModuleEditorWindow extends EditorWindow {
 
     saveAction.setEnabled(true);
     saveAsAction.setEnabled(true);
-    createUpdater.setEnabled(true);
     updateSavedGame.setEnabled(true);
     refreshPredefinedSetups.setEnabled(true);
 

--- a/vassal-app/src/main/java/VASSAL/launch/PlayerWindow.java
+++ b/vassal-app/src/main/java/VASSAL/launch/PlayerWindow.java
@@ -192,6 +192,7 @@ public class PlayerWindow extends JFrame {
    * @return the {@link ComponentSplitter.SplitPane} containing the two components
    *
    */
+  @SuppressWarnings("removal")
   @Deprecated(since = "2020-07-28", forRemoval = true)
   public ComponentSplitter.SplitPane splitControlPanel(Component newComponent, int hideablePosition, boolean resize) {
     int index = -1;

--- a/vassal-app/src/main/java/VASSAL/search/HTMLImageFinder.java
+++ b/vassal-app/src/main/java/VASSAL/search/HTMLImageFinder.java
@@ -5,14 +5,16 @@ import VASSAL.build.GameModule;
 import VASSAL.i18n.Resources;
 import VASSAL.tools.DataArchive;
 import VASSAL.tools.ErrorDialog;
-import VASSAL.tools.io.IOUtils;
-import org.jsoup.Jsoup;
+
 import java.io.BufferedInputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Collection;
+
+import org.apache.commons.io.IOUtils;
+import org.jsoup.Jsoup;
 
 /**
  * Parses image tags out of an HTML file or string. Used to add the image filenames to a list, e.g. of images used.

--- a/vassal-app/src/main/java/VASSAL/tools/DataArchive.java
+++ b/vassal-app/src/main/java/VASSAL/tools/DataArchive.java
@@ -801,6 +801,7 @@ public class DataArchive extends SecureClassLoader implements Closeable {
   /**
    * @deprecated Don't use this. We've switched to Lanczos scaling.
    */
+  @SuppressWarnings("removal")
   @Deprecated(since = "2020-08-06", forRemoval = true)
   public Image improvedScaling(Image img, int width, int height) {
     ProblemDialog.showDeprecated("2020-08-06");

--- a/vassal-app/src/main/java/VASSAL/tools/JarArchive.java
+++ b/vassal-app/src/main/java/VASSAL/tools/JarArchive.java
@@ -81,7 +81,8 @@ public class JarArchive extends DataArchive {
   }
 
   /** @deprecated Use {@link #getInputStream(String)} instead. */
-  @Deprecated
+  @SuppressWarnings("removal")
+  @Deprecated(since = "2020-08-06", forRemoval = true)
   @Override
   public InputStream getFileStream(String fileName) throws IOException {
     return getInputStream(fileName);

--- a/vassal-app/src/main/java/VASSAL/tools/imports/adc2/ADC2Module.java
+++ b/vassal-app/src/main/java/VASSAL/tools/imports/adc2/ADC2Module.java
@@ -2299,6 +2299,7 @@ public class ADC2Module extends Importer {
 //  }
   }
 
+  @SuppressWarnings("removal")
   private void configureStatusFlagButtons() throws IOException {
     String imageName;
     MassKeyCommand command;
@@ -2424,6 +2425,7 @@ public class ADC2Module extends Importer {
     // TODO: set current turn
   }
 
+  @SuppressWarnings("removal")
   protected void configureDiceRoller(GameModule gameModule) {
     final DiceButton dice = new DiceButton();
     insertComponent(dice, gameModule);
@@ -2659,6 +2661,7 @@ public class ADC2Module extends Importer {
     }
   }
 
+  @SuppressWarnings("removal")
   protected void writeToolbarMenuToArchive(GameModule gameModule) {
     final int nHands = forcePools.count(HandPool.class);
     if (nHands == 0)

--- a/vassal-app/src/main/java/VASSAL/tools/imports/adc2/MapBoard.java
+++ b/vassal-app/src/main/java/VASSAL/tools/imports/adc2/MapBoard.java
@@ -111,6 +111,7 @@ public class MapBoard extends Importer {
       this.switchable = switchable;
     }
 
+    @SuppressWarnings("removal")
     void writeToArchive() throws IOException {
       // write piece
       final Rectangle r = writeImageToArchive();
@@ -2859,6 +2860,7 @@ public class MapBoard extends Importer {
     return p;
   }
 
+  @SuppressWarnings("removal")
   @Override
   public void writeToArchive() throws IOException {
 
@@ -3069,6 +3071,7 @@ public class MapBoard extends Importer {
     return board;
   }
 
+  @SuppressWarnings("removal")
   private ToolbarMenu getToolbarMenu() {
     final List<ToolbarMenu> list = getMainMap().getComponentsOf(ToolbarMenu.class);
     ToolbarMenu menu = null;

--- a/vassal-app/src/main/java/VASSAL/tools/version/VassalVersionTokenizer.java
+++ b/vassal-app/src/main/java/VASSAL/tools/version/VassalVersionTokenizer.java
@@ -41,6 +41,7 @@ import java.util.regex.Pattern;
  * @author Joel Uckelman
  * @see VersionFormatException
  */
+@SuppressWarnings("removal")
 @Deprecated(since = "2020-08-28", forRemoval = true)
 public class VassalVersionTokenizer implements VersionTokenizer {
   protected String v;

--- a/vassal-app/src/main/java/VASSAL/tools/version/VersionTokenizer.java
+++ b/vassal-app/src/main/java/VASSAL/tools/version/VersionTokenizer.java
@@ -50,5 +50,6 @@ public interface VersionTokenizer {
    * @throws NoSuchElementException if this method is called when
    * {@link #hasNext()} would return <code>false</code>.
    */
+  @SuppressWarnings("removal")
   int next() throws VersionFormatException;
 }

--- a/vassal-app/src/test/java/VASSAL/chat/CompressorTest.java
+++ b/vassal-app/src/test/java/VASSAL/chat/CompressorTest.java
@@ -11,10 +11,10 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
 
+import org.apache.commons.io.IOUtils;
+
 import org.junit.Ignore;
 import org.junit.Test;
-
-import VASSAL.tools.io.IOUtils;
 
 public class CompressorTest {
 

--- a/vassal-app/src/test/java/VASSAL/tools/io/RereadableInputStreamTest.java
+++ b/vassal-app/src/test/java/VASSAL/tools/io/RereadableInputStreamTest.java
@@ -22,6 +22,7 @@ import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.io.IOException;
 
+import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.input.NullInputStream;
 
 import org.junit.Test;

--- a/vassal-app/src/test/java/VASSAL/tools/version/VassalVersionTokenizerTest.java
+++ b/vassal-app/src/test/java/VASSAL/tools/version/VassalVersionTokenizerTest.java
@@ -27,6 +27,7 @@ import static org.junit.Assert.*;
 import java.util.Arrays;
 import java.util.Collection;
 
+@SuppressWarnings("removal")
 @Deprecated(since = "2020-08-28", forRemoval = true)
 @RunWith(Parameterized.class)
 public class VassalVersionTokenizerTest {

--- a/vassal-app/src/test/resources/clirr-ignored-differences.xml
+++ b/vassal-app/src/test/resources/clirr-ignored-differences.xml
@@ -3,7 +3,6 @@
         documentation at https://www.mojohaus.org/clirr-maven-plugin/examples/ignored-differences.html
     -->
 
-
     <difference>  
         <!-- It is okay to add classes to the set of superclasses -->
         <className>**</className>
@@ -135,6 +134,13 @@
         <differenceType>7002</differenceType>
         <method>FormattedStringArrayConfigurer(java.lang.String, java.lang.String, VASSAL.build.module.properties.PropertyChangerConfigurer$Constraints, int, int)</method>
         <justification>Nothing external should use this</justification>
+    </difference>
+
+    <difference>
+        <className>VASSAL/launch/EditorWindow</className>
+        <differenceType>6001</differenceType>
+        <field>createUpdater</field>
+        <justification>Northing external should use this</justification>
     </difference>
 
     <!-- Removal of MM <-> Player/Editor IPC -->


### PR DESCRIPTION
Deprecated elements marked "forRemoval" have deprecation warnings of type "removal", not "deprecation". Elements which are themselves deprecated which also refer to deprecated-for-removal elements need to have the "removal" warnings on them suppressed explicitly.