### PR TITLE
10565 - While double-clicking to open component in Editor, holding Alt, Shift, and/or Ctrl affects the location the new window opens.

### DIFF
--- a/vassal-app/src/main/java/VASSAL/configure/ConfigureTree.java
+++ b/vassal-app/src/main/java/VASSAL/configure/ConfigureTree.java
@@ -1193,7 +1193,7 @@ public class ConfigureTree extends JTree implements PropertyChangeListener, Mous
       if (target.getConfigurer() != null) {
         final Action a = buildEditAction(target);
         if (a != null) {
-          a.actionPerformed(new ActionEvent(e.getSource(), ActionEvent.ACTION_PERFORMED, "Edit")); //NON-NLS
+          a.actionPerformed(new ActionEvent(e.getSource(), ActionEvent.ACTION_PERFORMED, "Edit", e.getModifiersEx())); //NON-NLS
         }
       }
     }

--- a/vassal-app/src/main/java/VASSAL/configure/EditPropertiesAction.java
+++ b/vassal-app/src/main/java/VASSAL/configure/EditPropertiesAction.java
@@ -19,7 +19,11 @@ package VASSAL.configure;
 
 import VASSAL.tools.swing.SwingUtils;
 import java.awt.Frame;
+import java.awt.GraphicsDevice;
+import java.awt.GraphicsEnvironment;
+import java.awt.Rectangle;
 import java.awt.event.ActionEvent;
+import java.awt.event.MouseEvent;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
 import java.util.HashMap;
@@ -78,7 +82,55 @@ public class EditPropertiesAction extends AbstractAction {
       });
       openWindows.put(target, w);
       w.setVisible(true);
+
+      //BR// If a modifier key was held with double-clicking, displace the window to a corner.
+      final boolean alt = (evt.getModifiers() & MouseEvent.ALT_DOWN_MASK) != 0;
+      final boolean shift = (evt.getModifiers() & MouseEvent.SHIFT_DOWN_MASK) != 0;
+      final boolean ctrl = (evt.getModifiers() & MouseEvent.CTRL_DOWN_MASK) != 0;
+      if (alt || shift || ctrl) {
+        final GraphicsEnvironment ge = GraphicsEnvironment.getLocalGraphicsEnvironment();
+        final GraphicsDevice defaultScreen = ge.getDefaultScreenDevice();
+        final Rectangle rect = defaultScreen.getDefaultConfiguration().getBounds();
+
+        final int x, y;
+
+        if (alt) {
+          if (ctrl && shift) { // ctrl+alt+shift == lower left
+            x = 30;
+            y = (int) rect.getMaxY() - w.getHeight() - 30;
+          }
+          else if (ctrl) {     // alt+ctrl = lower right
+            x = (int) rect.getMaxX() - w.getWidth() - 30;
+            y = (int) rect.getMaxY() - w.getHeight() - 30;
+          }
+          else if (shift) { // alt+shift = upper right;
+            x = ((int) rect.getMaxX() - w.getWidth() - 30);
+            y = 30;
+          }
+          else { // alt = center right
+            x = ((int) rect.getMaxX() - w.getWidth() - 30);
+            y = (int) (rect.getMaxY() - w.getHeight()) / 2;
+          }
+        }
+        else if (shift) {
+          if (ctrl) { // ctrl+shift = upper left
+            x = 30;
+            y = 30;
+          }
+          else {  // shift = center
+            x = ((int)rect.getMaxX() - w.getWidth()) / 2;
+            y = ((int)rect.getMaxY() - w.getHeight()) / 2;
+          }
+        }
+        else {  // Ctrl = center left
+          x = 30;
+          y = ((int)rect.getMaxY() - w.getHeight()) / 2;
+        }
+        w.setLocation(x, y);
+      }
+
       SwingUtils.ensureOnScreen(w);
