### PR TITLE
14198 - Translated private windows do not work when changing sides if…

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/module/PlayerRoster.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/PlayerRoster.java
@@ -569,9 +569,12 @@ public class PlayerRoster extends AbstractToolbarItem implements CommandEncoder,
       nextChoice // Offer calculated most likely "next side" as the default
     );
 
-    // OBSERVER must always be stored internally in English.
+    // sides must always be stored internally in English.
     if (translatedObserver.equals(newSide)) {
       newSide = OBSERVER;
+    }
+    else {
+      newSide = untranslateSide(newSide);
     }
     return newSide;
   }


### PR DESCRIPTION
… module is translated

PrivateMap and other private components expect to handle the side name in English, but the prompt
for choosing a new side is always in translated language.