### PR TITLE
14423 - True is a better always-active default for brand new Layer traits

### DIFF
--- a/vassal-app/src/main/java/VASSAL/counters/Embellishment.java
+++ b/vassal-app/src/main/java/VASSAL/counters/Embellishment.java
@@ -191,6 +191,9 @@ public class Embellishment extends Decorator implements TranslatablePiece {
     }
     else {
       s = s.substring(ID.length());
+
+      final boolean brandNew = Resources.getString("Editor.Embellishment.activate").equals(s);
+
       final SequenceEncoder.Decoder st = new SequenceEncoder.Decoder(s, ';');
       activateCommand = st.nextToken("");
       activateModifiers = st.nextInt(InputEvent.CTRL_DOWN_MASK);
@@ -228,7 +231,7 @@ public class Embellishment extends Decorator implements TranslatablePiece {
       firstLevelValue = st.nextInt(1);
 
       version = st.nextInt(0);
-      alwaysActive = st.nextBoolean(false);
+      alwaysActive = st.nextBoolean(true);
       activateKeyStroke = st.nextNamedKeyStroke();
       increaseKeyStroke = st.nextNamedKeyStroke();
       decreaseKeyStroke = st.nextNamedKeyStroke();
@@ -237,7 +240,7 @@ public class Embellishment extends Decorator implements TranslatablePiece {
 
       // Conversion?
       if (version == BASE_VERSION) {
-        alwaysActive = activateKey.length() == 0;
+        alwaysActive = brandNew ? true : (activateKey.length() == 0);
 
         // Cannot convert if activate, up or down has more than 1 char specified
         if (activateKey.length() <= 1 && upKey.length() <= 1 && downKey.length() <= 1) {

--- a/vassal-app/src/main/java/VASSAL/counters/Embellishment.java
+++ b/vassal-app/src/main/java/VASSAL/counters/Embellishment.java
@@ -240,7 +240,7 @@ public class Embellishment extends Decorator implements TranslatablePiece {
 
       // Conversion?
       if (version == BASE_VERSION) {
-        alwaysActive = brandNew ? true : (activateKey.length() == 0);
+        alwaysActive = brandNew || (activateKey.length() == 0);
 
         // Cannot convert if activate, up or down has more than 1 char specified
         if (activateKey.length() <= 1 && upKey.length() <= 1 && downKey.length() <= 1) {


### PR DESCRIPTION
I propose that we set the default for the "Always Active" checkbox on brand new Layer traits to be "true". 

My reasoning:
(1) Having it default to "false" leads to confusion when beginner (or merely hasty) module designers make a layer trait and it doesn't "show up" when they look at their piece in the definer / palette / module.
(2) "Modern" modules are more likely to have layers "follow expression value" than be "activated" by keystrokes
(3) I have had to remember to manually check this box in 100% of the Layers in 100% of the modules I have ever worked on.