### PR TITLE
Fix a little goof in the Trait Summary improvement

### DIFF
--- a/vassal-app/src/main/java/VASSAL/counters/PieceDefiner.java
+++ b/vassal-app/src/main/java/VASSAL/counters/PieceDefiner.java
@@ -107,7 +107,8 @@ public class PieceDefiner extends JPanel {
   private static final SortedMap<String, GamePiece> alphaMap = new TreeMap<>();
   private static Boolean sorted = false;
   protected DefaultListModel<GamePiece> inUseModel;
-  protected ListCellRenderer<? super GamePiece> r;
+  protected ListCellRenderer<? super GamePiece> inUseRenderer;
+  protected ListCellRenderer<? super GamePiece> availableRenderer;
   protected ScaleablePieceSlot slot;
   private GamePiece piece;
   protected static TraitClipboard clipBoard;
@@ -148,7 +149,8 @@ public class PieceDefiner extends JPanel {
 
     initDefinitions();
     inUseModel = new DefaultListModel<>();
-    r = new Renderer();
+    inUseRenderer = new Renderer();
+    availableRenderer = new AvailableRenderer();
     slot = new ScaleablePieceSlot();
     initComponents();
     availableList.setSelectedIndex(0);
@@ -446,7 +448,7 @@ public class PieceDefiner extends JPanel {
     availableList.setTransferHandler(transferHandler);
     availableList.setModel(availableModel);
     availableList.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
-    availableList.setCellRenderer(r);
+    availableList.setCellRenderer(availableRenderer);
     availableList.addKeyListener(new AvailableListKeyAdapter(this));
     availableList.setVisibleRowCount(99);
     availableList.addListSelectionListener(evt -> {
@@ -521,7 +523,7 @@ public class PieceDefiner extends JPanel {
     inUseList.setVisibleRowCount(99);
     inUseList.setModel(inUseModel);
     inUseList.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
-    inUseList.setCellRenderer(r);
+    inUseList.setCellRenderer(inUseRenderer);
     inUseList.addListSelectionListener(evt -> {
       final Object o = inUseList.getSelectedValue();
       propsButton.setEnabled(o instanceof EditablePiece);
@@ -1053,6 +1055,33 @@ public class PieceDefiner extends JPanel {
       super.getListCellRendererComponent(list, "", index, selected, hasFocus);
       if (value instanceof EditablePiece) {
         setText(((EditablePiece) value).getDescription());
+      }
+      else {
+        final String s = value.getClass().getName();
+        setText(s.substring(s.lastIndexOf('.') + 1));
+      }
+      return this;
+    }
+  }
+
+  private static class AvailableRenderer extends DefaultListCellRenderer {
+    private static final long serialVersionUID = 1L;
+
+    @Override
+    public Component getListCellRendererComponent(
+      JList list, Object value, int index, boolean selected, boolean hasFocus) {
+
+      // DO NOT pass value to super.getListCellRendererComponent()
+      // It is incredibly inefficient for GamePieces and is not needed
+      // since we overwrite the label text anyway.
+      super.getListCellRendererComponent(list, "", index, selected, hasFocus);
+      if (value instanceof EditablePiece) {
+        String desc = ((EditablePiece) value).getDescription();
+        if (desc.contains(" - ")) {
+          desc = desc.substring(0, desc.indexOf(" - "));
+        }
+
+        setText(desc);
       }
       else {
         final String s = value.getClass().getName();

--- a/vassal-app/src/main/java/VASSAL/counters/PlaySound.java
+++ b/vassal-app/src/main/java/VASSAL/counters/PlaySound.java
@@ -153,7 +153,7 @@ public class PlaySound extends Decorator implements TranslatablePiece {
   @Override
   public String getDescription() {
     String s = buildDescription("Editor.PlaySound.trait_description", format.getFormat(), description);
-    s = getCommandDesc(menuText, stroke);
+    s += getCommandDesc(menuText, stroke);
     return s;
   }
 


### PR DESCRIPTION
Found a little goof in the Trait Summaries improvement (#10569) -- it was including "extra summary information" (in the form of various default field values) in the descriptions of the Available Traits (on the _left_ side of the piece definer). Oops. 

Anyway this fixes it. Would be better if a "pure" request-clean-description could be added to EditablePiece interface, but that of course would break every custom class in the universe. Fortunately we were always consistent with the " - " thing and have not supplied that as an option for translators to change. 