### PR TITLE
Trait AuditTrail Improvements for beta-2

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/BadDataReport.java
+++ b/vassal-app/src/main/java/VASSAL/build/BadDataReport.java
@@ -24,6 +24,7 @@ import VASSAL.counters.EditablePiece;
 import VASSAL.i18n.Resources;
 import VASSAL.script.expression.AuditTrail;
 import VASSAL.script.expression.Auditable;
+import VASSAL.script.expression.AuditableException;
 import VASSAL.script.expression.ExpressionException;
 
 /**
@@ -123,9 +124,12 @@ public class BadDataReport {
   }
 
   public BadDataReport(String pieceName, String traitDesc, String message, String data, Throwable cause) {
-    String m = ((pieceName != null && pieceName.length() > 0) ? pieceName + " " : "");
-    m += ((traitDesc != null && traitDesc.length() > 0) ? "[" + traitDesc + "] " : "");
-    m += m.length() > 0 ? ". " : "";
+    String m = "";
+    if (! (cause instanceof AuditableException)) {
+      m = ((pieceName != null && pieceName.length() > 0) ? pieceName + " " : "");
+      m += ((traitDesc != null && traitDesc.length() > 0) ? "[" + traitDesc + "] " : "");
+      m += m.length() > 0 ? ". " : "";
+    }
     m += message + ". " + getAuditMessage();
 
     this.message = m;
@@ -206,7 +210,7 @@ public class BadDataReport {
   public String getMessage() {
     final StringBuilder sb = new StringBuilder();
     if (owner != null) {
-      sb.append(getDescription(owner)).append(":");
+      sb.append(getDescription(owner));
     }
     if (data != null) {
       sb.append(" ").append(Resources.getString("Audit.source", data));
@@ -225,9 +229,9 @@ public class BadDataReport {
 
   private void setCause(Throwable cause) {
     this.cause = cause;
-    if (cause instanceof ExpressionException) {
-      auditTrail = ((ExpressionException) cause).getAuditTrail();
-      owner =  ((ExpressionException) cause).getOwner();
+    if (cause instanceof AuditableException) {
+      auditTrail = ((AuditableException) cause).getAuditTrail();
+      owner =  ((AuditableException) cause).getOwner();
     }
   }
 

--- a/vassal-app/src/main/java/VASSAL/counters/Embellishment.java
+++ b/vassal-app/src/main/java/VASSAL/counters/Embellishment.java
@@ -31,6 +31,8 @@ import VASSAL.configure.StringConfigurer;
 import VASSAL.i18n.PieceI18nData;
 import VASSAL.i18n.Resources;
 import VASSAL.i18n.TranslatablePiece;
+import VASSAL.script.expression.AuditTrail;
+import VASSAL.script.expression.AuditableException;
 import VASSAL.script.expression.Expression;
 import VASSAL.tools.FormattedString;
 import VASSAL.tools.NamedKeyStroke;
@@ -634,14 +636,15 @@ public class Embellishment extends Decorator implements TranslatablePiece, Recur
 
       if (resetKey != null && resetKey.equals(stroke)) {
         final GamePiece outer = Decorator.getOutermost(this);
-        final String levelText = resetLevel.getText(outer, this, "Editor.Embellishment.reset_to_level");
+        final AuditTrail audit = AuditTrail.create(this, resetLevel, Resources.getString("Editor.Embellishment.reset_to_level"));
+        final String levelText = resetLevel.getText(outer, this, audit);
         try {
           final int level = Integer.parseInt(levelText);
           setValue(Math.abs(level) - 1);
           setActive(level > 0);
         }
         catch (NumberFormatException e) {
-          reportDataError(this, Resources.getString("Error.non_number_error"), resetLevel.debugInfo(levelText, "resetLevel"), e); // NON-NLS
+          reportDataError(this, Resources.getString("Error.non_number_error"), resetLevel.debugInfo(levelText, "resetLevel"), new AuditableException(this, audit)); // NON-NLS
         }
       }
       // random layers

--- a/vassal-app/src/main/java/VASSAL/counters/PlaySound.java
+++ b/vassal-app/src/main/java/VASSAL/counters/PlaySound.java
@@ -28,6 +28,8 @@ import VASSAL.configure.StringConfigurer;
 import VASSAL.i18n.PieceI18nData;
 import VASSAL.i18n.Resources;
 import VASSAL.i18n.TranslatablePiece;
+import VASSAL.script.expression.AuditTrail;
+import VASSAL.script.expression.AuditableException;
 import VASSAL.tools.AudioClip;
 import VASSAL.tools.FormattedString;
 import VASSAL.tools.NamedKeyStroke;
@@ -107,7 +109,8 @@ public class PlaySound extends Decorator implements TranslatablePiece {
     myGetKeyCommands();
     Command c = null;
     if (command.matches(stroke)) {
-      final String clipName = format.getText(Decorator.getOutermost(this), this, "Editor.PlaySound.sound_clip");
+      final AuditTrail audit = AuditTrail.create(this, format, Resources.getString("Editor.PlaySound.sound_clip"));
+      final String clipName = format.getText(Decorator.getOutermost(this), this, audit);
       c = new PlayAudioClipCommand(clipName);
       try {
         if (!GlobalOptions.getInstance().isSoundGlobalMute()) {
@@ -120,7 +123,8 @@ public class PlaySound extends Decorator implements TranslatablePiece {
         }
       }
       catch (IOException e) {
-        reportDataError(this, Resources.getString("Error.not_found", "Audio Clip"), "Clip=" + clipName, e); //NON-NLS
+        reportDataError(this, Resources.getString("Error.not_found", "Audio Clip"), "Clip=" + clipName,
+          new AuditableException(this, audit)); //NON-NLS
       }
     }
     return c;

--- a/vassal-app/src/main/java/VASSAL/counters/ReturnToDeck.java
+++ b/vassal-app/src/main/java/VASSAL/counters/ReturnToDeck.java
@@ -17,7 +17,6 @@
  */
 package VASSAL.counters;
 
