### PR TITLE
10486 Better obscurable option for insetting

### DIFF
--- a/vassal-app/src/main/java/VASSAL/counters/Obscurable.java
+++ b/vassal-app/src/main/java/VASSAL/counters/Obscurable.java
@@ -63,6 +63,7 @@ public class Obscurable extends Decorator implements TranslatablePiece {
   protected static final char BACKGROUND = 'B';
   protected static final char PEEK = 'P';
   protected static final char IMAGE = 'G';
+  protected static final char INSET2 = '2';
   protected static final String DEFAULT_PEEK_COMMAND = Resources.getString("Editor.Obscurable.default_peek_command");
 
   protected char obscureKey;
@@ -207,6 +208,8 @@ public class Obscurable extends Decorator implements TranslatablePiece {
         return obscuredToMeView.getShape();
       case INSET:
         return piece.getShape();
+      case INSET2:
+        return obscuredToMeView.getShape();
       case PEEK:
         if (peeking && Boolean.TRUE.equals(getProperty(Properties.SELECTED))) {
           return piece.getShape();
@@ -367,6 +370,14 @@ public class Obscurable extends Decorator implements TranslatablePiece {
         y - (int) (zoom * bounds.height / 2
           - .5 * zoom * obsBounds.height / 2),
         obs, zoom * 0.5);
+      break;
+    case INSET2:
+      obscuredToMeView.draw(g, x, y, obs, zoom);
+      final Rectangle bounds2 = piece.getShape().getBounds();
+      final Rectangle obsBounds2 = obscuredToMeView.getShape().getBounds();
+      piece.draw(g, x - (int) (zoom * .8 * obsBounds2.width / 2  - .8 * zoom * bounds2.width/2),
+                    y - (int) (zoom * .8 * obsBounds2.height / 2 - .8 * zoom * bounds2.height/2),
+        obs, zoom * 0.8);
       break;
     case PEEK:
       if (peeking && Boolean.TRUE.equals(getProperty(Properties.SELECTED))) {
@@ -629,14 +640,15 @@ public class Obscurable extends Decorator implements TranslatablePiece {
     private final NamedHotKeyConfigurer peekKeyInput;
     private final StringConfigurer peekCommandInput;
     private final TraitConfigPanel controls = new TraitConfigPanel();
-    private final String[] optionNames = {"B", "P", "I", "U"}; // NON-NLS
+    private final String[] optionNames = {"B", "P", "I", "2", "U"}; // NON-NLS
     private final String[] optionKeys = {
       "Editor.Obscurable.background",
       "Editor.Obscurable.plain",
       "Editor.Obscurable.inset",
+      "Editor.Obscurable.inset2",
       "Editor.Obscurable.use_image"
     };
-    private final char[] optionChars = {BACKGROUND, PEEK, INSET, IMAGE};
+    private final char[] optionChars = {BACKGROUND, PEEK, INSET, INSET2, IMAGE};
     private final ImageSelector imagePicker;
     private final PieceAccessConfigurer accessConfig;
     private final JPanel showDisplayOption;
@@ -697,7 +709,15 @@ public class Obscurable extends Decorator implements TranslatablePiece {
         @Override
         public void paint(Graphics g) {
           g.clearRect(0, 0, getWidth(), getHeight());
-          switch (displayOption.getValueString().charAt(0)) {
+          char style = INSET;
+          for (int i = 0; i < optionNames.length; ++i) {
+            if (optionNames[i].equals(displayOption.getValueString())) {
+              style = optionChars[i];
+              break;
+            }
+          }
+
+          switch (style) {
             case BACKGROUND:
               g.setColor(Color.black);
               g.fillRect(0, 0, 60, 60);
@@ -709,6 +729,12 @@ public class Obscurable extends Decorator implements TranslatablePiece {
               g.fillRect(0, 0, 60, 60);
               g.setColor(Color.black);
               g.fillRect(0, 0, 30, 30);
+              break;
+            case INSET2:
+              g.setColor(Color.black);
+              g.fillRect(0, 0, 60, 60);
+              g.setColor(Color.white);
+              g.fillRect(10, 10, 40, 40);
               break;
             case PEEK:
               g.setColor(Color.black);
@@ -745,8 +771,8 @@ public class Obscurable extends Decorator implements TranslatablePiece {
         peekKeyInput.getControls().setVisible(optionNames[1].equals(evt.getNewValue()));
         peekCommandLabel.setVisible(optionNames[1].equals(evt.getNewValue()));
         peekCommandInput.getControls().setVisible(optionNames[1].equals(evt.getNewValue()));
-        imagePicker.getControls().setVisible(optionNames[3].equals(evt.getNewValue()));
-        showDisplayOption.setVisible(!optionNames[3].equals(evt.getNewValue()));
+        imagePicker.getControls().setVisible(optionNames[4].equals(evt.getNewValue()));
+        showDisplayOption.setVisible(!optionNames[4].equals(evt.getNewValue()));
         repack(controls);
       });
     }

--- a/vassal-app/src/main/java/VASSAL/counters/Obscurable.java
+++ b/vassal-app/src/main/java/VASSAL/counters/Obscurable.java
@@ -375,8 +375,8 @@ public class Obscurable extends Decorator implements TranslatablePiece {
       obscuredToMeView.draw(g, x, y, obs, zoom);
       final Rectangle bounds2 = piece.getShape().getBounds();
       final Rectangle obsBounds2 = obscuredToMeView.getShape().getBounds();
-      piece.draw(g, x - (int) (zoom * .8 * obsBounds2.width / 2  - .8 * zoom * bounds2.width/2),
-                    y - (int) (zoom * .8 * obsBounds2.height / 2 - .8 * zoom * bounds2.height/2),
+      piece.draw(g, x - (int) (0.4 * zoom * (obsBounds2.width - bounds2.width)),
+                    y - (int) (0.4 * zoom * (obsBounds2.height - bounds2.height)), 
         obs, zoom * 0.8);
       break;
     case PEEK:

--- a/vassal-app/src/main/resources/VASSAL/i18n/Editor.properties
+++ b/vassal-app/src/main/resources/VASSAL/i18n/Editor.properties
@@ -1364,6 +1364,7 @@ Editor.Obscurable.peek_menu_command=Peek menu command
 Editor.Obscurable.background=Background
 Editor.Obscurable.plain=Plain
 Editor.Obscurable.inset=Inset
+Editor.Obscurable.inset2=Image Inset
 Editor.Obscurable.use_image=Use image
 Editor.Obscurable.mask_command=Mask command
 Editor.Obscurable.peek_command=Peek command

--- a/vassal-doc/src/main/readme-referencemanual/ReferenceManual/Mask.adoc
+++ b/vassal-doc/src/main/readme-referencemanual/ReferenceManual/Mask.adoc
@@ -53,7 +53,9 @@ This is useful for referee players or games with multi-player teams.
 *Display style:*:: Determines how a masked piece is seen by the owning player.
 The following options are available:
 +
-_Inset_ draws the regular piece image at reduced size over top of the mask image, inset into the upper left corner.
+_Inset_ draws the mask image at reduced size over top of the regular image, inset into the upper left corner.
++
+_Inset Image_ draws the regular image at reduced size over top of the mask image, inset into the center.
 +
 _Background_ draws the mask image at full size and the regular piece at reduced size centered within it.
 +


### PR DESCRIPTION
In a "Mask" trait, the current "Inset" option doesn't work well (at least for me) because it draws the "masked back" over top of 1/4 of the "real" image, meaning that if you need to be able to read the card text of the real image, you can't. 

So I have added a second inset option, which instead uses the "masked back" as the "behind part" and puts the "real image" as the inset, and at a larger amount of space.

![image](https://user-images.githubusercontent.com/3742246/135735600-29871416-4c7f-49a2-a44e-eb0736ca18e8.png)
