### PR TITLE
10569 - Better trait one-line summaries in editor; Folder summary includes description

### DIFF
--- a/vassal-app/src/main/java/VASSAL/configure/ConfigureTree.java
+++ b/vassal-app/src/main/java/VASSAL/configure/ConfigureTree.java
@@ -19,6 +19,7 @@ package VASSAL.configure;
 
 import VASSAL.build.AbstractBuildable;
 import VASSAL.build.AbstractConfigurable;
+import VASSAL.build.AbstractFolder;
 import VASSAL.build.Buildable;
 import VASSAL.build.Builder;
 import VASSAL.build.Configurable;
@@ -2295,6 +2296,13 @@ public class ConfigureTree extends JTree implements PropertyChangeListener, Mous
           }
         }
         description += " [" + getConfigureName(c.getClass()) + "]";
+
+        if (c instanceof AbstractFolder) {
+          final String desc = ((AbstractFolder)c).getAttributeValueString(AbstractFolder.DESCRIPTION);
+          if (!desc.isEmpty()) {
+            description += " - " + desc;
+          }
+        }
       }
       return description;
     }

--- a/vassal-app/src/main/java/VASSAL/counters/ActionButton.java
+++ b/vassal-app/src/main/java/VASSAL/counters/ActionButton.java
@@ -151,7 +151,9 @@ public class ActionButton extends Decorator implements EditablePiece, Loopable {
 
   @Override
   public String getDescription() {
-    return buildDescription("Editor.ActionButton.trait_description", description);
+    String s = buildDescription("Editor.ActionButton.trait_description", description);
+    s += getCommandDesc("", stroke);
+    return s;
   }
 
 

--- a/vassal-app/src/main/java/VASSAL/counters/Clone.java
+++ b/vassal-app/src/main/java/VASSAL/counters/Clone.java
@@ -151,7 +151,9 @@ public class Clone extends Decorator implements TranslatablePiece {
 
   @Override
   public String getDescription() {
-    return buildDescription("Editor.Clone.trait_description", description);
+    String s = buildDescription("Editor.Clone.trait_description", description);
+    s += getCommandDesc(commandName, key);
+    return s;
   }
 
   /**

--- a/vassal-app/src/main/java/VASSAL/counters/CounterGlobalKeyCommand.java
+++ b/vassal-app/src/main/java/VASSAL/counters/CounterGlobalKeyCommand.java
@@ -245,6 +245,15 @@ public class CounterGlobalKeyCommand extends Decorator
     if (description.length() > 0) {
       d += " - " + description;
     }
+
+    if (key != null) {
+      d += getCommandDesc(commandName, key);
+    }
+
+    if (globalKey != null) {
+      d += getCommandDesc("", globalKey);
+    }
+
     return d;
   }
 

--- a/vassal-app/src/main/java/VASSAL/counters/Decorator.java
+++ b/vassal-app/src/main/java/VASSAL/counters/Decorator.java
@@ -910,5 +910,20 @@ public abstract class Decorator extends AbstractImageFinder implements EditableP
     return Resources.getString("Audit.piece", piece.getName());
   }
 
+  /**
+   * @param command Menu text
+   * @param key Keystroke
+   * @return Display-ready description of a command, that may include a menu string and/or a NamedKeystroke
+   */
+  public String getCommandDesc(String command, NamedKeyStroke key) {
+    String s = "";
+    if (command != null && (command.length() > 0)) {
+      s += " - " + command;
+    }
+    if (key != null) {
+      s += " - " + key.getDesc();
+    }
+    return s;
+  }
 }
 

--- a/vassal-app/src/main/java/VASSAL/counters/Delete.java
+++ b/vassal-app/src/main/java/VASSAL/counters/Delete.java
@@ -202,7 +202,9 @@ public class Delete extends Decorator implements TranslatablePiece {
 
   @Override
   public String getDescription() {
-    return buildDescription("Editor.Delete.trait_description", description);
+    String s = buildDescription("Editor.Delete.trait_description", description);
+    s += getCommandDesc(commandName, key);
+    return s;
   }
 
   @Override

--- a/vassal-app/src/main/java/VASSAL/counters/Deselect.java
+++ b/vassal-app/src/main/java/VASSAL/counters/Deselect.java
@@ -197,7 +197,9 @@ public class Deselect extends Decorator implements TranslatablePiece {
 
   @Override
   public String getDescription() {
-    return buildDescription("Editor.Deselect.deselect", description);
+    String s = buildDescription("Editor.Deselect.deselect", description);
+    s += getCommandDesc(commandName, key);
+    return s;
   }
 
   @Override

--- a/vassal-app/src/main/java/VASSAL/counters/Embellishment.java
+++ b/vassal-app/src/main/java/VASSAL/counters/Embellishment.java
@@ -752,8 +752,11 @@ public class Embellishment extends Decorator implements TranslatablePiece, Recur
         displayName = imageName[0];
       }
     }
-    return Resources.getString("Editor.Embellishment.trait_description") +
-      ((displayName == null || displayName.isEmpty()) ? "" : (" - " + displayName));
+    String s = buildDescription("Editor.Embellishment.trait_description", description);
+    if ((displayName != null) && !displayName.isEmpty()) {
+      s += " - " + displayName;
+    }
+    return s;
   }
 
   @Override

