### PR TITLE
9391 - Beanshell can now access $$ variables in Report Formats

### DIFF
--- a/vassal-app/src/main/java/VASSAL/script/ExpressionInterpreter.java
+++ b/vassal-app/src/main/java/VASSAL/script/ExpressionInterpreter.java
@@ -237,6 +237,11 @@ public class ExpressionInterpreter extends AbstractInterpreter implements Loopab
   }
 
   public String evaluate(PropertySource ps, boolean localized, Auditable owner, AuditTrail audit) throws ExpressionException {
+    return evaluate(ps, null, localized, owner, audit);
+  }
+
+  public String evaluate(PropertySource ps, java.util.Map<String, String> properties, boolean localized, Auditable owner, AuditTrail audit) throws ExpressionException {
+
     if (getExpression().length() == 0) {
       return "";
     }
@@ -259,7 +264,11 @@ public class ExpressionInterpreter extends AbstractInterpreter implements Loopab
         if (name.length() > 2 && name.startsWith("$") && name.endsWith("$")) {
           name = name.substring(1, name.length() - 1);
         }
-        final Object prop = localized ? source.getLocalizedProperty(name) : source.getProperty(name);
+        // Check for a propoerty in the passed property Map, then check the source if not found
+        Object prop = properties == null ? null : properties.get(name);
+        if (prop == null) {
+          prop = localized ? source.getLocalizedProperty(name) : source.getProperty(name);
+        }
         final String value = prop == null ? "" : prop.toString();
         if (audit != null) {
           audit.addMessage(origName + "=" + (value == null ? "" : value));

--- a/vassal-app/src/main/java/VASSAL/script/expression/BeanShellExpression.java
+++ b/vassal-app/src/main/java/VASSAL/script/expression/BeanShellExpression.java
@@ -60,7 +60,7 @@ public class BeanShellExpression extends Expression {
     if (interpreter == null) {
       interpreter = new ExpressionInterpreter(strip(getExpression()));
     }
-    return interpreter.evaluate(ps, localized, owner, audit);
+    return interpreter.evaluate(ps, properties, localized, owner, audit);
   }
 
   /** @deprecated Use {@link #evaluate(PropertySource, Map, boolean, Auditable, AuditTrail)} */


### PR DESCRIPTION
I have stopped short of adding a Calculator Icon and Expression builder and providing full Beanshell input support. However, if you happen to use a Beanshell expression to generate a Report Format, you can now access the local $$ variables that are defined for that specific Report Format (The ones on the 'Insert' drop-down menu)