### PR TITLE
10586 - Better defaults for Send To Location offsets

### DIFF
--- a/vassal-app/src/main/java/VASSAL/counters/SendToLocation.java
+++ b/vassal-app/src/main/java/VASSAL/counters/SendToLocation.java
@@ -153,8 +153,8 @@ public class SendToLocation extends Decorator implements TranslatablePiece {
     backKey = st.nextNamedKeyStroke(null);
     xIndex.setFormat(st.nextToken("0"));
     yIndex.setFormat(st.nextToken("0"));
-    xOffset.setFormat(st.nextToken("0"));
-    yOffset.setFormat(st.nextToken("0"));
+    xOffset.setFormat(st.nextToken("1")); //BR// Better defaults
+    yOffset.setFormat(st.nextToken("1"));
     description = st.nextToken("");
     destination = st.nextToken(DEST_LOCATION.substring(0, 1));
     if (destination.length() == 0) {


### PR DESCRIPTION
The offsets should really start as 0 * 1 instead of 0 * 0 so that when you want to put a truly simple offset in you don't have to manually change 4 fields.

![image](https://user-images.githubusercontent.com/3742246/138496014-cff1820b-e2b3-433b-90d7-6fa3e98bfcc3.png)
