### PR TITLE
10547 Improve fast match expressions interaction w/ $...$ and Beanshell

### DIFF
--- a/vassal-app/src/main/java/VASSAL/counters/GlobalCommand.java
+++ b/vassal-app/src/main/java/VASSAL/counters/GlobalCommand.java
@@ -30,6 +30,7 @@ import VASSAL.configure.PropertyExpression;
 import VASSAL.i18n.Resources;
 import VASSAL.script.expression.AuditTrail;
 import VASSAL.script.expression.Auditable;
+import VASSAL.script.expression.Expression;
 import VASSAL.tools.ErrorDialog;
 import VASSAL.tools.FormattedString;
 import VASSAL.tools.NamedKeyStroke;
@@ -275,29 +276,38 @@ public class GlobalCommand implements Auditable {
           break;
         case ZONE:
           fastZone = target.targetZone.tryEvaluate(source, owner, "Editor.GlobalKeyCommand.zone_name");
+          fastZone = Expression.createExpression(fastZone).tryEvaluate(source, owner, "Editor.GlobalKeyCommand.zone_name");
           break;
         case DECK:
           fastDeck = target.targetDeck.tryEvaluate(source, owner, "Editor.GlobalKeyCommand.deck_name");
+          fastDeck = Expression.createExpression(fastDeck).tryEvaluate(source, owner, "Editor.GlobalKeyCommand.deck_name");
           break;
         case LOCATION:
           fastLocation = target.targetLocation.tryEvaluate(source, owner, "Editor.GlobalKeyCommand.location_name");
+          fastLocation = Expression.createExpression(fastLocation).tryEvaluate(source, owner, "Editor.GlobalKeyCommand.location_name");
           break;
         case XY:
           fastBoard = target.targetLocation.tryEvaluate(source, owner, "Editor.GlobalKeyCommand.board_name");
+          fastBoard = Expression.createExpression(fastBoard).tryEvaluate(source, owner, "Editor.GlobalKeyCommand.board_name");
           fastX = target.targetX.tryEvaluate(source, owner, "Editor.GlobalKeyCommand.x_position");
+          fastX = Expression.createExpression(fastX).tryEvaluate(source, owner, "Editor.GlobalKeyCommand.x_position");
           fastY = target.targetY.tryEvaluate(source, owner, "Editor.GlobalKeyCommand.y_position");
+          fastY = Expression.createExpression(fastY).tryEvaluate(source, owner, "Editor.GlobalKeyCommand.y_position");
           break;
         }
 
         if (!target.targetType.isCurrent()) {
           fastMap = target.targetMap.tryEvaluate(source, owner, "Editor.GlobalKeyCommand.map_name");
+          fastMap = Expression.createExpression(fastMap).tryEvaluate(source, owner, "Editor.GlobalKeyCommand.map_name");
         }
       }
 
       // Evaluate any property-based expressions we will be using - these are evaluated w/r/t the SOURCE of the command, not target pieces.
       if (target.fastMatchProperty) {
         fastProperty = target.targetProperty.tryEvaluate(source, owner, "Editor.GlobalKeyCommand.property_name");
+        fastProperty = Expression.createExpression(fastProperty).tryEvaluate(source, owner, "Editor.GlobalKeyCommand.property_name");
         fastValue    = target.targetValue.tryEvaluate(source, owner, "Editor.GlobalKeyCommand.property_compare");
+        fastValue    = Expression.createExpression(fastValue).tryEvaluate(source, owner, "Editor.GlobalKeyCommand.property_compare");
         if ((target.targetCompare == GlobalCommandTarget.CompareMode.EQUALS) ||
             (target.targetCompare == GlobalCommandTarget.CompareMode.NOT_EQUALS)) {
           fastIsNumber = false;

--- a/vassal-app/src/main/java/VASSAL/counters/GlobalCommandTarget.java
+++ b/vassal-app/src/main/java/VASSAL/counters/GlobalCommandTarget.java
@@ -23,6 +23,7 @@ import VASSAL.configure.Configurer;
 import VASSAL.configure.ConfigurerFactory;
 import VASSAL.configure.GlobalCommandTargetConfigurer;
 import VASSAL.script.expression.Expression;
+import VASSAL.script.expression.FormattedStringExpression;
 import VASSAL.search.SearchTarget;
 import VASSAL.tools.NamedKeyStroke;
 import VASSAL.tools.SequenceEncoder;
@@ -44,17 +45,17 @@ public class GlobalCommandTarget implements ConfigurerFactory, SearchTarget {
 
   protected boolean fastMatchLocation = false; // True if we are doing Fast Match by location (else other values in this block unused)
   protected Target targetType = Target.MAP;    // Type of location Fast Match we are doing
-  protected Expression targetMap;              // Specified Map (for MAP, ZONE, LOCATION, XY types)
-  protected Expression targetBoard;            // Specified Board (for XY type)
-  protected Expression targetZone;             // Specified Zone (for ZONE type)
-  protected Expression targetLocation;         // Specified Location (for LOCATION type)
-  protected Expression targetDeck;             // Specified Deck (for DECK type)
-  protected Expression targetX;                // Specified X (for XY type)
-  protected Expression targetY;                // Specified Y (for XY type)
+  protected FormattedStringExpression targetMap;              // Specified Map (for MAP, ZONE, LOCATION, XY types)
+  protected FormattedStringExpression targetBoard;            // Specified Board (for XY type)
+  protected FormattedStringExpression targetZone;             // Specified Zone (for ZONE type)
+  protected FormattedStringExpression targetLocation;         // Specified Location (for LOCATION type)
+  protected FormattedStringExpression targetDeck;             // Specified Deck (for DECK type)
+  protected FormattedStringExpression targetX;                // Specified X (for XY type)
+  protected FormattedStringExpression targetY;                // Specified Y (for XY type)
 
   protected boolean fastMatchProperty = false; // True if we're doing a Fast Match by property value (else next two values ignored)
-  protected Expression targetProperty;         // Name/Key of Fast Match property
-  protected Expression targetValue;            // Value to match for that property
+  protected FormattedStringExpression targetProperty;         // Name/Key of Fast Match property
+  protected FormattedStringExpression targetValue;            // Value to match for that property
   protected CompareMode targetCompare;         // Comparison mode
 
   private GamePiece curPiece; // Reference piece for "current <place>". NOT encoded into the module, only set and used at time of command execution.
@@ -168,15 +169,15 @@ public class GlobalCommandTarget implements ConfigurerFactory, SearchTarget {
     setGKCtype(gkc);
 
     // Can't just let this shit be null => ANGRY ENCODER IS ANGRY!!!
-    targetMap      = Expression.createExpression("");
-    targetBoard    = Expression.createExpression("");
-    targetZone     = Expression.createExpression("");
-    targetLocation = Expression.createExpression("");
-    targetDeck     = Expression.createExpression("");
-    targetProperty = Expression.createExpression("");
-    targetValue    = Expression.createExpression("");
-    targetX        = Expression.createExpression("0");
-    targetY        = Expression.createExpression("0");
+    targetMap      = new FormattedStringExpression("");
+    targetBoard    = new FormattedStringExpression("");
+    targetZone     = new FormattedStringExpression("");
+    targetLocation = new FormattedStringExpression("");
+    targetDeck     = new FormattedStringExpression("");
+    targetProperty = new FormattedStringExpression("");
+    targetValue    = new FormattedStringExpression("");
+    targetX        = new FormattedStringExpression("0");
+    targetY        = new FormattedStringExpression("0");
     targetCompare  = CompareMode.EQUALS;
   }
 
@@ -223,16 +224,16 @@ public class GlobalCommandTarget implements ConfigurerFactory, SearchTarget {
     fastMatchLocation = sd.nextBoolean(false);
     final String type = sd.nextToken(Target.MAP.name());
     targetType = type.isEmpty() ? Target.MAP : Target.valueOf(type);
-    targetMap = Expression.createExpression(sd.nextToken(""));
-    targetBoard = Expression.createExpression(sd.nextToken(""));
-    targetZone = Expression.createExpression(sd.nextToken(""));
-    targetLocation = Expression.createExpression(sd.nextToken(""));
-    targetX = Expression.createExpression(sd.nextToken("0"));
-    targetY = Expression.createExpression(sd.nextToken("0"));
-    targetDeck = Expression.createExpression(sd.nextToken(""));
+    targetMap = new FormattedStringExpression(sd.nextToken(""));
+    targetBoard = new FormattedStringExpression(sd.nextToken(""));
+    targetZone = new FormattedStringExpression(sd.nextToken(""));
+    targetLocation = new FormattedStringExpression(sd.nextToken(""));
+    targetX = new FormattedStringExpression(sd.nextToken("0"));
+    targetY = new FormattedStringExpression(sd.nextToken("0"));
+    targetDeck = new FormattedStringExpression(sd.nextToken(""));
     fastMatchProperty = sd.nextBoolean(false);
-    targetProperty = Expression.createExpression(sd.nextToken(""));
-    targetValue = Expression.createExpression(sd.nextToken(""));
+    targetProperty = new FormattedStringExpression(sd.nextToken(""));
+    targetValue = new FormattedStringExpression(sd.nextToken(""));
     final String compare = sd.nextToken(CompareMode.EQUALS.name());
     targetCompare = compare.isEmpty() ? CompareMode.EQUALS : CompareMode.valueOf(compare);
   }
@@ -374,89 +375,89 @@ public class GlobalCommandTarget implements ConfigurerFactory, SearchTarget {
     this.targetType = Target.valueOf(targetType);
   }
 
-  public Expression getTargetMap() {
+  public FormattedStringExpression getTargetMap() {
     return targetMap;
   }
 
-  public void setTargetMap(Expression targetMap) {
+  public void setTargetMap(FormattedStringExpression targetMap) {
     this.targetMap = targetMap;
   }
 
   public void setTargetMap(String targetMap) {
-    this.targetMap = Expression.createExpression(targetMap);
+    this.targetMap = new FormattedStringExpression(targetMap);
   }
 
-  public Expression getTargetBoard() {
+  public FormattedStringExpression getTargetBoard() {
     return targetBoard;
   }
 
-  public void setTargetBoard(Expression targetBoard) {
+  public void setTargetBoard(FormattedStringExpression targetBoard) {
     this.targetBoard = targetBoard;
   }
 
   public void setTargetBoard(String targetBoard) {
-    this.targetBoard = Expression.createExpression(targetBoard);
+    this.targetBoard = new FormattedStringExpression(targetBoard);
   }
 
-  public Expression getTargetZone() {
+  public FormattedStringExpression getTargetZone() {
     return targetZone;
   }
 
-  public void setTargetZone(Expression targetZone) {
+  public void setTargetZone(FormattedStringExpression targetZone) {
     this.targetZone = targetZone;
   }
 
   public void setTargetZone(String targetZone) {
-    this.targetZone = Expression.createExpression(targetZone);
+    this.targetZone = new FormattedStringExpression(targetZone);
   }
 
-  public Expression getTargetLocation() {
+  public FormattedStringExpression getTargetLocation() {
     return targetLocation;
   }
 
-  public void setTargetLocation(Expression targetLocation) {
+  public void setTargetLocation(FormattedStringExpression targetLocation) {
     this.targetLocation = targetLocation;
   }
 
   public void setTargetLocation(String targetLocation) {
-    this.targetLocation = Expression.createExpression(targetLocation);
+    this.targetLocation = new FormattedStringExpression(targetLocation);
   }
 
 
-  public Expression getTargetDeck() {
+  public FormattedStringExpression getTargetDeck() {
     return targetDeck;
   }
 
-  public void setTargetDeck(Expression targetDeck) {
+  public void setTargetDeck(FormattedStringExpression targetDeck) {
     this.targetDeck = targetDeck;
   }
 
   public void setTargetDeck(String targetDeck) {
-    this.targetDeck = Expression.createExpression(targetDeck);
+    this.targetDeck = new FormattedStringExpression(targetDeck);
   }
 
-  public Expression getTargetProperty() {
+  public FormattedStringExpression getTargetProperty() {
     return targetProperty;
   }
 
-  public void setTargetProperty(Expression targetProperty) {
+  public void setTargetProperty(FormattedStringExpression targetProperty) {
     this.targetProperty = targetProperty;
   }
 
   public void setTargetProperty(String targetProperty) {
-    this.targetProperty = Expression.createExpression(targetProperty);
+    this.targetProperty = new FormattedStringExpression(targetProperty);
   }
 
-  public Expression getTargetValue() {
+  public FormattedStringExpression getTargetValue() {
     return targetValue;
   }
 
-  public void setTargetValue(Expression targetValue) {
+  public void setTargetValue(FormattedStringExpression targetValue) {
     this.targetValue = targetValue;
   }
 
   public void setTargetValue(String targetValue) {
-    this.targetValue = Expression.createExpression(targetValue);
+    this.targetValue = new FormattedStringExpression(targetValue);
   }
 
   public CompareMode getTargetCompare() {
@@ -475,28 +476,28 @@ public class GlobalCommandTarget implements ConfigurerFactory, SearchTarget {
     return targetX;
   }
 
-  public void setTargetX(Expression targetX) {
+  public void setTargetX(FormattedStringExpression targetX) {
     this.targetX = targetX;
   }
   public void setTargetX(String targetX) {
-    this.targetX = Expression.createExpression(targetX);
+    this.targetX = new FormattedStringExpression(targetX);
   }
   public void setTargetX(int targetX) {
-    this.targetX = Expression.createExpression(Integer.toString(targetX));
+    this.targetX = new FormattedStringExpression(Integer.toString(targetX));
   }
 
   public Expression getTargetY() {
     return targetY;
   }
 
-  public void setTargetY(Expression targetY) {
+  public void setTargetY(FormattedStringExpression targetY) {
     this.targetY = targetY;
   }
   public void setTargetY(String targetY) {
-    this.targetY = Expression.createExpression(targetY);
+    this.targetY = new FormattedStringExpression(targetY);
   }
   public void setTargetY(int targetY) {
-    this.targetY = Expression.createExpression(Integer.toString(targetY));
+    this.targetY = new FormattedStringExpression(Integer.toString(targetY));
   }
 
   public void setCurPiece(GamePiece curPiece) {

--- a/vassal-app/src/test/resources/clirr-ignored-differences.xml
+++ b/vassal-app/src/test/resources/clirr-ignored-differences.xml
@@ -1257,56 +1257,8 @@
     <difference>
         <className>VASSAL/counters/GlobalCommandTarget</className>
         <differenceType>7005</differenceType>
-        <method>void setTargetBoard(VASSAL.script.expression.Expression)</method>
-        <to>void setTargetBoard(VASSAL.script.expression.FormattedStringExpression)</to>
-    </difference>
-    <difference>
-        <className>VASSAL/counters/GlobalCommandTarget</className>
-        <differenceType>7005</differenceType>
-        <method>void setTargetDeck(VASSAL.script.expression.Expression)</method>
-        <to>void setTargetDeck(VASSAL.script.expression.FormattedStringExpression)</to>
-    </difference>
-    <difference>
-        <className>VASSAL/counters/GlobalCommandTarget</className>
-        <differenceType>7005</differenceType>
-        <method>void setTargetLocation(VASSAL.script.expression.Expression)</method>
-        <to>void setTargetLocation(VASSAL.script.expression.FormattedStringExpression)</to>
-    </difference>
-    <difference>
-        <className>VASSAL/counters/GlobalCommandTarget</className>
-        <differenceType>7005</differenceType>
-        <method>void setTargetMap(VASSAL.script.expression.Expression)</method>
-        <to>void setTargetMap(VASSAL.script.expression.FormattedStringExpression)</to>
-    </difference>
-    <difference>
-        <className>VASSAL/counters/GlobalCommandTarget</className>
-        <differenceType>7005</differenceType>
-        <method>void setTargetProperty(VASSAL.script.expression.Expression)</method>
-        <to>void setTargetProperty(VASSAL.script.expression.FormattedStringExpression)</to>
-    </difference>
-    <difference>
-        <className>VASSAL/counters/GlobalCommandTarget</className>
-        <differenceType>7005</differenceType>
-        <method>void setTargetValue(VASSAL.script.expression.Expression)</method>
-        <to>void setTargetValue(VASSAL.script.expression.FormattedStringExpression)</to>
-    </difference>
-    <difference>
-        <className>VASSAL/counters/GlobalCommandTarget</className>
-        <differenceType>7005</differenceType>
-        <method>void setTargetX(VASSAL.script.expression.Expression)</method>
-        <to>void setTargetX(VASSAL.script.expression.FormattedStringExpression)</to>
-    </difference>
-    <difference>
-        <className>VASSAL/counters/GlobalCommandTarget</className>
-        <differenceType>7005</differenceType>
-        <method>void setTargetY(VASSAL.script.expression.Expression)</method>
-        <to>void setTargetY(VASSAL.script.expression.FormattedStringExpression)</to>
-    </difference>
-    <difference>
-        <className>VASSAL/counters/GlobalCommandTarget</className>
-        <differenceType>7005</differenceType>
-        <method>void setTargetZone(VASSAL.script.expression.Expression)</method>
-        <to>void setTargetZone(VASSAL.script.expression.FormattedStringExpression)</to>
+        <method>**</method>
+        <to>**</to>
     </difference>
 
 </differences>

--- a/vassal-app/src/test/resources/clirr-ignored-differences.xml
+++ b/vassal-app/src/test/resources/clirr-ignored-differences.xml
@@ -1254,60 +1254,59 @@
         <method>Expression getTargetZone()</method>
         <to>FormattedStringExpression</to>
     </difference>
-
     <difference>
         <className>VASSAL/counters/GlobalCommandTarget</className>
         <differenceType>7005</differenceType>
-        <method>void setTargetBoard(VASSAL.script.expression.Expression</method>
-        <to>void setTargetBoard(VASSAL.script.expression.FormattedStringExpression</to>
+        <method>void setTargetBoard(VASSAL.script.expression.Expression)</method>
+        <to>void setTargetBoard(VASSAL.script.expression.FormattedStringExpression)</to>
     </difference>
     <difference>
         <className>VASSAL/counters/GlobalCommandTarget</className>
         <differenceType>7005</differenceType>
-        <method>void setTargetDeck(VASSAL.script.expression.Expression</method>
-        <to>void setTargetDeck(VASSAL.script.expression.FormattedStringExpression</to>
+        <method>void setTargetDeck(VASSAL.script.expression.Expression)</method>
+        <to>void setTargetDeck(VASSAL.script.expression.FormattedStringExpression)</to>
     </difference>
     <difference>
         <className>VASSAL/counters/GlobalCommandTarget</className>
         <differenceType>7005</differenceType>
-        <method>void setTargetLocation(VASSAL.script.expression.Expression</method>
-        <to>void setTargetLocation(VASSAL.script.expression.FormattedStringExpression</to>
+        <method>void setTargetLocation(VASSAL.script.expression.Expression)</method>
+        <to>void setTargetLocation(VASSAL.script.expression.FormattedStringExpression)</to>
     </difference>
     <difference>
         <className>VASSAL/counters/GlobalCommandTarget</className>
         <differenceType>7005</differenceType>
-        <method>void setTargetMap(VASSAL.script.expression.Expression</method>
-        <to>void setTargetMap(VASSAL.script.expression.FormattedStringExpression</to>
+        <method>void setTargetMap(VASSAL.script.expression.Expression)</method>
+        <to>void setTargetMap(VASSAL.script.expression.FormattedStringExpression)</to>
     </difference>
     <difference>
         <className>VASSAL/counters/GlobalCommandTarget</className>
         <differenceType>7005</differenceType>
-        <method>void setTargetProperty(VASSAL.script.expression.Expression</method>
-        <to>void setTargetProperty(VASSAL.script.expression.FormattedStringExpression</to>
+        <method>void setTargetProperty(VASSAL.script.expression.Expression)</method>
+        <to>void setTargetProperty(VASSAL.script.expression.FormattedStringExpression)</to>
     </difference>
     <difference>
         <className>VASSAL/counters/GlobalCommandTarget</className>
         <differenceType>7005</differenceType>
-        <method>void setTargetValue(VASSAL.script.expression.Expression</method>
-        <to>void setTargetValue(VASSAL.script.expression.FormattedStringExpression</to>
+        <method>void setTargetValue(VASSAL.script.expression.Expression)</method>
+        <to>void setTargetValue(VASSAL.script.expression.FormattedStringExpression)</to>
     </difference>
     <difference>
         <className>VASSAL/counters/GlobalCommandTarget</className>
         <differenceType>7005</differenceType>
-        <method>void setTargetX(VASSAL.script.expression.Expression</method>
-        <to>void setTargetX(VASSAL.script.expression.FormattedStringExpression</to>
+        <method>void setTargetX(VASSAL.script.expression.Expression)</method>
+        <to>void setTargetX(VASSAL.script.expression.FormattedStringExpression)</to>
     </difference>
     <difference>
         <className>VASSAL/counters/GlobalCommandTarget</className>
         <differenceType>7005</differenceType>
-        <method>void setTargetY(VASSAL.script.expression.Expression</method>
-        <to>void setTargetY(VASSAL.script.expression.FormattedStringExpression</to>
+        <method>void setTargetY(VASSAL.script.expression.Expression)</method>
+        <to>void setTargetY(VASSAL.script.expression.FormattedStringExpression)</to>
     </difference>
     <difference>
         <className>VASSAL/counters/GlobalCommandTarget</className>
         <differenceType>7005</differenceType>
-        <method>void setTargetZone(VASSAL.script.expression.Expression</method>
-        <to>void setTargetZone(VASSAL.script.expression.FormattedStringExpression</to>
+        <method>void setTargetZone(VASSAL.script.expression.Expression)</method>
+        <to>void setTargetZone(VASSAL.script.expression.FormattedStringExpression)</to>
     </difference>
 
 </differences>

--- a/vassal-app/src/test/resources/clirr-ignored-differences.xml
+++ b/vassal-app/src/test/resources/clirr-ignored-differences.xml
@@ -1215,44 +1215,44 @@
     <difference>
         <className>VASSAL/counters/GlobalCommandTarget</className>
         <differenceType>7006</differenceType>
-        <method>Expression getTargetBoard()</method>
-        <to>FormattedStringExpression</to>
+        <method>VASSAL.script.expression.Expression getTargetBoard()</method>
+        <to>VASSAL.script.expression.FormattedStringExpression</to>
     </difference>
     <difference>
         <className>VASSAL/counters/GlobalCommandTarget</className>
         <differenceType>7006</differenceType>
-        <method>Expression getTargetDeck()</method>
-        <to>FormattedStringExpression</to>
+        <method>VASSAL.script.expression.Expression getTargetDeck()</method>
+        <to>VASSAL.script.expression.FormattedStringExpression</to>
     </difference>
     <difference>
         <className>VASSAL/counters/GlobalCommandTarget</className>
         <differenceType>7006</differenceType>
-        <method>Expression getTargetLocation()</method>
-        <to>FormattedStringExpression</to>
+        <method>VASSAL.script.expression.Expression getTargetLocation()</method>
+        <to>VASSAL.script.expression.FormattedStringExpression</to>
     </difference>
     <difference>
         <className>VASSAL/counters/GlobalCommandTarget</className>
         <differenceType>7006</differenceType>
-        <method>Expression getTargetMap()</method>
-        <to>FormattedStringExpression</to>
+        <method>VASSAL.script.expression.Expression getTargetMap()</method>
+        <to>VASSAL.script.expression.FormattedStringExpression</to>
     </difference>
     <difference>
         <className>VASSAL/counters/GlobalCommandTarget</className>
         <differenceType>7006</differenceType>
-        <method>Expression getTargetProperty()</method>
-        <to>FormattedStringExpression</to>
+        <method>VASSAL.script.expression.Expression getTargetProperty()</method>
+        <to>VASSAL.script.expression.FormattedStringExpression</to>
     </difference>
     <difference>
         <className>VASSAL/counters/GlobalCommandTarget</className>
         <differenceType>7006</differenceType>
-        <method>Expression getTargetValue()</method>
-        <to>FormattedStringExpression</to>
+        <method>VASSAL.script.expression.Expression getTargetValue()</method>
+        <to>VASSAL.script.expression.FormattedStringExpression</to>
     </difference>
     <difference>
         <className>VASSAL/counters/GlobalCommandTarget</className>
         <differenceType>7006</differenceType>
-        <method>Expression getTargetZone()</method>
-        <to>FormattedStringExpression</to>
+        <method>VASSAL.script.expression.Expression getTargetZone()</method>
+        <to>VASSAL.script.expression.FormattedStringExpression</to>
     </difference>
     <difference>
         <className>VASSAL/counters/GlobalCommandTarget</className>

--- a/vassal-app/src/test/resources/clirr-ignored-differences.xml
+++ b/vassal-app/src/test/resources/clirr-ignored-differences.xml
@@ -1149,5 +1149,165 @@
         <method>void setBaseWindow(VASSAL.build.module.documentation.HelpWindow)</method>
         <justification>Deprecated for a year</justification>
     </difference>
+    <difference>
+        <className>VASSAL/counters/GlobalCommandTarget</className>
+        <differenceType>6004</differenceType>
+        <field>targetBoard</field>
+        <from>VASSAL.script.expression.Expression</from>
+        <to>VASSAL.script.expression.FormattedStringExpression</to>
+    </difference>
+    <difference>
+        <className>VASSAL/counters/GlobalCommandTarget</className>
+        <differenceType>6004</differenceType>
+        <field>targetDeck</field>
+        <from>VASSAL.script.expression.Expression</from>
+        <to>VASSAL.script.expression.FormattedStringExpression</to>
+    </difference>
+    <difference>
+        <className>VASSAL/counters/GlobalCommandTarget</className>
+        <differenceType>6004</differenceType>
+        <field>targetLocation</field>
+        <from>VASSAL.script.expression.Expression</from>
+        <to>VASSAL.script.expression.FormattedStringExpression</to>
+    </difference>
+    <difference>
+        <className>VASSAL/counters/GlobalCommandTarget</className>
+        <differenceType>6004</differenceType>
+        <field>targetMap</field>
+        <from>VASSAL.script.expression.Expression</from>
+        <to>VASSAL.script.expression.FormattedStringExpression</to>
+    </difference>
+    <difference>
+        <className>VASSAL/counters/GlobalCommandTarget</className>
+        <differenceType>6004</differenceType>
+        <field>targetProperty</field>
+        <from>VASSAL.script.expression.Expression</from>
+        <to>VASSAL.script.expression.FormattedStringExpression</to>
+    </difference>
+    <difference>
+        <className>VASSAL/counters/GlobalCommandTarget</className>
+        <differenceType>6004</differenceType>
+        <field>targetValue</field>
+        <from>VASSAL.script.expression.Expression</from>
+        <to>VASSAL.script.expression.FormattedStringExpression</to>
+    </difference>
+    <difference>
+        <className>VASSAL/counters/GlobalCommandTarget</className>
+        <differenceType>6004</differenceType>
+        <field>targetX</field>
+        <from>VASSAL.script.expression.Expression</from>
+        <to>VASSAL.script.expression.FormattedStringExpression</to>
+    </difference>
+    <difference>
+        <className>VASSAL/counters/GlobalCommandTarget</className>
+        <differenceType>6004</differenceType>
+        <field>targetY</field>
+        <from>VASSAL.script.expression.Expression</from>
+        <to>VASSAL.script.expression.FormattedStringExpression</to>
+    </difference>
+    <difference>
+        <className>VASSAL/counters/GlobalCommandTarget</className>
+        <differenceType>6004</differenceType>
+        <field>targetZone</field>
+        <from>VASSAL.script.expression.Expression</from>
+        <to>VASSAL.script.expression.FormattedStringExpression</to>
+    </difference>
+    <difference>
+        <className>VASSAL/counters/GlobalCommandTarget</className>
+        <differenceType>7006</differenceType>
+        <method>Expression getTargetBoard()</method>
+        <to>FormattedStringExpression</to>
+    </difference>
+    <difference>
+        <className>VASSAL/counters/GlobalCommandTarget</className>
+        <differenceType>7006</differenceType>
+        <method>Expression getTargetDeck()</method>
+        <to>FormattedStringExpression</to>
+    </difference>
+    <difference>
+        <className>VASSAL/counters/GlobalCommandTarget</className>
+        <differenceType>7006</differenceType>
+        <method>Expression getTargetLocation()</method>
+        <to>FormattedStringExpression</to>
+    </difference>
+    <difference>
+        <className>VASSAL/counters/GlobalCommandTarget</className>
+        <differenceType>7006</differenceType>
+        <method>Expression getTargetMap()</method>
+        <to>FormattedStringExpression</to>
+    </difference>
+    <difference>
+        <className>VASSAL/counters/GlobalCommandTarget</className>
+        <differenceType>7006</differenceType>
+        <method>Expression getTargetProperty()</method>
+        <to>FormattedStringExpression</to>
+    </difference>
+    <difference>
+        <className>VASSAL/counters/GlobalCommandTarget</className>
+        <differenceType>7006</differenceType>
+        <method>Expression getTargetValue()</method>
+        <to>FormattedStringExpression</to>
+    </difference>
+    <difference>
+        <className>VASSAL/counters/GlobalCommandTarget</className>
+        <differenceType>7006</differenceType>
+        <method>Expression getTargetZone()</method>
+        <to>FormattedStringExpression</to>
+    </difference>
+
+    <difference>
+        <className>VASSAL/counters/GlobalCommandTarget</className>
+        <differenceType>7005</differenceType>
+        <method>void setTargetBoard(VASSAL.script.expression.Expression</method>
+        <to>void setTargetBoard(VASSAL.script.expression.FormattedStringExpression</to>
+    </difference>
+    <difference>
+        <className>VASSAL/counters/GlobalCommandTarget</className>
+        <differenceType>7005</differenceType>
+        <method>void setTargetDeck(VASSAL.script.expression.Expression</method>
+        <to>void setTargetDeck(VASSAL.script.expression.FormattedStringExpression</to>
+    </difference>
+    <difference>
+        <className>VASSAL/counters/GlobalCommandTarget</className>
+        <differenceType>7005</differenceType>
+        <method>void setTargetLocation(VASSAL.script.expression.Expression</method>
+        <to>void setTargetLocation(VASSAL.script.expression.FormattedStringExpression</to>
+    </difference>
+    <difference>
+        <className>VASSAL/counters/GlobalCommandTarget</className>
+        <differenceType>7005</differenceType>
+        <method>void setTargetMap(VASSAL.script.expression.Expression</method>
+        <to>void setTargetMap(VASSAL.script.expression.FormattedStringExpression</to>
+    </difference>
+    <difference>
+        <className>VASSAL/counters/GlobalCommandTarget</className>
+        <differenceType>7005</differenceType>
+        <method>void setTargetProperty(VASSAL.script.expression.Expression</method>
+        <to>void setTargetProperty(VASSAL.script.expression.FormattedStringExpression</to>
+    </difference>
+    <difference>
+        <className>VASSAL/counters/GlobalCommandTarget</className>
+        <differenceType>7005</differenceType>
+        <method>void setTargetValue(VASSAL.script.expression.Expression</method>
+        <to>void setTargetValue(VASSAL.script.expression.FormattedStringExpression</to>
+    </difference>
+    <difference>
+        <className>VASSAL/counters/GlobalCommandTarget</className>
+        <differenceType>7005</differenceType>
+        <method>void setTargetX(VASSAL.script.expression.Expression</method>
+        <to>void setTargetX(VASSAL.script.expression.FormattedStringExpression</to>
+    </difference>
+    <difference>
+        <className>VASSAL/counters/GlobalCommandTarget</className>
+        <differenceType>7005</differenceType>
+        <method>void setTargetY(VASSAL.script.expression.Expression</method>
+        <to>void setTargetY(VASSAL.script.expression.FormattedStringExpression</to>
+    </difference>
+    <difference>
+        <className>VASSAL/counters/GlobalCommandTarget</className>
+        <differenceType>7005</differenceType>
+        <method>void setTargetZone(VASSAL.script.expression.Expression</method>
+        <to>void setTargetZone(VASSAL.script.expression.FormattedStringExpression</to>
+    </difference>
 
 </differences>


### PR DESCRIPTION
Previously having a fast match field set to
`$Side$ Lords Area`
worked right, but
`{"$Side$" + " Lords Area"}`
did not.

This "Weird Trick" seems to make it all work right.