### PR TITLE
3.5.4 - 14136 - Module level GKCs were not honoring fast match

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/module/GlobalKeyCommand.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/GlobalKeyCommand.java
@@ -59,7 +59,7 @@ public class GlobalKeyCommand extends MassKeyCommand {
   public void apply() {
     final List<Map> l = Map.getMapList();
     GameModule.getGameModule().sendAndLog(
-      globalCommand.apply(l.toArray(new Map[0]), getFilter()));
+      globalCommand.apply(l.toArray(new Map[0]), getFilter(), target));
   }
 
   // Hide 'This Map only' option


### PR DESCRIPTION
The little tag probably got lost during some complex merge back when 3.5 was pre-release and large swathes of things were getting changed.