### PR TITLE
9226 - When Editor changes a prototype, clear the prototype cache and all pieceslot caches

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/module/PrototypeDefinition.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/PrototypeDefinition.java
@@ -183,9 +183,21 @@ public class PrototypeDefinition extends AbstractConfigurable
     return piece;
   }
 
+
+  public void clearCache() {
+    pieces.clear();
+  }
+
+
   public void setPiece(GamePiece p) {
     pieceDefinition = p == null ? null : GameModule.getGameModule().encode(new AddPiece(p));
     pieces.clear();
+
+    //BR// Clear the cached pieces array for ALL existing prototypes when any of them changes. Thus chained/nested prototypes will be properly rebuilt.
+    final PrototypesContainer container = PrototypesContainer.findInstance();
+    if (container != null) {
+      container.resetCache();
+    }
   }
 
   public String getDescription() {

--- a/vassal-app/src/main/java/VASSAL/build/module/PrototypesContainer.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/PrototypesContainer.java
@@ -171,7 +171,7 @@ public class PrototypesContainer extends AbstractConfigurable {
 
   public static PrototypeDefinition getPrototype(String name) {
     findInstance();
-    return instance.definitions.get(name);
+    return (instance == null) ? null : instance.definitions.get(name);
   }
 
   @Override

--- a/vassal-app/src/main/java/VASSAL/build/module/PrototypesContainer.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/PrototypesContainer.java
@@ -17,12 +17,15 @@
  */
 package VASSAL.build.module;
 
+import VASSAL.build.AbstractBuildable;
 import VASSAL.build.AbstractConfigurable;
+import VASSAL.build.AbstractFolder;
 import VASSAL.build.Buildable;
 import VASSAL.build.Configurable;
 import VASSAL.build.GameModule;
 import VASSAL.build.module.documentation.HelpFile;
 import VASSAL.build.module.folder.PrototypeFolder;
+import VASSAL.build.widget.PieceSlot;
 import VASSAL.configure.Configurer;
 import VASSAL.i18n.ComponentI18nData;
 import VASSAL.i18n.Resources;
@@ -121,12 +124,12 @@ public class PrototypesContainer extends AbstractConfigurable {
   public void removeFrom(Buildable parent) {
   }
 
-  public static PrototypeDefinition getPrototype(String name) {
+  public static PrototypesContainer findInstance() {
     if (instance == null) {
       final Iterator<PrototypesContainer> i =
         GameModule.getGameModule()
-                  .getComponentsOf(PrototypesContainer.class)
-                  .iterator();
+          .getComponentsOf(PrototypesContainer.class)
+          .iterator();
       if (i.hasNext()) {
         instance = i.next();
       }
@@ -134,6 +137,40 @@ public class PrototypesContainer extends AbstractConfigurable {
         return null;
       }
     }
+    return instance;
+  }
+
+  private void resetCache(AbstractBuildable target) {
+    for (final Buildable b : target.getBuildables()) {
+      if (b instanceof PrototypeDefinition) {
+        ((PrototypeDefinition)b).clearCache();
+      }
+      else if (b instanceof AbstractFolder) {
+        resetCache((AbstractBuildable)b);
+      }
+    }
+  }
+
+
+  private void resetPieceCache(AbstractBuildable target) {
+    for (final Buildable b : target.getBuildables()) {
+      if (b instanceof PieceSlot) {
+        ((PieceSlot)b).clearCache();
+      }
+      else if (b instanceof AbstractBuildable) {
+        resetPieceCache((AbstractBuildable)b);
+      }
+    }
+  }
+
+  public void resetCache() {
+    resetCache(this);
+
+    resetPieceCache(GameModule.getGameModule());
+  }
+
+  public static PrototypeDefinition getPrototype(String name) {
+    findInstance();
     return instance.definitions.get(name);
   }
 

--- a/vassal-app/src/main/java/VASSAL/build/module/map/SetupStack.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/SetupStack.java
@@ -419,6 +419,7 @@ public class SetupStack extends AbstractConfigurable implements GameComponent, U
       if (configurable instanceof PieceSlot) {
         num++;
         final PieceSlot slot = (PieceSlot) configurable;
+        slot.clearCache(); //BR// Always rebuild piece at beginning - we might be starting a new game in Editor after changing prototypes
         GamePiece p = slot.getPiece();
         if (p != null) { // In case slot fails to "build the piece", which is a possibility.
           p = PieceCloner.getInstance().clonePiece(p);

--- a/vassal-app/src/main/java/VASSAL/build/widget/PieceSlot.java
+++ b/vassal-app/src/main/java/VASSAL/build/widget/PieceSlot.java
@@ -211,6 +211,11 @@ public class PieceSlot extends Widget implements MouseListener, KeyListener {
     expanded = null;
   }
 
+  public void clearCache() {
+    c = null;
+    expanded = null;
+  }
+
   /**
    * Return defined GamePiece with prototypes unexpanded.
    *


### PR DESCRIPTION
Something I've wanted to fix for a long time, and certainly gets mentioned a lot by other module designers: until now when you changed a prototype you basically had to completely restart vassal (not even just restart the game -- restart _VASSAL_) because none of your prototype changes would be honored until you did -- they all get cached in various places. 

So this PR clears out the cache from startup stacks and piece palettes and the like whenever a prototype is changed. This not only fixes the problem Claudio originally described (cascading changes among multiple prototypes), it also fixes the palettes and startup stacks.

Doesn't affect performance for normal _Player_ operations because no prototype ever changes during a Player session.

In testing this out I opened a module and changed some prototypes. The changes were _immediately_ felt in pieces then dragged from the Piece Palette. For At-Start Stacks, if I did a "Close Game" and then started a new game, the newly placed At Start stack pieces reflected my changes. Neither of these were true before this PR.