### PR TITLE
Fix the Refresh Predefined Setups flow that I broke

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/GameModule.java
+++ b/vassal-app/src/main/java/VASSAL/build/GameModule.java
@@ -273,7 +273,6 @@ public class GameModule extends AbstractConfigurable
    * Reads/writes full game state; starts/stops gameplay.
    */
   private GameState theState;
-  private boolean loadOverSemaphore = false; // if we're currently loading overtop of another game (so don't disturb UI if possible, it will get a setup(true) soon enough)
 
   /**
    * Our "zip" archive with a .vmod file extension
@@ -375,6 +374,7 @@ public class GameModule extends AbstractConfigurable
    */
   private static boolean errorLogToChat = false;
 
+  private boolean loadOverSemaphore = false; // if we're currently loading overtop of another game (so don't disturb UI if possible, it will get a setup(true) soon enough)
   /**
    * @paramn state - true if we're loading-over-top of an existing game (so don't disturb UI elements if possible, will receive a setup(true) soon enough)
    */
@@ -388,6 +388,23 @@ public class GameModule extends AbstractConfigurable
   public boolean isLoadOverSemaphore() {
     return loadOverSemaphore;
   }
+
+
+  private boolean refreshingSemaphore = false; // if we're currently loading a game just to refresh its (not to play it)
+  /**
+   * @param state - true if refreshing (suppresses GameState.setup method)
+   */
+  public void setRefreshingSemaphore(boolean state) {
+    loadOverSemaphore = state;
+  }
+
+  /**
+   * @return true if refreshing (suppresses GameState.setup method)
+   */
+  public boolean isRefreshingSemaphore() {
+    return loadOverSemaphore;
+  }
+
 
   /**
    * @return the top-level frame of the controls window

--- a/vassal-app/src/main/java/VASSAL/build/GameModule.java
+++ b/vassal-app/src/main/java/VASSAL/build/GameModule.java
@@ -395,14 +395,14 @@ public class GameModule extends AbstractConfigurable
    * @param state - true if refreshing (suppresses GameState.setup method)
    */
   public void setRefreshingSemaphore(boolean state) {
-    loadOverSemaphore = state;
+    refreshingSemaphore = state;
   }
 
   /**
    * @return true if refreshing (suppresses GameState.setup method)
    */
   public boolean isRefreshingSemaphore() {
-    return loadOverSemaphore;
+    return refreshingSemaphore;
   }
 
 

--- a/vassal-app/src/main/java/VASSAL/build/module/GameState.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/GameState.java
@@ -353,6 +353,10 @@ public class GameState implements CommandEncoder {
   public void setup(boolean gameStarting) {
     final GameModule g = GameModule.getGameModule();
 
+    if (g.isRefreshingSemaphore()) {
+      return; // Blocks setup method during Game Refresh
+    }
+
     if (!gameStarting && gameStarted && isModified()) {
       switch (JOptionPane.showConfirmDialog(
         g.getPlayerWindow(),

--- a/vassal-app/src/main/java/VASSAL/build/module/PredefinedSetup.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/PredefinedSetup.java
@@ -281,7 +281,14 @@ public class PredefinedSetup extends AbstractConfigurable implements GameCompone
 
     // get a stream to the saved game in the module file
     gs.setupRefresh();
-    gs.loadGameInForeground(fileName, getSavedGameContents());
+
+    mod.setRefreshingSemaphore(true);
+    try {
+      gs.loadGameInForeground(fileName, getSavedGameContents());
+    }
+    finally {
+      mod.setRefreshingSemaphore(false);
+    }
 
     // call the gameRefresher
     gameRefresher.execute(refresherOptions, null);


### PR DESCRIPTION
I had removed a "gameLoadingInForeground" flag that I thought *I* had put in, since it was interfering with using the LoadGameInForeground method. But it turns out @claudiociardelli had put it in for the Refresh Predefined Setups tool -- so in other words I broke that. This restores the semaphore that should get Refresh Predefined Setups back to how it previously behaved while letting LoadGameInForeground still work for me -- by slightly changing where the semaphore is activated.