### PR TITLE
10272 Don't auto-name new regions a long string

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/module/map/boardPicker/board/Region.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/boardPicker/board/Region.java
@@ -45,7 +45,7 @@ public class Region extends AbstractConfigurable {
   private boolean selected = false;
 
   public Region() {
-    setConfigureName(Resources.getString("Editor.Region.new_region")); //$NON-NLS-1$
+    setConfigureName("");
   }
 
   public Region(Point p) {

--- a/vassal-app/src/main/resources/VASSAL/i18n/Editor.properties
+++ b/vassal-app/src/main/resources/VASSAL/i18n/Editor.properties
@@ -1509,7 +1509,6 @@ Editor.RectangleGrid.corners=Corners are legal locations
 Editor.RectangleGrid.component_type=Rectangular Grid
 
 # Region
-Editor.Region.new_region=
 Editor.Region.x_coord=X co-ord
 Editor.Region.y_coord=Y co-ord
 Editor.Region.component_type=Region

--- a/vassal-app/src/main/resources/VASSAL/i18n/Editor.properties
+++ b/vassal-app/src/main/resources/VASSAL/i18n/Editor.properties
@@ -1509,7 +1509,7 @@ Editor.RectangleGrid.corners=Corners are legal locations
 Editor.RectangleGrid.component_type=Rectangular Grid
 
 # Region
-Editor.Region.new_region=New region
+Editor.Region.new_region=
 Editor.Region.x_coord=X co-ord
 Editor.Region.y_coord=Y co-ord
 Editor.Region.component_type=Region


### PR DESCRIPTION
Right new every time you make a new region it gets auto-named "New Region" which means you have to first delete all of that text every single time. So I've changed it to a blank string which seems a lot easier-to-use. 

