### PR TITLE
Properties for OldMat, OldMatID, etc.

### DIFF
--- a/vassal-app/src/main/java/VASSAL/counters/BasicPiece.java
+++ b/vassal-app/src/main/java/VASSAL/counters/BasicPiece.java
@@ -95,6 +95,8 @@ public class BasicPiece extends AbstractImageFinder implements TranslatablePiece
   public static final String OLD_Y = "OldY"; // NON-NLS
   public static final String OLD_MAT = "OldMat"; //NON-NLS
   public static final String OLD_MAT_ID = "OldMatID"; //NON-NLS
+  public static final String OLD_MAT_PIECE_NAME = "OldMatPieceName"; //NON-NLS
+  public static final String OLD_MAT_BASIC_NAME = "OldMatBasicName"; //NON-NLS
   public static final String BASIC_NAME = "BasicName"; // NON-NLS
   public static final String PIECE_NAME = "PieceName"; // NON-NLS
   public static final String LOCALIZED_BASIC_NAME = "LocalizedBasicName"; //NON-NLS
@@ -1160,14 +1162,16 @@ public class BasicPiece extends AbstractImageFinder implements TranslatablePiece
     l.add(OLD_ZONE);
     l.add(OLD_X);
     l.add(OLD_Y);
-    l.add(OLD_MAT);
-    l.add(OLD_MAT_ID);
     l.add(BASIC_NAME);
     l.add(PIECE_NAME);
     l.add(DECK_NAME);
     l.add(CLICKED_X);
     l.add(CLICKED_Y);
     l.add(PIECE_UID);
+    l.add(OLD_MAT);
+    l.add(OLD_MAT_ID);
+    l.add(OLD_MAT_PIECE_NAME);
+    l.add(OLD_MAT_BASIC_NAME);
     return l;
   }
 

--- a/vassal-app/src/main/java/VASSAL/counters/BasicPiece.java
+++ b/vassal-app/src/main/java/VASSAL/counters/BasicPiece.java
@@ -93,6 +93,8 @@ public class BasicPiece extends AbstractImageFinder implements TranslatablePiece
   public static final String OLD_ZONE = "OldZone"; // NON-NLS
   public static final String OLD_X = "OldX"; // NON-NLS
   public static final String OLD_Y = "OldY"; // NON-NLS
+  public static final String OLD_MAT = "OldMat"; //NON-NLS
+  public static final String OLD_MAT_ID = "OldMatID"; //NON-NLS
   public static final String BASIC_NAME = "BasicName"; // NON-NLS
   public static final String PIECE_NAME = "PieceName"; // NON-NLS
   public static final String LOCALIZED_BASIC_NAME = "LocalizedBasicName"; //NON-NLS
@@ -1158,6 +1160,8 @@ public class BasicPiece extends AbstractImageFinder implements TranslatablePiece
     l.add(OLD_ZONE);
     l.add(OLD_X);
     l.add(OLD_Y);
+    l.add(OLD_MAT);
+    l.add(OLD_MAT_ID);
     l.add(BASIC_NAME);
     l.add(PIECE_NAME);
     l.add(DECK_NAME);

--- a/vassal-app/src/main/java/VASSAL/counters/Decorator.java
+++ b/vassal-app/src/main/java/VASSAL/counters/Decorator.java
@@ -18,6 +18,7 @@
 package VASSAL.counters;
 
 import VASSAL.build.BadDataReport;
+import VASSAL.build.GameModule;
 import VASSAL.build.module.GameState;
 import VASSAL.build.module.Map;
 import VASSAL.build.module.map.boardPicker.Board;
@@ -726,6 +727,8 @@ public abstract class Decorator extends AbstractImageFinder implements EditableP
     String boardName = ""; //$NON-NLS-1$
     String zoneName = ""; //$NON-NLS-1$
     String locationName = ""; //$NON-NLS-1$
+    String matName = "";
+    String matID = "";
     final Map m = p.getMap();
     final Point pos = p.getPosition();
     Command comm = new NullCommand();
@@ -741,6 +744,19 @@ public abstract class Decorator extends AbstractImageFinder implements EditableP
         zoneName = z.getName();
       }
       locationName = m.locationName(pos);
