### PR TITLE
10698 - When inventory grouping specifies properties that aren't internally strings ... don't break

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/module/Inventory.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/Inventory.java
@@ -476,7 +476,7 @@ public class Inventory extends AbstractToolbarItem
       if (p instanceof Decorator || p instanceof BasicPiece) {
         for (final String s : groupBy) {
           if (s.length() > 0) {
-            final String prop = (String) p.getLocalizedProperty(s);
+            final String prop = String.valueOf(p.getLocalizedProperty(s)); // Doesn't necessarily start as string
             if (prop != null)
               groups.add(prop);
           }


### PR DESCRIPTION
Fixes #10698

@riverwanderer This should fix the GPIW bug you just encountered. The property you asked to group by was stored internally as not-a-string (but how would you know that) and Java got mad. Should no longer be a problem once this is merged.