+
       if (tree != null) {
         tree.notifyStateChanged(true);
         tree.nodeEdited(target);

--- a/vassal-app/src/main/java/VASSAL/configure/EditPropertiesAction.java
+++ b/vassal-app/src/main/java/VASSAL/configure/EditPropertiesAction.java
@@ -86,7 +86,7 @@ public class EditPropertiesAction extends AbstractAction {
       //BR// If a modifier key was held with double-clicking, displace the window to a corner.
       final boolean alt = (evt.getModifiers() & MouseEvent.ALT_DOWN_MASK) != 0;
       final boolean shift = (evt.getModifiers() & MouseEvent.SHIFT_DOWN_MASK) != 0;
-      final boolean ctrl = (evt.getModifiers() & MouseEvent.CTRL_DOWN_MASK) != 0;
+      final boolean ctrl = (evt.getModifiers() & (MouseEvent.CTRL_DOWN_MASK + MouseEvent.META_DOWN_MASK)) != 0; // PC or Mac, everybody's favorite key works
       if (alt || shift || ctrl) {
         final GraphicsEnvironment ge = GraphicsEnvironment.getLocalGraphicsEnvironment();
         final GraphicsDevice defaultScreen = ge.getDefaultScreenDevice();
@@ -94,36 +94,44 @@ public class EditPropertiesAction extends AbstractAction {
 
         final int x, y;
 
+        //
+        // C+A             C+S
+        //
+        // A        C        S
+        //
+        // C+A+S           A+S
+        //
         if (alt) {
           if (ctrl && shift) { // ctrl+alt+shift == lower left
             x = 30;
             y = (int) rect.getMaxY() - w.getHeight() - 30;
           }
-          else if (ctrl) {     // alt+ctrl = lower right
+          else if (ctrl) {     // alt+ctrl = upper left
+            x = 30;
+            y = 30;
+          }
+          else if (shift) { // alt+shift = lower right;
             x = (int) rect.getMaxX() - w.getWidth() - 30;
             y = (int) rect.getMaxY() - w.getHeight() - 30;
           }
-          else if (shift) { // alt+shift = upper right;
+          else { // alt = center left
+            x = 30;
+            y = ((int)rect.getMaxY() - w.getHeight()) / 2;
+          }
+        }
+        else if (shift) {
+          if (ctrl) { // ctrl+shift = upper right
             x = ((int) rect.getMaxX() - w.getWidth() - 30);
             y = 30;
+
           }
-          else { // alt = center right
+          else {  // shift = center right
             x = ((int) rect.getMaxX() - w.getWidth() - 30);
             y = (int) (rect.getMaxY() - w.getHeight()) / 2;
           }
         }
-        else if (shift) {
-          if (ctrl) { // ctrl+shift = upper left
-            x = 30;
-            y = 30;
-          }
-          else {  // shift = center
-            x = ((int)rect.getMaxX() - w.getWidth()) / 2;
-            y = ((int)rect.getMaxY() - w.getHeight()) / 2;
-          }
-        }
-        else {  // Ctrl = center left
-          x = 30;
+        else {  // Ctrl = center
+          x = ((int)rect.getMaxX() - w.getWidth()) / 2; //center
           y = ((int)rect.getMaxY() - w.getHeight()) / 2;
         }
         w.setLocation(x, y);

--- a/vassal-doc/src/main/readme-referencemanual/ReferenceManual/Editor.adoc
+++ b/vassal-doc/src/main/readme-referencemanual/ReferenceManual/Editor.adoc
@@ -26,6 +26,8 @@ a|
 All modifications to a module are done through the Configuration Window, which is a familiar file/folder type browser in which each file/folder represents a module <<GameModule.adoc#top,Component>>. Right-click on any Component to get a context menu with options for that Component.
 Use the _Cut_, _Copy_, _Paste_, and _Move_ commands to move Components around within the module, and use the _Search_ command from the _Edit_ menu if you need to find one.
 
+Double-clicking a component opens it for editing. *Tip:* You can affect _where_ the configuration window opens by holding down the _shift_ key, _alt_ key, _ctrl_ key, or some combination thereof while double-clicking.
+
 ===== Properties
 
 Brings up a dialog in which you specify the options for that components.

--- a/vassal-doc/src/main/readme-referencemanual/ReferenceManual/Editor.adoc
+++ b/vassal-doc/src/main/readme-referencemanual/ReferenceManual/Editor.adoc
@@ -28,6 +28,13 @@ Use the _Cut_, _Copy_, _Paste_, and _Move_ commands to move Components around wi
 
 Double-clicking a component opens it for editing. *Tip:* You can affect _where_ the configuration window opens by holding down the _shift_ key, _alt_ key, _ctrl_ key, or some combination thereof while double-clicking.
 
+  // Ctrl+Alt                         Ctrl+Shift
+  //
+  // Alt                Ctrl            Shift
+  //
+  // Ctrl+Alt+Shift                   Alt+Shift
+
+
 ===== Properties
 
 Brings up a dialog in which you specify the options for that components.


### PR DESCRIPTION
So now when opening e.g. two Pieces (or a piece and a prototype) to copy things between them, it is no longer necessary to be constantly dragging the two configurer windows off of being right over top of one another.

```
        //
        // C+A             C+S
        //
        // A        C        S
        //
        // C+A+S           A+S
        //
```