### PR TITLE
10523 - Protect CounterDetailViewer from designers who set the drawing scale to 0.0

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/module/map/CounterDetailViewer.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/CounterDetailViewer.java
@@ -1266,6 +1266,11 @@ public class CounterDetailViewer extends AbstractConfigurable implements Drawabl
         value = Double.valueOf((String) value);
       }
       zoomLevel = (Double) value;
+
+      // Java will throw up at a true 0 scale
+      if (zoomLevel < 0.001) {
+        zoomLevel = 0.001;
+      }
     }
     else if (DRAW_PIECES_AT_ZOOM.equals(name)) {
       if (value instanceof String) {

--- a/vassal-app/src/main/java/VASSAL/build/module/map/CounterDetailViewer.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/CounterDetailViewer.java
@@ -371,13 +371,15 @@ public class CounterDetailViewer extends AbstractConfigurable implements Drawabl
         piece.setProperty(Properties.OBSCURED_BY, faceDown ? Deck.NO_USER : null);
       }
 
-      piece.draw(
-        g,
-        dbounds.x - (int) (pieceBounds.x * graphicsZoom * os_scale) + (int)(borderOffset * os_scale),
-        dbounds.y - (int) (pieceBounds.y * graphicsZoom * os_scale) + (int)(borderWidth * os_scale),
-        comp,
-        graphicsZoom * os_scale
-      );
+      if (graphicsZoom > 0) {
+        piece.draw(
+          g,
+          dbounds.x - (int) (pieceBounds.x * graphicsZoom * os_scale) + (int) (borderOffset * os_scale),
+          dbounds.y - (int) (pieceBounds.y * graphicsZoom * os_scale) + (int) (borderWidth * os_scale),
+          comp,
+          graphicsZoom * os_scale
+        );
+      }
       if (parent instanceof Deck) piece.setProperty(Properties.OBSCURED_BY, owner);
       if (unrotatePieces) piece.setProperty(Properties.USE_UNROTATED_SHAPE, Boolean.FALSE);
       g.setClip(oldClip);
@@ -1266,11 +1268,6 @@ public class CounterDetailViewer extends AbstractConfigurable implements Drawabl
         value = Double.valueOf((String) value);
       }
       zoomLevel = (Double) value;
-
-      // Java will throw up at a true 0 scale
-      if (zoomLevel < 0.001) {
-        zoomLevel = 0.001;
-      }
     }
     else if (DRAW_PIECES_AT_ZOOM.equals(name)) {
       if (value instanceof String) {


### PR DESCRIPTION
Fixes #10523 

Went along with what he seemed to want to do, which is "pretend we're drawing pieces, but don't actually draw any" (go figure) 