### PR TITLE
Add option to disable OpenGL FBOs on Macs

### DIFF
--- a/vassal-app/src/main/java/VASSAL/launch/AbstractLaunchAction.java
+++ b/vassal-app/src/main/java/VASSAL/launch/AbstractLaunchAction.java
@@ -557,6 +557,14 @@ public abstract class AbstractLaunchAction extends AbstractAction {
 
         result.add("-Xdock:name=" + d_name); //NON-NLS
         result.add("-Xdock:icon=" + d_icon); //NON-NLS
+
+        // M1 Macs need FBOs disabled in OpenGL, at least until Metal in Java 17
+        final Boolean disableOGLFBO =
+          (Boolean) Prefs.getGlobalPrefs().getValue(Prefs.DISABLE_OGL_FBO);
+        if (Boolean.TRUE.equals(disableOGLFBO)) {
+          result.add("-Dsun.java2d.opengl=true"); //NON-NLS
+          result.add("-Dsun.java2d.opengl.fbobject=false"); //NON-NLS
+        }
       }
       else if (SystemUtils.IS_OS_WINDOWS) {
         // Disable the 2D to Direct3D pipeline?

--- a/vassal-app/src/main/java/VASSAL/preferences/Prefs.java
+++ b/vassal-app/src/main/java/VASSAL/preferences/Prefs.java
@@ -55,6 +55,7 @@ public class Prefs implements Closeable {
   /** Preferences key for the directory containing modules */
   public static final String MODULES_DIR_KEY = "modulesDir"; //NON-NLS
   public static final String DISABLE_D3D = "disableD3d"; //NON-NLS
+  public static final String DISABLE_OGL_FBO = "disableOGLFBO"; //NON-NLS
   public static final String BAD_DATA_AUDIT_TRAILS = "badDataAuditTrails"; //NON-NLS
 
   public static final String MAIN_WINDOW_REMEMBER = "mainWindowRemember"; //NON-NLS
@@ -297,14 +298,25 @@ public class Prefs implements Closeable {
     );
     globalPrefs.addOption(null, windowHeight);
 
-    // Option to disable D3D pipeline
     if (SystemUtils.IS_OS_WINDOWS) {
+      // Option to disable D3D pipeline
       final BooleanConfigurer d3dConf = new BooleanConfigurer(
         DISABLE_D3D,
         Resources.getString("Prefs.disable_d3d"),
         Boolean.FALSE
       );
       globalPrefs.addOption(Resources.getString("Prefs.compatibility_tab"), d3dConf);
+    }
+    else if (SystemUtils.IS_OS_MAC) {
+      // Option to disable OpenGL FBOs
+      // M1 Macs need FBOs disabled in OpenGL, at least until Metal in Java 17;
+      // Intel Mac users probably want this turned off.
+      final BooleanConfigurer oglfboConf = new BooleanConfigurer(
+        DISABLE_OGL_FBO,
+        Resources.getString("Prefs.disable_ogl_fbo"),
+        "aarch64".equals(System.getProperty("os.arch"))
+      );
+      globalPrefs.addOption(Resources.getString("Prefs.compatibility_tab"), oglfboConf);
     }
 
     final BooleanConfigurer wizardConf = new BooleanConfigurer(

--- a/vassal-app/src/main/resources/VASSAL/i18n/VASSAL.properties
+++ b/vassal-app/src/main/resources/VASSAL/i18n/VASSAL.properties
@@ -895,6 +895,7 @@ Prefs.sounds_tab=Sounds
 Prefs.initial_setup=Initial Setup
 Prefs.unable_to_save=Unable to save preferences.\n
 Prefs.disable_d3d=Disable DirectX D3D pipeline (Can resolve some graphics glitching issues)
+Prefs.disable_ogl_fbo=Disable OpenGL FBOs (Recommended for M1 Macs)
 Prefs.main_window=Remember main window size between sessions
 Prefs.developer_info=Show developer information in Module Manager window
 Prefs.override_default_font_size=Override default font size (0 = default; restart required)


### PR DESCRIPTION
This provides the solution to poor rendering performance on M1 Macs, discovered in a comment here:

https://youtrack.jetbrains.com/issue/JBR-3237
