### PR TITLE
9478 - More robust configurer for PredefinedSetup

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/module/PredefinedSetup.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/PredefinedSetup.java
@@ -183,7 +183,7 @@ public class PredefinedSetup extends AbstractConfigurable implements GameCompone
       return showUseFile;
     }
     else if (IS_MENU.equals(name)) {
-      return () -> (getBuildables().size() <= 0);
+      return () -> getBuildables().isEmpty();
     }
     else {
       return super.getAttributeVisibility(name);


### PR DESCRIPTION
No longer lets you convert a PredefinedSetup back to non-parent-menu item when it currently has children.