### PR TITLE
More robust Java version check for Linux

### DIFF
--- a/dist/linux/VASSAL.sh
+++ b/dist/linux/VASSAL.sh
@@ -12,31 +12,14 @@ if [ ! -x "$JAVA" ]; then
   exit 1
 fi
 
-# Check the Java vesion; we require Java 11+.
-VERSION=$("$JAVA" -version 2>&1 | head -1 | sed -e 's/.* version "//; s/".*//')
-
-# Java 8 and earlier formats version x.y as 1.x.y
-# Java 9 and later formats version x.y as x.y
-MAJOR=$(echo "$VERSION" | sed -e 's/\..*//')
-if [ "$MAJOR" = '1' ]; then
-  MAJOR=$(echo "$VERSION" | sed -e 's/[0-9]\+\.//; s/[^0-9].*//')
-fi
-
-# Check that the major version we found is an integer
-MAJOR=$(echo "$MAJOR" | sed -e 's/[^0-9]//g')
-if [ -z "$MAJOR" ]; then
-  echo "Error: VASSAL requires Java 11 or later. The Java you are using ($JAVA) has an unrecognizable version '$VERSION'." 2>&1
-  exit 1
-fi
-
-# Check that the major version we found is >= 11
-if [ "$MAJOR" -lt 11 ]; then
-  echo "Error: VASSAL requires Java 11 or later. The Java you are using ($JAVA) is Java $MAJOR." 2>&1
-  exit 1
-fi
-
 # Find absolute path where VASSAL is installed
 INSTALL_DIR=$(cd "$(dirname "$0")"; pwd)
+
+# Check that java is new enough
+if ! "$JAVA" -classpath "$INSTALL_DIR"/lib/Vengine.jar VASSAL.launch.JavaVersionChecker 2>/dev/null ; then
+  echo "Error: $JAVA is too old to run this version of Vassal. Please use Java 11 or later." 2>&1
+  exit 1
+fi
 
 # Launch VASSSAL
 "$JAVA" -Duser.dir="$INSTALL_DIR" -classpath "$INSTALL_DIR"/lib/Vengine.jar --add-exports java.desktop/sun.java2d.cmm=ALL-UNNAMED VASSAL.launch.ModuleManager "$@"

--- a/vassal-app/src/main/java/VASSAL/launch/JavaVersionChecker.java
+++ b/vassal-app/src/main/java/VASSAL/launch/JavaVersionChecker.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2021 by Joel Uckelman
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License (LGPL) as published by the Free Software Foundation.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public
+ * License along with this library; if not, copies are available
+ * at http://www.opensource.org.
+ */
+
+package VASSAL.launch;
+
+/** This class exists solely for checking if Java can load classes compiled
+    with the class version we've used. Do not add code to this class. */
+public final class JavaVersionChecker {
+  public static void main(String[] args) {
+  }
+}


### PR DESCRIPTION
lUse an empty class with a main() to check if the java on the path can load our class files; if not, complain. Should be more reliable than
trying to parse `java -version`.