### PR TITLE
9890 - Startup Global Key Commands - always fire in order, can't be undone, and can be configured to e.g. "once per game"

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/module/GameState.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/GameState.java
@@ -18,7 +18,6 @@ package VASSAL.build.module;
 
 import VASSAL.build.AbstractBuildable;
 import VASSAL.build.Buildable;
-import VASSAL.build.widget.PieceSlot;
 import VASSAL.preferences.Prefs;
 import VASSAL.tools.ProblemDialog;
 import java.awt.Cursor;

--- a/vassal-app/src/main/java/VASSAL/build/module/PredefinedSetup.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/PredefinedSetup.java
@@ -194,7 +194,7 @@ public class PredefinedSetup extends AbstractConfigurable implements GameCompone
     final GameModule g = GameModule.getGameModule();
     if (useFile && fileName != null) {
       try {
-        g.getGameState().loadGameInBackground(fileName, getSavedGameContents());
+        g.getGameState().loadGameInBackground(fileName, getSavedGameContents(), true);
         g.setGameFile(fileName, GameModule.GameFileMode.LOADED_GAME);
       }
       catch (IOException e) {
@@ -205,6 +205,7 @@ public class PredefinedSetup extends AbstractConfigurable implements GameCompone
       g.setGameFile(fileName, GameModule.GameFileMode.NEW_GAME);
       GameModule.getGameModule().getGameState().setup(false);
       GameModule.getGameModule().getGameState().setup(true);
+      GameModule.getGameModule().getGameState().freshenStartupGlobalKeyCommands(GameModule.getGameModule());
     }
   }
 

--- a/vassal-app/src/main/java/VASSAL/build/module/StartupGlobalKeyCommand.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/StartupGlobalKeyCommand.java
@@ -21,12 +21,15 @@ import VASSAL.build.AutoConfigurable;
 import VASSAL.build.Buildable;
 import VASSAL.build.GameModule;
 import VASSAL.build.module.documentation.HelpFile;
+import VASSAL.build.module.map.MassKeyCommand;
 import VASSAL.command.Command;
 import VASSAL.configure.TranslatableStringEnum;
 import VASSAL.configure.VisibilityCondition;
 import VASSAL.i18n.Resources;
-import org.apache.commons.lang3.ArrayUtils;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -69,6 +72,7 @@ public class StartupGlobalKeyCommand extends GlobalKeyCommand implements GameCom
   @SuppressWarnings("removal")
   public StartupGlobalKeyCommand() {
     super();
+    condition = null;
     /* These four fields pertaining to the physical representation of the
      * GKC on the toolbar are not applicable in this implementation.
      */
@@ -77,6 +81,20 @@ public class StartupGlobalKeyCommand extends GlobalKeyCommand implements GameCom
     launch.setAttribute(ICON, "");  //NON-NLS
     launch.setAttribute(HOTKEY, "");  //NON-NLS
   }
+
+  @SuppressWarnings("removal")
+  public StartupGlobalKeyCommand(MassKeyCommand gkc) {
+    super(gkc);
+    condition = null;
+    /* These four fields pertaining to the physical representation of the
+     * GKC on the toolbar are not applicable in this implementation.
+     */
+    launch.setAttribute(BUTTON_TEXT, "");  //NON-NLS
+    launch.setAttribute(TOOLTIP, "");  //NON-NLS
+    launch.setAttribute(ICON, "");  //NON-NLS
+    launch.setAttribute(HOTKEY, "");  //NON-NLS
+  }
+
 
   //---------------------- GlobalKeyCommand extension ---------------------
   @Override
