### PR TITLE
13915 - GridOp.TileOp should include its parent GridOp in its hash rather than its parent's source

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/module/map/boardPicker/board/GridOp.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/boardPicker/board/GridOp.java
@@ -162,7 +162,7 @@ public class GridOp extends AbstractTiledOpImpl {
 
       size = new Dimension(dw, dh);
 
-      hash = Objects.hash(sop, dx0, dy0, dw, dh);
+      hash = Objects.hash(gop, dx0, dy0, dw, dh);
     }
 
     @Override


### PR DESCRIPTION
its parent's source.