### PR TITLE
14245 - Works around bug in JTabbedPane

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/widget/TabWidget.java
+++ b/vassal-app/src/main/java/VASSAL/build/widget/TabWidget.java
@@ -40,7 +40,7 @@ import VASSAL.i18n.Resources;
  * (via {@link Configurable#getConfigureName})
  */
 public class TabWidget extends Widget
-    implements ChangeListener, PropertyChangeListener {
+  implements ChangeListener, PropertyChangeListener {
   private JTabbedPane tab = null;
   private final List<Widget> widgets = new ArrayList<>();
 
@@ -54,6 +54,7 @@ public class TabWidget extends Widget
     if (index >= 0) {
       tab.setComponentAt(index, widgets.get(index).getComponent());
     }
+    refreshTabs();
   }
 
   @Override
@@ -101,6 +102,19 @@ public class TabWidget extends Widget
     }
   }
 
+
+  /**
+   * Shouldn't be necessary, but there's a bug in JTabbedPane with HTML items. Doing this (unsetting and then resetting each title) seems to clear up the problem.
+   */
+  private void refreshTabs() {
+    int index = 0;
+    for (final Widget w : widgets) {
+      tab.setTitleAt(index, "");
+      tab.setTitleAt(index, w.getConfigureName());
+      index++;
+    }
+  }
+
   @Override
   public Component getComponent() {
     if (tab == null) {
@@ -108,13 +122,15 @@ public class TabWidget extends Widget
       tab = new JTabbedPane();
       for (final Widget w : widgets) {
         w.addPropertyChangeListener(this);
-        tab.addTab(w.getConfigureName(), new JPanel());
+        tab.addTab("", new JPanel());
       }
       tab.addChangeListener(this);
       if (!widgets.isEmpty()) {
         tab.setSelectedIndex(0);
       }
       stateChanged(null);
+
+      refreshTabs();
     }
     return tab;
   }


### PR DESCRIPTION
When module designers put html (e.g. "<html><b>Bold Boy</b></html>") in the text of the widgets for chart windows, Swing seems to do some grotesque things (losing track of the ordering of the list of tabs). Refreshing them "every time you do anything" seems to be a workaround. Note that when refreshing them you have to kind of "unset" and then "set" their title otherwise Swing has some "oh look it's the same as before so I will do nothing" code that prevents the desired relief.