@@ -107,26 +125,35 @@ public class StartupGlobalKeyCommand extends GlobalKeyCommand implements GameCom
 
   @Override
   public String[] getAttributeDescriptions() {
-    return ArrayUtils.addAll(
-      super.getAttributeDescriptions(),
-      Resources.getString("Editor.StartupGlobalKeyCommand.when_to_apply")
-    );
+    final List<String> descs = new ArrayList<>();
+    descs.add(Resources.getString("Editor.StartupGlobalKeyCommand.when_to_apply"));
+    Collections.addAll(descs, super.getAttributeDescriptions());
+    return descs.toArray(new String[0]);
   }
 
   @Override
   public String[] getAttributeNames() {
-    return ArrayUtils.addAll(
-      super.getAttributeNames(),
-      WHEN_TO_APPLY
-    );
+    final List<String> names = new ArrayList<>();
+
+    names.add(WHEN_TO_APPLY);
+
+    // Filter some of the crazy out of the original MassKeyCommand list, so we can add more things "safely"
+    for (final String n : super.getAttributeNames()) {
+      if (List.of(CHECK_VALUE, CHECK_PROPERTY, AFFECTED_PIECE_NAMES).contains(n)) {
+        continue;
+      }
+      names.add(n);
+    }
+
+    return names.toArray(new String[0]);
   }
 
   @Override
   public Class<?>[] getAttributeTypes() {
-    return ArrayUtils.addAll(
-      super.getAttributeTypes(),
-      Prompt.class
-    );
+    final List<Class<?>> types = new ArrayList<>();
+    types.add(Prompt.class);
+    Collections.addAll(types, super.getAttributeTypes());
+    return types.toArray(new Class<?>[0]);
   }
 
   @Override

--- a/vassal-app/src/main/java/VASSAL/build/module/StartupGlobalKeyCommand.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/StartupGlobalKeyCommand.java
@@ -28,7 +28,6 @@ import VASSAL.configure.VisibilityCondition;
 import VASSAL.i18n.Resources;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 

--- a/vassal-app/src/main/java/VASSAL/build/module/StartupGlobalKeyCommand.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/StartupGlobalKeyCommand.java
@@ -152,21 +152,22 @@ public class StartupGlobalKeyCommand extends GlobalKeyCommand implements GameCom
   }
 
 
-  public void applyIfNotApplied() {
+  public boolean applyIfNotApplied() {
     if (APPLY_FIRST_LAUNCH_OF_SESSION.equals(whenToApply)) {
       if (hasEverApplied) {
-        return;
+        return false;
       }
     }
     else if (APPLY_START_OF_GAME_ONLY.equals(whenToApply)) {
       if (hasAppliedThisGame) {
-        return;
+        return false;
       }
     }
 
     hasEverApplied = true;     // This one will be false again next time anything calls GameState.setup(true)
     hasAppliedThisGame = true; // This one will be remembered as part of the game state (i.e. even after loading a game)
     apply();
+    return true;
   }
 
   @Override

--- a/vassal-app/src/main/java/VASSAL/build/module/StartupGlobalKeyCommand.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/StartupGlobalKeyCommand.java
@@ -56,7 +56,7 @@ public class StartupGlobalKeyCommand extends GlobalKeyCommand implements GameCom
   protected static final UniqueIdManager idMgr = new UniqueIdManager("SGKC"); //$NON-NLS-1$
   protected String id = "";     // Our unique ID
 
-  public String whenToApply = APPLY_FIRST_LAUNCH_OF_SESSION;
+  public String whenToApply = APPLY_EVERY_LAUNCH_OF_SESSION;
 
   private boolean hasEverApplied     = false;  // Has ever been applied during this session   (NOT saved with game state)
   private boolean hasAppliedThisGame = false;  // Has ever been applied during this *game*    (Saved with game state)

--- a/vassal-app/src/main/java/VASSAL/build/module/StartupGlobalKeyCommand.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/StartupGlobalKeyCommand.java
@@ -105,6 +105,7 @@ public class StartupGlobalKeyCommand extends GlobalKeyCommand implements GameCom
     }
   }
 
