### PR TITLE
3.5.4 - 14217 - $countPieces$ to sum all pieces without having to create a property

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/module/properties/SumProperties.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/properties/SumProperties.java
@@ -64,6 +64,9 @@ public class SumProperties implements PropertySource {
         value = sum + (indeterminate ? "+?" : "");
       }
     }
+    else if (keyString.equals("sumpieces")) { //NON-NLS
+      value = pieces.size();
+    }
     else if (!pieces.isEmpty()) {
       value = pieces.iterator().next().getProperty(key);
     }

--- a/vassal-app/src/main/java/VASSAL/build/module/properties/SumProperties.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/properties/SumProperties.java
@@ -64,7 +64,7 @@ public class SumProperties implements PropertySource {
         value = sum + (indeterminate ? "+?" : "");
       }
     }
-    else if (keyString.equals("sumpieces")) { //NON-NLS
+    else if (keyString.equals("countPieces")) { //NON-NLS
       value = pieces.size();
     }
     else if (!pieces.isEmpty()) {

--- a/vassal-doc/src/main/readme-referencemanual/ReferenceManual/Map.adoc
+++ b/vassal-doc/src/main/readme-referencemanual/ReferenceManual/Map.adoc
@@ -316,7 +316,7 @@ Otherwise, it will display only if 1 or 2 pieces have been included via the sett
 *Font size:* Fort size for the text drawn by the stack viewer.
 
 *Summary text above pieces:*  A <<MessageFormat.adoc#top,Message Format>> specifying the text to display above the drawn pieces in the viewer.
-In addition to standard <<Properties.adoc#top,Properties>>, you can include $countPieces$ to sum the pieces included in the display. You can also include a property with the name _sum(propertyName)_ where _propertyName_ is a property defined on a Game Piece.
+In addition to standard <<Properties.adoc#top,Properties>>, you can include $countPieces$ to count the pieces included in the display. You can also include a property with the name _sum(propertyName)_ where _propertyName_ is a property defined on a Game Piece.
 The sum of the numeric values of this property for all included pieces will be substituted.
 
 *Text below each piece:*  A <<MessageFormat.adoc#top,Message Format>> specifying the text to display below each included piece.

--- a/vassal-doc/src/main/readme-referencemanual/ReferenceManual/Map.adoc
+++ b/vassal-doc/src/main/readme-referencemanual/ReferenceManual/Map.adoc
@@ -316,7 +316,7 @@ Otherwise, it will display only if 1 or 2 pieces have been included via the sett
 *Font size:* Fort size for the text drawn by the stack viewer.
 
 *Summary text above pieces:*  A <<MessageFormat.adoc#top,Message Format>> specifying the text to display above the drawn pieces in the viewer.
-In addition to standard <<Properties.adoc#top,Properties>>, you can include $sumpieces$ to sum the pieces included in the display. You can also include a property with the name _sum(propertyName)_ where _propertyName_ is a property defined on a Game Piece.
+In addition to standard <<Properties.adoc#top,Properties>>, you can include $countPieces$ to sum the pieces included in the display. You can also include a property with the name _sum(propertyName)_ where _propertyName_ is a property defined on a Game Piece.
 The sum of the numeric values of this property for all included pieces will be substituted.
 
 *Text below each piece:*  A <<MessageFormat.adoc#top,Message Format>> specifying the text to display below each included piece.

--- a/vassal-doc/src/main/readme-referencemanual/ReferenceManual/Map.adoc
+++ b/vassal-doc/src/main/readme-referencemanual/ReferenceManual/Map.adoc
@@ -316,8 +316,8 @@ Otherwise, it will display only if 1 or 2 pieces have been included via the sett
 *Font size:* Fort size for the text drawn by the stack viewer.
 
 *Summary text above pieces:*  A <<MessageFormat.adoc#top,Message Format>> specifying the text to display above the drawn pieces in the viewer.
-In addition to standard <<Properties.adoc#top,Properties>>, you can include a property with the name _sum(propertyName)_ where _propertyName_ is a property defined on a Game Piece.
-The numeric values of this property for all included pieces will be substituted.
+In addition to standard <<Properties.adoc#top,Properties>>, you can include $sumpieces$ to sum the pieces included in the display. You can also include a property with the name _sum(propertyName)_ where _propertyName_ is a property defined on a Game Piece.
+The sum of the numeric values of this property for all included pieces will be substituted.
 
 *Text below each piece:*  A <<MessageFormat.adoc#top,Message Format>> specifying the text to display below each included piece.
 


### PR DESCRIPTION
Existing functionality only allows $sum(somePropertyName) and then sums the property, which can be useful but is unfortunately infuriating when you only want a sum of how many pieces met the qualifications to be displayed, because then you have to go add a property to every possible piece "StupidProperty" and set its value to "1". So that you can sum it. 

Anyway this fixes that.