-import VASSAL.build.BadDataReport;
 import VASSAL.build.GameModule;
 import VASSAL.build.module.Map;
 import VASSAL.build.module.documentation.HelpFile;
@@ -30,7 +29,8 @@ import VASSAL.configure.StringConfigurer;
 import VASSAL.i18n.PieceI18nData;
 import VASSAL.i18n.Resources;
 import VASSAL.i18n.TranslatablePiece;
-import VASSAL.tools.ErrorDialog;
+import VASSAL.script.expression.AuditTrail;
+import VASSAL.script.expression.AuditableException;
 import VASSAL.tools.FormattedString;
 import VASSAL.tools.NamedKeyStroke;
 import VASSAL.tools.ScrollPane;
@@ -176,10 +176,11 @@ public class ReturnToDeck extends Decorator implements TranslatablePiece {
         pile = promptForDrawPile();
       }
       else {
-        final String evalName = deckExpression.getText(Decorator.getOutermost(this), this, "Editor.ReturnToDeck.deck_name");
+        final AuditTrail audit = AuditTrail.create(this, deckExpression, Resources.getString("Editor.ReturnToDeck.deck_name"));
+        final String evalName = deckExpression.getText(Decorator.getOutermost(this), this, audit);
         pile = DrawPile.findDrawPile(evalName);
         if (pile == null) {
-          ErrorDialog.dataWarning(new BadDataReport("Deck Not Found for Return-to-Deck trait: " + evalName, deckExpression.getFormat())); //NON-NLS
+          reportDataError(this, "Deck Not Found for Return-to-Deck trait: " + evalName, deckExpression.getFormat(), new AuditableException(this, audit));
         }
       }
 

--- a/vassal-app/src/main/java/VASSAL/script/expression/AuditableException.java
+++ b/vassal-app/src/main/java/VASSAL/script/expression/AuditableException.java
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright (c) 2009-2021 The VASSAL Development Team
+ * Copyright (c) 2021 The VASSAL Development Team
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -17,32 +17,26 @@
  */
 package VASSAL.script.expression;
 
