### PR TITLE
10006 - Don't unselect piece about to get context menu with Ctrl+RightClick

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/module/map/KeyBufferer.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/KeyBufferer.java
@@ -294,7 +294,7 @@ public class KeyBufferer extends MouseAdapter implements Buildable, MouseMotionL
 
         // RFE 1659481 Ctrl/Command-click ("toggle") deselects clicked units
         // (if they are already selected)
-        if (SwingUtils.isSelectionToggle(e)) {
+        if (SwingUtils.isSelectionToggle(e) && !SwingUtils.isContextMouseButtonDown(e)) {
           removePieceOrStack(p);
         }
         // End RFE 1659481


### PR DESCRIPTION
@riverwanderer is correct - Ctrl+Rightclick (Cmd + Rightclick on Mac) should not toggle a piece _out_ of a selection if it is about to get a context menu.