### PR TITLE
10484 - Deselect trait improvements and double-click Mat

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/module/map/KeyBufferer.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/KeyBufferer.java
@@ -53,6 +53,8 @@ import VASSAL.counters.Properties;
 import VASSAL.counters.Stack;
 import VASSAL.tools.swing.SwingUtils;
 
+import static VASSAL.counters.Mat.MAT_NAME;
+
 /**
  * Selects and unselects pieces on the map, using the mouse.
  * <br><br>
@@ -258,7 +260,6 @@ public class KeyBufferer extends MouseAdapter implements Buildable, MouseMotionL
 
           // If we've added a mat, add all its pieces to the selection.
           if (GameModule.getGameModule().isMatSupport() && !SwingUtils.isSelectionToggle(e)) {
-
             final Object o = p.getProperty(Mat.MAT_CONTENTS);
             if (o instanceof List) {
               final List<GamePiece> matPieces = (List<GamePiece>)o;
@@ -266,18 +267,6 @@ public class KeyBufferer extends MouseAdapter implements Buildable, MouseMotionL
                 kbuf.add(mp);
               }
             }
-
-            /*
-            if (p instanceof Decorator) {
-              final Mat mat = (Mat)Decorator.getDecorator(Decorator.getOutermost(p), Mat.class);
-              if (mat != null) {
-                final List<GamePiece> matPieces = new ArrayList<GamePiece>(mat.getContents());
-                for (final GamePiece mp : matPieces) {
-                  kbuf.add(mp);
-                }
-              }
-            }
-            */
           }
         }
         else {
@@ -298,12 +287,30 @@ public class KeyBufferer extends MouseAdapter implements Buildable, MouseMotionL
         }
         // End RFE 1659481
 
-        // If we're a cargo piece, and on a mat, then a simple left click grabs us uniquely out of the selection if we're in it
         if (GameModule.getGameModule().isMatSupport() && !SwingUtils.isSelectionToggle(e) && !SwingUtils.isContextMouseButtonDown(e) && !e.isShiftDown()) {
-          final String matName = (String)p.getProperty(MatCargo.CURRENT_MAT);
+          // If we're a cargo piece, and on a mat, then a simple left click grabs us uniquely out of the selection if we're in it
+          String matName = (String)p.getProperty(MatCargo.CURRENT_MAT);
           if ((matName != null) && !matName.isEmpty()) {
             maybeClickPiece = p;
             bandSelect = BandSelectType.NONE;
+          }
+
+          // If we ARE a mat, then double-clicking selects ONLY this piece, but single clicking guarantees picking up all the cargo
+          matName = (String)p.getProperty(MAT_NAME);
+          if ((matName != null) && !matName.isEmpty()) {
+            if (e.getClickCount() > 1) {
+              kbuf.clear();
+              kbuf.add(p);
+            }
+            else {
+              final Object o = p.getProperty(Mat.MAT_CONTENTS);
+              if (o instanceof List) {
+                final List<GamePiece> matPieces = (List<GamePiece>)o;
+                for (final GamePiece mp : matPieces) {
+                  kbuf.add(mp);
+                }
+              }
+            }
           }
         }
       }

--- a/vassal-app/src/main/resources/VASSAL/i18n/Editor.properties
+++ b/vassal-app/src/main/resources/VASSAL/i18n/Editor.properties
@@ -457,6 +457,10 @@ Editor.Delete.delete=Delete
 Editor.Deselect.deselect=Deselect
 Editor.Deselect.remove_piece_from_stack=Remove piece from stack
 Editor.Deselect.deselect_command=Deselect command
+Editor.Deselect.deselection_type=Deselection type
+Editor.Deselect.deselect_this_piece=Deselect This Piece
+Editor.Deselect.deselect_all_pieces=Deselect ALL Pieces
+Editor.Deselect.select_only_this_piece=Select ONLY This Piece
 
 # Dice Button
 Editor.DiceButton.component_type=Dice Button

--- a/vassal-doc/src/main/readme-referencemanual/ReferenceManual/Deselect.adoc
+++ b/vassal-doc/src/main/readme-referencemanual/ReferenceManual/Deselect.adoc
@@ -20,6 +20,8 @@ A <<GamePiece.adoc#top,Game Piece>> with this trait will have a command that cau
 
 *Remove piece from stack:*:: If checked, then when this trait is activated the piece will _also_ be removed from any Stack it is a part of. This can be useful in games that involve "dropping off and picking up" units from armies, because a <<Marker.adoc#top,Place Marker>> trait will normally add the new marker to the current stack.
 
+*Deselection type:*:: Choose whether you wish to deselect this piece, deselect all pieces, or select only this piece.
+
 |image:images/Deselect.png[]
 _Deselect this piece without removing it from it's Stack when the *Deselect* menu command is selected, on receipt of the *Ctrl+K* Keystroke Command._
 |===


### PR DESCRIPTION
I've discovered a few more UX cases for Mats that led me to want to improve the select/deselect options.

I've improved the existing Deselect trait to allow three "modes" of Deselection:
(1) Deselect this piece (default & what the trait formerly only did)
(2) Deselect ALL pieces
(3) Select ONLY this piece

Also double clicking a Mat can be used to ditch selection of cargo items.