### PR TITLE
10348 - Fix NPE joining chat room when socket drops early

### DIFF
--- a/vassal-app/src/main/java/VASSAL/chat/node/NodeClient.java
+++ b/vassal-app/src/main/java/VASSAL/chat/node/NodeClient.java
@@ -180,6 +180,9 @@ public class NodeClient implements LockableChatServerConnection,
   }
 
   protected void registerNewConnection() {
+    if (sender == null) { // If already hung up
+      return;
+    }
     final String path = new SequenceEncoder(moduleName, '/').append(defaultRoomName)
         .getValue();
     send(Protocol.encodeRegisterCommand(me.getId(), path,


### PR DESCRIPTION
If socket drops before we manage to log into it, can produce an NPE