### PR TITLE
13944 - Ensure that deprecated mainWindowDock is fiddled on first pass only

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/module/Map.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/Map.java
@@ -2565,7 +2565,7 @@ public class Map extends AbstractToolbarItem implements GameComponent, MouseList
       if (shouldDockIntoMainWindow()) {
         // kludge for modules which still use mainWindowDock
         // remove this when mainWindowDock is removed
-        if (mainWindowDock != null) {
+        if (mainWindowDock != null && splitPane == null) {
           splitPane = new SplitPane(
             SplitPane.VERTICAL_SPLIT,
             mainWindowDock.getTopComponent(),


### PR DESCRIPTION
Check that splitPane is null---i.e., we have not yet nicked the components from mainWindowDock---in modules where mainWindowDock is used by custom code.