### PR TITLE
3.6 - Stay compatible with 3.5 non-rectangular traits as long as possible

### DIFF
--- a/vassal-app/src/main/java/VASSAL/counters/NonRectangular.java
+++ b/vassal-app/src/main/java/VASSAL/counters/NonRectangular.java
@@ -370,6 +370,10 @@ public class NonRectangular extends Decorator implements EditablePiece {
         }
       }
 
+      if ("1.0".equals(scaleConfig.getValueString())) {
+        return OLD_ID + buffer.toString();
+      }
+
       final SequenceEncoder se = new SequenceEncoder(';');
 
       se.append(scaleConfig.getValueString())

--- a/vassal-app/src/main/java/VASSAL/counters/NonRectangular.java
+++ b/vassal-app/src/main/java/VASSAL/counters/NonRectangular.java
@@ -91,6 +91,10 @@ public class NonRectangular extends Decorator implements EditablePiece {
 
   @Override
   public String myGetType() {
+    if (scale == 1.0) {
+      return OLD_ID + shapeSpec; // If module has not availed itself of 3.6 features, stay compatible with 3.5
+    }
+
     final SequenceEncoder se = new SequenceEncoder(';');
 
     se.append(scale)


### PR DESCRIPTION
This will make non-rectangular traits in 3.6 modules more compatible with 3.5, assuming the module designer hasn't actually implemented any 3.6 features (so merely *running* 3.6 won't be incompatible with 3.5)