### PR TITLE
10585 - Movement Trail "initial visibility" bug(s)

### DIFF
--- a/vassal-app/src/main/java/VASSAL/counters/Footprint.java
+++ b/vassal-app/src/main/java/VASSAL/counters/Footprint.java
@@ -293,6 +293,7 @@ public class Footprint extends MovementMarkable {
   }
 
   protected void clearTrail() {
+    myBoundingBox = null;
     pointList.clear();
     addPoint(getPosition());
     if (!initialized) {       //BR// Bug 12980 - prevent multiple re-initializations
@@ -317,6 +318,7 @@ public class Footprint extends MovementMarkable {
   }
 
   public void redraw() {
+    myBoundingBox = null;
     final Map m = getMap();
     if (m != null) {
       m.repaint(getMyBoundingBox());


### PR DESCRIPTION
Hohohohohohoho.

`return gv.booleanValue() + ";;0";`

(Shoot me now). Probably because of the cryptic "iv"/"gv" names of the many configurers, the initial state was getting set based on "gv" (whether trail is normally seen the same way by all players) rather than by "iv" which is of course *supposed* to control the initial visibility. Probably more than one bug and/or weird hack in Footprint downstream from this is a result of this original bug/typo/poor-naming-choice.

I eventually only found this when I discovered in the debugger that the new pieces were getting their initial state from the state of the Move Trail trait in the *Prototype* object, and that it somehow had a state of "true". 

Retested this new version with various combinations of Move Trail visibility, and it seems to be behaving a lot more reasonably now.

p.s. There were bounding box caching issues too, because of course there were.