+  @Override
   public String[] getAttributeDescriptions() {
     return ArrayUtils.addAll(
       super.getAttributeDescriptions(),

--- a/vassal-app/src/main/resources/VASSAL/i18n/Editor.properties
+++ b/vassal-app/src/main/resources/VASSAL/i18n/Editor.properties
@@ -1812,6 +1812,10 @@ Editor.StartStack.component_type=At-Start Stack
 
 # Startup Global Key Command
 Editor.StartupGlobalKeyCommand.component_type=Startup Global Key Command
+Editor.StartupGlobalKeyCommand.when_to_apply=When To Apply
+Editor.StartupGlobalKeyCommand.first_launch_of_session=On First Game Launch/Load Of Session
+Editor.StartupGlobalKeyCommand.every_launch_of_session=On Every Game Launch/Load Of Session
+Editor.StartupGlobalKeyCommand.start_of_game_only=At Start Of Every Fresh Game Only
 
 # String Builder
 Editor.StringBuilder.component_type=String Builder

--- a/vassal-doc/src/main/readme-referencemanual/ReferenceManual/Map.adoc
+++ b/vassal-doc/src/main/readme-referencemanual/ReferenceManual/Map.adoc
@@ -404,7 +404,7 @@ Startup Global Key Commands can be configured to any of three modes:
 
 **(2) On Every Game Launch/Load Of Session**: These fire every time a game is launched or loaded during the session.
 
-**(3) At Start Of Every Fresh Game Only**: These fire only when a _new game_ is starting. If the game is saved and later restored, or is being exchanged back and forth in log form, the key command will not fire on subsequent loads.
+**(3) At Start Of Every Fresh Game Only**: These fire only when a _new game_ is starting. If the game is saved and later restored, or is being exchanged back and forth in log form, the key command will not fire on subsequent loads. For clarity, a new game started from a <<GameModule.adoc#PredefinedSetup, Pre-defined Setup>> _does_ count as a fresh new game.
 
 
 '''

--- a/vassal-doc/src/main/readme-referencemanual/ReferenceManual/Map.adoc
+++ b/vassal-doc/src/main/readme-referencemanual/ReferenceManual/Map.adoc
@@ -396,10 +396,15 @@ image:images/StartupGlobalKeyCommand.png[]
 An extension of <<#GlobalKeyCommand,Global Key Command>> that fires automatically upon completion of module load, once all the key listeners are started up.
 All fields behave identically to the corresponding ones in <<#GlobalKeyCommand,Global Key Command>>, except that those pertaining to the physical representation of a Toolbar button are suppressed as being inapplicable.
 
-If multiple start-up commands need to be run in a particular order, they should be combined in a <<MultiActionButton.adoc#top,MultiAction Button>> and then launched from a single instance of Startup Global Key Command, as the sequence in which multiple instances of StartupGlobalKeyCommand are fired is undetermined.
+As of VASSAL 3.6, multiple start-up global key commands _can_ be depended on to run in the order they are listed in the module.
 
-NOTE:  Startup Global Key Commands fire _every_ time the module starts up, whether it is to begin a new game or to load and continue an existing one.
-Thus if you need the Startup GKC to initiate an activity that should only be done once at the very _beginning_ of a game, then it would need to send a key command to a pre-designated piece, which could then check a Global Property (called, perhaps, "StartupDone") to determine whether the game had already been started -- if it hadn't, the piece could then perform those tasks and set "StartupDone" to true, which would prevent the actions from being taken on a subsequent load of a saved game.
+Startup Global Key Commands can be configured to any of three modes:
+
+**(1) On First Game Launch/Load Of Session**: These fire every time the _module_ starts up, regardless of whether it is to begin a new game or to load and continue an existing one.
+
+**(2) On Every Game Launch/Load Of Session**: These fire every time a game is launched or loaded during the session.
+
+**(3) At Start Of Every Fresh Game Only**: These fire only when a _new game_ is starting. If the game is saved and later restored, or is being exchanged back and forth in log form, the key command will not fire on subsequent loads.
 
 
 '''


### PR DESCRIPTION
Fixes #9890

* SGKCs are now guaranteed to fire in the order they are listed in the module. There's no need to support returning to the old functionality because the old functionality was (a) officially undetermined, so the fact that we're doing them in the right order fulfills their non-expectations (b) but in fact seemed to fire more or less in order anyway. 
* SGKCs can now be configured as to whether they fire (a) once per player session (the default and the old functionality), (b) every time a game is started or loaded during the session, or (c) once per *game* when the game is being started for the first time, either blank or from a predefined setup (i.e. the flag whether the SGKC has been applied is saved with the game)
* SGKCs cannot be undone past