### PR TITLE
Password UX improvements (aka "Just shoot me now")

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/GameModule.java
+++ b/vassal-app/src/main/java/VASSAL/build/GameModule.java
@@ -653,6 +653,7 @@ public class GameModule extends AbstractConfigurable
     initFrame();
   }
 
+
   /**
    * Associates our user identity with the module's preferences.
    */
@@ -662,7 +663,7 @@ public class GameModule extends AbstractConfigurable
     fullName.addPropertyChangeListener(evt -> idChangeSupport.firePropertyChange(evt));
     final TextConfigurer profile = new TextConfigurer(GameModule.PERSONAL_INFO, Resources.getString("Prefs.personal_info"), "");   //$NON-NLS-1$ //$NON-NLS-2$
     profile.addPropertyChangeListener(evt -> idChangeSupport.firePropertyChange(evt));
-    final ToggleablePasswordConfigurer user = new ToggleablePasswordConfigurer(GameModule.SECRET_NAME, Resources.getString("Prefs.password_label"), Resources.getString("Prefs.password_prompt", System.getProperty("user.name"))); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+    final ToggleablePasswordConfigurer user = new ToggleablePasswordConfigurer(GameModule.SECRET_NAME, Resources.getString("Prefs.password_label"), ""); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
     user.addPropertyChangeListener(evt -> GameModule.setUserId((String) evt.getNewValue()));
     getPrefs().addOption(Resources.getString("Prefs.personal_tab"), fullName);   //$NON-NLS-1$ //$NON-NLS-2$
     getPrefs().addOption(Resources.getString("Prefs.personal_tab"), user);   //$NON-NLS-1$ //$NON-NLS-2$
