### PR TITLE
10028 - Sanitize temporary file names a bit earlier

### DIFF
--- a/vassal-app/src/main/java/VASSAL/tools/io/ZipArchive.java
+++ b/vassal-app/src/main/java/VASSAL/tools/io/ZipArchive.java
@@ -442,7 +442,7 @@ public class ZipArchive implements FileArchive {
   }
 
   private static File makeTempFileFor(String path, Path tmpDir) throws IOException {
-    final String base = sanitize(FilenameUtils.getBaseName(path)) + "_";
+    final String base = FilenameUtils.getBaseName(sanitize(path)) + "_";
     final String ext = extensionOf(path);
     Files.createDirectories(tmpDir);
     return Files.createTempFile(tmpDir, base, ext).toFile();


### PR DESCRIPTION
Fixes #10028 and some duplicates. 

It was already trying to sanitize illegal characters from temp filenames, it just wasn't doing it soon enough and was getting caught on a library method getting mad and throwing an exception.