### PR TITLE
10273 Mat Cargo can be set to detect mats way from their exact center

### DIFF
--- a/vassal-app/src/main/java/VASSAL/counters/MatCargo.java
+++ b/vassal-app/src/main/java/VASSAL/counters/MatCargo.java
@@ -424,8 +424,8 @@ public class MatCargo extends Decorator implements TranslatablePiece {
     private final StringConfigurer descInput;
     private final BooleanConfigurer rotInput;
     private final TraitConfigPanel controls;
-    private final IntConfigurer XInput;
-    private final IntConfigurer YInput;
+    private final IntConfigurer xInput;
+    private final IntConfigurer yInput;
 
     public Ed(MatCargo p) {
       controls = new TraitConfigPanel();
@@ -437,11 +437,11 @@ public class MatCargo extends Decorator implements TranslatablePiece {
       rotInput = new BooleanConfigurer(p.maintainRelativeFacing);
       controls.add("Editor.MatCargo.maintain_relative_facing", rotInput);
 
-      XInput = new IntConfigurer(p.detectionDistanceX);
-      controls.add("Editor.MatCargo.detection_distance_x", XInput);
+      xInput = new IntConfigurer(p.detectionDistanceX);
+      controls.add("Editor.MatCargo.detection_distance_x", xInput);
 
-      YInput = new IntConfigurer(p.detectionDistanceY);
-      controls.add("Editor.MatCargo.detection_distance_y", YInput);
+      yInput = new IntConfigurer(p.detectionDistanceY);
+      controls.add("Editor.MatCargo.detection_distance_y", yInput);
     }
 
     @Override
@@ -454,8 +454,8 @@ public class MatCargo extends Decorator implements TranslatablePiece {
       final SequenceEncoder se = new SequenceEncoder(';');
       se.append(descInput.getValueString())
         .append(rotInput.getValueBoolean())
-        .append(XInput.getIntValue(0))
-        .append(YInput.getIntValue(0));
+        .append(xInput.getIntValue(0))
+        .append(yInput.getIntValue(0));
 
       return ID + se.getValue();
     }

--- a/vassal-app/src/main/java/VASSAL/counters/MatCargo.java
+++ b/vassal-app/src/main/java/VASSAL/counters/MatCargo.java
@@ -21,6 +21,7 @@ import VASSAL.command.ChangeTracker;
 import VASSAL.command.Command;
 import VASSAL.command.NullCommand;
 import VASSAL.configure.BooleanConfigurer;
+import VASSAL.configure.IntConfigurer;
 import VASSAL.configure.StringConfigurer;
 import VASSAL.i18n.TranslatablePiece;
 import VASSAL.tools.SequenceEncoder;
@@ -41,6 +42,8 @@ public class MatCargo extends Decorator implements TranslatablePiece {
   protected String desc;
 
   protected boolean maintainRelativeFacing;
+  protected int detectionDistanceX;
+  protected int detectionDistanceY;
   protected GamePieceOp gpOp;
   protected java.util.Map<Double, Rectangle> bounds = new HashMap<>();
   protected java.util.Map<Double, RotateScaleOp> rotOp = new HashMap<>();
@@ -64,13 +67,17 @@ public class MatCargo extends Decorator implements TranslatablePiece {
     final SequenceEncoder.Decoder st = new SequenceEncoder.Decoder(type, ';');
     desc = st.nextToken();
     maintainRelativeFacing = st.nextBoolean(true);
+    detectionDistanceX = st.nextInt(0);
+    detectionDistanceY = st.nextInt(0);
   }
 
   @Override
   public String myGetType() {
     final SequenceEncoder se = new SequenceEncoder(';');
     se.append(desc)
-      .append(maintainRelativeFacing);
+      .append(maintainRelativeFacing)
+      .append(detectionDistanceX)
+      .append(detectionDistanceY);
     return ID + se.getValue();
   }
 
@@ -163,7 +170,34 @@ public class MatCargo extends Decorator implements TranslatablePiece {
   public Command findNewMat(Map map, Point pt) {
     Command comm = new NullCommand();
     if (map != null) {
-      final GamePiece newMat = map.findAnyPiece(pt, PieceFinder.MAT_ONLY);
+      GamePiece newMat = map.findAnyPiece(pt, PieceFinder.MAT_ONLY);
+
+      if ((newMat == null) && (detectionDistanceX != 0) || (detectionDistanceY != 0)) {
+        final Point pt2 = new Point();
+
+        pt2.x = pt.x + detectionDistanceX;
+        pt2.y = pt.y + detectionDistanceY;
+        newMat = map.findAnyPiece(pt2, PieceFinder.MAT_ONLY);
+
+        if (newMat == null) {
+          pt2.x = pt.x - detectionDistanceX;
+          pt2.y = pt.y + detectionDistanceY;
+          newMat = map.findAnyPiece(pt2, PieceFinder.MAT_ONLY);
+
+          if (newMat == null) {
+            pt2.x = pt.x + detectionDistanceX;
+            pt2.y = pt.y - detectionDistanceY;
+            newMat = map.findAnyPiece(pt2, PieceFinder.MAT_ONLY);
+
+            if (newMat == null) {
+              pt2.x = pt.x - detectionDistanceX;
+              pt2.y = pt.y - detectionDistanceY;
+              newMat = map.findAnyPiece(pt2, PieceFinder.MAT_ONLY);
+            }
+          }
+        }
+      }
+
       if (newMat != null) {
         final Mat mat = (Mat) Decorator.getDecorator(newMat, Mat.class);
         if (mat != null) {
@@ -390,6 +424,8 @@ public class MatCargo extends Decorator implements TranslatablePiece {
     private final StringConfigurer descInput;
     private final BooleanConfigurer rotInput;
     private final TraitConfigPanel controls;
+    private final IntConfigurer XInput;
+    private final IntConfigurer YInput;
 
     public Ed(MatCargo p) {
       controls = new TraitConfigPanel();
@@ -400,6 +436,12 @@ public class MatCargo extends Decorator implements TranslatablePiece {
 
       rotInput = new BooleanConfigurer(p.maintainRelativeFacing);
       controls.add("Editor.MatCargo.maintain_relative_facing", rotInput);
+
+      XInput = new IntConfigurer(p.detectionDistanceX);
+      controls.add("Editor.MatCargo.detection_distance_x", XInput);
+
+      YInput = new IntConfigurer(p.detectionDistanceY);
+      controls.add("Editor.MatCargo.detection_distance_y", YInput);
     }
 
     @Override
@@ -411,7 +453,10 @@ public class MatCargo extends Decorator implements TranslatablePiece {
     public String getType() {
       final SequenceEncoder se = new SequenceEncoder(';');
       se.append(descInput.getValueString())
-        .append(rotInput.getValueBoolean());
+        .append(rotInput.getValueBoolean())
+        .append(XInput.getIntValue(0))
+        .append(YInput.getIntValue(0));
+
       return ID + se.getValue();
     }
 

--- a/vassal-app/src/main/resources/VASSAL/i18n/Editor.properties
+++ b/vassal-app/src/main/resources/VASSAL/i18n/Editor.properties
@@ -1186,6 +1186,8 @@ Editor.Mat.name_label=Mat Name
 # Mat Cargo
 Editor.MatCargo.trait_description=Mat Cargo
 Editor.MatCargo.maintain_relative_facing=Maintain facing relative to mat
+Editor.MatCargo.detection_distance_x=X Extra detection distance from center
+Editor.MatCargo.detection_distance_y=Y Extra detection distance from center
 
 # Menu Separator
 Editor.MenuSeparator.trait_description=Menu Separator

--- a/vassal-doc/src/main/readme-referencemanual/ReferenceManual/MatCargo.adoc
+++ b/vassal-doc/src/main/readme-referencemanual/ReferenceManual/MatCargo.adoc
@@ -31,6 +31,10 @@ the Mat Cargo trait should be placed _below_ the graphical elements (e.g. Layer 
 potentially be rotated. A Mat Cargo piece does _not_ need a separate Can Rotate trait in order to be able to maintain
 relative facing, although it is permitted to have its own Can Rotate trait as well.
 
+*X Extra detection distance from center:* If non-zero, then VASSAL will look this distance to the left and right of the piece's center when trying to attach it to a mat. Useful e.g. for cards that are tucked halfway under a mat surface, as it does not require the precise center of the card to be on the mat.
+
+*Y Extra detection distance from center:* If non-zero, then VASSAL will look this distance above and below the piece's center when trying to attach it to a mat. Useful e.g. for cards that are tucked halfway under a mat surface, as it does not require the precise center of the card to be on the mat.
+
 |image:images/MatCargo.png[]
 
 image:images/Mat2.png[]


### PR DESCRIPTION
I have cards that I need to "tuck halfway under mats". Obviously making the user get the precise one-pixel center point just onto the mat as opposed to just-not-on-it would be "Bad UX". 

So here's a way to add some extra detection points to the MatCargo when it goes looking for its next mat. 

A bit kludgey but (a) it should solve 99% of conceivable issues in this depatment, (b) I don't have the math to do better, and (c) doing *much* better would presumably require rewriting PieceFinder.