### PR TITLE
10563 - Paste button in PieceDefiner no longer gets stuck greyed out

### DIFF
--- a/vassal-app/src/main/java/VASSAL/counters/PieceDefiner.java
+++ b/vassal-app/src/main/java/VASSAL/counters/PieceDefiner.java
@@ -532,7 +532,6 @@ public class PieceDefiner extends JPanel {
       copyButton.setEnabled(copyAndRemove);
       removeButton.setEnabled(copyAndRemove);
 
-      pasteButton.setEnabled(clipBoard != null);
       moveUpButton.setEnabled(index > 1);
       moveTopButton.setEnabled(index > 1);
       moveDownButton.setEnabled(index > 0 && index < inUseModel.size() - 1);
@@ -564,7 +563,6 @@ public class PieceDefiner extends JPanel {
     inUseButtonPanel.add(copyButton, "sg 1"); // NON-NLS
 
     pasteButton = new JButton(Resources.getString("Editor.paste") + " (" + getCtrlKeyName('V') + ")");
-    pasteButton.setEnabled(clipBoard != null);
     pasteButton.addActionListener(evt -> doPaste());
     inUseButtonPanel.add(pasteButton, "sg 1"); // NON-NLS
 


### PR DESCRIPTION
Presently the Paste button in the PieceDefiner remains greyed out at inappropriate times, if you're cut-and-pasting from one PieceDefiner window into an empty one. 

Since the Paste function is already protected against null clipboards, it doesn't really need "enabled" protection -- so rather than try to trace down esoteric ways of detecting one greyed-out Piece Definer paste button from another Piece Definer instance, I've just removed the greying out. 