### PR TITLE
10226 Force Game Piece Image names to be valid png filenames

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/module/gamepieceimage/GamePieceImage.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/gamepieceimage/GamePieceImage.java
@@ -540,9 +540,9 @@ public class GamePieceImage extends AbstractConfigurable implements Visualizable
 
   /**
    * ImageNameFilter that controls how the user can change the Image Name.
-   * If the GPI is still version 0, then no controls. Note we can't force an image
+   * If the GPI is still version 0, then no controls. Note we can't force change an image
    * name because other components may reference that image.
-   * Once the GPI is version 0, then enfore a .png suffix and
+   * Once the GPI is version 1, then enforce a .png suffix
    */
   private static class ImageNameFilter extends DocumentFilter {
     private final PngImageNameConfigurer config;

--- a/vassal-app/src/main/java/VASSAL/build/module/gamepieceimage/GamePieceImage.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/gamepieceimage/GamePieceImage.java
@@ -507,7 +507,7 @@ public class GamePieceImage extends AbstractConfigurable implements Visualizable
   }
 
   private boolean isVersion1ImageName(String name) {
-    return name != null && !name.isEmpty() && name.matches("^[\\w]*\\.png$");
+    return name != null && !name.isEmpty() && name.matches("^\\w+\\.png$");
   }
 
   public static class ImageNameConfig implements ConfigurerFactory {
@@ -571,7 +571,7 @@ public class GamePieceImage extends AbstractConfigurable implements Visualizable
 
     /** Does the current text end in '.png'? */
     private boolean isPng(FilterBypass fb) {
-      return getText(fb).toUpperCase().endsWith(PNG_SUFFIX.toUpperCase());
+      return getText(fb).toLowerCase().endsWith(PNG_SUFFIX);
     }
 
     /** Ensure the current value ends in '.png' */

--- a/vassal-app/src/main/java/VASSAL/build/module/gamepieceimage/GamePieceImage.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/gamepieceimage/GamePieceImage.java
@@ -577,25 +577,9 @@ public class GamePieceImage extends AbstractConfigurable implements Visualizable
     /** Ensure the current value ends in '.png' */
     private void fixPng(FilterBypass fb, int caretPos) throws BadLocationException {
       if (!isPng(fb)) {
-        final String text = getText(fb);
-        if (text.endsWith(".")) {
-          super.replace(fb, text.length() - 1, 1, PNG_SUFFIX, null);
-          config.setCaretPosition(caretPos);
-        }
-        else if (text.toUpperCase().endsWith(".p")) {
-          super.replace(fb, text.length() - 2, 2, PNG_SUFFIX, null);
-          config.setCaretPosition(caretPos);
-        }
-        else if (text.toUpperCase().endsWith(".pn")) {
-          super.replace(fb, text.length() - 3, 3, PNG_SUFFIX, null);
-          config.setCaretPosition(caretPos);
-        }
-        else {
-          super.replace(fb, text.length(), 0, PNG_SUFFIX, null);
-          config.setCaretPosition(caretPos);
-        }
+        super.replace(fb, getText(fb).length(), 0, PNG_SUFFIX, null);
+        config.setCaretPosition(caretPos);
       }
-
     }
 
     private String clean(String string) {

--- a/vassal-app/src/main/java/VASSAL/build/module/gamepieceimage/GamePieceImage.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/gamepieceimage/GamePieceImage.java
@@ -507,7 +507,7 @@ public class GamePieceImage extends AbstractConfigurable implements Visualizable
   }
 
   private boolean isVersion1ImageName(String name) {
-    return name != null && !name.isEmpty() && name.toLowerCase().endsWith(PNG_SUFFIX) && name.matches("^[a-zA-Z0-9$_]*\\.png$");
+    return name != null && !name.isEmpty() && name.toLowerCase().endsWith(PNG_SUFFIX) && name.matches("^[a-zA-Z0-9_]*\\.png$");
   }
 
   public static class ImageNameConfig implements ConfigurerFactory {
@@ -606,7 +606,7 @@ public class GamePieceImage extends AbstractConfigurable implements Visualizable
       final StringBuilder sb = new StringBuilder();
       for (int i = 0; i < string.length(); i++) {
         final char c = string.charAt(i);
-        if (c == '$' || c == '_' || (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9')) {
+        if (c == '_' || (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9')) {
           sb.append(c);
         }
       }

--- a/vassal-app/src/main/resources/VASSAL/i18n/Editor.properties
+++ b/vassal-app/src/main/resources/VASSAL/i18n/Editor.properties
@@ -722,6 +722,7 @@ Editor.GameModule.saved=!Module saved: <b>%1$s</b>
 
 # GamePieceImage
 Editor.GamePieceImage.component_type=Game Piece Image
+Editor.GamePieceImage.png_image_name=Image name. Must end in .png
 
 # GamePieceImageDefinitions
 Editor.GamePieceImageDefinitions.component_type=Game Piece Image Definitions


### PR DESCRIPTION
Newly created GPI's will be forced to be a valid file name containing only 09,a-z,A-Z and _ and ending in .png.

Not much can be done about filenames of existing GPI's as other components will be referencing them. However, if an existing GPI has a valid filename, or is changed to gave a valid filename, then valid filenames will be enforced for that GPI from then on.