### PR TITLE
10452 - Fix Mat related crash in Game Refresher

### DIFF
--- a/vassal-app/src/main/java/VASSAL/counters/Mat.java
+++ b/vassal-app/src/main/java/VASSAL/counters/Mat.java
@@ -119,7 +119,7 @@ public class Mat extends Decorator implements TranslatablePiece {
     final int num = st.nextInt(0);
     final GameState gs = GameModule.getGameModule().getGameState();
     for (int i = 0; i < num; i++) {
-      GamePiece piece = gs.getPieceForId(st.nextToken());
+      final GamePiece piece = gs.getPieceForId(st.nextToken());
       if (piece != null) { //BR// getPieceForId can return null.
         contents.add(piece);
       }

--- a/vassal-app/src/main/java/VASSAL/counters/Mat.java
+++ b/vassal-app/src/main/java/VASSAL/counters/Mat.java
@@ -119,7 +119,10 @@ public class Mat extends Decorator implements TranslatablePiece {
     final int num = st.nextInt(0);
     final GameState gs = GameModule.getGameModule().getGameState();
     for (int i = 0; i < num; i++) {
-      contents.add(gs.getPieceForId(st.nextToken()));
+      GamePiece piece = gs.getPieceForId(st.nextToken());
+      if (piece != null) { //BR// getPieceForId can return null.
+        contents.add(piece);
+      }
     }
 
     GameModule.getGameModule().setMatSupport(true);


### PR DESCRIPTION
I had a NullPointerException when running GameRefresher on a game with Mats in it. It appears that at some point the "getPieceForId" returned a null instead of a piece, and this got inserted into a Mat's "contents" list, leading to Bad Things later on.

This patches the Mat not to accept a null contents member. Which is correct and reasonable behavior as far as it goes. 

What it does not fix is whatever reason getPieceForId() returns null in the first place, which may well be some "temporary state during GameRefreshing". In which case GameRefreshing a Mat-game might possibly dissociate pieces from their Mats in some cases. But at least that's better than crashing. 