### PR TITLE
Change launch4j version to 3.13

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -51,8 +51,8 @@ popd
 mkdir -p "$L4JDIR"
 pushd "$L4JDIR"
 
-wget https://downloads.sourceforge.net/project/launch4j/launch4j-3/3.12/launch4j-3.12-linux-x64.tgz
-tar -xvf launch4j-3.12-linux-x64.tgz
+wget https://downloads.sourceforge.net/project/launch4j/launch4j-3/3.13/launch4j-3.13-linux-x64.tgz
+tar -xvf launch4j-3.13-linux-x64.tgz
 
 popd
 


### PR DESCRIPTION
It was updated last month, and the download URL now refers to 3.13