### PR TITLE
2623 - Can Rotate trait respects mask image when sides change

### DIFF
--- a/vassal-app/src/main/java/VASSAL/counters/Obscurable.java
+++ b/vassal-app/src/main/java/VASSAL/counters/Obscurable.java
@@ -284,7 +284,7 @@ public class Obscurable extends Decorator implements TranslatablePiece {
       return obscuredBy;
     }
     else if (Properties.VISIBLE_STATE.equals(key)) {
-      return myGetState() + isPeeking() + getProperty(Properties.SELECTED) + piece.getProperty(key);
+      return myGetState() + isPeeking() + getProperty(Properties.SELECTED) + obscuredToMe() + piece.getProperty(key);
     }
     // FIXME: Access to Obscured properties
     // If piece is obscured to me, then mask any properties returned by


### PR DESCRIPTION
Check Invisible trait as well and it was already doing the correct thing.