### PR TITLE
9800 - Fixed bug where Place Marker, Send-to-Location, and Translate traits didn't always repaint maps

### DIFF
--- a/vassal-app/src/main/java/VASSAL/counters/PlaceMarker.java
+++ b/vassal-app/src/main/java/VASSAL/counters/PlaceMarker.java
@@ -239,6 +239,8 @@ public class PlaceMarker extends Decorator implements TranslatablePiece, Recursi
         parent.insert(marker, index);
         c = c.append(ct.getChangeCommand());
       }
+
+      m.repaint();
     }
     else {
       c = m.placeAt(marker, p);

--- a/vassal-app/src/main/java/VASSAL/counters/SendToLocation.java
+++ b/vassal-app/src/main/java/VASSAL/counters/SendToLocation.java
@@ -422,6 +422,7 @@ public class SendToLocation extends Decorator implements TranslatablePiece {
     List<Point> offsets = null;
     Command c = null;
     Point dest = null;
+    final Map oldMap = outer.getMap();
 
     // If we're about to move a Mat, establish the initial relative positions of all its "contents"
     if (GameModule.getGameModule().isMatSupport()) {
@@ -548,6 +549,11 @@ public class SendToLocation extends Decorator implements TranslatablePiece {
         }
       }
     }
+
+    if (oldMap != map) {
+      oldMap.repaint();
+    }
+    map.repaint();
 
     return c;
   }

--- a/vassal-app/src/main/java/VASSAL/counters/Translate.java
+++ b/vassal-app/src/main/java/VASSAL/counters/Translate.java
@@ -266,6 +266,11 @@ public class Translate extends Decorator implements TranslatablePiece {
       }
     }
 
+    final Map map = target.getMap();
+    if (map != null) {
+      map.repaint();
+    }
+
     return c;
   }
 


### PR DESCRIPTION
Fixes #9800 

SOME situations were repainting the maps (e.g. if a piece was actually added to the map as opposed to a stack), but other situations were not (like merging a piece into an existing stack). 

I'm absolutely flabbergasted that this has existed for apparently forever.