### PR TITLE
14163 - NPE due to File.listFiles() returning null for symlnks on Macs

### DIFF
--- a/vassal-app/src/main/java/VASSAL/launch/ModuleManagerWindow.java
+++ b/vassal-app/src/main/java/VASSAL/launch/ModuleManagerWindow.java
@@ -1470,6 +1470,20 @@ public class ModuleManagerWindow extends JFrame {
     }
 
     public void addFolder(File f) {
+      try {
+        f = f.getCanonicalFile();
+      }
+      catch (final IOException e) {
+        JOptionPane.showMessageDialog(
+          ModuleManagerWindow.this,
+          Resources.getString("Error.file_read_error", f.getPath()),
+          "Error",
+          JOptionPane.ERROR_MESSAGE
+        );
+
+        return;
+      }
+
       // try to create the directory if it doesn't exist
       if (!f.exists() && !f.mkdirs()) {
         JOptionPane.showMessageDialog(


### PR DESCRIPTION
Try getting a canonical path before calling File.listFiles(), since that seems to have a problem on MacOS when the path is a symlink.