### PR TITLE
14261 - fix infinite loop protection for Labeler

### DIFF
--- a/vassal-app/src/main/java/VASSAL/counters/Labeler.java
+++ b/vassal-app/src/main/java/VASSAL/counters/Labeler.java
@@ -257,7 +257,7 @@ public class Labeler extends Decorator implements TranslatablePiece, Loopable {
         result = nameFormat.getText(Decorator.getOutermost(this));
       }
       catch (RecursionLimitException e) {
-        e.printStackTrace();
+        RecursionLimiter.infiniteLoop(e);
       }
       finally {
         RecursionLimiter.endExecution();


### PR DESCRIPTION
The Labeler's recursion limit protection appears to have been misimplemented.