### PR TITLE
9759 - UNDO of movement will no longer deny lone stackable pieces their own stack (fixes some obscure stack-related bugs)

### DIFF
--- a/vassal-app/src/main/java/VASSAL/command/MovePiece.java
+++ b/vassal-app/src/main/java/VASSAL/command/MovePiece.java
@@ -129,7 +129,16 @@ public class MovePiece extends Command {
         }
         else {
           if (newMap.apply(mergeFinder) == null) {
-            newMap.placeAt(piece, newPosition);
+            if (newMap.getStackMetrics().isStackingEnabled()
+                && !Boolean.TRUE.equals(piece.getProperty(Properties.NO_STACK))) {
+              final Stack s = new Stack();
+              s.add(piece);
+              GameModule.getGameModule().getGameState().addPiece(s);
+              newMap.placeAt(s, newPosition);
+            }
+            else {
+              newMap.placeAt(piece, newPosition);
+            }
           }
           if (piece.getParent() != null) {
             piece.getParent().insert(piece, 0);

--- a/vassal-app/src/main/java/VASSAL/command/MovePiece.java
+++ b/vassal-app/src/main/java/VASSAL/command/MovePiece.java
@@ -105,6 +105,22 @@ public class MovePiece extends Command {
     return playerId;
   }
 
+  private void stackOrPlacePiece(GamePiece piece, Map newMap, Point newPosition, boolean toTop) {
+    if (newMap.getStackMetrics().isStackingEnabled()
+      && !Boolean.TRUE.equals(piece.getProperty(Properties.NO_STACK))) {
+      final Stack s = new Stack();
+      s.add(piece);
+      GameModule.getGameModule().getGameState().addPiece(s);
+      newMap.placeAt(s, newPosition);
+    }
+    else {
+      newMap.placeAt(piece, newPosition);
+      if (toTop && (piece.getParent() != null)) {
+        piece.getParent().insert(piece, 0);
+      }
+    }
+  }
+
   @Override
   protected void executeCommand() {
     final GamePiece piece = GameModule.getGameModule().getGameState().getPieceForId(id);
@@ -123,25 +139,13 @@ public class MovePiece extends Command {
           }
           else {
             if (newMap.apply(mergeFinder) == null) {
-              newMap.placeAt(piece, newPosition);
+              stackOrPlacePiece(piece, newMap, newPosition, false);
             }
           }
         }
         else {
           if (newMap.apply(mergeFinder) == null) {
-            if (newMap.getStackMetrics().isStackingEnabled()
-                && !Boolean.TRUE.equals(piece.getProperty(Properties.NO_STACK))) {
-              final Stack s = new Stack();
-              s.add(piece);
-              GameModule.getGameModule().getGameState().addPiece(s);
-              newMap.placeAt(s, newPosition);
-            }
-            else {
-              newMap.placeAt(piece, newPosition);
-            }
-          }
-          if (piece.getParent() != null) {
-            piece.getParent().insert(piece, 0);
+            stackOrPlacePiece(piece, newMap, newPosition, true);
           }
         }
       }


### PR DESCRIPTION
Fixes #9759 

On this one we should be a bit careful about whether we're solving a problem that needs to be solved. 

The problem is that the MovePiece command used to process undo (unlike PieceMover when processing drag-and-drops) does not place *lone* stackable pieces into a new stack when it doesn't find any existing piece/stack to merge with. 

The PR handles making sure lone stackable pieces are placed into stacks. So it's _probably_ benignly harmless. But you know, stacks and movement and undo -- OH MY! 

I'm not _sure_ what the story is with that getParent()-and-insert-at-0 thing going on in there -- it seems like something that would never actually run or matter in this case. 