+
+      if (GameModule.getGameModule().isMatSupport()) {
+        if (Boolean.TRUE.equals(p.getProperty(MatCargo.IS_CARGO))) {
+          final MatCargo cargo = (MatCargo) Decorator.getDecorator(p, MatCargo.class);
+          if (cargo != null) {
+            final GamePiece mat = cargo.getMat();
+            if (mat != null) {
+              matName = mat.getName();
+              matID   = mat.getName() + "_" + Decorator.getInnermost(mat).getId();
+            }
+          }
+        }
+      }
     }
 
     comm = comm.append(container.setPersistentProperty(BasicPiece.OLD_X, String.valueOf(pos.x)));
@@ -749,6 +765,8 @@ public abstract class Decorator extends AbstractImageFinder implements EditableP
     comm = comm.append(container.setPersistentProperty(BasicPiece.OLD_BOARD, boardName));
     comm = comm.append(container.setPersistentProperty(BasicPiece.OLD_ZONE, zoneName));
     comm = comm.append(container.setPersistentProperty(BasicPiece.OLD_LOCATION_NAME, locationName));
+    comm = comm.append(container.setPersistentProperty(BasicPiece.OLD_MAT, matName));
+    comm = comm.append(container.setPersistentProperty(BasicPiece.OLD_MAT_ID, matID));
 
     return comm;
   }

--- a/vassal-app/src/main/java/VASSAL/counters/Decorator.java
+++ b/vassal-app/src/main/java/VASSAL/counters/Decorator.java
@@ -734,7 +734,6 @@ public abstract class Decorator extends AbstractImageFinder implements EditableP
     String matID = "";
     String matPieceName = "";
     String matBasicName = "";
-    boolean wasOnMat = false;
     final Map m = p.getMap();
     final Point pos = p.getPosition();
     Command comm = new NullCommand();
