### PR TITLE
10589 - Fix Mat send-to-location bug (which created problems in Undo & multiplayer) 

### DIFF
--- a/vassal-app/src/main/java/VASSAL/counters/SendToLocation.java
+++ b/vassal-app/src/main/java/VASSAL/counters/SendToLocation.java
@@ -526,7 +526,7 @@ public class SendToLocation extends Decorator implements TranslatablePiece {
               piece.setProperty(Properties.MOVED, Boolean.TRUE);
             }
 
-            c = tracker.getChangeCommand();
+            c = c.append(tracker.getChangeCommand());
             c = c.append(putOldProperties(piece));
 
             //BR// I sort of think cargo shouldn't snap when moving in lockstep with its mat.


### PR DESCRIPTION
Send-to-Location was forgetting to fold in the Mat itself into its "command"