### PR TITLE
Mat Touchups - proper default names, proper default checkbox, and don't put spurious description in piece definer's version of the name

### DIFF
--- a/vassal-app/src/main/java/VASSAL/counters/Mat.java
+++ b/vassal-app/src/main/java/VASSAL/counters/Mat.java
@@ -32,7 +32,11 @@ public class Mat extends Decorator implements TranslatablePiece {
   protected List<GamePiece> contents = new ArrayList<>();
 
   public Mat() {
-    this(ID + ";Mat;", null); //NON-NLS
+    this(ID + "Mat;;", null); //NON-NLS
+  }
+
+  public Mat(String name) {
+    this (ID + name + ";;", null);
   }
 
   public Mat(String type, GamePiece inner) {
@@ -207,7 +211,7 @@ public class Mat extends Decorator implements TranslatablePiece {
 
   @Override
   public String getDescription() {
-    return buildDescription("Editor.Mat.trait_description", desc);
+    return buildDescription("Editor.Mat.trait_description", matName, desc);
   }
 
   @Override

--- a/vassal-app/src/main/java/VASSAL/counters/MatCargo.java
+++ b/vassal-app/src/main/java/VASSAL/counters/MatCargo.java
@@ -50,7 +50,7 @@ public class MatCargo extends Decorator implements TranslatablePiece {
   protected GamePiece mat; // Mat piece we are assigned to, or null
 
   public MatCargo() {
-    this(ID + ";", null);
+    this(ID + ";true", null); //NON-NLS
   }
 
   public MatCargo(String type, GamePiece inner) {

--- a/vassal-app/src/main/java/VASSAL/counters/PieceDefiner.java
+++ b/vassal-app/src/main/java/VASSAL/counters/PieceDefiner.java
@@ -225,7 +225,7 @@ public class PieceDefiner extends JPanel implements HelpWindowExtension {
       addElement(new SetGlobalProperty());
       addElement(new Deselect());
       addElement(new TranslatableMessage());
-      addElement(new Mat());
+      addElement(new Mat(""));
       addElement(new MatCargo());
 
       // Generate a model sorted by description, in the current users language


### PR DESCRIPTION
Some cosmetic touchups I noticed needing to be done when I started using Mats:
(1) Was defaulting the Mat *description* rather than the *name* to be "Mat". Have swapped.
(2) Was defaulting keep-facing-with-mat to "false", have swapped to "true".
(3) There were buildDescription shenanigans when displaying the name of the the potential new trait in PieceDefiner. 
