### PR TITLE
13959 - 3.5.1 - Wizard should add loaded-file name to app window title

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/module/WizardSupport.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/WizardSupport.java
@@ -649,6 +649,7 @@ public class WizardSupport {
                   @Override
                   public void run() {
                     GameModule.getGameModule().getFileChooser().setSelectedFile(f); //BR// When loading a saved game from Wizard, put it appropriately into the "default" for the next save/load/etc.
+                    GameModule.getGameModule().setGameFile(f.getName(), GameModule.GameFileMode.LOADED_GAME); //BR// ... aaaand put it in the app window description.
                     super.run();
                     processing.remove(f);
                   }


### PR DESCRIPTION
Found a code path where the saved-game name doesn't get added to the app title. 