### PR TITLE
9359 - MACOS - Eliminate Command+A key conflict in Editor

### DIFF
--- a/vassal-app/src/main/java/VASSAL/launch/EditorWindow.java
+++ b/vassal-app/src/main/java/VASSAL/launch/EditorWindow.java
@@ -221,7 +221,11 @@ public abstract class EditorWindow extends JFrame {
     };
 
     saveAsAction.setEnabled(false);
-    saveAsAction.putValue(Action.ACCELERATOR_KEY, KeyStroke.getKeyStroke(KeyEvent.VK_A, mask));
+
+    if (!SystemUtils.IS_OS_MAC) {
+      saveAsAction.putValue(Action.ACCELERATOR_KEY, KeyStroke.getKeyStroke(KeyEvent.VK_A, mask));
+    }
+
     mm.addAction("Editor.save_as", saveAsAction);
     toolBar.add(saveAsAction);
 


### PR DESCRIPTION
The Command+A shortcut in the Editor conflicts with the standard Mac Command+A to "Select All", and so promotes user error by firing off at unexpected times. 

At @riverwanderer 's recommendation I've simply removed the shortcut on Macs. 