### PR TITLE
10297 - EDITOR - After duplicating an item in the Editor and saving it, select the duplicate

### DIFF
--- a/vassal-app/src/main/java/VASSAL/configure/ConfigureTree.java
+++ b/vassal-app/src/main/java/VASSAL/configure/ConfigureTree.java
@@ -857,6 +857,20 @@ public class ConfigureTree extends JTree implements PropertyChangeListener, Mous
                   ConfigureTree.this.remove(target, child);
                   dispose();
                 }
+
+                @Override
+                public void save() {
+                  //BR// If we've just created a new duplicate and saved it, then select the duplicate rather than leaving the original selected
+                  if (duplicate != null) {
+                    DefaultMutableTreeNode node = getTreeNode(child);
+                    if (node != null) {
+                      final TreePath path = new TreePath(node.getPath());
+                      setSelectionPath(path);
+                      scrollPathToVisible(path);
+                    }
+                  }
+                  super.save();
+                }
               };
               w.setVisible(true);
             }


### PR DESCRIPTION
Minor touchup of the "Duplicate" action that I believe is already a "new with 3.6 feature"

PREVIOUSLY - if you duplicated an item and accepted/saved from the configurer that appeared, the OLD item (the one you'd duplicated) would stay selected. This got a bit confusing to me, because when you'd just been editing the NEW item it seemed like the new item would be the one selected (and so I'd sometimes end up next editing a child of the OLD item by accident)

NOW - if you duplicate an item and save/accept from the configurer, the NEW item becomes selected (if you cancel, the old item stays selected since the new item ends up not actually being created)

Not sure this even needs a new entry in the change list (since it's just a touchup of a new feature)

