### PR TITLE
Fix crash when copying Toolbar Menu to a newly created map

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/module/ToolbarMenu.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/ToolbarMenu.java
@@ -161,9 +161,11 @@ public class ToolbarMenu extends AbstractToolbarItem
     if (parent instanceof ToolBarComponent) {
       toolbar = ((ToolBarComponent) parent).getToolBar();
     }
-    toolbar.add(getLaunchButton());
-    toolbar.addContainerListener(this);
-    scheduleBuildMenu();
+    if (toolbar != null) { // Newly created Map windows in editor may not have toolbar object yet.
+      toolbar.add(getLaunchButton());
+      toolbar.addContainerListener(this);
+      scheduleBuildMenu();
+    }
   }
 
   @Override


### PR DESCRIPTION
I was able to easily reproduce #10545 by creating a brand new Map Window and attempting to copy an existing ToolbarMenu to it. The newly created MapWindow did not have a toolbar object yet. 

