### PR TITLE
10056 - chat problems with spaces in addresses/names

### DIFF
--- a/vassal-app/src/main/java/org/litesoft/p2pchat/PeerInfo.java
+++ b/vassal-app/src/main/java/org/litesoft/p2pchat/PeerInfo.java
@@ -84,9 +84,10 @@ public class PeerInfo {
   public static PeerInfo deFormat(String pFormatted) {
     IllegalArgument.ifNull("Formatted", pFormatted);
     int colonAt = pFormatted.indexOf(':');
-    int spaceAt = pFormatted.indexOf(' ');
     if (colonAt == -1)
       return null;
+
+    int spaceAt = pFormatted.indexOf(' ', colonAt);
     String chatName = null;
     if (spaceAt == -1) {
       spaceAt = pFormatted.length();


### PR DESCRIPTION
I see this bug come through the ABR every now and then and finally took a look. 

What happens is it's finding a space *before* the colon in the string it's passed, which is an oopsie for what-comes-after. This adjustment handles that situation in I-think-the-intended-way.