### PR TITLE
14468 - CounterDetailViewer fix

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/module/map/CounterDetailViewer.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/CounterDetailViewer.java
@@ -388,7 +388,7 @@ public class CounterDetailViewer extends AbstractConfigurable implements Drawabl
 
           // Draw text label for this counter. If we already have a combine-o-rama box, don't draw an extra round of box & background
           if (!combineCounterSummary || !stretchWidthSummary || (pieces.size() != 1)) {
-            final int x = dbounds.x - (int) (pieceBounds.x * graphicsZoom * os_scale) + (int) (borderOffset * os_scale); // + (int) (borderWidth * os_scale);
+            final int x = dbounds.x - (int) (pieceBounds.x * graphicsZoom * os_scale) + (int) (borderOffset * os_scale);
             drawLabel(g, new Point(x, y), text, LabelUtils.CENTER, LabelUtils.CENTER, 0, 0, 0, combineCounterSummary && stretchWidthSummary);
           }
           anyUnderText = true;

--- a/vassal-app/src/main/java/VASSAL/build/module/map/CounterDetailViewer.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/CounterDetailViewer.java
@@ -388,7 +388,7 @@ public class CounterDetailViewer extends AbstractConfigurable implements Drawabl
 
           // Draw text label for this counter. If we already have a combine-o-rama box, don't draw an extra round of box & background
           if (!combineCounterSummary || !stretchWidthSummary || (pieces.size() != 1)) {
-            final int x = dbounds.x /*- (int) (pieceBounds.x * graphicsZoom * os_scale)*/ + (int) (borderOffset * os_scale);
+            final int x = dbounds.x + (int) (borderOffset * os_scale);
             drawLabel(g, new Point(x, y), text, LabelUtils.CENTER, LabelUtils.CENTER, (int)(pieceBounds.width * graphicsZoom * os_scale), 0, 0, combineCounterSummary && stretchWidthSummary);
           }
           anyUnderText = true;

--- a/vassal-app/src/main/java/VASSAL/build/module/map/CounterDetailViewer.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/CounterDetailViewer.java
@@ -388,6 +388,11 @@ public class CounterDetailViewer extends AbstractConfigurable implements Drawabl
 
           // Draw text label for this counter. If we already have a combine-o-rama box, don't draw an extra round of box & background
           if (!combineCounterSummary || !stretchWidthSummary || (pieces.size() != 1)) {
+            //BR// We now use the left-side position of the piece region and pass the full width of the piece to center
+            //BR// in (pieceBounds.width appropriately scaled), rather than the old method of scaling pieceBounds.x and
+            //BR// applying to the X position, because for whatever reason a 100x100 square piece can apparently return
+            //BR// values like "-46" for the pieceBounds.x. Which apparently causes the *piece* to get *drawn* in the
+            //BR// right place but is clearly NOT the way to center text beneath the piece. AIEEEEEEEEEEEEEEEEEEEEEE!!!
             final int x = dbounds.x + (int) (borderOffset * os_scale);
             drawLabel(g, new Point(x, y), text, LabelUtils.CENTER, LabelUtils.CENTER, (int)(pieceBounds.width * graphicsZoom * os_scale), 0, 0, combineCounterSummary && stretchWidthSummary);
           }

--- a/vassal-app/src/main/java/VASSAL/build/module/map/CounterDetailViewer.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/CounterDetailViewer.java
@@ -388,8 +388,8 @@ public class CounterDetailViewer extends AbstractConfigurable implements Drawabl
 
           // Draw text label for this counter. If we already have a combine-o-rama box, don't draw an extra round of box & background
           if (!combineCounterSummary || !stretchWidthSummary || (pieces.size() != 1)) {
-            final int x = dbounds.x - (int) (pieceBounds.x * graphicsZoom * os_scale) + (int) (borderOffset * os_scale);
-            drawLabel(g, new Point(x, y), text, LabelUtils.CENTER, LabelUtils.CENTER, 0, 0, 0, combineCounterSummary && stretchWidthSummary);
+            final int x = dbounds.x /*- (int) (pieceBounds.x * graphicsZoom * os_scale)*/ + (int) (borderOffset * os_scale);
+            drawLabel(g, new Point(x, y), text, LabelUtils.CENTER, LabelUtils.CENTER, (int)(pieceBounds.width * graphicsZoom * os_scale), 0, 0, combineCounterSummary && stretchWidthSummary);
           }
           anyUnderText = true;
         }

--- a/vassal-app/src/main/java/VASSAL/build/module/map/CounterDetailViewer.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/CounterDetailViewer.java
@@ -388,7 +388,7 @@ public class CounterDetailViewer extends AbstractConfigurable implements Drawabl
 
           // Draw text label for this counter. If we already have a combine-o-rama box, don't draw an extra round of box & background
           if (!combineCounterSummary || !stretchWidthSummary || (pieces.size() != 1)) {
-            final int x = dbounds.x - (int) (pieceBounds.x * graphicsZoom * os_scale) + (int) (borderOffset * os_scale) + (int) (borderWidth * os_scale);
+            final int x = dbounds.x - (int) (pieceBounds.x * graphicsZoom * os_scale) + (int) (borderOffset * os_scale); // + (int) (borderWidth * os_scale);
             drawLabel(g, new Point(x, y), text, LabelUtils.CENTER, LabelUtils.CENTER, 0, 0, 0, combineCounterSummary && stretchWidthSummary);
           }
           anyUnderText = true;


### PR DESCRIPTION
Mark found a text alignment problem when "extra space between" was being selected, and I discovered a spurious "additional add" of the value. This should correct it.