### PR TITLE
14069 ArrayOutOfBounds exception in StringArrayConfigurer

### DIFF
--- a/vassal-app/src/main/java/VASSAL/configure/StringArrayConfigurer.java
+++ b/vassal-app/src/main/java/VASSAL/configure/StringArrayConfigurer.java
@@ -205,9 +205,10 @@ public class StringArrayConfigurer extends Configurer implements ConfigurableLis
   private void rebuildControls() {
     for (final StringEntry entry : entries) {
       entry.removeFocusListener(sharedFocusListener);
+      entry.removePropertyChangeListener(entry);
     }
-    entries.clear();
     controls.removeAll();
+    entries.clear();
 
     final String[] strings = getStringArray();
 


### PR DESCRIPTION
There was a race condition when adding/removing/moving an entry while also typing. A hanging PropertyChangeListener could fire after it's owning ListEntry had been removed from the array of known ListEntries before being rebuilt.