### PR TITLE
13796 - Fix problem with multiple stacks dragged to a snap-to map

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/module/map/PieceMover.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/PieceMover.java
@@ -728,10 +728,8 @@ public class PieceMover extends AbstractBuildable
           p = map.snapTo(p);
         }
 
-        if (offset == null) {
-          offset = new Point(p.x - dragging.getPosition().x,
-                             p.y - dragging.getPosition().y);
-        }
+        offset = new Point(p.x - dragging.getPosition().x,
+                           p.y - dragging.getPosition().y);
 
         // If we've HAVE found a piece to merge with, and we're going to a map that allows stacking, then
         // add our current piece & the mergable one to our cached list of merge targets.


### PR DESCRIPTION
This should be "looked at carefully by experts". 

REALLY I wish the whole "offset" thing didn't exist -- it seems to bounce "p" back and forth between values in a maybe-not-very-understandable way. 

Like couldn't we just use **dragging.getPosition()** for each unit coming through the loop as the "p" for that unit? Maybe I'm missing something important that bouncing around with offset does?

Anyway removing the "offset == null" **seems** to fix 13796. Only adding making the offset when offset == null seemed to be the reason that only the "first stack it started making" got created correctly.