### PR TITLE
13145 - Allow the inner listeners of KeyStrokeListeners to be chained

### DIFF
--- a/vassal-app/src/main/java/VASSAL/tools/KeyStrokeListener.java
+++ b/vassal-app/src/main/java/VASSAL/tools/KeyStrokeListener.java
@@ -144,11 +144,8 @@ public class KeyStrokeListener {
       final Action a = ActionChain.remove(amap.get(o), l);
       if (a == null) {
         imap.remove(k);
-        amap.remove(o);
       }
-      else {
-        amap.put(o, a);
-      }
+      amap.put(o, a);
     }
   }
 

--- a/vassal-app/src/main/java/VASSAL/tools/KeyStrokeListener.java
+++ b/vassal-app/src/main/java/VASSAL/tools/KeyStrokeListener.java
@@ -146,6 +146,9 @@ public class KeyStrokeListener {
         imap.remove(k);
         amap.remove(o);
       }
+      else {
+        amap.put(o, a);
+      }
     }
   }
 


### PR DESCRIPTION
This prevents later listeners from unregistering earlier ones.