### PR TITLE
14104 - Do not set image name to (No Image) when clearing Image

### DIFF
--- a/vassal-app/src/main/java/VASSAL/configure/ImageSelector.java
+++ b/vassal-app/src/main/java/VASSAL/configure/ImageSelector.java
@@ -143,7 +143,7 @@ public class ImageSelector extends Configurer implements ItemListener {
     controls.revalidate();
     repack(controls);
 
-    setValue((Object) s);
+    setValue((Object) imageName);
   }
 
   @Override


### PR DESCRIPTION
This fixes the bug that is causing the problem, but makes no attempt to hide the error or fix the module. Do we need this?