### PR TITLE
6130 Grid Numbering dialog can appear blank when grid size is very large

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/module/map/boardPicker/board/mapgrid/HexGridNumbering.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/boardPicker/board/mapgrid/HexGridNumbering.java
@@ -305,6 +305,10 @@ public class HexGridNumbering extends RegularGridNumbering {
           final AffineTransform orig_t = g2d.getTransform();
           g2d.setTransform(SwingUtils.descaleTransform(orig_t));
 
+          final double orig_grid_size = grid.getHexSize();
+          final double orig_grid_width = grid.getHexWidth();
+          grid.setHexSize(VISUALIZER_GRID_SIZE);
+
           final Rectangle bounds = new Rectangle(0, 0, getWidth(), getHeight());
           bounds.x *= os_scale;
           bounds.y *= os_scale;
@@ -316,11 +320,13 @@ public class HexGridNumbering extends RegularGridNumbering {
           forceDraw(g, bounds, bounds, os_scale, false);
 
           g2d.setTransform(orig_t);
+          grid.setHexSize(orig_grid_size);
+          grid.setHexWidth(orig_grid_width);
         }
 
         @Override
         public Dimension getPreferredSize() {
-          return new Dimension(4 * (int) grid.getHexSize(), 4 * (int) grid.getHexWidth());
+          return new Dimension(6 * (int) VISUALIZER_GRID_SIZE, 4 * (int) VISUALIZER_GRID_SIZE);
         }
       };
     }

--- a/vassal-app/src/main/java/VASSAL/build/module/map/boardPicker/board/mapgrid/RegularGridNumbering.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/boardPicker/board/mapgrid/RegularGridNumbering.java
@@ -89,6 +89,8 @@ public abstract class RegularGridNumbering extends AbstractConfigurable implemen
   public static final String ROW = "row"; //NON-NLS
   public static final String COLUMN = "column"; //NON-NLS
 
+  public static final double VISUALIZER_GRID_SIZE = 100.0;
+
   @Override
   public String getAttributeValueString(String key) {
     if (FIRST.equals(key)) {
@@ -399,7 +401,7 @@ public abstract class RegularGridNumbering extends AbstractConfigurable implemen
     for (final String value : s) {
       c.getConfigurer(value).addPropertyChangeListener(evt -> visualizer.repaint());
     }
-    ((Container) c.getControls()).add(getGridVisualizer());
+    ((Container) c.getControls()).add(getGridVisualizer(), "span 2, align left");
     return c;
   }
 

--- a/vassal-app/src/main/java/VASSAL/build/module/map/boardPicker/board/mapgrid/SquareGridNumbering.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/boardPicker/board/mapgrid/SquareGridNumbering.java
@@ -57,6 +57,23 @@ public class SquareGridNumbering extends RegularGridNumbering {
           final AffineTransform orig_t = g2d.getTransform();
           g2d.setTransform(SwingUtils.descaleTransform(orig_t));
 
+          final double orig_dx = grid.getDx();
+          final double orig_dy = grid.getDy();
+          double new_dx = orig_dx;
+          double new_dy = orig_dy;
+
+          if (orig_dx > VISUALIZER_GRID_SIZE * 2 && orig_dx > orig_dy) {
+            new_dx = VISUALIZER_GRID_SIZE * 2;
+            new_dy = orig_dy * VISUALIZER_GRID_SIZE * 2 / orig_dx;
+          }
+          else if (orig_dy > VISUALIZER_GRID_SIZE * 2 && orig_dy > orig_dx) {
+            new_dy = VISUALIZER_GRID_SIZE * 2;
+            new_dx = orig_dx * VISUALIZER_GRID_SIZE * 2 / orig_dy;
+          }
+
+          grid.setDx(new_dx);
+          grid.setDy(new_dy);
+
           final Rectangle bounds = new Rectangle(0, 0, getWidth(), getHeight());
           bounds.x *= os_scale;
           bounds.y *= os_scale;
@@ -68,11 +85,13 @@ public class SquareGridNumbering extends RegularGridNumbering {
           forceDraw(g, bounds, bounds, os_scale, false);
 
           g2d.setTransform(orig_t);
+          grid.setDx(orig_dx);
+          grid.setDy(orig_dy);
         }
 
         @Override
         public Dimension getPreferredSize() {
-          return new Dimension(3 * (int) grid.getDx(), 3 * (int) grid.getDy());
+          return new Dimension(6 * (int) VISUALIZER_GRID_SIZE, 4 * (int) VISUALIZER_GRID_SIZE);
         }
       };
     }


### PR DESCRIPTION
Set a maximum hex size of 100 px wide when drawing grid visualiser to keep it usable with large hex sizes.

Closing #6130 