### PR TITLE
3.6 - 14358 - ReportState checkbox overrides GKC suppression of individual reports

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/module/Map.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/Map.java
@@ -3256,6 +3256,14 @@ public class Map extends AbstractToolbarItem implements GameComponent, MouseList
   }
 
   /**
+   * @return "changed on map" format string
+   */
+  public String getChangeFormat(boolean noSuppress) {
+    return (isChangeReportingEnabled() || noSuppress) ? changeFormat : "";
+  }
+
+
+  /**
    * @return "moved to map" format string
    */
   public String getMoveToFormat() {

--- a/vassal-app/src/main/java/VASSAL/counters/ReportState.java
+++ b/vassal-app/src/main/java/VASSAL/counters/ReportState.java
@@ -68,6 +68,7 @@ public class ReportState extends Decorator implements TranslatablePiece {
   protected NamedKeyStroke[] cycleDownKeys;
   protected int cycleIndex = -1;
   protected String description;
+  protected boolean noSuppress;
 
   public ReportState() {
     this(ID, null);
@@ -110,7 +111,8 @@ public class ReportState extends Decorator implements TranslatablePiece {
       .append(reportFormat)
       .append(NamedKeyStrokeArrayConfigurer.encode(cycleDownKeys))
       .append(StringArrayConfigurer.arrayToString(cycleReportFormat))
-      .append(description);
+      .append(description)
+      .append(noSuppress);
     return ID + se.getValue();
   }
 
@@ -203,9 +205,9 @@ public class ReportState extends Decorator implements TranslatablePiece {
           String reportText = format.getLocalizedText(properties);
 
           if (getMap() != null) {
-            format.setFormat(getMap().getChangeFormat());
+            format.setFormat(getMap().getChangeFormat(noSuppress));
           }
-          else if (!Map.isChangeReportingEnabled()) {
+          else if (!Map.isChangeReportingEnabled() && !noSuppress) {
             format.setFormat("");
           }
           else {
@@ -299,6 +301,7 @@ public class ReportState extends Decorator implements TranslatablePiece {
     }
     cycleReportFormat = StringArrayConfigurer.stringToArray(st.nextToken(""));
     description = st.nextToken("");
+    noSuppress = st.nextBoolean(false);
   }
 
   @Override
@@ -330,8 +333,8 @@ public class ReportState extends Decorator implements TranslatablePiece {
     if (! Objects.equals(reportFormat, c.reportFormat)) return false;
     if (!Arrays.equals(cycleDownKeys, c.cycleDownKeys)) return false;
     if (!Arrays.equals(cycleReportFormat, c.cycleReportFormat)) return false;
+    if (!Objects.equals(noSuppress, c.noSuppress)) return false;
     return Objects.equals(description, c.description);
-
   }
 
   public static final String OLD_UNIT_NAME = "oldPieceName"; // NON-NLS
@@ -354,6 +357,7 @@ public class ReportState extends Decorator implements TranslatablePiece {
     private final NamedKeyStrokeArrayConfigurer cycleDownKeys;
     protected StringConfigurer descInput;
     private final TraitConfigPanel box;
+    private final BooleanConfigurer noSuppressConfig;
 
     public Ed(ReportState piece) {
 
@@ -391,6 +395,9 @@ public class ReportState extends Decorator implements TranslatablePiece {
       cycleDownKeys = new NamedKeyStrokeArrayConfigurer(piece.cycleDownKeys);
       box.add(cycleDownLabel, cycleDownKeys);
 
+      noSuppressConfig = new BooleanConfigurer(piece.noSuppress);
+      box.add("Editor.ReportState.no_suppress", noSuppressConfig);
+
       adjustVisibilty();
     }
 
@@ -421,7 +428,8 @@ public class ReportState extends Decorator implements TranslatablePiece {
         .append(format.getValueString())
         .append(cycleDownKeys.getValueString())
         .append(cycleFormat.getValueString())
-        .append(descInput.getValueString());
+        .append(descInput.getValueString())
+        .append(noSuppressConfig.getValueString());
       return ID + se.getValue();
     }
   }

--- a/vassal-app/src/main/resources/VASSAL/i18n/Editor.properties
+++ b/vassal-app/src/main/resources/VASSAL/i18n/Editor.properties
@@ -1530,6 +1530,7 @@ Editor.ReportState.cycle_through_different_messages=Cycle through different mess
 Editor.ReportState.report_format_3=Report format
 Editor.ReportState.message_formats=Message formats
 Editor.ReportState.report_previous=Report previous message on these Key Commands
+Editor.ReportState.no_suppress=Override suppression by Global Key Commands
 
 # RestrictCommands
 Editor.RestrictCommands.trait_description=Restrict Commands

--- a/vassal-doc/src/main/readme-referencemanual/ReferenceManual/ReportChanges.adoc
+++ b/vassal-doc/src/main/readme-referencemanual/ReferenceManual/ReportChanges.adoc
@@ -21,6 +21,8 @@ Each time one of the key commands is received, the next message in the list will
 
 *Report Format:* The <<MessageFormat.adoc#top,Message Format>> for the message that will appear in the <<ChatLog.adoc#top,Chat Log>>.
 
+*Override suppression by Global Key Commands:* If this box is checked, the message will be displayed when triggered even if it is triggered by a Global Key Command with the "Suppress Individual Reports" option checked. This can be used to ensure that certain key messages are displayed no matter what.
+
 *ENHANCED CHAT LOG:* Note that the Chat Log now supports *bold text*, _italicized text_, *and even colored text* and image:images/ChatLogDice.png[]. See the <<ChatLog.adoc#top,Chat Log>> article for full details.
 
 *IMPORTANT*: When HTML is enabled in the chat log, it is important to remember that the `<` character will be interpreted as the beginning of an HTML tag, rather than simply displaying a "less than" or "left angle bracket" symbol. Thus, modules which use the `<` symbol to indicate "less than" or to "draw an arrow" or enclose a user name, etc, will need to have those instances changed to `\&lt;` (the HTML escape code which causes a literal `<` character to be printed). Otherwise you may


### PR DESCRIPTION
Here's something I've always wanted (and need!) -- a way to ensure certain critical report messages can override the "suppress individual reports" checkbox of a GKC. My use case is for "Warning! You probably just broke the rules!" messages -- allowing those to "pop through" the GKC suppression which otherwise needs to suppress a whole lot of more routine messages.