### PR TITLE
14139 - Delete trait to set old... properties before deleting unit

### DIFF
--- a/vassal-app/src/main/java/VASSAL/counters/Delete.java
+++ b/vassal-app/src/main/java/VASSAL/counters/Delete.java
@@ -119,7 +119,8 @@ public class Delete extends Decorator implements TranslatablePiece {
           SwingUtilities.invokeLater(runnable);
         }
       }
-      c = new RemovePiece(outer);
+      c = putOldProperties(Decorator.getOutermost(this));
+      c = c.append(new RemovePiece(outer));
       c.execute();
     }
     return c;


### PR DESCRIPTION
This one that should have been done ages ago. Delete is really a 'Move' type trait, so the oldxxxx Properties need to be set prior to deleting the counter. There have been many complaints and questions about correctly reporting the location of deleted counters over the years.

Currently, it is impossible to report the location a counter is being deleted from if it has not been moved since being added to the map.