### PR TITLE
6476 Repositioning Stacks/Decks optionally draws ghosted images of other stacks/decks

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/module/map/SetupStack.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/SetupStack.java
@@ -1127,7 +1127,7 @@ public class SetupStack extends AbstractConfigurable implements GameComponent, U
     public void paint(Graphics g) {
       // Since this configurer is non-modal, there is always the possibility that user is switching back and forth.
       // In which case they get to eat the not-inconsequential perf hit of re-whatevering all the configurers.
-      if (!myBoard.getName().equals(getCachedBoard())) {
+      if (isShowOthers() && !myBoard.getName().equals(getCachedBoard())) {
         SetupStack.setCachedBoard(myBoard.getName());
         SetupStack.setUsedBoardWildcard(myBoard.getName());
         for (final SetupStack s : otherStacks) {

--- a/vassal-app/src/main/java/VASSAL/build/module/map/SetupStack.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/SetupStack.java
@@ -1119,9 +1119,9 @@ public class SetupStack extends AbstractConfigurable implements GameComponent, U
       final int x = (int)(s.pos.x * os_scale);
       final int y = (int)(s.pos.y * os_scale);
 
-      final Rectangle bb = s.stackConfigurer.getCachedBoundingBox();
-      bb.x = x;
-      bb.y = y;
+      final Rectangle bb = new Rectangle(s.stackConfigurer.getCachedBoundingBox());
+      bb.x += x;
+      bb.y += y;
 
       if (vrect.intersects(bb)) {
         s.stackConfigurer.drawImage(g, x, y, null, os_scale);

--- a/vassal-app/src/main/java/VASSAL/build/module/map/SetupStack.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/SetupStack.java
@@ -1075,10 +1075,16 @@ public class SetupStack extends AbstractConfigurable implements GameComponent, U
       findOtherStacks();
     }
 
-    private void findOtherStacks() {
+    private void prepareOtherConfigurers() {
       SetupStack.setUsedBoardWildcard(myBoard.getName()); //This will make "any board" stacks match our selected board
       SetupStack.setCachedBoard(myBoard.getName());
+      for (final SetupStack s : otherStacks) {
+        s.prepareConfigurer(myBoard);
+      }
+      SetupStack.setUsedBoardWildcard("");
+    }
 
+    private void findOtherStacks() {
       otherStacks = GameModule
         .getGameModule()
         .getAllDescendantComponentsOf(SetupStack.class)
@@ -1103,11 +1109,9 @@ public class SetupStack extends AbstractConfigurable implements GameComponent, U
         })
         .collect(Collectors.toList());
 
-      for (final SetupStack s : otherStacks) {
-        s.prepareConfigurer(myBoard);
+      if (isShowOthers()) {
+        prepareOtherConfigurers();
       }
-
-      SetupStack.setUsedBoardWildcard("");
     }
 
     private void drawOtherStack(SetupStack s, Graphics2D g, Rectangle vrect, double os_scale) {
@@ -1128,12 +1132,7 @@ public class SetupStack extends AbstractConfigurable implements GameComponent, U
       // Since this configurer is non-modal, there is always the possibility that user is switching back and forth.
       // In which case they get to eat the not-inconsequential perf hit of re-whatevering all the configurers.
       if (isShowOthers() && !myBoard.getName().equals(getCachedBoard())) {
-        SetupStack.setCachedBoard(myBoard.getName());
-        SetupStack.setUsedBoardWildcard(myBoard.getName());
-        for (final SetupStack s : otherStacks) {
-          s.prepareConfigurer(myBoard);
-        }
-        SetupStack.setUsedBoardWildcard("");
+        prepareOtherConfigurers();
       }
 
       final Graphics2D g2d = (Graphics2D) g;

--- a/vassal-app/src/main/java/VASSAL/build/module/map/SetupStack.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/SetupStack.java
@@ -582,6 +582,7 @@ public class SetupStack extends AbstractConfigurable implements GameComponent, U
     if ((stackConfigurer == null) || (stackConfigurer.board != board)) {
       stackConfigurer = new StackConfigurer(this);
       stackConfigurer.board = getConfigureBoard(true);
+      stackConfigurer.cacheBoundingBox();
       updatePosition();
     }
   }
@@ -685,6 +686,7 @@ public class SetupStack extends AbstractConfigurable implements GameComponent, U
     protected BufferedImage dummyImage;
     protected JLabel coords;
     protected JCheckBox shouldShowOthers;
+    protected Rectangle cachedBoundingBox;
 
     public StackConfigurer(SetupStack stack) {
       super(Resources.getString("Editor.SetupStack.adjust_at_start_stack"));
@@ -893,6 +895,14 @@ public class SetupStack extends AbstractConfigurable implements GameComponent, U
         r.height = dummySize.height;
       }
       return r;
+    }
+
+    public void cacheBoundingBox() {
+      cachedBoundingBox = getPieceBoundingBox();
+    }
+
+    public Rectangle getCachedBoundingBox() {
+      return cachedBoundingBox;
     }
 
     @Override
@@ -1104,7 +1114,7 @@ public class SetupStack extends AbstractConfigurable implements GameComponent, U
       final int x = (int)(s.pos.x * os_scale);
       final int y = (int)(s.pos.y * os_scale);
 
-      final Rectangle bb = s.stackConfigurer.getPieceBoundingBox();
+      final Rectangle bb = s.stackConfigurer.getCachedBoundingBox();
       bb.x = x;
       bb.y = y;
 

--- a/vassal-app/src/main/java/VASSAL/build/module/map/SetupStack.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/SetupStack.java
@@ -889,11 +889,12 @@ public class SetupStack extends AbstractConfigurable implements GameComponent, U
     public Rectangle getPieceBoundingBox() {
       final Rectangle r = myPiece == null ? new Rectangle() : myPiece.boundingBox();
       if (r.width == 0 || r.height == 0) {
-        r.x = 0 - dummySize.width / 2;
-        r.y = 0 - dummySize.height / 2;
         r.width = dummySize.width;
         r.height = dummySize.height;
+        r.x = -r.width / 2;
+        r.y = -r.height / 2;
       }
+
       return r;
     }
 

--- a/vassal-app/src/main/java/VASSAL/build/module/map/SetupStack.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/SetupStack.java
@@ -887,7 +887,7 @@ public class SetupStack extends AbstractConfigurable implements GameComponent, U
     }
 
     public Rectangle getPieceBoundingBox() {
-      final Rectangle r = myPiece == null ? new Rectangle() : myPiece.getShape().getBounds();
+      final Rectangle r = myPiece == null ? new Rectangle() : myPiece.boundingBox();
       if (r.width == 0 || r.height == 0) {
         r.x = 0 - dummySize.width / 2;
         r.y = 0 - dummySize.height / 2;

--- a/vassal-app/src/main/resources/VASSAL/i18n/Editor.properties
+++ b/vassal-app/src/main/resources/VASSAL/i18n/Editor.properties
@@ -1756,6 +1756,7 @@ Editor.SetupStack.ctrl_shift_keys_move_stack_faster=Ctrl/Shift Keys - Move stack
 Editor.SetupStack.shift_command_keys_move_stack_faster_mac=Shift/Command Keys - Move stack faster
 Editor.SetupStack.snap_to_grid=Snap to grid
 Editor.SetupStack.any_name=[any]
+Editor.SetupStack.show_others=Show other stacks/decks
 
 # Folder
 Editor.Folder.component_type=Folder


### PR DESCRIPTION
* You have to turn it on with a checkbox (because it's a bit slow/sluggish) 
* -Possibly- it could be optimized and thus run faster? Also possibly that's not worth the trouble. 
* -Certainly- @BrentEaston could make the configurer layout look better

Even in sluggish mode it is something I will often want to use
