### PR TITLE
10375 NPE in EnumeratedPropertyPrompt

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/module/properties/EnumeratedPropertyPrompt.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/properties/EnumeratedPropertyPrompt.java
@@ -32,17 +32,15 @@ public class EnumeratedPropertyPrompt extends PropertyPrompt {
   protected String[] validValues;
   protected Expression[] valueExpressions;
   protected DialogParent dialogParent;
-  protected Constraints propertySource;
 
   public EnumeratedPropertyPrompt(DialogParent dialogParent, String prompt, String[] validValues, Constraints propertySource) {
-    super(null, prompt);
+    super(propertySource, prompt);
     this.validValues = validValues;
     valueExpressions = new Expression[validValues.length];
     for (int i = 0; i < validValues.length; i++) {
       valueExpressions[i] = Expression.createExpression(validValues[i]);
     }
     this.dialogParent = dialogParent;
-    this.propertySource = propertySource;
   }
 
   public Expression[] getValueExpressions() {
@@ -55,12 +53,12 @@ public class EnumeratedPropertyPrompt extends PropertyPrompt {
     for (int i = 0; i < finalValues.length; i++) {
       String value;
       try {
-        final AuditTrail audit = AuditTrail.create(constraints.getPropertySource(), valueExpressions[i].getExpression());
-        if (propertySource == null) {
-          value = valueExpressions[i].evaluate(propertySource.getPropertySource(), audit);
+        final AuditTrail audit = AuditTrail.create(constraints == null ? null : constraints.getPropertySource(), valueExpressions[i].getExpression());
+        if (constraints == null) {
+          value = valueExpressions[i].evaluate(constraints.getPropertySource(), audit);
         }
         else {
-          value = valueExpressions[i].evaluate(propertySource.getPropertySource(), propertySource.getPropertySource(), audit);
+          value = valueExpressions[i].evaluate(constraints.getPropertySource(), constraints.getPropertySource(), audit);
         }
       }
       catch (final ExpressionException e) {

--- a/vassal-app/src/test/resources/clirr-ignored-differences.xml
+++ b/vassal-app/src/test/resources/clirr-ignored-differences.xml
@@ -1116,4 +1116,10 @@
         <differenceType>8001</differenceType>
         <justification>Deprecated for a year</justification>
     </difference>
+    <difference>
+        <className>VASSAL/build/module/properties/EnumeratedPropertyPrompt</className>
+        <differenceType>6001</differenceType>
+        <field>propertySource</field>
+        <justification>Duplicate field</justification>
+    </difference>
 </differences>


### PR DESCRIPTION
This was caused by addition of AuditTrails exposing a shadowed field. 3.6 bug only.