### PR TITLE
10552 - CounterDetailViewer - can combine layer filters with property match expression

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/module/map/CounterDetailViewer.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/CounterDetailViewer.java
@@ -144,7 +144,6 @@ public class CounterDetailViewer extends AbstractConfigurable implements Drawabl
   public static final String INC_LAYERS = "from listed layers only";             //NON-NLS (yes, really)
   public static final String EXC_LAYERS = "from layers other than those listed"; //NON-NLS (yes, really)
   public static final String FILTER = "by using a property filter";              //NON-NLS (yes, really)
-  public static final String FILTER_TOP = "filterTop"; //NON-NLS
 
   public static final String SUM = "sum(propertyName)"; //NON-NLS
 
@@ -941,9 +940,6 @@ public class CounterDetailViewer extends AbstractConfigurable implements Drawabl
     if ("2".equals(version)) {
       if (FILTER.equals(displayWhat)) {
         displayWhat = ALL_LAYERS;
-      }
-      else if (FILTER_TOP.equals(displayWhat)) {
-        displayWhat = TOP_LAYER;
       }
       else {
         propertyFilter.setExpression("");

--- a/vassal-app/src/main/java/VASSAL/build/module/map/CounterDetailViewer.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/CounterDetailViewer.java
@@ -144,6 +144,7 @@ public class CounterDetailViewer extends AbstractConfigurable implements Drawabl
   public static final String INC_LAYERS = "from listed layers only";             //NON-NLS (yes, really)
   public static final String EXC_LAYERS = "from layers other than those listed"; //NON-NLS (yes, really)
   public static final String FILTER = "by using a property filter";              //NON-NLS (yes, really)
+  public static final String FILTER_TOP = "filterTop"; //NON-NLS
 
   public static final String SUM = "sum(propertyName)"; //NON-NLS
 
@@ -678,6 +679,14 @@ public class CounterDetailViewer extends AbstractConfigurable implements Drawabl
           return layer == topLayer;
         }
 
+        // Option to filter by property expression but ONLY from top-most layer (the single one of the layer options that can't be duplicated in a property match)
+        if (displayWhat.equals(FILTER_TOP)) {
+          if (layer != topLayer) {
+            return false;
+          }
+          return propertyFilter.accept(piece);
+        }
+
         // Include pieces on named layers only
         else if (displayWhat.equals(INC_LAYERS)) {
           for (final String displayLayer : displayLayers) {
@@ -1067,7 +1076,7 @@ public class CounterDetailViewer extends AbstractConfigurable implements Drawabl
   public static class DisplayConfig extends TranslatableStringEnum {
     @Override
     public String[] getValidValues(AutoConfigurable target) {
-      return new String[] {TOP_LAYER, ALL_LAYERS, INC_LAYERS, EXC_LAYERS, FILTER};
+      return new String[] {TOP_LAYER, ALL_LAYERS, INC_LAYERS, EXC_LAYERS, FILTER, FILTER_TOP};
     }
 
     @Override
@@ -1076,7 +1085,8 @@ public class CounterDetailViewer extends AbstractConfigurable implements Drawabl
                             "Editor.CounterDetailViewer.all_layers",
                             "Editor.CounterDetailViewer.inc_layers",
                             "Editor.CounterDetailViewer.exc_layers",
-                            "Editor.CounterDetailViewer.filter"
+                            "Editor.CounterDetailViewer.filter",
+                            "Editor.CounterDetailViewer.filter_top"
       };
     }
   }
@@ -1518,7 +1528,7 @@ public class CounterDetailViewer extends AbstractConfigurable implements Drawabl
       return () -> (displayWhat.equals(INC_LAYERS) || displayWhat.equals(EXC_LAYERS));
     }
     else if (PROPERTY_FILTER.equals(name)) {
-      return () -> displayWhat.equals(FILTER);
+      return () -> (displayWhat.equals(FILTER) || displayWhat.equals(FILTER_TOP));
     }
     else if (EMPTY_HEX_REPORT_FORMAT.equals(name)) {
       return () -> showText && minimumDisplayablePieces == 0;

--- a/vassal-app/src/main/java/VASSAL/build/module/map/CounterDetailViewer.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/CounterDetailViewer.java
@@ -97,7 +97,7 @@ import javax.swing.Timer;
  */
 public class CounterDetailViewer extends AbstractConfigurable implements Drawable, DragSourceMotionListener, MouseMotionListener, MouseListener, KeyListener {
 
-  public static final String LATEST_VERSION = "2";                //NON-NLS
+  public static final String LATEST_VERSION = "3";                //NON-NLS
   public static final String USE_KEYBOARD = "ShowCounterDetails"; //NON-NLS
   public static final String PREFERRED_DELAY = "PreferredDelay";  //NON-NLS
 
@@ -220,6 +220,8 @@ public class CounterDetailViewer extends AbstractConfigurable implements Drawabl
 
   @Override
   public void addTo(Buildable b) {
+    checkUpgrade();
+
     if (b instanceof AbstractFolder) {
       b = ((AbstractFolder)b).getNonFolderAncestor();
     }
@@ -659,14 +661,9 @@ public class CounterDetailViewer extends AbstractConfigurable implements Drawabl
         return false;
       }
 
-      // Select by property filter
-      if (displayWhat.equals(FILTER)) {
-        return propertyFilter.accept(piece);
-      }
-
       // Looking at All Layers accepts anything.
       else if (displayWhat.equals(ALL_LAYERS)) {
-        return true;
+        return propertyFilter.accept(piece);
       }
       else {
 
@@ -676,22 +673,14 @@ public class CounterDetailViewer extends AbstractConfigurable implements Drawabl
 
         // Pieces are passed to us top down, so only display the top-most layer
         if (displayWhat.equals(TOP_LAYER)) {
-          return layer == topLayer;
-        }
-
-        // Option to filter by property expression but ONLY from top-most layer (the single one of the layer options that can't be duplicated in a property match)
-        if (displayWhat.equals(FILTER_TOP)) {
-          if (layer != topLayer) {
-            return false;
-          }
-          return propertyFilter.accept(piece);
+          return (layer == topLayer) && propertyFilter.accept(piece);
         }
 
         // Include pieces on named layers only
         else if (displayWhat.equals(INC_LAYERS)) {
           for (final String displayLayer : displayLayers) {
             if (layerName.equals(displayLayer)) {
-              return true;
+              return propertyFilter.accept(piece);
             }
           }
         }
@@ -703,14 +692,13 @@ public class CounterDetailViewer extends AbstractConfigurable implements Drawabl
               return false;
             }
           }
-          return true;
+          return propertyFilter.accept(piece);
         }
       }
 
       // Ignore anything else
       return false;
     }
