### PR TITLE
10306 - Fix NPE if try to open translations but the buildable doesn't exist

### DIFF
--- a/vassal-app/src/main/java/VASSAL/i18n/TranslateWindow.java
+++ b/vassal-app/src/main/java/VASSAL/i18n/TranslateWindow.java
@@ -32,6 +32,7 @@ import java.awt.event.WindowEvent;
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.EventObject;
+import java.util.List;
 
 import javax.swing.JButton;
 import javax.swing.JComboBox;
@@ -164,8 +165,9 @@ public class TranslateWindow extends JDialog implements ListSelectionListener,
    * @param target new Translation
    */
   protected void refreshTranslationList(Configurable target) {
-    final Language language = GameModule.getGameModule().getComponentsOf(Language.class).iterator().next();
-    if (language != null) {
+    final List<Language> list = GameModule.getGameModule().getComponentsOf(Language.class);
+    if (list != null) {
+      final Language language = list.iterator().next();
       myConfigureTree.externalInsert(language, target);
     }
     langBox.removeAllItems();


### PR DESCRIPTION
Fixes #10306 

The null check was at the wrong place.