### PR TITLE
10405 Fix issue with Delete trait failing after load log file

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/module/GameState.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/GameState.java
@@ -545,6 +545,7 @@ public class GameState implements CommandEncoder {
           
           GameModule.getGameModule().setLoadOverSemaphore(true); // Stop updating Map UI etc for a bit
           try {
+            pieces.clear();
             loadGameInForeground(f); // Foreground loading minimizes the bad behavior of windows during vlog load "mid game"
           }
           finally {


### PR DESCRIPTION
Clear the pieces in the current game state completely before loading a new log file on top. 