-public class ExpressionException extends AuditableException {
+public class AuditableException extends Exception {
   private static final long serialVersionUID = 1L;
 
-  protected String expression;
-  protected String error;
+  protected Auditable owner;
+  protected AuditTrail auditTrail;
 
-  public ExpressionException(String s) {
-    this(s, "");
+  public AuditableException(Auditable owner, AuditTrail auditTrail) {
+    this.owner = owner;
+    this.auditTrail = auditTrail;
   }
 
-  public ExpressionException(String s, String e) {
-    this(s, e, null, null);
+  public Auditable getOwner() {
+    return owner;
   }
 
-  public ExpressionException(String s, String e, Auditable owner, AuditTrail auditTrail) {
-    super(owner, auditTrail);
-    expression = s;
-    error = e;
+  public AuditTrail getAuditTrail() {
+    return auditTrail;
   }
 
-  public String getExpression() {
-    return expression;
+  public String getAuditReport() {
+    return auditTrail == null ? "" : auditTrail.toString();
   }
-
-  public String getError() {
-    return error;
-  }
-
 }

--- a/vassal-app/src/main/java/VASSAL/tools/FormattedString.java
+++ b/vassal-app/src/main/java/VASSAL/tools/FormattedString.java
@@ -25,6 +25,7 @@ import VASSAL.counters.GamePiece;
 import VASSAL.i18n.Resources;
 import VASSAL.script.expression.AuditTrail;
 import VASSAL.script.expression.Auditable;
+import VASSAL.script.expression.AuditableException;
 import VASSAL.script.expression.Expression;
 import VASSAL.tools.RecursionLimiter.Loopable;
 import VASSAL.tools.concurrent.ConcurrentSoftHashMap;
@@ -347,7 +348,8 @@ public class FormattedString implements Loopable {
    */
   public int getTextAsInt(PropertySource ps, String description, EditablePiece source) {
     int result = 0;
-    final String value = getText(ps, "0", source, AuditTrail.create(source, fsdata.formatString, description));
+    final AuditTrail audit = AuditTrail.create((Auditable) ps, this, description);
+    final String value = getText(ps, "0", source, audit);
     try {
       result = Integer.parseInt(value);
     }
@@ -355,7 +357,7 @@ public class FormattedString implements Loopable {
       ErrorDialog.dataWarning(new BadDataReport(
         source,
         Resources.getString("Error.non_number_error"),
-        debugInfo(this, value, description), e
+        debugInfo(this, value, description), new AuditableException((Auditable) ps, audit)
       ));
     }
     return result;
@@ -363,7 +365,8 @@ public class FormattedString implements Loopable {
 
   public int getTextAsInt(PropertySource ps, String description, AbstractConfigurable source) {
     int result = 0;
-    final String value = getText(ps, "0", source, AuditTrail.create(source, fsdata.formatString, description));
+    final AuditTrail audit = AuditTrail.create((Auditable) ps, this, description);
+    final String value = getText(ps, "0", source, audit);
     try {
       result = Integer.parseInt(value);
     }
@@ -371,7 +374,7 @@ public class FormattedString implements Loopable {
       ErrorDialog.dataWarning(new BadDataReport(
         source,
         Resources.getString("Error.non_number_error"),
-        debugInfo(this, value, description), e
+        debugInfo(this, value, description), new AuditableException((Auditable) ps, audit)
       ));
     }
     return result;

--- a/vassal-app/src/test/resources/clirr-ignored-differences.xml
+++ b/vassal-app/src/test/resources/clirr-ignored-differences.xml
@@ -1116,4 +1116,12 @@
         <differenceType>8001</differenceType>
         <justification>Deprecated for a year</justification>
     </difference>
+
+    <difference>
+        <className>VASSAL/script/expression/ExpressionException</className>
+        <differenceType>6001</differenceType>
+        <field>**</field>
+        <justification>Moved to superclass.</justification>
+    </difference>
+
 </differences>


### PR DESCRIPTION
Show a complete audit trail where an expression does not fail, but produces an invalid value in the context of the command being executed. e.g. returning a non-number for an x co-ord.