-
   }
 
   /*
@@ -909,39 +897,58 @@ public class CounterDetailViewer extends AbstractConfigurable implements Drawabl
     map.repaint();
   }
 
-  /*
+  /**
    * Compatibility. If this component has not yet been saved by this version of
    * vassal, convert the old-style options to new and update the version.
    */
+  protected void checkUpgrade() {
+    // Previous version needing upgrading?
+    if (!version.equals(LATEST_VERSION)) {
+      upgrade();
+    }
+  }
+
   @Override
   public Configurer getConfigurer() {
-
-    // New version 2 viewer being created
+    // New viewer being created
     if (map == null) {
       version = LATEST_VERSION;
     }
-    // Previous version needing upgrading?
-    else if (!version.equals(LATEST_VERSION)) {
-      upgrade();
+    else {
+      checkUpgrade();
     }
     return super.getConfigurer();
   }
 
   protected void upgrade() {
+    if ("1".equals(version)) {
+      if (!drawPieces && !showText) {
+        minimumDisplayablePieces = Integer.MAX_VALUE;
+      }
+      else if (drawSingleDeprecated) {
+        minimumDisplayablePieces = 1;
+      }
+      else {
+        minimumDisplayablePieces = 2;
+      }
 
-    if (!drawPieces && !showText) {
-      minimumDisplayablePieces = Integer.MAX_VALUE;
-    }
-    else if (drawSingleDeprecated) {
-      minimumDisplayablePieces = 1;
-    }
-    else {
-      minimumDisplayablePieces = 2;
+      fgColor = map.getHighlighter() instanceof ColoredBorder ? ((ColoredBorder) map.getHighlighter()).getColor() : Color.black;
+
+      bgColor = new Color(255 - fgColor.getRed(), 255 - fgColor.getGreen(), 255 - fgColor.getBlue());
+      version = "2";
     }
 
-    fgColor = map.getHighlighter() instanceof ColoredBorder ? ((ColoredBorder) map.getHighlighter()).getColor() : Color.black;
-
-    bgColor = new Color(255 - fgColor.getRed(), 255 - fgColor.getGreen(), 255 - fgColor.getBlue());
+    if ("2".equals(version)) {
+      if (FILTER.equals(displayWhat)) {
+        displayWhat = ALL_LAYERS;
+      }
+      else if (FILTER_TOP.equals(displayWhat)) {
+        displayWhat = TOP_LAYER;
+      }
+      else {
+        propertyFilter.setExpression("");
+      }
+    }
 
     version = LATEST_VERSION;
   }
@@ -1076,7 +1083,7 @@ public class CounterDetailViewer extends AbstractConfigurable implements Drawabl
   public static class DisplayConfig extends TranslatableStringEnum {
     @Override
     public String[] getValidValues(AutoConfigurable target) {
-      return new String[] {TOP_LAYER, ALL_LAYERS, INC_LAYERS, EXC_LAYERS, FILTER, FILTER_TOP};
+      return new String[] {TOP_LAYER, ALL_LAYERS, INC_LAYERS, EXC_LAYERS};
     }
 
     @Override
@@ -1084,9 +1091,7 @@ public class CounterDetailViewer extends AbstractConfigurable implements Drawabl
       return new String[] { "Editor.CounterDetailViewer.top_layer",
                             "Editor.CounterDetailViewer.all_layers",
                             "Editor.CounterDetailViewer.inc_layers",
-                            "Editor.CounterDetailViewer.exc_layers",
-                            "Editor.CounterDetailViewer.filter",
-                            "Editor.CounterDetailViewer.filter_top"
+                            "Editor.CounterDetailViewer.exc_layers"
       };
     }
   }
@@ -1528,7 +1533,7 @@ public class CounterDetailViewer extends AbstractConfigurable implements Drawabl
       return () -> (displayWhat.equals(INC_LAYERS) || displayWhat.equals(EXC_LAYERS));
     }
     else if (PROPERTY_FILTER.equals(name)) {
-      return () -> (displayWhat.equals(FILTER) || displayWhat.equals(FILTER_TOP));
+      return () -> true;
     }
     else if (EMPTY_HEX_REPORT_FORMAT.equals(name)) {
       return () -> showText && minimumDisplayablePieces == 0;

--- a/vassal-app/src/main/java/VASSAL/counters/Embellishment.java
+++ b/vassal-app/src/main/java/VASSAL/counters/Embellishment.java
@@ -723,6 +723,8 @@ public class Embellishment extends Decorator implements TranslatablePiece, Recur
   public Shape getShape() {
     final Shape innerShape = piece.getShape();
 
+    checkPropertyLevel(); //BR// Layer might have changed
+
     if (value > 0 && !drawUnderneathWhenSelected) {
       final Rectangle r = getCurrentImageBounds();
 

--- a/vassal-app/src/main/resources/VASSAL/i18n/Editor.properties
+++ b/vassal-app/src/main/resources/VASSAL/i18n/Editor.properties
@@ -409,6 +409,7 @@ Editor.CounterDetailViewer.all_layers=from all layers
 Editor.CounterDetailViewer.inc_layers=from listed layers only
 Editor.CounterDetailViewer.exc_layers=from layers other than those listed
 Editor.CounterDetailViewer.filter=by using a property filter
+Editor.CounterDetailViewer.filter_top=from top-most layer only, and using a property filter
 
 # Counter TurnLevel
 Editor.CounterTurnLevel.component_type=Counter

--- a/vassal-doc/src/main/readme-referencemanual/ReferenceManual/MouseOver.adoc
+++ b/vassal-doc/src/main/readme-referencemanual/ReferenceManual/MouseOver.adoc
@@ -54,9 +54,10 @@ The sum of the numeric values of this property for all included pieces will be s
 
 *Text for empty location:*::  A <<MessageFormat.adoc#top,Message Format>> specifying the text to display when no pieces have been selected.
 
-*Include individual pieces:*::  Specifies how pieces are to be selected for inclusion in the viewer.
+*Include individual pieces:*::  Specifies whether/how pieces are to be selected for inclusion in the viewer based on their layer.
 You may restrict the pieces according to the <<GamePieceLayers.adoc#top,Game Piece Layer>> to which they belong.
-Alternatively, you may specify a <<PropertyMatchExpression.adoc#top,Property Match Expression>> to match desired values of one or more <<Properties.adoc#top,Properties>> in order for a piece to be included. You can also combine use of a property match expression with the option to display pieces from only the topmost layer (the other layer options can all be duplicated within a property match expression).
+
+*Property Match Expression:*::  You may specify a <<PropertyMatchExpression.adoc#top,Property Match Expression>> to match desired values of one or more <<Properties.adoc#top,Properties>> in order for a piece to be included.
 
 *Include non-stacking pieces:*::  If selected, then pieces with a <<NonStacking.adoc#top,Does not stack>> trait specifying the piece does not Stack are eligible for inclusion in the viewer.
 Otherwise, they are excluded regardless of any other filters.

--- a/vassal-doc/src/main/readme-referencemanual/ReferenceManual/MouseOver.adoc
+++ b/vassal-doc/src/main/readme-referencemanual/ReferenceManual/MouseOver.adoc
@@ -56,7 +56,7 @@ The sum of the numeric values of this property for all included pieces will be s
 
 *Include individual pieces:*::  Specifies how pieces are to be selected for inclusion in the viewer.
 You may restrict the pieces according to the <<GamePieceLayers.adoc#top,Game Piece Layer>> to which they belong.
-Alternatively, you may specify a <<PropertyMatchExpression.adoc#top,Property Match Expression>> to match desired values of one or more <<Properties.adoc#top,Properties>> in order for a piece to be included.
+Alternatively, you may specify a <<PropertyMatchExpression.adoc#top,Property Match Expression>> to match desired values of one or more <<Properties.adoc#top,Properties>> in order for a piece to be included. You can also combine use of a property match expression with the option to display pieces from only the topmost layer (the other layer options can all be duplicated within a property match expression).
 
 *Include non-stacking pieces:*::  If selected, then pieces with a <<NonStacking.adoc#top,Does not stack>> trait specifying the piece does not Stack are eligible for inclusion in the viewer.
 Otherwise, they are excluded regardless of any other filters.


### PR DESCRIPTION
The CounterDetailViewer has an irritating quirk where one can't combine the "top layer only" filter with the use of a property match expression. All the other layer options can be duplicated from inside of a property match expression, but not that one.

So this allows the option to "do both".

Example: doesn't pick up the ginormous card underneath the mat (or for that matter the mat itself), but *does* allow multiple pieces to be picked up if they're all e.g.  overlapping markers. *Would* pick up the card if I rolled over that. 
![image](https://user-images.githubusercontent.com/3742246/137557745-8565a9b7-77d4-49a6-8ddb-ec57cdd639c5.png)

I tried to "solve it from within the existing Vassal stuff" e.g. by making two different CounterDetailViewers and having one for e.g. Cards and one for e.g. Regular Pieces, but the problem is if I have a property match expression to get e.g. "only the cards" or "only the regular pieces", then I end up getting two viewers pasting over top of each other simultaneously -- since I can't ask the key question "is it also the thing on top". 