### PR TITLE
14059 - better piece definer descriptions of Marker traits

### DIFF
--- a/vassal-app/src/main/java/VASSAL/counters/Marker.java
+++ b/vassal-app/src/main/java/VASSAL/counters/Marker.java
@@ -162,13 +162,20 @@ public class Marker extends Decorator implements EditablePiece {
 
   @Override
   public String getDescription() {
-    if (keys != null
-      && keys.length > 0 && keys[0].length() > 0
-      && values.length > 0 && values[0].length() > 0) {
-      return Resources.getString("Editor.Marker.trait_description") + " - " + keys[0] + " = " + values[0];
+    String result = Resources.getString("Editor.Marker.trait_description");
+
+    if (keys != null && keys.length > 0 && keys[0].length() > 0) {
+      result += " - " + keys[0];
+      if (values.length > 0 && values[0].length() > 0) {
+        result += " = " + values[0];
+      }
+
+      if (keys.length > 1) {
+        result += " " + Resources.getString("Editor.Marker.more_keys", keys.length - 1);
+      }
     }
-    else
-      return Resources.getString("Editor.Marker.trait_description");
+
+    return result;
   }
 
   @Override

--- a/vassal-app/src/main/resources/VASSAL/i18n/Editor.properties
+++ b/vassal-app/src/main/resources/VASSAL/i18n/Editor.properties
@@ -1109,6 +1109,7 @@ Editor.MapWidget.component_type=Map
 Editor.Marker.trait_description=Marker
 Editor.Marker.property_name=Property name
 Editor.Marker.property_value=Property value
+Editor.Marker.more_keys=  [+%1$s more keys]
 
 # Mass Key Command
 Editor.MassKey.match=Additional matching expression


### PR DESCRIPTION
BEFORE:
![image](https://user-images.githubusercontent.com/3742246/108133176-2395a080-7082-11eb-881a-f7c7f08a1a83.png)

AFTER:
![image](https://user-images.githubusercontent.com/3742246/108133191-2beddb80-7082-11eb-983c-07ace8e5a06f.png)
