### PR TITLE
3.5.6 - 14370 - safer behavior of log startup/ending

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/module/GameState.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/GameState.java
@@ -239,6 +239,14 @@ public class GameState implements CommandEncoder {
     return s != null && !s.equals(lastSave);
   }
 
+
+  /**
+   * @return true if saveGame action is enabled (mainly to detect if logging can start)
+   */
+  public boolean isSaveEnabled() {
+    return (saveGame == null) ? false : saveGame.isEnabled();
+  }
+
   /**
    * Add a {@link GameComponent} to the list of objects that will
    * be notified when a game is started/ended

--- a/vassal-app/src/main/java/VASSAL/build/module/GameState.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/GameState.java
@@ -244,7 +244,7 @@ public class GameState implements CommandEncoder {
    * @return true if saveGame action is enabled (mainly to detect if logging can start)
    */
   public boolean isSaveEnabled() {
-    return (saveGame == null) ? false : saveGame.isEnabled();
+    return saveGame != null && saveGame.isEnabled();
   }
 
   /**


### PR DESCRIPTION
"End logging" managed to throw an exception in the wild. On analysis the conditions for starting/stopping logs looked a little delicate & sensitive, and subject to being called at "odd times". So now it will be safer in several ways.