### PR TITLE
10590 - Better ConfigureTree summary on PieceSlot w/ a BasicName-using piece in it

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/widget/PieceSlot.java
+++ b/vassal-app/src/main/java/VASSAL/build/widget/PieceSlot.java
@@ -528,11 +528,8 @@ public class PieceSlot extends Widget implements MouseListener, KeyListener {
     else if (getPiece() != null) {
       return Decorator.getOutermost(getExpandedPiece()).getName();
     }
-    else if (name != null) { // Doubt this can happen, but just in case it matters
-      return name;
-    }
     else {
-      return null;
+      return name; // Name could possibly be empty string, or otherwise null.
     }
   }
 


### PR DESCRIPTION
Now a piece that uses the new "Basic Name" trait somewhere in its prototype tree, and leaves the Basic Piece fields blank, appears in the Editor in its PieceSlots (e.g. in the palette, in an at-start stack, wherever) with an actual name.

So instead of just...
[Single Piece]

You get...
My Basic Name [Single Piece]