### PR TITLE
10558 - "Current Mat" Fast-Match option

### DIFF
--- a/vassal-app/src/main/java/VASSAL/configure/GlobalCommandTargetConfigurer.java
+++ b/vassal-app/src/main/java/VASSAL/configure/GlobalCommandTargetConfigurer.java
@@ -157,10 +157,12 @@ public class GlobalCommandTargetConfigurer extends Configurer {
         options.add(GlobalCommandTarget.Target.CURMAP.toString());
         options.add(GlobalCommandTarget.Target.CURZONE.toString());
         options.add(GlobalCommandTarget.Target.CURLOC.toString());
+        options.add(GlobalCommandTarget.Target.CURMAT.toString());
         i18nKeys.add(GlobalCommandTarget.Target.CURSTACK.toTranslatedString());
         i18nKeys.add(GlobalCommandTarget.Target.CURMAP.toTranslatedString());
         i18nKeys.add(GlobalCommandTarget.Target.CURZONE.toTranslatedString());
         i18nKeys.add(GlobalCommandTarget.Target.CURLOC.toTranslatedString());
+        i18nKeys.add(GlobalCommandTarget.Target.CURMAT.toTranslatedString());
       }
       options.add(GlobalCommandTarget.Target.MAP.toString());
       options.add(GlobalCommandTarget.Target.ZONE.toString());

--- a/vassal-app/src/main/java/VASSAL/counters/GlobalCommand.java
+++ b/vassal-app/src/main/java/VASSAL/counters/GlobalCommand.java
@@ -38,6 +38,7 @@ import VASSAL.tools.RecursionLimiter;
 import VASSAL.tools.RecursionLimiter.Loopable;
 
 import java.awt.Point;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.regex.Pattern;
@@ -373,6 +374,36 @@ public class GlobalCommand implements Auditable {
 
             if ((useFromDeck > 0) && visitor.getSelectedCount() >= useFromDeck) {
               break;
+            }
+          }
+        }
+      }
+      // If we're using "current mat", then we find either this piece (if it is a Mat), or a mat this pieces is on (if it is a MatCargo).
+      // We then iterate through the Mat itself (first) followed by each MatCargo piece.
+      else if (target.fastMatchLocation && target.targetType == GlobalCommandTarget.Target.CURMAT) {
+        if (curPiece instanceof Decorator) {
+          // First check if we are a mat
+          GamePiece matPiece = Decorator.getDecorator(curPiece, Mat.class);
+          if (matPiece == null) {
+            // Otherwise check if we're a cargo that's currently ON a mat.
+            final MatCargo cargo = (MatCargo)Decorator.getDecorator(curPiece, MatCargo.class);
+            if (cargo != null) {
+              matPiece = cargo.getMat();
+            }
+          }
+          if (matPiece != null) {
+            final Mat mat = (Mat)Decorator.getDecorator(matPiece, Mat.class);
+            final List<GamePiece> pieces = new ArrayList<>(mat.getContents());
+            pieces.add(0, mat);
+
+            for (final GamePiece gamePiece : pieces) {
+              // If a property-based Fast Match is specified, we eliminate non-matchers of that first.
+              if (!passesPropertyFastMatch(gamePiece)) {
+                continue;
+              }
+
+              // Anything else we send to dispatcher to apply BeanShell filter and issue the command if the piece matches
+              dispatcher.accept(gamePiece);
             }
           }
         }

--- a/vassal-app/src/main/java/VASSAL/counters/GlobalCommandTarget.java
+++ b/vassal-app/src/main/java/VASSAL/counters/GlobalCommandTarget.java
@@ -125,13 +125,14 @@ public class GlobalCommandTarget implements ConfigurerFactory, SearchTarget {
     ZONE,      // Specified zone
     LOCATION,  // Specified location name
     XY,        // Specified X/Y position
-    DECK;      // Specified Deck
+    DECK,      // Specified Deck
+    CURMAT;    // Current mat (either this piece is the mat, or this piece is on the mat: matches mat & all cargo)
 
     /**
      * @return true if our match is relative to an issuing piece or deck
      */
     public boolean isCurrent() {
-      return (this == CURSTACK) || (this == CURMAP) || (this == CURZONE) || (this == CURLOC);
+      return (this == CURSTACK) || (this == CURMAP) || (this == CURZONE) || (this == CURLOC) || (this == CURMAT);
     }
 
     /**

--- a/vassal-app/src/main/resources/VASSAL/i18n/Editor.properties
+++ b/vassal-app/src/main/resources/VASSAL/i18n/Editor.properties
@@ -782,6 +782,7 @@ Editor.GlobalKeyCommand.target_curstack=Current Stack or Deck
 Editor.GlobalKeyCommand.target_curmap=Current Map
 Editor.GlobalKeyCommand.target_curzone=Current Zone
 Editor.GlobalKeyCommand.target_curloc=Current Location
+Editor.GlobalKeyCommand.target_curmat=Current Mat & Cargo
 Editor.GlobalKeyCommand.target_map=Specific Map
 Editor.GlobalKeyCommand.target_zone=Specific Zone
 Editor.GlobalKeyCommand.target_location=Specific Location

--- a/vassal-doc/src/main/readme-referencemanual/ReferenceManual/FastMatch.adoc
+++ b/vassal-doc/src/main/readme-referencemanual/ReferenceManual/FastMatch.adoc
@@ -31,6 +31,8 @@ You should aim to choose Fast-match conditions that exclude as many pieces as po
 +
 *_Current Location_* - Only pieces in the same Location (i.e. LocationName property the same) as the piece issuing the Global Key Command will be checked.
 +
+*_Current Mat_* - If this piece is a Mat, or if it is a Mat Cargo piece that is currently _on_ a Mat, then the Mat itself and all of its current Cargo will be checked.
++
 *_Specific Map_* - Only sends to pieces that are on the Map matching the supplied expression. The _expression_ is evaluated against the properties of the _source_ piece, i.e. the piece issuing the Global Key Command, but then the result of the expression is compared to the Map of potential _target_ pieces to determine if they are valid targets.
 +
 *_Specific Zone_* - Only sends to pieces that are in the Zone matching the supplied expression (an optional Map expression can be supplied as well). The _expressions_ are evaluated against the properties of the _source_ piece, i.e. the piece issuing the Global Key Command, but then the results of the expressions are compared to the CurrentZone (and optionally CurrentMap) of potential _target_ pieces to determine if they are valid targets.


### PR DESCRIPTION
Global Key Commands now include a fast-match location option of "Current Mat".

If the current piece is either a Mat, or a MatCargo piece that is currently _on_ a Mat, then the Mat followed by each of its MatCargo  pieces are checked.

![image](https://user-images.githubusercontent.com/3742246/137609611-410b63b1-2243-4b1f-8a9d-67a009dec565.png)
