### PR TITLE
Small fixes to docs

### DIFF
--- a/vassal-doc/pom.xml
+++ b/vassal-doc/pom.xml
@@ -40,7 +40,7 @@
                             <backend>html</backend>
                             <preserveDirectories>true</preserveDirectories>
                             <attributes>
-                                <filetype>htm</filetype>
+                                <outfilesuffix>.htm</outfilesuffix>
                             </attributes>
                         </configuration>
                     </execution>

--- a/vassal-doc/src/main/designerguide/designerguide.adoc
+++ b/vassal-doc/src/main/designerguide/designerguide.adoc
@@ -9,7 +9,7 @@
 // :compress: // needs ghostscript
 :front-cover-image: image:_images/image1.jpeg[image,width=784,height=1024]
 :media: screen
-:optimize: screen
+:optimize:
 
 Version {project-version}, {docdate}
 

--- a/vassal-doc/src/main/userguide/userguide.adoc
+++ b/vassal-doc/src/main/userguide/userguide.adoc
@@ -10,7 +10,7 @@
 // :compress: // needs ghostscript
 :front-cover-image: image:image1.png[image,width=816,height=1054]
 :media: screen
-:optimize: screen
+:optimize:
 
 Version {project-version}, {docdate}
 


### PR DESCRIPTION
Just checked the configuration and found some things to improve.
Feel free to ignore this PR this don't make sense to your current approach.

* Fix html file extension override
`filetype` attribute does not apply to file conversion, you need to use `outfilesuffix`.
If you don't want to change the file extension, just remove the attribute.

* Simplify `optimize` attr
This attribute does not need any value. Also if it's causinf trouble due to the issue with asciidoctor-pdf, you can just run the command with `-Dasciidoctor.attributes=!optimize` to unset it from the command line. You can also add this to the properties section in settings.xml to avoid typing it any time.

Also saw, you are composing the user guide. You may be interested to use `:leveloffset: +1` https://docs.asciidoctor.org/asciidoc/latest/directives/include-with-leveloffset/#manipulate-heading-levels-with-leveloffset. That way, the composed parts don't need to add +1 to the section headers. It makes writting simpler and useful if you want to reuse the pages for other convertions, like individual HTML.
