### PR TITLE
MassPieceUploader adoc clarification

### DIFF
--- a/vassal-doc/src/main/readme-referencemanual/ReferenceManual/MassPieceLoader.adoc
+++ b/vassal-doc/src/main/readme-referencemanual/ReferenceManual/MassPieceLoader.adoc
@@ -72,7 +72,7 @@ The options you have to choose from are:
 * _Same as:_
 * _Use Base image:_
 
-==== Version 3.5.5 limitations
+==== Base name and suffix limitations
 The name of the file defining the base image of the piece cannot contain dots (apart from the file type separator).
 The suffixes defined for the extra layers must not contain dots.
 

--- a/vassal-doc/src/main/readme-referencemanual/ReferenceManual/MassPieceLoader.adoc
+++ b/vassal-doc/src/main/readme-referencemanual/ReferenceManual/MassPieceLoader.adoc
@@ -73,6 +73,7 @@ The options you have to choose from are:
 * _Use Base image:_
 
 ==== Base name and suffix limitations
+
 The name of the file defining the base image of the piece cannot contain dots (apart from the file type separator).
 The suffixes defined for the extra layers must not contain dots.
 

--- a/vassal-doc/src/main/readme-referencemanual/ReferenceManual/MassPieceLoader.adoc
+++ b/vassal-doc/src/main/readme-referencemanual/ReferenceManual/MassPieceLoader.adoc
@@ -72,6 +72,10 @@ The options you have to choose from are:
 * _Same as:_
 * _Use Base image:_
 
+==== Version 3.5.5 limitations
+The name of the file defining the base image of the piece cannot contain dots (apart from the file type separator).
+The suffixes defined for the extra layers must not contain dots.
+
 ==== EXAMPLE:
 
 (See image of Modified Layer Trait above) +


### PR DESCRIPTION
14409 MassPieceUploader - mention in help that filenames cannot contain dot + suffix separator cannot be dot