### PR TITLE
Don't force Game Piece Image Definitions

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/GameModule.java
+++ b/vassal-app/src/main/java/VASSAL/build/GameModule.java
@@ -679,7 +679,7 @@ public class GameModule extends AbstractConfigurable
     new PluginsLoader().addTo(this);
     if (e != null) {
       super.build(e);
-      ensureComponent(GamePieceImageDefinitions.class);
+      //ensureComponent(GamePieceImageDefinitions.class);
       ensureComponent(GlobalProperties.class);
       ensureComponent(GlobalTranslatableMessages.class);
       ensureComponent(Language.class);


### PR DESCRIPTION
I'm finding the force-re-add of Game Piece Image Definitions to be quite cluttery and annoying. 

We only added this for 3.6 so no ticket number. 

In theory we could allow the manual re-adding of these, although with them being so incredibly obsolete these days it doesn't particularly seem worth it?