@@ -757,8 +756,6 @@ public abstract class Decorator extends AbstractImageFinder implements EditableP
           if (cargo != null) {
             final GamePiece mat = cargo.getMat();
             if (mat != null) {
-              wasOnMat = true;
-
               matName = mat.getName();
               matID   = mat.getName() + "_" + Decorator.getInnermost(mat).getId();
 

--- a/vassal-app/src/main/java/VASSAL/counters/Decorator.java
+++ b/vassal-app/src/main/java/VASSAL/counters/Decorator.java
@@ -777,7 +777,7 @@ public abstract class Decorator extends AbstractImageFinder implements EditableP
     comm = comm.append(container.setPersistentProperty(BasicPiece.OLD_BOARD, boardName));
     comm = comm.append(container.setPersistentProperty(BasicPiece.OLD_ZONE, zoneName));
     comm = comm.append(container.setPersistentProperty(BasicPiece.OLD_LOCATION_NAME, locationName));
-    if (wasOnMat) {
+    if (GameModule.getGameModule().isMatSupport()) {
       comm = comm.append(container.setPersistentProperty(BasicPiece.OLD_MAT, matName));
       comm = comm.append(container.setPersistentProperty(BasicPiece.OLD_MAT_ID, matID));
       comm = comm.append(container.setPersistentProperty(BasicPiece.OLD_MAT_PIECE_NAME, matPieceName));

--- a/vassal-app/src/main/java/VASSAL/counters/Decorator.java
+++ b/vassal-app/src/main/java/VASSAL/counters/Decorator.java
@@ -55,6 +55,9 @@ import javax.swing.KeyStroke;
 
 import org.apache.commons.lang3.ArrayUtils;
 
+import static VASSAL.counters.BasicPiece.BASIC_NAME;
+import static VASSAL.counters.BasicPiece.PIECE_NAME;
+
 /**
  * The abstract class describing a generic 'Trait' of a full GamePiece. Follows the <a href="https://en.wikipedia.org/wiki/Decorator_pattern"></a>Decorator design pattern</a>
  * of wrapping around another instance of GamePiece (the 'inner' piece) and delegating some of the GamePiece methods to it. The
@@ -729,6 +732,9 @@ public abstract class Decorator extends AbstractImageFinder implements EditableP
     String locationName = ""; //$NON-NLS-1$
     String matName = "";
     String matID = "";
+    String matPieceName = "";
+    String matBasicName = "";
+    boolean wasOnMat = false;
     final Map m = p.getMap();
     final Point pos = p.getPosition();
     Command comm = new NullCommand();
@@ -751,8 +757,14 @@ public abstract class Decorator extends AbstractImageFinder implements EditableP
           if (cargo != null) {
             final GamePiece mat = cargo.getMat();
             if (mat != null) {
+              wasOnMat = true;
+
               matName = mat.getName();
               matID   = mat.getName() + "_" + Decorator.getInnermost(mat).getId();
+
+              final GamePiece outer = getOutermost(mat);
+              matPieceName = (String)outer.getProperty(PIECE_NAME);
+              matBasicName = (String)outer.getProperty(BASIC_NAME);
             }
           }
         }
@@ -765,8 +777,12 @@ public abstract class Decorator extends AbstractImageFinder implements EditableP
     comm = comm.append(container.setPersistentProperty(BasicPiece.OLD_BOARD, boardName));
     comm = comm.append(container.setPersistentProperty(BasicPiece.OLD_ZONE, zoneName));
     comm = comm.append(container.setPersistentProperty(BasicPiece.OLD_LOCATION_NAME, locationName));
-    comm = comm.append(container.setPersistentProperty(BasicPiece.OLD_MAT, matName));
-    comm = comm.append(container.setPersistentProperty(BasicPiece.OLD_MAT_ID, matID));
+    if (wasOnMat) {
+      comm = comm.append(container.setPersistentProperty(BasicPiece.OLD_MAT, matName));
+      comm = comm.append(container.setPersistentProperty(BasicPiece.OLD_MAT_ID, matID));
+      comm = comm.append(container.setPersistentProperty(BasicPiece.OLD_MAT_PIECE_NAME, matPieceName));
+      comm = comm.append(container.setPersistentProperty(BasicPiece.OLD_MAT_BASIC_NAME, matBasicName));
+    }
 
     return comm;
   }

--- a/vassal-app/src/main/java/VASSAL/counters/Mat.java
+++ b/vassal-app/src/main/java/VASSAL/counters/Mat.java
@@ -167,6 +167,9 @@ public class Mat extends Decorator implements TranslatablePiece {
         final GamePiece mt = ((MatCargo)cargo).getMat();
         if ((mt != null) && (mt != Decorator.getOutermost(this))) {
           ct3 = new ChangeTracker(mt);
+
+          final Mat mat = (Mat)Decorator.getDecorator(mt, Mat.class);
+          mat.removeCargo(p);
         }
       }
     }
@@ -182,16 +185,12 @@ public class Mat extends Decorator implements TranslatablePiece {
   }
 
   /**
-   * Removes a MatCargo piece from our list of cargo
+   * Removes a MatCargo piece from our list of cargo. Does NOT clear MatCargo's reference to this mat - must be done separately.
    * @param p Cargo to remove
    */
   public void removeCargo(GamePiece p) {
     if ((p instanceof Decorator) && hasCargo(p)) {
       contents.remove(p);
-      final GamePiece mp = Decorator.getDecorator(p, MatCargo.class);
-      if (mp != null) {
-        ((MatCargo)mp).clearMat();
-      }
     }
   }
 

--- a/vassal-app/src/main/java/VASSAL/counters/MatCargo.java
+++ b/vassal-app/src/main/java/VASSAL/counters/MatCargo.java
@@ -313,7 +313,7 @@ public class MatCargo extends Decorator implements TranslatablePiece {
       return 0.0;
     }
 
-    final FreeRotator mrot = (FreeRotator) Decorator.getDecorator(mat, FreeRotator.class);
+    final FreeRotator mrot = (FreeRotator) Decorator.getDecorator(getOutermost(mat), FreeRotator.class);
     return mrot == null ? 0.0 : mrot.getAngle();
   }
 

--- a/vassal-app/src/main/java/VASSAL/counters/MatCargo.java
+++ b/vassal-app/src/main/java/VASSAL/counters/MatCargo.java
@@ -110,16 +110,10 @@ public class MatCargo extends Decorator implements TranslatablePiece {
   }
 
   /**
-   * Clear our relationship with any Mat we're assigned to
+   * Clear our relationship with any Mat we're assigned to. Does NOT clear the Mat's reference to us -- must be done separately.
    */
   public void clearMat() {
-    if (mat != null) {
-      final GamePiece actualMat = Decorator.getDecorator(mat, Mat.class);
-      mat = null;
-      if (actualMat != null) {
-        ((Mat)actualMat).removeCargo(Decorator.getOutermost(this));
-      }
-    }
+    mat = null;
   }
 
   /**
@@ -440,7 +434,8 @@ public class MatCargo extends Decorator implements TranslatablePiece {
         return Decorator.getOutermost(mat).getProperty(key);
       }
     }
-    else if (IS_CARGO.equals(key)) {
+
+    if (IS_CARGO.equals(key)) {
       return Boolean.TRUE;
     }
     return super.getProperty(key);
@@ -475,7 +470,8 @@ public class MatCargo extends Decorator implements TranslatablePiece {
         return Decorator.getOutermost(mat).getLocalizedProperty(key);
       }
     }
-    else if (List.of(
+
+    if (List.of(
       CURRENT_MAT_ID,
       CURRENT_MAT_X,
       CURRENT_MAT_Y,

--- a/vassal-doc/src/main/readme-referencemanual/ReferenceManual/BasicPiece.adoc
+++ b/vassal-doc/src/main/readme-referencemanual/ReferenceManual/BasicPiece.adoc
@@ -58,6 +58,8 @@ The following <<Properties.adoc#top,Properties>> are defined after a piece is mo
 * _OldY_ contains the previous map Y coordinate
 * _OldMat_ contains the previous <<Mat.adoc#top,Mat>>, if this is a <<MatCargo.adoc#top, Mat Cargo>> piece.
 * _OldMatID_ contains the previous <<Mat.adoc#top,Mat>> ID, if this is a <<MatCargo.adoc#top, Mat Cargo>> piece.
+* _OldMatPieceName_ contains the previous Mat's Piece Name
+* _OldMatBasicName_ contains the previous Mat's Basic Name
 
 The following <<Properties.adoc#top,Properties>> are defined after the player has selected something from the piece's right-click context menu:
 

--- a/vassal-doc/src/main/readme-referencemanual/ReferenceManual/BasicPiece.adoc
+++ b/vassal-doc/src/main/readme-referencemanual/ReferenceManual/BasicPiece.adoc
@@ -56,6 +56,8 @@ The following <<Properties.adoc#top,Properties>> are defined after a piece is mo
 * _OldZone_ contains the name of the previous <<ZonedGrid.adoc#top,Zone>>
 * _OldX_ contains the previous map X coordinate
 * _OldY_ contains the previous map Y coordinate
+* _OldMat_ contains the previous <<Mat.adoc#top,Mat>>, if this is a <<MatCargo.adoc#top, Mat Cargo>> piece.
+* _OldMatID_ contains the previous <<Mat.adoc#top,Mat>> ID, if this is a <<MatCargo.adoc#top, Mat Cargo>> piece.
 
 The following <<Properties.adoc#top,Properties>> are defined after the player has selected something from the piece's right-click context menu:
 

--- a/vassal-doc/src/main/readme-referencemanual/ReferenceManual/MatCargo.adoc
+++ b/vassal-doc/src/main/readme-referencemanual/ReferenceManual/MatCargo.adoc
@@ -79,5 +79,11 @@ Mat's _Mat Name_ field. If the piece is not sitting on any Mat, this property wi
 * _IsCargo_ will always contain the string _"true"_ for a Mat Cargo piece (it will contain an empty string, "" for a
 piece which does not have this trait).
 
+* _OldMat_ contains the previous Mat name, if any (former contents of CurrentMat).
+
+* _OldMatID_ contains the previous Mat unique ID, if any (former contents of CurrentMatID)
+
+
+
 
 

--- a/vassal-doc/src/main/readme-referencemanual/ReferenceManual/MatCargo.adoc
+++ b/vassal-doc/src/main/readme-referencemanual/ReferenceManual/MatCargo.adoc
@@ -83,6 +83,11 @@ piece which does not have this trait).
 
 * _OldMatID_ contains the previous Mat unique ID, if any (former contents of CurrentMatID)
 
+* _OldMatPieceName_ contains the previous Mat's piece name, if any
+
+* _OldMatBasicName_ contains the previous Mat's basic name, if any
+
+
 
 
 


### PR DESCRIPTION
Mat Cargo now track an OldMat and OldMatID, corresponding with CurrentMat and CurrentMatID.

This also fixes some bugs I found with moving a piece from one mat to another (apparently my testing was mostly moving onto and off of mats, less transferring between mats). Hooray for actually making a module in parallel with the new feature :)

"This PR is its own ticket"