### PR TITLE
10643 - Players loading games through the starting Wizard should actually see saved game mismatch warnings (e.g. loading wrong version)

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/module/WizardSupport.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/WizardSupport.java
@@ -612,7 +612,6 @@ public class WizardSupport {
           final SaveMetaData saveData = (SaveMetaData) metaData;
           String saveModuleVersion = "?";
           if (saveData.getModuleData() != null) {
-            final String loadComments = saveData.getLocalizedDescription();
             final String saveModuleName = saveData.getModuleName();
             saveModuleVersion = saveData.getModuleVersion();
             final String moduleName = GameModule.getGameModule().getGameName();


### PR DESCRIPTION
Apparently running the startup wizard completely bypassed all the Saved Game validation, like checking if you're trying to load the saved game into an earlier version of the module and printing a warning instead of throwing an exception.