### PR TITLE
Mat/Cargo Click Support Tuneup - ability to "narrow the selection" by plain left-clicking on cargo

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/module/Map.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/Map.java
@@ -821,6 +821,18 @@ public class Map extends AbstractToolbarItem implements GameComponent, MouseList
   }
 
   /**
+   * @return KeyBufferer (if any) for this map.
+   */
+  public KeyBufferer getKeyBufferer() {
+    for (final Object o : drawComponents) {
+      if (o instanceof KeyBufferer) {
+        return (KeyBufferer)o;
+      }
+    }
+    return null;
+  }
+
+  /**
    * Registers this Map as a child of another buildable component, usually the {@link GameModule}. Determines a unique id for
    * this Map. Registers itself as {@link KeyStrokeSource}. Registers itself as a {@link GameComponent}. Registers itself as
    * a drop target and drag source. If the map is to be removed or otherwise shutdown, it can be deregistered, reversing this

--- a/vassal-app/src/main/java/VASSAL/build/module/map/PieceMover.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/PieceMover.java
@@ -1559,6 +1559,16 @@ public class PieceMover extends AbstractBuildable
       );
 
       dge.getDragSource().addDragSourceMotionListener(this);
+
+      // Let our map's KeyBufferer know that this is now a drag not a click.
+      final Map map = dge.getComponent() instanceof Map.View ?
+        ((Map.View) dge.getComponent()).getMap() : null;
+      if (map != null) {
+        final KeyBufferer kb = map.getKeyBufferer();
+        if (kb != null) {
+          kb.dragStarted();
+        }
+      }
     }
 
     /**************************************************************************

--- a/vassal-app/src/main/java/VASSAL/build/module/map/StackExpander.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/StackExpander.java
@@ -60,9 +60,12 @@ public class StackExpander extends MouseAdapter implements Buildable {
                         && SwingUtils.isMainMouseButtonDown(e)) {
       final GamePiece p = map.findPiece(e.getPoint(), PieceFinder.STACK_ONLY);
       if (p != null) {
-        KeyBuffer.getBuffer().clear();
-        ((Stack) p).setExpanded(!((Stack) p).isExpanded());
-        KeyBuffer.getBuffer().add(((Stack) p).topPiece());  //NOTE: topPiece() returns the top VISIBLE piece (not hidden by Invisible trait)
+        final Stack s = (Stack)p;
+        if (s.nVisible() > 1) {
+          KeyBuffer.getBuffer().clear();
+          ((Stack) p).setExpanded(!((Stack) p).isExpanded());
+          KeyBuffer.getBuffer().add(((Stack) p).topPiece());  //NOTE: topPiece() returns the top VISIBLE piece (not hidden by Invisible trait)
+        }
       }
       e.consume();
     }


### PR DESCRIPTION
TL;DR Clicking/Dragging on Mat Cargo "feels more right" now.

I remember a previous conversation where we found it bothersome that when a Mat-and-its-Cargo all get selected, that you don't have an easy way to then grab "just one piece of Cargo" and move it around the mat, because just clicking on an already-selected piece leaves everything selected -- that's because of the separate-silo way that we handle "clicks" vs. "drags": if we changed the selection on initial mousePressed, we might find that we'd bollixed up the drag the player was trying to do.

So, for Mat Cargo pieces, I have provided some better coordination of "what is a click" vs. "what is a drag" so that we can have a more detailed selection algorithm without screwing up our drag-and-drops. 

If a Mat Cargo piece and its Mat (and possibly other cargo) are selected, then beginning a drag-and-drop on ANY of those pieces will still grab them all -- this is correct, and still as before.

However for Mat Cargo pieces ONLY, a completely vanilla left _click_ (NOT drag) on a cargo piece that is already part of a larger selection will remove everything else but THAT piece (or unexpanded stack of Mat Cargo pieces) from the selection. So THEN the Mat Cargo can be e.g. dragged off the Mat (or adjusted on top of the mat). 

For the moment this functionality applies only to Mat Cargo pieces that are currently on Mats. But we could use the same functionality (the "maybeClickPiece") on other pieces in the future if we decide that it makes sense to provide ways to click on pieces in a selection and narrow the selection.