### PR TITLE
Store the tile cache in %LOCALAPPDATA% instead of %APPDATA% on Windows.

### DIFF
--- a/vassal-app/src/main/java/VASSAL/Info.java
+++ b/vassal-app/src/main/java/VASSAL/Info.java
@@ -100,6 +100,10 @@ public final class Info {
     return CONFIG.getConfDir().toFile();
   }
 
+  public static File getCacheDir() {
+    return CONFIG.getCacheDir().toFile();
+  }
+
   public static File getTempDir() {
     return CONFIG.getTempDir().toFile();
   }

--- a/vassal-app/src/main/java/VASSAL/build/GameModule.java
+++ b/vassal-app/src/main/java/VASSAL/build/GameModule.java
@@ -1880,7 +1880,7 @@ public class GameModule extends AbstractConfigurable
       final String hstr =
         DigestUtils.sha1Hex(getGameName() + "_" + getGameVersion()); //NON-NLS
 
-      final File tc = new File(Info.getConfDir(), "tiles/" + hstr); //NON-NLS
+      final File tc = new File(Info.getCacheDir(), "tiles/" + hstr); //NON-NLS
       tcache = new ImageTileDiskCache(tc.getAbsolutePath());
     }
 

--- a/vassal-app/src/main/java/VASSAL/launch/AbstractLaunchAction.java
+++ b/vassal-app/src/main/java/VASSAL/launch/AbstractLaunchAction.java
@@ -277,7 +277,7 @@ public abstract class AbstractLaunchAction extends AbstractAction {
         final String hstr =
           DigestUtils.sha1Hex(meta.getName() + "_" + meta.getVersion());
 
-        final File cdir = new File(Info.getConfDir(), "tiles/" + hstr);
+        final File cdir = new File(Info.getCacheDir(), "tiles/" + hstr);
 
         final TilingHandler th = new TilingHandler(
           aname,

--- a/vassal-app/src/main/java/VASSAL/launch/Config.java
+++ b/vassal-app/src/main/java/VASSAL/launch/Config.java
@@ -29,6 +29,8 @@ public interface Config {
 
   Path getConfDir();
 
+  Path getCacheDir();
+
   Path getTempDir();
 
   Path getPrefsDir();

--- a/vassal-app/src/main/java/VASSAL/launch/DummyConfig.java
+++ b/vassal-app/src/main/java/VASSAL/launch/DummyConfig.java
@@ -40,6 +40,11 @@ public class DummyConfig implements Config {
   }
 
   @Override
+  public Path getCacheDir() {
+    return getTempDir();
+  }
+
+  @Override
   public Path getConfDir() {
     return getTempDir();
   }

--- a/vassal-app/src/main/java/VASSAL/launch/ModuleManagerWindow.java
+++ b/vassal-app/src/main/java/VASSAL/launch/ModuleManagerWindow.java
@@ -297,7 +297,7 @@ public class ModuleManagerWindow extends JFrame {
 
         if (dialogResult == JOptionPane.OK_OPTION) {
 
-          final File tdir = new File(Info.getConfDir(), "tiles");
+          final File tdir = new File(Info.getCacheDir(), "tiles");
           if (tdir.exists()) {
             try {
               FileUtils.forceDelete(tdir);
@@ -1587,7 +1587,7 @@ public class ModuleManagerWindow extends JFrame {
         metadata.getName() + "_" + metadata.getVersion()
       );
 
-      final File tdir = new File(Info.getConfDir(), "tiles/" + hstr);
+      final File tdir = new File(Info.getCacheDir(), "tiles/" + hstr);
       if (tdir.exists()) {
         try {
           FileUtils.forceDelete(tdir);

--- a/vassal-app/src/main/java/VASSAL/launch/ModuleManagerWindow.java
+++ b/vassal-app/src/main/java/VASSAL/launch/ModuleManagerWindow.java
@@ -293,18 +293,21 @@ public class ModuleManagerWindow extends JFrame {
           Resources.getString("ModuleManager.clear_tilecache_heading"),
           Resources.getString("ModuleManager.clear_tilecache_message"),
           JOptionPane.WARNING_MESSAGE,
-          JOptionPane.OK_CANCEL_OPTION);
+          JOptionPane.OK_CANCEL_OPTION
+        );
 
         if (dialogResult == JOptionPane.OK_OPTION) {
-
-          final File tdir = new File(Info.getCacheDir(), "tiles");
-          if (tdir.exists()) {
-            try {
-              FileUtils.forceDelete(tdir);
-              FileUtils.forceMkdir(tdir);
-            }
-            catch (IOException e) {
-              WriteErrorDialog.error(e, tdir);
+          // clear tiles in both old (conf) and new (cache) locations
+          for (final File d : List.of(Info.getCacheDir(), Info.getConfDir())) {
+            final File tdir = new File(d, "tiles");
+            if (tdir.exists()) {
+              try {
+                FileUtils.forceDelete(tdir);
+                FileUtils.forceMkdir(tdir);
+              }
+              catch (IOException e) {
+                WriteErrorDialog.error(e, tdir);
+              }
             }
           }
         }

--- a/vassal-app/src/main/java/VASSAL/launch/StandardConfig.java
+++ b/vassal-app/src/main/java/VASSAL/launch/StandardConfig.java
@@ -27,6 +27,7 @@ import VASSAL.tools.version.GitProperties;
 public class StandardConfig implements Config {
   private final Path baseDir;
   private final Path docDir;
+  private final Path cacheDir;
   private final Path confDir;
   private final Path tmpDir;
   private final Path prefsDir;
@@ -66,6 +67,17 @@ public class StandardConfig implements Config {
       confDir = Path.of(System.getProperty("user.home"), ".VASSAL"); //NON-NLS
     }
 
+    final String cacheProp = System.getProperty("VASSAL.cache");
+    if (cacheProp != null) {
+      cacheDir = Path.of(cacheProp);
+    }
+    else if (SystemUtils.IS_OS_WINDOWS) {
+      cacheDir = Path.of(System.getenv("LOCALAPPDATA"), "VASSAL"); //NON-NLS
+    }
+    else {
+      cacheDir = confDir;
+    }
+
     Files.createDirectories(confDir);
 
     prefsDir = confDir.resolve("prefs");
@@ -101,6 +113,11 @@ public class StandardConfig implements Config {
   @Override
   public Path getConfDir() {
     return confDir;
+  }
+
+  @Override
+  public Path getCacheDir() {
+    return cacheDir;
   }
 
   @Override


### PR DESCRIPTION
The latter causes problems for people with a settings directory which
lives on a network share.