@@ -1705,6 +1706,39 @@ public class GameModule extends AbstractConfigurable
    */
   public void clearPausedCommands() {
     pausedCommands.clear();
+  }
+
+
+  /**
+   * @return List of currently matchable passwords, including "defaults" of various types.
+   */
+  public static List<String> getCurrentPasswords() {
+    final List<String> l = new ArrayList<>();
+    l.add(GameModule.getUserId());
+    l.add(Resources.getString("Prefs.password_prompt", System.getProperty("user.name")));
+    l.add("");
+    return l;
+  }
+
+  static String tempUserId = null;
+
+  /**
+   * @return the userId/password we're currently using, in case we're using one of our alternate defaults. Or if none explicitly picked, the actual contents of our password field.
+   */
+  public static String getActiveUserId() {
+    return (tempUserId == null) ? userId : tempUserId;
+  }
+
+  public static String getTempUserId() {
+    return tempUserId;
+  }
+
+  public static void setTempUserId(String id) {
+    tempUserId = id;
+  }
+
+  public static void clearTempUserId() {
+    tempUserId = null;
   }
 
   /**

--- a/vassal-app/src/main/java/VASSAL/build/GameModule.java
+++ b/vassal-app/src/main/java/VASSAL/build/GameModule.java
@@ -1709,17 +1709,6 @@ public class GameModule extends AbstractConfigurable
   }
 
 
-  /**
-   * @return List of currently matchable passwords, including "defaults" of various types.
-   */
-  public static List<String> getCurrentPasswords() {
-    final List<String> l = new ArrayList<>();
-    l.add(GameModule.getUserId());
-    l.add(Resources.getString("Prefs.password_prompt", System.getProperty("user.name")));
-    l.add("");
-    return l;
-  }
-
   static String tempUserId = null;
 
   /**

--- a/vassal-app/src/main/java/VASSAL/build/module/BasicCommandEncoder.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/BasicCommandEncoder.java
@@ -368,7 +368,7 @@ public class BasicCommandEncoder implements CommandEncoder, Buildable {
       final int oldX = Integer.parseInt(st.nextToken());
       final int oldY = Integer.parseInt(st.nextToken());
       final String oldUnderId = unwrapNull(st.nextToken());
-      final String playerid = st.nextToken(GameModule.getUserId());
+      final String playerid = st.nextToken(GameModule.getActiveUserId());
       return new MovePiece(id, newMapId, new Point(newX, newY), newUnderId, oldMapId, new Point(oldX, oldY), oldUnderId, playerid);
     }
     else {

--- a/vassal-app/src/main/java/VASSAL/build/module/ObscurableOptions.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/ObscurableOptions.java
@@ -72,14 +72,14 @@ public class ObscurableOptions implements CommandEncoder, GameComponent {
     GameModule.getGameModule().getPrefs().addOption(c);
     c.addPropertyChangeListener(evt -> {
       if (Boolean.TRUE.equals(evt.getNewValue())) {
-        ObscurableOptions.getInstance().allow(GameModule.getUserId());
+        ObscurableOptions.getInstance().allow(GameModule.getActiveUserId());
         final String side = PlayerRoster.getMySide();
         if (side != null) {
           ObscurableOptions.getInstance().allow(side);
         }
       }
       else {
-        ObscurableOptions.getInstance().disallow(GameModule.getUserId());
+        ObscurableOptions.getInstance().disallow(GameModule.getActiveUserId());
         final String side = PlayerRoster.getMySide();
         if (side != null) {
           ObscurableOptions.getInstance().disallow(side);
@@ -89,10 +89,10 @@ public class ObscurableOptions implements CommandEncoder, GameComponent {
                 .getServer().sendToOthers(new SetAllowed(instance.allowed));
     });
     if (Boolean.TRUE.equals(c.getValue())) {
-      allow(GameModule.getUserId());
+      allow(GameModule.getActiveUserId());
     }
     else {
-      disallow(GameModule.getUserId());
+      disallow(GameModule.getActiveUserId());
     }
   }
 
@@ -208,7 +208,7 @@ public class ObscurableOptions implements CommandEncoder, GameComponent {
     }
     else if (Boolean.TRUE.equals(
                GameModule.getGameModule().getPrefs().getValue(PREFS_KEY))) {
-      allow(GameModule.getUserId());
+      allow(GameModule.getActiveUserId());
     }
   }
 

--- a/vassal-app/src/main/java/VASSAL/build/module/PlayerRoster.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/PlayerRoster.java
@@ -262,6 +262,9 @@ public class PlayerRoster extends AbstractToolbarItem implements CommandEncoder,
   }
 
 
+  /**
+   * Called when the Launch Button for the player roster is clicked (i.e. the "Retire" or "Change Sides" button)
+   */
   protected void launch() {
     final String mySide = getMySide();
     if (mySide == null && allSidesAllocated()) {
@@ -277,7 +280,7 @@ public class PlayerRoster extends AbstractToolbarItem implements CommandEncoder,
     final GameModule gm = GameModule.getGameModule();
 
     final PlayerInfo me = new PlayerInfo(
-      GameModule.getUserId(),
+      GameModule.getActiveUserId(),
       GlobalOptions.getInstance().getPlayerId(),
       newSide
     );
@@ -285,7 +288,7 @@ public class PlayerRoster extends AbstractToolbarItem implements CommandEncoder,
     Command c = new Chatter.DisplayText(gm.getChatter(), Resources.getString(GlobalOptions.getInstance().chatterHTMLSupport() ? "PlayerRoster.changed_sides_2" : "PlayerRoster.changed_sides", me.playerName, mySide, newSide));
     c.execute();
 
-    remove(GameModule.getUserId());
+    remove(GameModule.getActiveUserId());
 
     final Add a = new Add(this, me.playerId, me.playerName, me.side);
     a.execute();
@@ -327,7 +330,7 @@ public class PlayerRoster extends AbstractToolbarItem implements CommandEncoder,
     final PlayerRoster r = GameModule.getGameModule().getPlayerRoster();
     if (r != null) {
       for (final PlayerInfo pi : r.getPlayers()) {
-        if (pi.playerId.equals(GameModule.getUserId())) {
+        if (pi.playerId.equals(GameModule.getActiveUserId())) {
           return localized ? pi.getLocalizedSide() : pi.getSide();
         }
       }
@@ -343,6 +346,12 @@ public class PlayerRoster extends AbstractToolbarItem implements CommandEncoder,
     return new ArrayList<>(sides);
   }
 
+  /**
+   * Adds a player to the list of active players occupying sides
+   * @param playerId player unique id (password)
+   * @param playerName player name
+   * @param side player side
+   */
   public void add(String playerId, String playerName, String side) {
     final PlayerInfo e = new PlayerInfo(playerId, playerName, side);
     if (players.contains(e)) {
@@ -360,6 +369,10 @@ public class PlayerRoster extends AbstractToolbarItem implements CommandEncoder,
     }
   }
 
+  /**
+   * Remove a player from the list of active players occupying sides
+   * @param playerId player unique id (password)
+   */
   public void remove(String playerId) {
     final PlayerInfo e = new PlayerInfo(playerId, null, null);
     players.remove(e);
@@ -404,7 +417,7 @@ public class PlayerRoster extends AbstractToolbarItem implements CommandEncoder,
   @Override
   public void setup(boolean gameStarting) {
     if (gameStarting) {
-      final PlayerInfo me = new PlayerInfo(GameModule.getUserId(),
+      final PlayerInfo me = new PlayerInfo(GameModule.getActiveUserId(),
         GlobalOptions.getInstance().getPlayerId(), null);
       if (players.contains(me)) {
         final PlayerInfo saved = players.get(players.indexOf(me));
@@ -424,11 +437,14 @@ public class PlayerRoster extends AbstractToolbarItem implements CommandEncoder,
     pickedSide = false;
   }
 
+  /**
+   * finish() step for Wizard
+   */
   @Override
   public void finish() {
     final String newSide = untranslateSide(sideConfig.getValueString());
     if (newSide != null) {
-      final Add a = new Add(this, GameModule.getUserId(), GlobalOptions.getInstance().getPlayerId(), newSide);
+      final Add a = new Add(this, GameModule.getActiveUserId(), GlobalOptions.getInstance().getPlayerId(), newSide);
       a.execute();
       GameModule.getGameModule().getServer().sendToOthers(a);
     }
@@ -454,12 +470,18 @@ public class PlayerRoster extends AbstractToolbarItem implements CommandEncoder,
     return sideConfig.getControls();
   }
 
+  /**
+   * @return step title for Wizard's GameSetupStep
+   */
   @Override
   public String getStepTitle() {
     return Resources.getString("PlayerRoster.choose_side"); //$NON-NLS-1$
   }
 
-  // Implement GameSetupStep
+  /**
+   * Implement GameSetupStep for Wizard
+   * @return true if Wizard GameSetupStep is finished
+   */
   @Override
   public boolean isFinished() {
     if (pickedSide) {
@@ -474,7 +496,7 @@ public class PlayerRoster extends AbstractToolbarItem implements CommandEncoder,
     // If we are already recorded as a player (i.e. in Saved Game), then
     // the step is only finished if we are not the Observer.
     final PlayerInfo newPlayerInfo = new PlayerInfo(
-      GameModule.getUserId(),
+      GameModule.getActiveUserId(),
       GlobalOptions.getInstance().getPlayerId(), null
     );
 

--- a/vassal-app/src/main/java/VASSAL/build/module/PlayerRoster.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/PlayerRoster.java
@@ -501,6 +501,8 @@ public class PlayerRoster extends AbstractToolbarItem implements CommandEncoder,
       return true;
     }
 
+    claimOccupiedSide();
+
     // If we are already recorded as a player (i.e. in Saved Game), then
     // the step is only finished if we are not the Observer.
     final PlayerInfo newPlayerInfo = new PlayerInfo(

--- a/vassal-app/src/main/java/VASSAL/build/module/PlayerRoster.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/PlayerRoster.java
@@ -330,11 +330,11 @@ public class PlayerRoster extends AbstractToolbarItem implements CommandEncoder,
    * @return List of currently matchable passwords, including "defaults" of various types.
    */
   protected static List<String> getCurrentPasswords() {
-    final List<String> l = new ArrayList<>();
-    l.add(GameModule.getUserId());
-    l.add(Resources.getString("Prefs.password_prompt", System.getProperty("user.name")));
-    l.add("");
-    return l;
+    return List.of(
+      GameModule.getUserId(),
+      Resources.getString("Prefs.password_prompt", System.getProperty("user.name")),
+      ""
+    );
   }
 
 

--- a/vassal-app/src/main/java/VASSAL/build/module/WizardSupport.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/WizardSupport.java
@@ -404,7 +404,7 @@ public class WizardSupport {
           if (nameConfig.getValue() == null || "".equals(nameConfig.getValue())) { //$NON-NLS-1$
             controller.setProblem(Resources.getString("WizardSupport.EnterYourName")); //$NON-NLS-1$
           }
-          else if (pwd.getValue() == null || "".equals(pwd.getValue())) { //$NON-NLS-1$
+          else if (pwd.getValue() == null) { //$NON-NLS-1$
             controller.setProblem(Resources.getString("WizardSupport.EnterYourPassword")); //$NON-NLS-1$
           }
           else if (!pwd.getValue().equals(pwd2.getValue())) {

--- a/vassal-app/src/main/java/VASSAL/build/module/chessclockcontrol/ChessClock.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/chessclockcontrol/ChessClock.java
@@ -992,7 +992,7 @@ public class ChessClock extends AbstractConfigurable implements CommandEncoder, 
         c = resetState();
 
         final PlayerRoster.PlayerInfo me = new PlayerRoster.PlayerInfo(
-          GameModule.getUserId(),
+          GameModule.getActiveUserId(),
           GlobalOptions.getInstance().getPlayerId(),
           PlayerRoster.getMySide()
         );

--- a/vassal-app/src/main/java/VASSAL/build/module/map/TextSaver.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/TextSaver.java
@@ -100,10 +100,10 @@ public class TextSaver extends AbstractToolbarItem {
       writeMapAsText();
       break;
     case JOptionPane.YES_OPTION:
-      final String myId = GameModule.getUserId();
-      GameModule.setUserId("yendoR117"); //NON-NLS
+      final String myId = GameModule.getTempUserId();
+      GameModule.setTempUserId("yendoR117"); //NON-NLS
       writeMapAsText();
-      GameModule.setUserId(myId);
+      GameModule.setTempUserId(myId);
       break;
     }
   }

--- a/vassal-app/src/main/java/VASSAL/build/module/noteswindow/PrivateNotesController.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/noteswindow/PrivateNotesController.java
@@ -62,7 +62,7 @@ public class PrivateNotesController implements GameComponent, CommandEncoder, Se
   public void addPrivateText(PrivateText p) {
     notes.remove(p);
     notes.add(p);
-    if (p.getOwner().equals(GameModule.getUserId())) {
+    if (p.getOwner().equals(GameModule.getActiveUserId())) {
       text.setValue(p.getText());
     }
   }
@@ -118,7 +118,7 @@ public class PrivateNotesController implements GameComponent, CommandEncoder, Se
   public Command save() {
     Command comm = null;
     if (!myLastSavedNotes.equals(text.getValue())) {
-      comm = new SetPrivateTextCommand(this, new PrivateText(GameModule.getUserId(), (String) text.getValue()));
+      comm = new SetPrivateTextCommand(this, new PrivateText(GameModule.getActiveUserId(), (String) text.getValue()));
       comm.execute();
     }
     return comm;

--- a/vassal-app/src/main/java/VASSAL/build/module/noteswindow/SecretNotesController.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/noteswindow/SecretNotesController.java
@@ -395,7 +395,7 @@ public class SecretNotesController implements GameComponent, CommandEncoder, Add
       final String selectedName = (String) table.getValueAt(selectedRow, COL_NAME);
       SecretNote note = getNoteForName(selectedName);
 
-      if (note.getOwner().equals(GameModule.getUserId())) {
+      if (note.getOwner().equals(GameModule.getActiveUserId())) {
         note = new SecretNote(note.getName(), note.getOwner(), note.getText(), false, note.getDate(), note.getHandle());
         if (note != null) {
           final int i = notes.indexOf(note);
@@ -436,7 +436,7 @@ public class SecretNotesController implements GameComponent, CommandEncoder, Add
       okButton.addActionListener(e -> {
         final SecretNote note = new SecretNote(
           name.getValueString(),
-          GameModule.getUserId(),
+          GameModule.getActiveUserId(),
           (String) text.getValue(),
           true
         );
@@ -487,7 +487,7 @@ public class SecretNotesController implements GameComponent, CommandEncoder, Add
       final SecretNote note = getNoteForName(selectedName);
 
       if (note != null) {
-        if (note.getOwner().equals(GameModule.getUserId())) {
+        if (note.getOwner().equals(GameModule.getActiveUserId())) {
           text.setText(note.getText());
           revealButton.setEnabled(note.isHidden());
         }

--- a/vassal-app/src/main/java/VASSAL/command/MoveTracker.java
+++ b/vassal-app/src/main/java/VASSAL/command/MoveTracker.java
@@ -64,6 +64,6 @@ public class MoveTracker {
       oldMapId,
       oldPosition,
       oldUnderneathId,
-      GameModule.getUserId());
+      GameModule.getActiveUserId());
   }
 }

--- a/vassal-app/src/main/java/VASSAL/counters/PlayerAccess.java
+++ b/vassal-app/src/main/java/VASSAL/counters/PlayerAccess.java
@@ -37,7 +37,7 @@ public class PlayerAccess implements PieceAccess {
 
   @Override
   public String getCurrentPlayerId() {
-    return GameModule.getUserId();
+    return GameModule.getActiveUserId();
   }
 
   @Override

--- a/vassal-app/src/main/java/VASSAL/counters/Restricted.java
+++ b/vassal-app/src/main/java/VASSAL/counters/Restricted.java
@@ -115,7 +115,7 @@ public class Restricted extends Decorator implements EditablePiece {
   public boolean isRestricted() {
     boolean restricted = false;
     if (restrictByPlayer) {
-      restricted = owningPlayer.length() > 0 && !GameModule.getUserId().equals(owningPlayer);
+      restricted = owningPlayer.length() > 0 && !GameModule.getActiveUserId().equals(owningPlayer);
     }
     if ((restricted || !restrictByPlayer)
         && PlayerRoster.isActive()
@@ -134,7 +134,7 @@ public class Restricted extends Decorator implements EditablePiece {
 /*  @Override
   public void setMap(Map m) {
     if (m != null && restrictByPlayer && owningPlayer.length() == 0) {
-      owningPlayer = GameModule.getUserId();
+      owningPlayer = GameModule.getActiveUserId();
     }
     super.setMap(m);
   }
@@ -143,7 +143,7 @@ public class Restricted extends Decorator implements EditablePiece {
   public void setProperty(Object key, Object val) {
     if (Properties.SELECTED.equals(key) && Boolean.TRUE.equals(val) && restrictByPlayer && owningPlayer.length() == 0) {
       if (getMap() != null) {
-        owningPlayer = GameModule.getUserId();
+        owningPlayer = GameModule.getActiveUserId();
       }
     }
     super.setProperty(key, val);
@@ -293,7 +293,7 @@ public class Restricted extends Decorator implements EditablePiece {
       final Restricted r = (Restricted)Decorator.getDecorator(p, Restricted.class);
       if (r != null
           && r.restrictByPlayer
-          && GameModule.getUserId().equals(r.owningPlayer)) {
+          && GameModule.getActiveUserId().equals(r.owningPlayer)) {
 
         final ChangeTracker t = new ChangeTracker(p);
         r.owningPlayer = "";

--- a/vassal-app/src/main/java/VASSAL/counters/Translate.java
+++ b/vassal-app/src/main/java/VASSAL/counters/Translate.java
@@ -359,7 +359,7 @@ public class Translate extends Decorator implements TranslatablePiece {
         && !outer.getParent().isExpanded()) {
       // Only move entire stack if this is the top piece
       // Otherwise moves the stack too far if the whole stack is multi-selected
-      if (outer != outer.getParent().topPiece(GameModule.getUserId())) {  //NOTE: topPiece() returns the top VISIBLE piece (not hidden by Invisible trait)
+      if (outer != outer.getParent().topPiece(GameModule.getActiveUserId())) {  //NOTE: topPiece() returns the top VISIBLE piece (not hidden by Invisible trait)
         target = null;
       }
       else {

--- a/vassal-app/src/main/resources/VASSAL/i18n/VASSAL.properties
+++ b/vassal-app/src/main/resources/VASSAL/i18n/VASSAL.properties
@@ -834,6 +834,12 @@ PlayerRoster.moderator=Moderator
 PlayerRoster.referee=Referee
 PlayerRoster.changed_sides=* ~%1$s switched sides from %2$s to %3$s.
 PlayerRoster.changed_sides_2=* ~<b>%1$s switched sides from %2$s to %3$s.</b>
+PlayerRoster.occupied_side=%1$s (%2$s)
+PlayerRoster.current_password=Current Password
+PlayerRoster.empty_password=Empty Password
+PlayerRoster.quoted_password="%1$s"
+PlayerRoster.pick_an_occupied_side=Your password profile matches several active players. Claim which side?
+
 
 #PlayerWindow
 


### PR DESCRIPTION
The _main_ problem this is intended to solve is that when people have been using a default password (whether "" or "Username's Password") then switch to using an "actual" password (i.e. that they've chosen themselves), they have been losing access to these old saved games. 

A _secondary_ problem that is also solved (or at least addressed) is that now "" will always be the default assigned password, no more "Username's Password". Which of course may produce more players with blank passwords discovering that a blank password isn't very useful for claiming a side in a multiplayer game, but that's probably at least "more transparent" than what's going on now.

The _mechanism_ I've chosen is to intervene primarily at the point a player claims an existing side in an existing game. 
* If, as will be normal, only one side matches the set of passwords { actual current password, "Username's Password", and completely blank password } then the player is automatically slotted into that side "just like always". 
* If MORE than one side matches, the player is given a one-time choice to claim one of the sides, in a popup that makes clear the differences in passwords, and if e.g. blank passwords are being used.
* One a side is claimed, the player's "tempUserId" is set to the correct password for the side chosen/slotted, which will cause it to  continue to be used, correctly, for the player's ID throughout the module. This will not change the player's "actual password" (e.g. GameModule.getUserId() and the password in the preferences configurer).

So hopefully solving the main problem in a way largely transparent to users, and with not-too-much code and not-too-many points of failure?