### PR TITLE
Check maps by id rather than by strict equality

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/module/GameState.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/GameState.java
@@ -1074,7 +1074,7 @@ public class GameState implements CommandEncoder {
           // nonnull map > null map
           return 1;
         }
-        else if (amap == bmap) {
+        else if (amap.getId().equals(bmap.getId())) {
           // same map, sort according to piece list
           return indexOf(a, amap) - indexOf(b, bmap);
         }


### PR DESCRIPTION
This should do the ight thing in odd situations where maps share an id (possibly due to
editing).

Fixes #8949.