### PR TITLE
10495 - Allow module manager to launch things from the debugger w/o deprecation manager crashing

### DIFF
--- a/vassal-app/src/main/java/VASSAL/tools/deprecation/RemovalAndDeprecationChecker.java
+++ b/vassal-app/src/main/java/VASSAL/tools/deprecation/RemovalAndDeprecationChecker.java
@@ -43,8 +43,10 @@ public class RemovalAndDeprecationChecker {
   private Map<String, String> readRemoved() throws IOException {
     final Map<String, String> r = new HashMap<>();
     try (InputStream in = getClass().getResourceAsStream("/removed")) {
-      // cols are item name, version when removed
-      Processor.readCompSet(in, cols -> r.put(cols[0], cols[1]));
+      if (in != null) {
+        // cols are item name, version when removed
+        Processor.readCompSet(in, cols -> r.put(cols[0], cols[1]));
+      }
     }
     return r;
   }
@@ -53,12 +55,14 @@ public class RemovalAndDeprecationChecker {
     // deprecated is tab-separated: name  since  forRemoval
     final Map<String, String> d = new HashMap<>();
     try (InputStream in = getClass().getResourceAsStream("/deprecated")) {
-      Processor.readCompSet(in, cols -> {
-        if ("true".equals(cols[2])) { // forRemoval
-          // item name, deprecation date
-          d.put(cols[0], cols[1]);
-        }
-      });
+      if (in != null) {
+        Processor.readCompSet(in, cols -> {
+          if ("true".equals(cols[2])) { // forRemoval
+            // item name, deprecation date
+            d.put(cols[0], cols[1]);
+          }
+        });
+      }
     }
     return d;
   }


### PR DESCRIPTION
Means deprecation checker doesn't run when you launch Module Manager from the debugger and then launch/edit a module, but better than crashing and not being able to use Module Manager in that context