### PR TITLE
3.6 - Default Font Size change

### DIFF
--- a/vassal-app/src/main/java/VASSAL/launch/Launcher.java
+++ b/vassal-app/src/main/java/VASSAL/launch/Launcher.java
@@ -18,11 +18,13 @@
 
 package VASSAL.launch;
 
+import java.awt.Font;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.nio.charset.Charset;
 
 import javax.swing.SwingUtilities;
+import javax.swing.UIManager;
 
 import org.apache.commons.lang3.SystemUtils;
 import org.slf4j.Logger;
@@ -47,6 +49,21 @@ public abstract class Launcher {
 
   public static Launcher getInstance() {
     return instance;
+  }
+
+  /**
+   * Changes all the UI fonts to the specified one
+   * @param f Font for UI
+   */
+  public static void setUIFont(javax.swing.plaf.FontUIResource f) {
+    java.util.Enumeration keys = UIManager.getDefaults().keys();
+    while (keys.hasMoreElements()) {
+      final Object key = keys.nextElement();
+      final Object value = UIManager.get(key);
+      if (value instanceof javax.swing.plaf.FontUIResource) {
+        UIManager.put(key, f);
+      }
+    }
   }
 
   protected Launcher(String[] args) {
@@ -78,6 +95,8 @@ public abstract class Launcher {
     start.initSystemProperties();
 
     createMenuManager();
+
+    setUIFont(new javax.swing.plaf.FontUIResource("SansSerif", Font.PLAIN, 18));
 
     SwingUtilities.invokeLater(new Runnable() {
       @Override

--- a/vassal-app/src/main/java/VASSAL/launch/Launcher.java
+++ b/vassal-app/src/main/java/VASSAL/launch/Launcher.java
@@ -18,13 +18,11 @@
 
 package VASSAL.launch;
 
-import java.awt.Font;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.nio.charset.Charset;
 
 import javax.swing.SwingUtilities;
-import javax.swing.UIManager;
 
 import org.apache.commons.lang3.SystemUtils;
 import org.slf4j.Logger;

--- a/vassal-app/src/main/java/VASSAL/launch/Launcher.java
+++ b/vassal-app/src/main/java/VASSAL/launch/Launcher.java
@@ -51,21 +51,6 @@ public abstract class Launcher {
     return instance;
   }
 
-  /**
-   * Changes all the UI fonts to the specified one
-   * @param f Font for UI
-   */
-  public static void setUIFont(javax.swing.plaf.FontUIResource f) {
-    final java.util.Enumeration keys = UIManager.getDefaults().keys();
-    while (keys.hasMoreElements()) {
-      final Object key = keys.nextElement();
-      final Object value = UIManager.get(key);
-      if (value instanceof javax.swing.plaf.FontUIResource) {
-        UIManager.put(key, f);
-      }
-    }
-  }
-
   protected Launcher(String[] args) {
     if (instance != null) throw new IllegalStateException();
     instance = this;
@@ -95,8 +80,6 @@ public abstract class Launcher {
     start.initSystemProperties();
 
     createMenuManager();
-
-    setUIFont(new javax.swing.plaf.FontUIResource("SansSerif", Font.PLAIN, 18));
 
     SwingUtilities.invokeLater(new Runnable() {
       @Override

--- a/vassal-app/src/main/java/VASSAL/launch/Launcher.java
+++ b/vassal-app/src/main/java/VASSAL/launch/Launcher.java
@@ -56,7 +56,7 @@ public abstract class Launcher {
    * @param f Font for UI
    */
   public static void setUIFont(javax.swing.plaf.FontUIResource f) {
-    java.util.Enumeration keys = UIManager.getDefaults().keys();
+    final java.util.Enumeration keys = UIManager.getDefaults().keys();
     while (keys.hasMoreElements()) {
       final Object key = keys.nextElement();
       final Object value = UIManager.get(key);

--- a/vassal-app/src/main/java/VASSAL/launch/StartUp.java
+++ b/vassal-app/src/main/java/VASSAL/launch/StartUp.java
@@ -19,12 +19,15 @@
 package VASSAL.launch;
 
 import java.awt.AWTError;
+import java.awt.Font;
 import java.awt.Toolkit;
 import java.lang.reflect.InvocationTargetException;
 import javax.swing.UIManager;
 import javax.swing.SwingUtilities;
 import javax.swing.UnsupportedLookAndFeelException;
 
+import VASSAL.preferences.Prefs;
+import VASSAL.preferences.ReadOnlyPrefs;
 import org.apache.commons.lang3.SystemUtils;
 
 import org.slf4j.Logger;
@@ -63,6 +66,22 @@ public class StartUp {
       System.setProperty(httpProxyPort, System.getProperty(proxyPort));
     }
   }
+
+  /**
+   * Changes all the UI fonts to the specified one
+   * @param f Font for UI
+   */
+  public void setUIFont(javax.swing.plaf.FontUIResource f) {
+    final java.util.Enumeration keys = UIManager.getDefaults().keys();
+    while (keys.hasMoreElements()) {
+      final Object key = keys.nextElement();
+      final Object value = UIManager.get(key);
+      if (value instanceof javax.swing.plaf.FontUIResource) {
+        UIManager.put(key, f);
+      }
+    }
+  }
+
 
   protected void initUIProperties() {
     System.setProperty("swing.aatext", "true"); //$NON-NLS-1$ //$NON-NLS-2$
@@ -125,6 +144,18 @@ public class StartUp {
         // upon a JPopupMenu closing (added for Windows L&F, but others might
         // also be affected.
         UIManager.put("PopupMenu.consumeEventOnClose", Boolean.FALSE);
+
+        // If user has chosen a different UI font size, then put that into effect
+        final String fontString = ReadOnlyPrefs.getGlobalPrefs().getStoredValue(Prefs.OVERRIDE_DEFAULT_FONT_SIZE);
+        try {
+          final int fontSize = Integer.parseInt(fontString);
+          if (fontSize >= 8) {
+            setUIFont(new javax.swing.plaf.FontUIResource("SansSerif", Font.PLAIN, Math.min(fontSize, 50)));
+          }
+        }
+        catch (NumberFormatException e) {
+          // No action, keep default system/java/whatever fonts.
+        }
       });
     }
     catch (InterruptedException | InvocationTargetException e) {

--- a/vassal-app/src/main/java/VASSAL/launch/StartUp.java
+++ b/vassal-app/src/main/java/VASSAL/launch/StartUp.java
@@ -149,9 +149,7 @@ public class StartUp {
         final String fontString = ReadOnlyPrefs.getGlobalPrefs().getStoredValue(Prefs.OVERRIDE_DEFAULT_FONT_SIZE);
         try {
           final int fontSize = Integer.parseInt(fontString);
-          if (fontSize >= 8) {
-            setUIFont(new javax.swing.plaf.FontUIResource("SansSerif", Font.PLAIN, Math.min(fontSize, 50)));
-          }
+          setUIFont(new javax.swing.plaf.FontUIResource("SansSerif", Font.PLAIN, Math.max(8, Math.min(fontSize, 32))));
         }
         catch (NumberFormatException e) {
           // No action, keep default system/java/whatever fonts.

--- a/vassal-app/src/main/java/VASSAL/preferences/Prefs.java
+++ b/vassal-app/src/main/java/VASSAL/preferences/Prefs.java
@@ -61,6 +61,8 @@ public class Prefs implements Closeable {
   public static final String MAIN_WINDOW_HEIGHT = "mainWindowHeight"; //NON-NLS
   public static final String MAIN_WINDOW_WIDTH  = "mainWindowWidth";  //NON-NLS
 
+  public static final String OVERRIDE_DEFAULT_FONT_SIZE = "overrideDefaultFontSize"; //NON-NLS
+
   public static final String TRANSLATABLE_SUPPORT = "translatableSupport"; //NON-NLS
 
   private static Prefs globalPrefs; // A Global Preferences object
@@ -266,6 +268,13 @@ public class Prefs implements Closeable {
       new DirectoryConfigurer(MODULES_DIR_KEY, null);
     c.setValue(new File(System.getProperty("user.home")));
     globalPrefs.addOption(null, c);
+
+    final IntConfigurer overrideDefaultFontSize = new IntConfigurer(
+        OVERRIDE_DEFAULT_FONT_SIZE,
+        Resources.getString("Prefs.override_default_font_size"),
+       0
+    );
+    globalPrefs.addOption(Resources.getString("Prefs.general_tab"), overrideDefaultFontSize);
 
     // Options to remember main window size
     final BooleanConfigurer windowRemember = new BooleanConfigurer(

--- a/vassal-app/src/main/resources/VASSAL/i18n/VASSAL.properties
+++ b/vassal-app/src/main/resources/VASSAL/i18n/VASSAL.properties
@@ -856,6 +856,7 @@ Prefs.unable_to_save=Unable to save preferences.\n
 Prefs.disable_d3d=Disable DirectX D3D pipeline? (Can resolve some graphics glitching issues)
 Prefs.main_window=Remember main window size between sessions?
 Prefs.developer_info=Show developer information in Module Manager window?
+Prefs.override_default_font_size=Override default font size? (0 = default; restart required)
 
 # Installation Resource Extractor
 


### PR DESCRIPTION
Allows the default font for VASSAL and the Editor to be a different size, via General Preferences tab.