### PR TITLE
5090 - Zone defining - when dragging a square to define initial zone, dragging at edge of screen scrolls

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/module/map/boardPicker/board/mapgrid/PolygonEditor.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/boardPicker/board/mapgrid/PolygonEditor.java
@@ -540,6 +540,7 @@ public class PolygonEditor extends JPanel {
       if (SwingUtils.isMainMouseButtonDown(e)) {
         polygon.xpoints[1] = polygon.xpoints[2] = e.getX();
         polygon.ypoints[2] = polygon.ypoints[3] = e.getY();
+        scrollAtEdge(e.getPoint(), 15);
         repaint();
         if (myConfigurer != null) {
           myConfigurer.updateCoords(polygon);


### PR DESCRIPTION
A one-line fix that took 12 years to get done!

