### PR TITLE
10536 - Fix crash ending logfiles- beginningState shouldn't be allowed to be non-null when outputfile is null

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/module/BasicLogger.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/BasicLogger.java
@@ -578,6 +578,7 @@ public class BasicLogger implements Logger, Buildable, GameComponent, CommandEnc
         }
         newLogAction.setEnabled(true);
         outputFile = null;
+        beginningState = null;
       }
       catch (IOException ex) {
         WriteErrorDialog.error(ex, outputFile);


### PR DESCRIPTION
The only way I can see for the exception to be thrown is if beginningState manages to get left non-null while outputFile is null. 

Probably through some funkery like the event getting sent twice in a row. Another possible pathway would be successfully ending one log, then failing to open for write the *next* log one tries (so outputfile is null because open failed, but beginningstate is still left non-null from the previous log).

This prevents the whole thing by not letting beginningState stay non-null once it's written -- clear it!