### PR TITLE
10628 - Autopeek Rollover

### DIFF
--- a/vassal-app/src/main/java/VASSAL/counters/Obscurable.java
+++ b/vassal-app/src/main/java/VASSAL/counters/Obscurable.java
@@ -210,9 +210,7 @@ public class Obscurable extends Decorator implements TranslatablePiece {
   }
 
   public boolean isAutoPeeking() {
-    if (!autoPeekRollover) return false;
-    if (!CounterDetailViewer.isDrawingMouseOver()) return false;
-    return obscuredToOthers() && !obscuredToMe();
+    return autoPeekRollover && CounterDetailViewer.isDrawingMouseOver() && obscuredToOthers() && !obscuredToMe();
   }
 
   @Override

--- a/vassal-app/src/main/resources/VASSAL/i18n/Editor.properties
+++ b/vassal-app/src/main/resources/VASSAL/i18n/Editor.properties
@@ -1400,6 +1400,7 @@ Editor.Obscurable.inset2=Image Inset
 Editor.Obscurable.use_image=Use image
 Editor.Obscurable.mask_command=Mask command
 Editor.Obscurable.peek_command=Peek command
+Editor.Obscurable.autopeek=Autopeek on Rollover
 
 # Panel Widget
 Editor.PanelWidget.component_type=Panel

--- a/vassal-doc/src/main/readme-referencemanual/ReferenceManual/Mask.adoc
+++ b/vassal-doc/src/main/readme-referencemanual/ReferenceManual/Mask.adoc
@@ -67,6 +67,9 @@ until he clicks elsewhere on the map). If the "Peek" command key is left blank, 
 _Use Image_ draws the unmasked piece and then a specifiable image on top of the piece.
 The image can make use of transparency to let some of the information through.
 
+*Autopeek on Rollover:*::  If checked, then when displayed in any <<MouseOver.adoc#top, Mouse-over Viewer>> to a player eligible to see the piece, the
+piece will appear unmasked.
+
 |
 image:images/Mask.png[]
 


### PR DESCRIPTION
Per @riverwanderer 's good idea in https://forum.vassalengine.org/t/mouse-over-to-show-unmasked-piece/72832/3

Masked pieces can be set to automatically display their unmasked versions in rollovers to players eligible to see the piece (i.e. owning players)