### PR TITLE
9063 - Deck Refresher

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/GameModule.java
+++ b/vassal-app/src/main/java/VASSAL/build/GameModule.java
@@ -1723,11 +1723,20 @@ public class GameModule extends AbstractConfigurable
    * @return true if the game is online or has ever had more than one player.
    */
   public boolean isMultiPlayer() {
-    final ServerConnection sv = getServer();
-    if ((sv != null) && sv.isConnected()) return true;
+    if (isMultiplayerConnected()) {
+      return true;
+    }
 
     final PlayerRoster pr = getPlayerRoster();
     return ((pr != null) && pr.isMultiPlayer());
+  }
+
+  /**
+   * @return true if the game is currently online
+   */
+  public boolean isMultiplayerConnected() {
+    final ServerConnection sv = getServer();
+    return (sv != null) && sv.isConnected();
   }
 
   /**

--- a/vassal-app/src/main/java/VASSAL/build/module/BasicLogger.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/BasicLogger.java
@@ -487,11 +487,11 @@ public class BasicLogger implements Logger, Buildable, GameComponent, CommandEnc
 
   /**
    * Mark the current command as a no-undo-past-this-point.
+   *
+   * @param block number extra command(s) into the future to block (when this is being executed "from inside a command")
    */
-  public void blockUndo() {
-    // +2 because this is done by a command that is about to be added to the
-    // list, and there's _also_ a sentinal command added after that
-    dontUndoPast = nextUndo + 2;
+  public void blockUndo(int block) {
+    dontUndoPast = nextUndo + block;
     undoAction.setEnabled(false);
   }
 

--- a/vassal-app/src/main/java/VASSAL/build/module/GameRefresher.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/GameRefresher.java
@@ -889,7 +889,7 @@ public final class GameRefresher implements CommandEncoder, GameComponent {
       g.sendAndLog(command);
 
       if (options.contains("RefreshDecks") && !refresher.isGameActive()) {
-        VASSAL.command.Logger log = GameModule.getGameModule().getLogger();
+        final VASSAL.command.Logger log = GameModule.getGameModule().getLogger();
         if (log instanceof BasicLogger) {
           ((BasicLogger)log).blockUndo(1);
         }

--- a/vassal-app/src/main/java/VASSAL/build/module/GameRefresher.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/GameRefresher.java
@@ -426,6 +426,14 @@ public final class GameRefresher implements CommandEncoder, GameComponent {
               for (final DrawPile drawPile : drawPiles) {
                 final String deckName = deck.getDeckName();
                 if (deckName.equals(drawPile.getAttributeValueString(SetupStack.NAME))) {
+
+                  // If drawPile is owned by a specific board, then we can only match it if that board is active in this game
+                  if (drawPile.getOwningBoardName() != null) {
+                    if (map.getBoardByName(drawPile.getOwningBoardName()) == null) {
+                      continue;
+                    }
+                  }
+
                   deckFound = true;
                   foundDrawPiles.add(drawPile);
 

--- a/vassal-app/src/main/java/VASSAL/build/module/GameRefresher.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/GameRefresher.java
@@ -568,6 +568,11 @@ public final class GameRefresher implements CommandEncoder, GameComponent {
         log(Resources.getString("GameRefresher.refreshable_decks", refreshable));
         log(Resources.getString(options.contains("DeleteOldDecks") ? "GameRefresher.deletable_decks" : "GameRefresher.deletable_decks_2", deletable)); //NON-NLS
         log(Resources.getString(options.contains("AddNewDecks") ? "GameRefresher.addable_decks" : "GameRefresher.addable_decks_2", addable)); //NON-NLS
+
+        final VASSAL.command.Logger log = GameModule.getGameModule().getLogger();
+        if (log instanceof BasicLogger) {
+          ((BasicLogger)log).blockUndo(0);
+        }
       }
     }
   }

--- a/vassal-app/src/main/java/VASSAL/build/module/GameRefresher.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/GameRefresher.java
@@ -447,8 +447,14 @@ public final class GameRefresher implements CommandEncoder, GameComponent {
 
                   // Make sure the deck is in the right place
                   final Point pt = drawPile.getPosition();
+                  final Map newMap = drawPile.getMap();
+                  if (newMap != map) {
+                    map.removePiece(deck);
+                    newMap.addPiece(deck);
+                  }
                   deck.setPosition(pt);
                   for (final GamePiece piece : deck.asList()) {
+                    piece.setMap(newMap);
                     piece.setPosition(pt);
                   }
 

--- a/vassal-app/src/main/java/VASSAL/build/module/GameRefresher.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/GameRefresher.java
@@ -568,11 +568,6 @@ public final class GameRefresher implements CommandEncoder, GameComponent {
         log(Resources.getString("GameRefresher.refreshable_decks", refreshable));
         log(Resources.getString(options.contains("DeleteOldDecks") ? "GameRefresher.deletable_decks" : "GameRefresher.deletable_decks_2", deletable)); //NON-NLS
         log(Resources.getString(options.contains("AddNewDecks") ? "GameRefresher.addable_decks" : "GameRefresher.addable_decks_2", addable)); //NON-NLS
-
-        final VASSAL.command.Logger log = GameModule.getGameModule().getLogger();
-        if (log instanceof BasicLogger) {
-          ((BasicLogger)log).blockUndo(0);
-        }
       }
     }
   }
@@ -892,6 +887,13 @@ public final class GameRefresher implements CommandEncoder, GameComponent {
 
       // Send the update to other clients (only done in Player mode)
       g.sendAndLog(command);
+
+      if (options.contains("RefreshDecks") && !refresher.isGameActive()) {
+        VASSAL.command.Logger log = GameModule.getGameModule().getLogger();
+        if (log instanceof BasicLogger) {
+          ((BasicLogger)log).blockUndo(1);
+        }
+      }
 
       exit();
     }

--- a/vassal-app/src/main/java/VASSAL/build/module/GameRefresher.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/GameRefresher.java
@@ -432,6 +432,14 @@ public final class GameRefresher implements CommandEncoder, GameComponent {
 
                   // This refreshes the existing deck with all the up-to-date drawPile fields from the module
                   deck.myRefreshType(drawPile.getDeckType());
+
+                  // Make sure the deck is in the right place
+                  final Point pt = drawPile.getPosition();
+                  deck.setPosition(pt);
+                  for (final GamePiece piece : deck.asList()) {
+                    piece.setPosition(pt);
+                  }
+
                   refreshable++;
                   break;
                 }

--- a/vassal-app/src/main/java/VASSAL/build/module/GameRefresher.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/GameRefresher.java
@@ -441,7 +441,9 @@ public final class GameRefresher implements CommandEncoder, GameComponent {
                   log(Resources.getString("GameRefresher.refreshing_deck", deckName, drawPileName));
 
                   // This refreshes the existing deck with all the up-to-date drawPile fields from the module
+                  deck.removeListeners();
                   deck.myRefreshType(drawPile.getDeckType());
+                  deck.addListeners();
 
                   // Make sure the deck is in the right place
                   final Point pt = drawPile.getPosition();

--- a/vassal-app/src/main/java/VASSAL/build/module/GameRefresher.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/GameRefresher.java
@@ -688,6 +688,7 @@ public final class GameRefresher implements CommandEncoder, GameComponent {
     private JCheckBox deleteOldDecks;
     private JCheckBox addNewDecks;
     private final Set<String> options = new HashSet<>();
+    JButton runButton;
 
     RefreshDialog(GameRefresher refresher) {
       super(GameModule.getGameModule().getPlayerWindow());
@@ -717,7 +718,7 @@ public final class GameRefresher implements CommandEncoder, GameComponent {
       final JPanel buttonPanel = new JPanel(new MigLayout("ins 0", "push[]rel[]rel[]push")); // NON-NLS
 
 
-      final JButton runButton = new JButton(Resources.getString("General.run"));
+      runButton = new JButton(Resources.getString("General.run"));
       runButton.addActionListener(e -> run());
 
       final JButton exitButton = new JButton(Resources.getString("General.cancel"));
@@ -809,7 +810,13 @@ public final class GameRefresher implements CommandEncoder, GameComponent {
     }
 */
 
+    private boolean hasAlreadyRun = false;
+
     protected void run() {
+      if (hasAlreadyRun) {
+        return;
+      }
+      hasAlreadyRun = true;
       final GameModule g = GameModule.getGameModule();
       final Command command = new NullCommand();
       final String player = GlobalOptions.getInstance().getPlayerId();
@@ -829,6 +836,7 @@ public final class GameRefresher implements CommandEncoder, GameComponent {
 
       // Send the update to other clients (only done in Player mode)
       g.sendAndLog(command);
+
       exit();
     }
 

--- a/vassal-app/src/main/java/VASSAL/build/module/GameState.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/GameState.java
@@ -411,7 +411,9 @@ public class GameState implements CommandEncoder {
     protected void executeCommand() {
       final Logger l = GameModule.getGameModule().getLogger();
       if (l instanceof BasicLogger) {
-        ((BasicLogger )l).blockUndo();
+        // +2 because this is done by a command that is about to be added to the
+        // list, and there's _also_ a sentinel command added after that
+        ((BasicLogger )l).blockUndo(2);
       }
     }
 

--- a/vassal-app/src/main/java/VASSAL/build/module/map/BoardPicker.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/BoardPicker.java
@@ -739,9 +739,12 @@ public class BoardPicker extends AbstractBuildable implements ActionListener, Ga
     @Override
     protected void executeCommand() {
       target.currentBoards = boards;
-      if (GameModule.getGameModule().getGameState().isGameStarted()) {
+      final GameModule gm = GameModule.getGameModule();
+      if (gm.getGameState().isGameStarted() || gm.isRefreshingSemaphore()) {
         target.map.setBoards(target.getSelectedBoards());
-        target.map.getView().revalidate();
+        if (gm.getGameState().isGameStarted()) {
+          target.map.getView().revalidate();
+        }
       }
     }
 

--- a/vassal-app/src/main/java/VASSAL/build/module/map/DrawPile.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/DrawPile.java
@@ -964,7 +964,10 @@ public class DrawPile extends SetupStack implements PropertySource, PropertyName
   public Point getPosition() {
     final Point p = new Point(pos);
     final Board b = getMap().getBoardByName(owningBoardName);
-    if (b != null) {
+    if (b == null) {
+      p.translate(getMap().getEdgeBuffer().width, getMap().getEdgeBuffer().height);
+    }
+    else {
       p.translate(b.bounds().x, b.bounds().y);
     }
     return p;

--- a/vassal-app/src/main/java/VASSAL/build/module/map/DrawPile.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/DrawPile.java
@@ -992,6 +992,13 @@ public class DrawPile extends SetupStack implements PropertySource, PropertyName
     return getMap().placeOrMerge(p, myDeck == null ? getPosition() : myDeck.getPosition());
   }
 
+  public Deck makeDeck() {
+    myDeck = new Deck(GameModule.getGameModule(), getDeckType());
+    myDeck.setPropertySource(source);
+    myDeck.setFaceDown(!Deck.NEVER.equals(dummy.getFaceDownOption()) && !Deck.USE_MENU_UP.equals(dummy.getFaceDownOption()));
+    return myDeck;
+  }
+
   @Override
   protected Stack initializeContents() {
     final Stack s = super.initializeContents();
@@ -1015,7 +1022,7 @@ public class DrawPile extends SetupStack implements PropertySource, PropertyName
     return false;
   }
 
-  protected String getDeckType() {
+  public String getDeckType() {
     return dummy.getType();
   }
 

--- a/vassal-app/src/main/java/VASSAL/build/module/map/SetupStack.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/SetupStack.java
@@ -273,6 +273,10 @@ public class SetupStack extends AbstractConfigurable implements GameComponent, U
     return true;
   }
 
+  public String getOwningBoardName() {
+    return owningBoardName;
+  }
+
   @Override
   public Command getRestoreCommand() {
     return null;
@@ -604,7 +608,7 @@ public class SetupStack extends AbstractConfigurable implements GameComponent, U
    * Return a board to configure the stack on.
    * @param checkSelectedBoards If true, prefer a board the player has actually selected from the menu over simply the top one in the list.
    */
-  protected Board getConfigureBoard(boolean checkSelectedBoards) {
+  public Board getConfigureBoard(boolean checkSelectedBoards) {
     Board board = null;
 
     final Map map = getMap();

--- a/vassal-app/src/main/java/VASSAL/build/module/map/SetupStack.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/SetupStack.java
@@ -277,6 +277,10 @@ public class SetupStack extends AbstractConfigurable implements GameComponent, U
     return owningBoardName;
   }
 
+  public void setOwningBoardName(String n) {
+    owningBoardName = n;
+  }
+
   @Override
   public Command getRestoreCommand() {
     return null;
@@ -494,6 +498,21 @@ public class SetupStack extends AbstractConfigurable implements GameComponent, U
     return id;
   }
 
+  public List<String> getValidOwningBoards() {
+    final ArrayList<String> l = new ArrayList<>();
+    final Map m = getMap();
+    if (m != null) {
+      l.addAll(Arrays.asList(m.getBoardPicker().getAllowableBoardNames()));
+    }
+    else {
+      for (final Map m2 : Map.getMapList()) {
+        l.addAll(
+          Arrays.asList(m2.getBoardPicker().getAllowableBoardNames()));
+      }
+    }
+    return l;
+  }
+
   public static class OwningBoardPrompt extends TranslatableStringEnum {
     public static final String ANY = "<any>"; //NON-NLS
     public static final String ANY_NAME = Resources.getString("Editor.SetupStack.any_name");
@@ -513,16 +532,16 @@ public class SetupStack extends AbstractConfigurable implements GameComponent, U
       if (target instanceof SetupStack) {
         final ArrayList<String> l = new ArrayList<>();
         l.add(ANY);
-        final Map m = ((SetupStack) target).getMap();
-        if (m != null) {
-          l.addAll(Arrays.asList(m.getBoardPicker().getAllowableBoardNames()));
+        l.addAll(((SetupStack) target).getValidOwningBoards());
+
+        // If we've been left with an illegal board (e.g. the board got deleted or we got cut-and-paste to a map without it), at least
+        // show that we have the wrong value when someone brings up the configurer. (This also lets it be changed to "any" rather than
+        // spuriously showing it is already set to "any").
+        final String owning = ((SetupStack) target).getOwningBoardName();
+        if ((owning != null) && !l.contains(owning)) {
+          l.add(owning);
         }
-        else {
-          for (final Map m2 : Map.getMapList()) {
-            l.addAll(
-              Arrays.asList(m2.getBoardPicker().getAllowableBoardNames()));
-          }
-        }
+
         values = l.toArray(new String[0]);
       }
       else {
@@ -536,17 +555,31 @@ public class SetupStack extends AbstractConfigurable implements GameComponent, U
       final String[] values;
       if (target instanceof SetupStack) {
         final ArrayList<String> l = new ArrayList<>();
+        final ArrayList<String> lkey = new ArrayList<>();
         l.add(ANY_NAME);
+        lkey.add(ANY);
         final Map m = ((SetupStack) target).getMap();
         if (m != null) {
           l.addAll(Arrays.asList(m.getBoardPicker().getAllowableLocalizedBoardNames()));
+          lkey.addAll(Arrays.asList(m.getBoardPicker().getAllowableBoardNames()));
         }
         else {
           for (final Map m2 : Map.getMapList()) {
             l.addAll(
               Arrays.asList(m2.getBoardPicker().getAllowableLocalizedBoardNames()));
+            lkey.addAll(
+              Arrays.asList(m2.getBoardPicker().getAllowableBoardNames()));
           }
         }
+
+        // If we've been left with an illegal board (e.g. the board got deleted or we got cut-and-paste to a map without it), at least
+        // show that we have the wrong value when someone brings up the configurer (this also lets it be changed to "any" rather than
+        // spuriously showing it is already set to "any")
+        final String owning = ((SetupStack) target).getOwningBoardName();
+        if ((owning != null) && !lkey.contains(owning)) {
+          l.add(Resources.getString("Editor.SetupStack.no_such_board", owning));
+        }
+
         values = l.toArray(new String[0]);
       }
       else {

--- a/vassal-app/src/main/java/VASSAL/configure/ConfigureTree.java
+++ b/vassal-app/src/main/java/VASSAL/configure/ConfigureTree.java
@@ -34,6 +34,7 @@ import VASSAL.build.module.documentation.HelpFile;
 import VASSAL.build.module.documentation.HelpWindow;
 import VASSAL.build.module.map.DeckGlobalKeyCommand;
 import VASSAL.build.module.map.MassKeyCommand;
+import VASSAL.build.module.map.SetupStack;
 import VASSAL.build.module.map.boardPicker.board.mapgrid.Zone;
 import VASSAL.build.module.properties.GlobalProperties;
 import VASSAL.build.module.properties.GlobalProperty;
@@ -576,6 +577,27 @@ public class ConfigureTree extends JTree implements PropertyChangeListener, Mous
     return a;
   }
 
+
+  /**
+   * If there are items that need to be adjusted after being pasted (to make sure they don't contain illegal values that will be hard to debug later),
+   * we can make them here.
+   * @param target Item we just pasted
+   */
+  private void postPasteFixups(final Configurable target) {
+    // SetupStacks (and thus DrawPiles) pasted to a new map, but whose owning board setting doesnt exist for this map, are forced to "any"
+    if (target instanceof SetupStack) {
+      final SetupStack ss = (SetupStack)target;
+      final String owning = ss.getOwningBoardName();
+      if (owning != null) {
+        final List<String> validBoards = ss.getValidOwningBoards();
+        if (!ss.getValidOwningBoards().contains(owning)) {
+          ss.setOwningBoardName(null);
+        }
+      }
+    }
+  }
+
+
   protected Action buildPasteAction(final Configurable target) {
     final Action a = new AbstractAction(pasteCmd) {
       private static final long serialVersionUID = 1L;
@@ -592,6 +614,7 @@ public class ConfigureTree extends JTree implements PropertyChangeListener, Mous
           final Configurable convertedCutObj = convertChild(target, cutObj);
           if ((getParent(cutData) == null) || remove(getParent(cutData), cutObj)) {
             insert(target, convertedCutObj, targetNode.getChildCount());
+            postPasteFixups(convertedCutObj);
           }
           copyData = getTreeNode(convertedCutObj);
         }
@@ -609,6 +632,7 @@ public class ConfigureTree extends JTree implements PropertyChangeListener, Mous
             clone.build(copyBase.getBuildElement(Builder.createNewDocument()));
             insert(target, clone, getTreeNode(target).getChildCount());
             updateGpIds(clone);
+            postPasteFixups(clone);
           }
         }
         cutData = null;

--- a/vassal-app/src/main/java/VASSAL/configure/ConfigureTree.java
+++ b/vassal-app/src/main/java/VASSAL/configure/ConfigureTree.java
@@ -33,6 +33,7 @@ import VASSAL.build.module.PrototypeDefinition;
 import VASSAL.build.module.documentation.HelpFile;
 import VASSAL.build.module.documentation.HelpWindow;
 import VASSAL.build.module.map.DeckGlobalKeyCommand;
+import VASSAL.build.module.map.DrawPile;
 import VASSAL.build.module.map.MassKeyCommand;
 import VASSAL.build.module.map.SetupStack;
 import VASSAL.build.module.map.boardPicker.board.mapgrid.Zone;
@@ -589,8 +590,8 @@ public class ConfigureTree extends JTree implements PropertyChangeListener, Mous
       final SetupStack ss = (SetupStack)target;
       final String owning = ss.getOwningBoardName();
       if (owning != null) {
-        final List<String> validBoards = ss.getValidOwningBoards();
         if (!ss.getValidOwningBoards().contains(owning)) {
+          ConfigureTree.chat(Resources.getString("Editor.convert_setupstack_or_deck", (target instanceof DrawPile) ? DrawPile.getConfigureTypeName() : SetupStack.getConfigureTypeName(), ss.getConfigureName(), owning));
           ss.setOwningBoardName(null);
         }
       }

--- a/vassal-app/src/main/java/VASSAL/configure/RefreshPredefinedSetupsDialog.java
+++ b/vassal-app/src/main/java/VASSAL/configure/RefreshPredefinedSetupsDialog.java
@@ -112,11 +112,11 @@ public class RefreshPredefinedSetupsDialog extends JDialog {
     testModeOn = new JCheckBox(Resources.getString("GameRefresher.test_mode"));
     panel.add(testModeOn);
     deletePieceNoMap = new JCheckBox(Resources.getString("GameRefresher.delete_piece_no_map"));
-    deletePieceNoMap.setSelected(true);
+    deletePieceNoMap.setSelected(false);
     panel.add(deletePieceNoMap);
 
     refreshDecks = new JCheckBox(Resources.getString("GameRefresher.refresh_decks"));
-    refreshDecks.setSelected(true);
+    refreshDecks.setSelected(false);
     refreshDecks.addChangeListener(new ChangeListener() {
       @Override
       public void stateChanged(ChangeEvent e) {
@@ -127,11 +127,11 @@ public class RefreshPredefinedSetupsDialog extends JDialog {
     panel.add(refreshDecks);
 
     deleteOldDecks = new JCheckBox(Resources.getString("GameRefresher.delete_old_decks"));
-    deleteOldDecks.setSelected(true);
+    deleteOldDecks.setSelected(false);
     panel.add(deleteOldDecks);
 
     addNewDecks = new JCheckBox(Resources.getString("GameRefresher.add_new_decks"));
-    addNewDecks.setSelected(true);
+    addNewDecks.setSelected(false);
     panel.add(addNewDecks);
 
     panel.add(buttonsBox, "grow"); // NON-NLS
@@ -139,6 +139,9 @@ public class RefreshPredefinedSetupsDialog extends JDialog {
 
     setLocationRelativeTo(getOwner());
     SwingUtils.repack(this);
+
+    deleteOldDecks.setVisible(refreshDecks.isSelected());
+    addNewDecks.setVisible(refreshDecks.isSelected());
   }
 
   protected void  setOptions() {

--- a/vassal-app/src/main/java/VASSAL/configure/RefreshPredefinedSetupsDialog.java
+++ b/vassal-app/src/main/java/VASSAL/configure/RefreshPredefinedSetupsDialog.java
@@ -178,8 +178,15 @@ public class RefreshPredefinedSetupsDialog extends JDialog {
     return options.contains("TestMode"); //$NON-NLS-1$
   }
 
-  private void refreshPredefinedSetups() {
 
+  private boolean hasAlreadyRun = false;
+
+  private void refreshPredefinedSetups() {
+    if (hasAlreadyRun) {
+      return;
+    }
+
+    hasAlreadyRun = true;
     refreshButton.setEnabled(false);
 
     setOptions();

--- a/vassal-app/src/main/java/VASSAL/configure/RefreshPredefinedSetupsDialog.java
+++ b/vassal-app/src/main/java/VASSAL/configure/RefreshPredefinedSetupsDialog.java
@@ -25,6 +25,7 @@ import VASSAL.build.module.documentation.HelpFile;
 import VASSAL.i18n.Resources;
 import VASSAL.tools.DataArchive;
 import VASSAL.tools.ErrorDialog;
+import VASSAL.tools.swing.FlowLabel;
 import VASSAL.tools.swing.SwingUtils;
 import java.awt.Frame;
 import java.awt.HeadlessException;
@@ -40,6 +41,9 @@ import javax.swing.JButton;
 import javax.swing.JCheckBox;
 import javax.swing.JDialog;
 import javax.swing.JPanel;
+import javax.swing.event.ChangeEvent;
+import javax.swing.event.ChangeListener;
+
 import net.miginfocom.swing.MigLayout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -53,6 +57,9 @@ public class RefreshPredefinedSetupsDialog extends JDialog {
   private JCheckBox layerNameCheck;
   private JCheckBox testModeOn;
   private JCheckBox deletePieceNoMap;
+  private JCheckBox refreshDecks;
+  private JCheckBox deleteOldDecks;
+  private JCheckBox addNewDecks;
   private final Set<String> options = new HashSet<>();
 
   public RefreshPredefinedSetupsDialog(Frame owner) throws HeadlessException {
@@ -66,6 +73,9 @@ public class RefreshPredefinedSetupsDialog extends JDialog {
 
     final JPanel panel = new JPanel(new MigLayout("hidemode 3,wrap 1" + "," + ConfigurerLayout.STANDARD_GAPY, "[fill]")); // NON-NLS
     panel.setBorder(BorderFactory.createEtchedBorder());
+
+    final FlowLabel header = new FlowLabel(Resources.getString("GameRefresher.predefined_header"));
+    panel.add(header);
 
     final JPanel buttonsBox = new JPanel(new MigLayout("ins 0", "push[]rel[]rel[]push")); // NON-NLS
     refreshButton = new JButton(Resources.getString("General.run"));
@@ -105,6 +115,25 @@ public class RefreshPredefinedSetupsDialog extends JDialog {
     deletePieceNoMap.setSelected(true);
     panel.add(deletePieceNoMap);
 
+    refreshDecks = new JCheckBox(Resources.getString("GameRefresher.refresh_decks"));
+    refreshDecks.setSelected(true);
+    refreshDecks.addChangeListener(new ChangeListener() {
+      @Override
+      public void stateChanged(ChangeEvent e) {
+        deleteOldDecks.setVisible(refreshDecks.isSelected());
+        addNewDecks.setVisible(refreshDecks.isSelected());
+      }
+    });
+    panel.add(refreshDecks);
+
+    deleteOldDecks = new JCheckBox(Resources.getString("GameRefresher.delete_old_decks"));
+    deleteOldDecks.setSelected(true);
+    panel.add(deleteOldDecks);
+
+    addNewDecks = new JCheckBox(Resources.getString("GameRefresher.add_new_decks"));
+    addNewDecks.setSelected(true);
+    panel.add(addNewDecks);
+
     panel.add(buttonsBox, "grow"); // NON-NLS
     add(panel, "grow"); // NON-NLS
 
@@ -128,6 +157,15 @@ public class RefreshPredefinedSetupsDialog extends JDialog {
     }
     if (deletePieceNoMap.isSelected()) {
       options.add("DeleteNoMap"); //$NON-NLS-1$
+    }
+    if (refreshDecks.isSelected()) {
+      options.add("RefreshDecks"); //NON-NLS
+      if (deleteOldDecks.isSelected()) {
+        options.add("DeleteOldDecks"); //NON-NLS
+      }
+      if (addNewDecks.isSelected()) {
+        options.add("AddNewDecks"); //NON-NLS
+      }
     }
   }
 
@@ -196,11 +234,9 @@ public class RefreshPredefinedSetupsDialog extends JDialog {
       finally {
         GameModule.getGameModule().setRefreshingSemaphore(false); //BR// Make sure we definitely lower the semaphore
       }
-
     }
     GameModule.getGameModule().getGameState().setup(false); //BR// Clear out whatever data (pieces, listeners, etc) left over from final game loaded.
 
     refreshButton.setEnabled(true);
   }
-
 }

--- a/vassal-app/src/main/java/VASSAL/counters/Deck.java
+++ b/vassal-app/src/main/java/VASSAL/counters/Deck.java
@@ -597,7 +597,7 @@ public class Deck extends Stack implements PlayerRoster.SideChangeListener {
   }
 
 
-  /** Sets the information for this Deck.  See {@link Decorator#myGetType}
+  /** Sets or refreshes the information for this Deck.  See {@link Decorator#myGetType}
    *  @param type a serialized configuration string to
    *              set the "type information" of this Deck, which is
    *              information that doesn't change during the course of
@@ -605,7 +605,7 @@ public class Deck extends Stack implements PlayerRoster.SideChangeListener {
    *              etc, rules about when deck is shuffled, whether it is
    *              face-up or face down, etc).
    */
-  protected void mySetType(String type) {
+  public void myRefreshType(String type) {
     final SequenceEncoder.Decoder st = new SequenceEncoder.Decoder(type, ';');
     st.nextToken();
     drawOutline = st.nextBoolean(true);
@@ -657,11 +657,18 @@ public class Deck extends Stack implements PlayerRoster.SideChangeListener {
     loadKey         = st.nextNamedKeyStroke(null);
     loadReport      = st.nextToken(Resources.getString("Deck.deck_loaded"));
 
+    commands = null;
+  }
+
+  protected void mySetType(String type) {
+    // Set the type information
+    myRefreshType(type);
+
     restrictAccess  = st.nextBoolean(false);
     owners          = st.nextStringArray(0);
 
     // Find the DrawPile that defines this Deck to access the new Deck Key Commands.
-    // If the designed has removed the DrawPile, or changed the name of it, then myPile will
+    // If the designer has removed the DrawPile, or changed the name of it, then myPile will
     // be null. This will not stop the Deck continuing to work in 'Legacy', but it will not
     // have access to the new-style Deck Key Commands.
     myPile = DrawPile.findDrawPile(getDeckName());

--- a/vassal-app/src/main/java/VASSAL/counters/Deck.java
+++ b/vassal-app/src/main/java/VASSAL/counters/Deck.java
@@ -657,15 +657,15 @@ public class Deck extends Stack implements PlayerRoster.SideChangeListener {
     loadKey         = st.nextNamedKeyStroke(null);
     loadReport      = st.nextToken(Resources.getString("Deck.deck_loaded"));
 
+    restrictAccess  = st.nextBoolean(false);
+    owners          = st.nextStringArray(0);
+
     commands = null;
   }
 
   protected void mySetType(String type) {
     // Set the type information
     myRefreshType(type);
-
-    restrictAccess  = st.nextBoolean(false);
-    owners          = st.nextStringArray(0);
 
     // Find the DrawPile that defines this Deck to access the new Deck Key Commands.
     // If the designer has removed the DrawPile, or changed the name of it, then myPile will

--- a/vassal-app/src/main/resources/VASSAL/i18n/Editor.properties
+++ b/vassal-app/src/main/resources/VASSAL/i18n/Editor.properties
@@ -111,6 +111,7 @@ Editor.top_right=Top right
 Editor.bottom_left=Bottom left
 Editor.bottom_right=Bottom right
 Editor.import_module=Import module
+Editor.convert_setupstack_or_deck=[%1$s] %2$s has "Belongs to Board" field set to a board (%3$s) that does not exist on the map to which it has just been pasted. Belongs to Board set to [any] instead. 
 
 # Serif Font
 Editor.Font.serif=Serif

--- a/vassal-app/src/main/resources/VASSAL/i18n/Editor.properties
+++ b/vassal-app/src/main/resources/VASSAL/i18n/Editor.properties
@@ -1789,6 +1789,7 @@ Editor.SetupStack.shift_command_keys_move_stack_faster_mac=Shift/Command Keys - 
 Editor.SetupStack.snap_to_grid=Snap to grid
 Editor.SetupStack.any_name=[any]
 Editor.SetupStack.show_others=Show other stacks/decks
+Editor.SetupStack.no_such_board=%1$s (NO SUCH BOARD ON THIS MAP) 
 
 # Folder
 Editor.Folder.component_type=Folder

--- a/vassal-app/src/main/resources/VASSAL/i18n/VASSAL.properties
+++ b/vassal-app/src/main/resources/VASSAL/i18n/VASSAL.properties
@@ -634,6 +634,7 @@ GameRefresher.deletable_decks_2=- %1$s Decks deletable (exist in current game bu
 GameRefresher.refresh_decks=Refresh decks' properties with latest settings from module
 GameRefresher.delete_old_decks=Delete decks which no longer exist in the module (any contents will be left on map in a stack)
 GameRefresher.add_new_decks=Add decks to game which have been added to the module since this game was created (empty deck will be added)
+GameRefresher.but_game_is_active=Deck Refresh not available with an active log or server connection
 
 # GameState
 GameState.save_game_query=Save Game?

--- a/vassal-app/src/main/resources/VASSAL/i18n/VASSAL.properties
+++ b/vassal-app/src/main/resources/VASSAL/i18n/VASSAL.properties
@@ -617,6 +617,24 @@ GameRefresher.refresh_error_nostack=Warning: Piece %1$s (%2$s) is not linked to 
 GameRefresher.refresh_error_nostackindex=Warning: Piece %1$s (%2$s) is missing position in stack. Will default to 1
 GameRefresher.refresh_error_nomatch_pieceslot=Cannot refresh piece  %1$s (%2$s): Can't find matching Piece Slot
 
+GameRefresher.header=<html><b>Game Refresher:</b> If you are using a more recent version of the module than this game was created with, this tool will update the pieces and decks in the game to use the latest up-to-date module prototypes & settings. See HELP for additional information.</html>
+GameRefresher.predefined_header=<html><b>Refresh Predefined Setups:</b> This tool updates the piece definitions and decks in all Pre-defined Setups to match the most up-to-date prototype definitions and deck settings. See HELP for additional information.</html>
+GameRefresher.deck_refresh_during_multiplayer=*** Decks cannot be refreshed while a logfile is being created or an online connection exists. ***
+GameRefresher.refreshing_decks=REFRESHING DECKS
+GameRefresher.refreshing_deck=Refreshing Deck: %1$s with properties from module deck %2$s
+GameRefresher.deleting_old_deck=Deleting old deck: %1$s (no matching deck found in module)
+GameRefresher.deletable_with_option=The following decks were not refreshed because no matching deck was found in the module (turn on delete-old-decks option to remove them)
+GameRefresher.adding_new_deck=Adding new deck: %1$s
+GameRefresher.addable_with_option=The following decks exist in the module but not this game/save. (Turn on add-new-decks option to add them)
+GameRefresher.refreshable_decks=- %1$s Decks refreshed
+GameRefresher.addable_decks=- %1$s Decks added
+GameRefresher.addable_decks_2=- %1$s Decks addable (exist in module but not in current game)
+GameRefresher.deletable_decks=- %1$s Decks deleted
+GameRefresher.deletable_decks_2=- %1$s Decks deletable (exist in current game but not in module)
+GameRefresher.refresh_decks=Refresh decks' properties with latest settings from module
+GameRefresher.delete_old_decks=Delete decks which no longer exist in the module (any contents will be left on map in a stack)
+GameRefresher.add_new_decks=Add decks to game which have been added to the module since this game was created (empty deck will be added)
+
 # GameState
 GameState.save_game_query=Save Game?
 GameState.load_game=Load Game...

--- a/vassal-doc/src/main/readme-referencemanual/ReferenceManual/GameRefresher.adoc
+++ b/vassal-doc/src/main/readme-referencemanual/ReferenceManual/GameRefresher.adoc
@@ -20,3 +20,16 @@ Click the _Run_ button when you are ready to perform the refresh. The chat log w
 
 You can then save the game, or simply continue playing it from that point.
 
+==== Deck Refresher
+
+As of VASSAL 3.6 you can also refresh the <<Deck.adoc#top, Decks>> in a module. Like Game Pieces, Decks are not normally updated from the module definitions _during_ a game, and so if you have an updated version of the module and load a saved game the deck will still behave according to the original settings. This maintains backward-compatibility with saves and logs made with earlier versions of a module, but it can become awkward when managing modules that use <<GameModule.adoc#PredefinedSetup,Pre-defined Setups>> as starting positions. The Deck Refresher lets you update, add, and delete decks in a game, for this reason.
+
+If you select the _Refresh decks_ option when running the Game Refresher, existing decks will be refreshed from the latest settings and positions in the module definition. This will update almost all of the properties of the deck, including key commands, menu text, and the various check-box options that configure a deck. A deck can even be moved from one position to another this way. However decks are matched by name, so changing the _name_ of a deck will make the deck refresher think that a deck of the old name has been deleted and a new deck has been created.
+
+===== Adding and Deleting Decks
+When _Refresh decks_ is selected, two additional options also become available, to add and delete decks.
+
+If you select the _Delete decks_ option, then any deck found in the current game that does not match (by name and board) a deck in the module definition will be deleted. Any current contents (e.g. cards) in that deck will be left in a stack at the deck's former location.
+
+If you select the _Add decks_ option, then any _new_ deck found in the module definition that does not exist in the game being refreshed will be _added_. Note this will not add any _contents_ (e.g. cards) to the deck, it will only add the deck. If you need to add contents you will need to arrange to add them separately, e.g. from a piece palette, or dragged in from some other location.
+

--- a/vassal-doc/src/main/readme-referencemanual/ReferenceManual/SavedGameUpdater.adoc
+++ b/vassal-doc/src/main/readme-referencemanual/ReferenceManual/SavedGameUpdater.adoc
@@ -22,3 +22,17 @@ Click the _Run_ button when you are ready to perform the refresh. _All_ Predefin
 
 Note that you should then save your module to complete the update.
 
+==== Deck Refresher
+
+As of VASSAL 3.6 you can also refresh the <<Deck.adoc#top, Decks>> in a module. Like Game Pieces, Decks are not normally updated from the module definitions _during_ a game, and so if you have an updated version of the module and load a saved game the deck will still behave according to the original settings. This maintains backward-compatibility with saves and logs made with earlier versions of a module, but it can become awkward when managing modules that use <<GameModule.adoc#PredefinedSetup,Pre-defined Setups>> as starting positions. The Deck Refresher lets you update, add, and delete decks in a game, for this reason.
+
+If you select the _Refresh decks_ option when running the Game Refresher, existing decks will be refreshed from the latest settings and positions in the module definition. This will update almost all of the properties of the deck, including key commands, menu text, and the various check-box options that configure a deck. A deck can even be moved from one position to another this way. However decks are matched by name, so changing the _name_ of a deck will make the deck refresher think that a deck of the old name has been deleted and a new deck has been created.
+
+===== Adding and Deleting Decks
+When _Refresh decks_ is selected, two additional options also become available, to add and delete decks.
+
+If you select the _Delete decks_ option, then any deck found in the game being refreshed that does not match (by name and board) a deck in the module definition will be deleted. Any current contents (e.g. cards) in that deck will be left in a stack at the deck's former location.
+
+If you select the _Add decks_ option, then any _new_ deck found in the module definition that does not exist in the game being refreshed will be _added_. Note this will not add any _contents_ (e.g. cards) to the deck, it will only add the deck. If you need to add contents you will need to arrange to add them separately, e.g. from a piece palette, or dragged in from some other location.
+
+


### PR DESCRIPTION
This supports basic deck refreshing:
(1) updates decks in the game to latest settings in module
(2) Optionally deletes decks from the game if the deck has been deleted from the module (any current contents of the deck will be left in a stack at the deck's former position)
(3) Optionally adds decks to the game if they have been added to the module. Does NOT add any contents to the deck, whether or not the module defines starting contents -- an empty deck will be added at the location. Module designer will have to work around adding contents by other means (e.g. dragging them in) 
