### PR TITLE
10474 - Movement traits need to update cargo's mat after movement before applying apply-on-move keystroke

### DIFF
--- a/vassal-app/src/main/java/VASSAL/counters/FreeRotator.java
+++ b/vassal-app/src/main/java/VASSAL/counters/FreeRotator.java
@@ -504,15 +504,8 @@ public class FreeRotator extends Decorator
     // Move the piece
     c = c.append(map.placeOrMerge(outer, dest));
 
-    if (GameModule.getGameModule().isMatSupport()) {
-      // If a cargo piece has been "sent", find it a new Mat if needed.
-      if (Boolean.TRUE.equals(outer.getProperty(MatCargo.IS_CARGO))) { //NON-NLS
-        final MatCargo cargo = (MatCargo) Decorator.getDecorator(outer, MatCargo.class);
-        if (cargo != null) {
-          c = c.append(cargo.findNewMat());
-        }
-      }
-    }
+    // If a cargo piece has been "sent", find it a new Mat if needed.
+    c = MatCargo.findNewMat(c, outer);
 
     // Apply after Move Key
     if (map.getMoveKey() != null) {

--- a/vassal-app/src/main/java/VASSAL/counters/FreeRotator.java
+++ b/vassal-app/src/main/java/VASSAL/counters/FreeRotator.java
@@ -504,6 +504,16 @@ public class FreeRotator extends Decorator
     // Move the piece
     c = c.append(map.placeOrMerge(outer, dest));
 
+    if (GameModule.getGameModule().isMatSupport()) {
+      // If a cargo piece has been "sent", find it a new Mat if needed.
+      if (Boolean.TRUE.equals(outer.getProperty(MatCargo.IS_CARGO))) { //NON-NLS
+        final MatCargo cargo = (MatCargo) Decorator.getDecorator(outer, MatCargo.class);
+        if (cargo != null) {
+          c = c.append(cargo.findNewMat());
+        }
+      }
+    }
+
     // Apply after Move Key
     if (map.getMoveKey() != null) {
       c = c.append(outer.keyEvent(map.getMoveKey()));
@@ -513,16 +523,6 @@ public class FreeRotator extends Decorator
     final Stack parent = outer.getParent();
     if (parent != null) {
       c = c.append(parent.pieceRemoved(outer));
-    }
-
-    if (GameModule.getGameModule().isMatSupport()) {
-      // If a cargo piece has been "sent", find it a new Mat if needed.
-      if (Boolean.TRUE.equals(outer.getProperty(MatCargo.IS_CARGO))) { //NON-NLS
-        final MatCargo cargo = (MatCargo) Decorator.getDecorator(outer, MatCargo.class);
-        if (cargo != null) {
-          c = c.append(cargo.findNewMat());
-        }
-      }
     }
 
     return c;

--- a/vassal-app/src/main/java/VASSAL/counters/MatCargo.java
+++ b/vassal-app/src/main/java/VASSAL/counters/MatCargo.java
@@ -242,6 +242,26 @@ public class MatCargo extends Decorator implements TranslatablePiece {
     return findNewMat(getMap(), getPosition());
   }
 
+
+  /**
+   * Checks if GamePiece gp is a MatCargo, and if so finds it a new mat if needed (or clears it if it has moved off its former mat)
+   * @param c Command to which to append
+   * @param gp GamePiece
+   * @return Command c with any needed additional commands appended
+   */
+  public static Command findNewMat(Command c, GamePiece gp) {
+    if (GameModule.getGameModule().isMatSupport()) {
+      // If a cargo piece has been "sent", find it a new Mat if needed.
+      if (Boolean.TRUE.equals(gp.getProperty(MatCargo.IS_CARGO))) { //NON-NLS
+        final MatCargo cargo = (MatCargo) Decorator.getDecorator(gp, MatCargo.class);
+        if (cargo != null) {
+          c = c.append(cargo.findNewMat());
+        }
+      }
+    }
+    return c;
+  }
+
   /**
    * @return current Mat we are on top of (or null for none)
    */

--- a/vassal-app/src/main/java/VASSAL/counters/SendToLocation.java
+++ b/vassal-app/src/main/java/VASSAL/counters/SendToLocation.java
@@ -403,10 +403,23 @@ public class SendToLocation extends Decorator implements TranslatablePiece {
           dest = map.snapTo(dest);
         }
         c = c.append(map.placeOrMerge(outer, dest));
+
+        // Mat support
+        if ((c != null) && GameModule.getGameModule().isMatSupport()) {
+          // If a cargo piece has been "sent", find it a new Mat if needed.
+          if (Boolean.TRUE.equals(outer.getProperty(MatCargo.IS_CARGO))) { //NON-NLS
+            final MatCargo cargo = (MatCargo) Decorator.getDecorator(outer, MatCargo.class);
+            if (cargo != null) {
+              c = c.append(cargo.findNewMat());
+            }
+          }
+        }
+
         // Apply Auto-move key
         if (map.getMoveKey() != null) {
           c = c.append(outer.keyEvent(map.getMoveKey()));
         }
+
         if (parent != null) {
           c = c.append(parent.pieceRemoved(outer));
         }
@@ -432,6 +445,17 @@ public class SendToLocation extends Decorator implements TranslatablePiece {
         c = c.append(backMap.placeOrMerge(outer, backPoint));
         dest = backPoint;
 
+        // Mat support
+        if ((c != null) && GameModule.getGameModule().isMatSupport()) {
+          // If a cargo piece has been "sent", find it a new Mat if needed.
+          if (Boolean.TRUE.equals(outer.getProperty(MatCargo.IS_CARGO))) { //NON-NLS
+            final MatCargo cargo = (MatCargo) Decorator.getDecorator(outer, MatCargo.class);
+            if (cargo != null) {
+              c = c.append(cargo.findNewMat());
+            }
+          }
+        }
+
         // Apply Auto-move key
         if (backMap.getMoveKey() != null) {
           c = c.append(outer.keyEvent(backMap.getMoveKey()));
@@ -441,15 +465,6 @@ public class SendToLocation extends Decorator implements TranslatablePiece {
 
     // Mat support
     if ((c != null) && GameModule.getGameModule().isMatSupport()) {
-
-      // If a cargo piece has been "sent", find it a new Mat if needed.
-      if (Boolean.TRUE.equals(outer.getProperty(MatCargo.IS_CARGO))) { //NON-NLS
-        final MatCargo cargo = (MatCargo) Decorator.getDecorator(outer, MatCargo.class);
-        if (cargo != null) {
-          c = c.append(cargo.findNewMat());
-        }
-      }
-
       // If a Mat has been sent, send all its contents, at an appropriate offset.
       if ((offsets != null) && dest != null) {
         for (int i = 0; i < contents.size(); i++) {

--- a/vassal-app/src/main/java/VASSAL/counters/SendToLocation.java
+++ b/vassal-app/src/main/java/VASSAL/counters/SendToLocation.java
@@ -404,16 +404,8 @@ public class SendToLocation extends Decorator implements TranslatablePiece {
         }
         c = c.append(map.placeOrMerge(outer, dest));
 
-        // Mat support
-        if ((c != null) && GameModule.getGameModule().isMatSupport()) {
-          // If a cargo piece has been "sent", find it a new Mat if needed.
-          if (Boolean.TRUE.equals(outer.getProperty(MatCargo.IS_CARGO))) { //NON-NLS
-            final MatCargo cargo = (MatCargo) Decorator.getDecorator(outer, MatCargo.class);
-            if (cargo != null) {
-              c = c.append(cargo.findNewMat());
-            }
-          }
-        }
+        // If a cargo piece has been "sent", find it a new Mat if needed.
+        c = MatCargo.findNewMat(c, outer);
 
         // Apply Auto-move key
         if (map.getMoveKey() != null) {
@@ -445,16 +437,8 @@ public class SendToLocation extends Decorator implements TranslatablePiece {
         c = c.append(backMap.placeOrMerge(outer, backPoint));
         dest = backPoint;
 
-        // Mat support
-        if ((c != null) && GameModule.getGameModule().isMatSupport()) {
-          // If a cargo piece has been "sent", find it a new Mat if needed.
-          if (Boolean.TRUE.equals(outer.getProperty(MatCargo.IS_CARGO))) { //NON-NLS
-            final MatCargo cargo = (MatCargo) Decorator.getDecorator(outer, MatCargo.class);
-            if (cargo != null) {
-              c = c.append(cargo.findNewMat());
-            }
-          }
-        }
+        // If a cargo piece has been "sent", find it a new Mat if needed.
+        c = MatCargo.findNewMat(c, outer);
 
         // Apply Auto-move key
         if (backMap.getMoveKey() != null) {

--- a/vassal-app/src/main/java/VASSAL/counters/Translate.java
+++ b/vassal-app/src/main/java/VASSAL/counters/Translate.java
@@ -283,16 +283,9 @@ public class Translate extends Decorator implements TranslatablePiece {
     // Move the piece
     c = c.append(map.placeOrMerge(outer, dest));
 
-    if (GameModule.getGameModule().isMatSupport()) {
-      // If a cargo piece has been "sent", find it a new Mat if needed.
-      if (Boolean.TRUE.equals(outer.getProperty(MatCargo.IS_CARGO))) { //NON-NLS
-        final MatCargo cargo = (MatCargo) Decorator.getDecorator(outer, MatCargo.class);
-        if (cargo != null) {
-          c = c.append(cargo.findNewMat());
-        }
-      }
-    }
-
+    // If a cargo piece has been "sent", find it a new Mat if needed.
+    c = MatCargo.findNewMat(c, outer);
+    
     // Apply after Move Key
     if (map.getMoveKey() != null) {
       c = c.append(outer.keyEvent(map.getMoveKey()));

--- a/vassal-app/src/main/java/VASSAL/counters/Translate.java
+++ b/vassal-app/src/main/java/VASSAL/counters/Translate.java
@@ -283,6 +283,16 @@ public class Translate extends Decorator implements TranslatablePiece {
     // Move the piece
     c = c.append(map.placeOrMerge(outer, dest));
 
+    if (GameModule.getGameModule().isMatSupport()) {
+      // If a cargo piece has been "sent", find it a new Mat if needed.
+      if (Boolean.TRUE.equals(outer.getProperty(MatCargo.IS_CARGO))) { //NON-NLS
+        final MatCargo cargo = (MatCargo) Decorator.getDecorator(outer, MatCargo.class);
+        if (cargo != null) {
+          c = c.append(cargo.findNewMat());
+        }
+      }
+    }
+
     // Apply after Move Key
     if (map.getMoveKey() != null) {
       c = c.append(outer.keyEvent(map.getMoveKey()));
@@ -292,16 +302,6 @@ public class Translate extends Decorator implements TranslatablePiece {
     final Stack parent = outer.getParent();
     if (parent != null) {
       c = c.append(parent.pieceRemoved(outer));
-    }
-
-    if (GameModule.getGameModule().isMatSupport()) {
-      // If a cargo piece has been "sent", find it a new Mat if needed.
-      if (Boolean.TRUE.equals(outer.getProperty(MatCargo.IS_CARGO))) { //NON-NLS
-        final MatCargo cargo = (MatCargo) Decorator.getDecorator(outer, MatCargo.class);
-        if (cargo != null) {
-          c = c.append(cargo.findNewMat());
-        }
-      }
     }
 
     return c;


### PR DESCRIPTION
Send-to-Location, Rotate, and Move-Fixed-Distance all had the "update our mat based on where we moved to" logic _after_ the apply-on-move key was applied to them. That was incorrect and was leading to "Current Mat" property not being updated correctly, wrong messages being printed, etc. 

I've moved the code blocks to the right location and verified that this was removing the "wrong messages" in my module. 

PieceMover was already working correctly (which is why I didn't notice this earlier)