--- a/vassal-app/src/main/java/VASSAL/counters/Labeler.java
+++ b/vassal-app/src/main/java/VASSAL/counters/Labeler.java
@@ -753,7 +753,7 @@ public class Labeler extends Decorator implements TranslatablePiece, Loopable {
 
   @Override
   public String getDescription() {
-    return buildDescription("Editor.TextLabel.component_type", description);
+    return buildDescription("Editor.TextLabel.component_type", description, label);
   }
 
   @Override

--- a/vassal-app/src/main/java/VASSAL/counters/MovementMarkable.java
+++ b/vassal-app/src/main/java/VASSAL/counters/MovementMarkable.java
@@ -175,7 +175,9 @@ public class MovementMarkable extends Decorator implements TranslatablePiece {
 
   @Override
   public String getDescription() {
-    return buildDescription("Editor.MovementMarkable.trait_description", description);
+    String s = buildDescription("Editor.MovementMarkable.trait_description", description);
+    s += getCommandDesc(command, key);
+    return s;
   }
 
   public void setDescription(String description) {

--- a/vassal-app/src/main/java/VASSAL/counters/NonRectangular.java
+++ b/vassal-app/src/main/java/VASSAL/counters/NonRectangular.java
@@ -153,7 +153,7 @@ public class NonRectangular extends Decorator implements EditablePiece {
 
   @Override
   public String getDescription() {
-    return Resources.getString("Editor.NonRectangular.trait_description");
+    return buildDescription("Editor.NonRectangular.trait_description", imageName);
   }
 
   @Override

--- a/vassal-app/src/main/java/VASSAL/counters/Obscurable.java
+++ b/vassal-app/src/main/java/VASSAL/counters/Obscurable.java
@@ -565,7 +565,9 @@ public class Obscurable extends Decorator implements TranslatablePiece {
 
   @Override
   public String getDescription() {
-    return buildDescription("Editor.Obscurable.trait_description", description);
+    String s = buildDescription("Editor.Obscurable.trait_description", description);
+    s += getCommandDesc(hideCommand, keyCommand);
+    return s;
   }
 
   @Override

--- a/vassal-app/src/main/java/VASSAL/counters/PlaceMarker.java
+++ b/vassal-app/src/main/java/VASSAL/counters/PlaceMarker.java
@@ -395,7 +395,9 @@ public class PlaceMarker extends Decorator implements TranslatablePiece, Recursi
 
   @Override
   public String getDescription() {
-    return buildDescription("Editor.PlaceMarker.trait_description", description);
+    String s = buildDescription("Editor.PlaceMarker.trait_description", description);
+    s += getCommandDesc(command.getName(), key);
+    return s;
   }
 
   @Override

--- a/vassal-app/src/main/java/VASSAL/counters/PlaySound.java
+++ b/vassal-app/src/main/java/VASSAL/counters/PlaySound.java
@@ -152,7 +152,9 @@ public class PlaySound extends Decorator implements TranslatablePiece {
 
   @Override
   public String getDescription() {
-    return buildDescription("Editor.PlaySound.trait_description", format.getFormat(), description);
+    String s = buildDescription("Editor.PlaySound.trait_description", format.getFormat(), description);
+    s = getCommandDesc(menuText, stroke);
+    return s;
   }
 
   @Override

--- a/vassal-app/src/main/java/VASSAL/counters/Replace.java
+++ b/vassal-app/src/main/java/VASSAL/counters/Replace.java
@@ -92,7 +92,9 @@ public class Replace extends PlaceMarker {
 
   @Override
   public String getDescription() {
-    return buildDescription("Editor.Replace.trait_description", description);
+    String s = buildDescription("Editor.Replace.trait_description", description);
+    s += getCommandDesc(command.getName(), key);
+    return s;
   }
 
   @Override

--- a/vassal-app/src/main/java/VASSAL/counters/ReportState.java
+++ b/vassal-app/src/main/java/VASSAL/counters/ReportState.java
@@ -269,7 +269,13 @@ public class ReportState extends Decorator implements TranslatablePiece {
 
   @Override
   public String getDescription() {
-    return buildDescription("Editor.ReportState.trait_description", description);
+    String s = buildDescription("Editor.ReportState.trait_description", description);
+
+    for (final NamedKeyStroke n : keys) {
+      s += getCommandDesc("", n);
+    }
+
+    return s;
   }
 
   @Override

--- a/vassal-app/src/main/java/VASSAL/counters/RestrictCommands.java
+++ b/vassal-app/src/main/java/VASSAL/counters/RestrictCommands.java
@@ -173,7 +173,11 @@ public class RestrictCommands extends Decorator implements EditablePiece {
 
   @Override
   public String getDescription() {
-    return buildDescription("Editor.RestrictCommands.trait_description", name);
+    String s = buildDescription("Editor.RestrictCommands.trait_description", name);
+    for (final NamedKeyStroke key : watchKeys) {
+      s += getCommandDesc("", key);
+    }
+    return s;
   }
 
   @Override

--- a/vassal-app/src/main/java/VASSAL/counters/ReturnToDeck.java
+++ b/vassal-app/src/main/java/VASSAL/counters/ReturnToDeck.java
@@ -267,7 +267,9 @@ public class ReturnToDeck extends Decorator implements TranslatablePiece {
 
   @Override
   public String getDescription() {
-    return buildDescription("Editor.ReturnToDeck.trait_description", deckSelect ? "" : deckExpression.getFormat(), description);
+    String s = buildDescription("Editor.ReturnToDeck.trait_description", deckSelect ? "" : deckExpression.getFormat(), description);
+    s += getCommandDesc(returnCommand, returnKey);
+    return s;
   }
 
   @Override

--- a/vassal-app/src/main/java/VASSAL/counters/SendToLocation.java
+++ b/vassal-app/src/main/java/VASSAL/counters/SendToLocation.java
@@ -569,6 +569,7 @@ public class SendToLocation extends Decorator implements TranslatablePiece {
     if (description.length() > 0) {
       d += " - " + description;
     }
+    d += getCommandDesc(commandName, key);
     return d;
   }
 

--- a/vassal-app/src/main/java/VASSAL/counters/Translate.java
+++ b/vassal-app/src/main/java/VASSAL/counters/Translate.java
@@ -89,7 +89,9 @@ public class Translate extends Decorator implements TranslatablePiece {
 
   @Override
   public String getDescription() {
-    return buildDescription("Editor.MoveFixedDistance.trait_description", description);
+    String s = buildDescription("Editor.MoveFixedDistance.trait_description", description);
+    s += getCommandDesc(commandName, keyCommand);
+    return s;
   }
 
   @Override

--- a/vassal-app/src/main/java/VASSAL/counters/TriggerAction.java
+++ b/vassal-app/src/main/java/VASSAL/counters/TriggerAction.java
@@ -371,6 +371,9 @@ public class TriggerAction extends Decorator implements TranslatablePiece,
     if (name.length() > 0) {
       s += " - " + name; //$NON-NLS-1$
     }
+
+    s += getCommandDesc(command, key);
+
     return s;
   }
 

--- a/vassal-app/src/main/java/VASSAL/tools/NamedKeyStroke.java
+++ b/vassal-app/src/main/java/VASSAL/tools/NamedKeyStroke.java
@@ -24,6 +24,7 @@ import java.util.Objects;
 
 import javax.swing.KeyStroke;
 
+import VASSAL.build.module.KeyNamer;
 import org.apache.commons.lang3.tuple.Pair;
 
 import VASSAL.tools.concurrent.ConcurrentSoftHashMap;
@@ -97,6 +98,21 @@ public class NamedKeyStroke {
    */
   public KeyStroke getStroke() {
     return stroke;
+  }
+
+  /**
+   * @return If a Named keystroke, returns the name string; otherwise if a "real" keystroke returns a string naming the keystroke (e.g. "Ctrl+C")
+   */
+  public String getDesc() {
+    if (isNamed()) {
+      return name;
+    }
+    else if (stroke != null) {
+      return KeyNamer.getKeyString(stroke);
+    }
+    else {
+      return "";
+    }
   }
 
   @Override


### PR DESCRIPTION
Basically it does a better job with describing traits when summarizing them in the piece definer.

E.g. A "Trigger" it will try to include the name of its menu command and main keystroke.

E.g. A "Report" it will try to list the keystrokes that it reports on

(I finally got tired of constantly typing the exact same thing into the "Description Line" that I'd just typed in somewhere else. Now the description line is more optional and more "for actual _additional_ information") 

Also the description line for a Folder now shows up in the Editor's summary line. Thus making the description feel less useless.
