### PR TITLE
10276 Expose property if we're currently drawing Counter Detail Viewer

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/GameModule.java
+++ b/vassal-app/src/main/java/VASSAL/build/GameModule.java
@@ -61,6 +61,7 @@ import VASSAL.build.module.gamepieceimage.ColorManager;
 import VASSAL.build.module.gamepieceimage.FontManager;
 import VASSAL.build.module.gamepieceimage.GamePieceImageDefinitions;
 import VASSAL.build.module.gamepieceimage.GamePieceLayoutsContainer;
+import VASSAL.build.module.map.CounterDetailViewer;
 import VASSAL.build.module.metadata.AbstractMetaData;
 import VASSAL.build.module.metadata.MetaDataFactory;
 import VASSAL.build.module.metadata.ModuleMetaData;
@@ -216,6 +217,8 @@ public class GameModule extends AbstractConfigurable
 
   public static final String MODULE_CURRENT_LOCALE = "CurrentLanguage"; //NON-NLS
   public static final String MODULE_CURRENT_LOCALE_NAME = "CurrentLanguageName"; //NON-NLS
+
+  public static final String DRAWING_MOUSEOVER_PROPERTY = "DrawingMouseover"; //NON-NLS
 
   private static final char COMMAND_SEPARATOR = KeyEvent.VK_ESCAPE;
 
@@ -2105,6 +2108,9 @@ public class GameModule extends AbstractConfigurable
     }
     else if (GameModule.MODULE_CURRENT_LOCALE_NAME.equals(key)) {
       return Resources.getLocale().getDisplayName();
+    }
+    else if (DRAWING_MOUSEOVER_PROPERTY.equals(key)) {
+      return CounterDetailViewer.isDrawingMouseOver();
     }
 
     //BR// MapName_isVisible property for each map window

--- a/vassal-app/src/main/java/VASSAL/build/module/map/CounterDetailViewer.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/CounterDetailViewer.java
@@ -207,6 +207,12 @@ public class CounterDetailViewer extends AbstractConfigurable implements Drawabl
   /** the JComponent which is repainted when the detail viewer changes */
   protected JComponent view;
 
+  private static boolean drawingMouseOver = false;
+
+  public static boolean isDrawingMouseOver() {
+    return drawingMouseOver;
+  }
+
   public CounterDetailViewer() {
     // Set up the timer; this isn't the real delay---we always check the
     // preferences for that.
@@ -268,6 +274,8 @@ public class CounterDetailViewer extends AbstractConfigurable implements Drawabl
     final double os_scale = g2d.getDeviceConfiguration().getDefaultTransform().getScaleX();
     g2d.setFont(font.deriveFont((float)(fontSize * os_scale)));
 
+    drawingMouseOver = true;
+
     if (graphicsVisible) {
       drawGraphics(g, pt, comp, displayablePieces);
     }
@@ -275,6 +283,8 @@ public class CounterDetailViewer extends AbstractConfigurable implements Drawabl
     if (textVisible) {
       drawText(g, pt, comp, displayablePieces);
     }
+
+    drawingMouseOver = false;
   }
 
   /**

--- a/vassal-doc/src/main/designerguide/maps-and-boards.adoc
+++ b/vassal-doc/src/main/designerguide/maps-and-boards.adoc
@@ -459,6 +459,10 @@ You can set a Stack Viewer to show the number of items contained in a stack.
 . Set a Marker Trait on all units you want to count. Name the Marker Trait _UnitCount_, and set the Value to 1.
 . Create a Stack Viewer for the Map Window. In *Summary Text Above Pieces*, select _$sum(PropertyName)$_. In the box, replace _PropertyName_ with _UnitCount_ (so it shows _$sum(UnitCount)$_). On mouseover, the Viewer will now display the total Unit Count of all pieces in the stack.
 
+=== Informing a GamePiece it is currently being drawn in the Mouseover Stack Viewer
+
+Occasionally pieces will want to "draw themselves differently" inside of a Mouseover Stack Viewer. For this purpose they can check the property `DrawingMouseover` in e.g. a Calculated Property or a Label's "Follows Expression Value" field.
+
 === Multiple Stack Viewers
 
 A Map Window can have any number of Stack Viewers, each with its own settings. You can use different Stack Viewers to view pieces of different types, on different Game Piece Layers, or with different attributes, and display them in different ways.


### PR DESCRIPTION
So I've got these cards that "tuck underneath the map", and it's working perfectly w/ a CalculatedProperty to tell them whether to use their "top half is transparent" version of the image.

However when one "rolled over" the card for CounterDetailViewer, it of course displays the ugly "half empty field" version of the image in the Mouseover box. 

(Oh and by the way this is NOT the first time this same issue has come up for me making a module - I've run into similar situations with previous modules and just never got around to making this change)

So this PR makes there be a property you can check if you're currently drawing the CounterDetailViewer, and results in the "correct result" below:
![image](https://user-images.githubusercontent.com/3742246/127794445-17494cd0-40df-4005-93fb-98a6d435efee.png)