### PR TITLE
10750 - Place Marker should put stacking markers in a stack (even if parent marker is non-stacking)

### DIFF
--- a/vassal-app/src/main/java/VASSAL/counters/PlaceMarker.java
+++ b/vassal-app/src/main/java/VASSAL/counters/PlaceMarker.java
@@ -242,6 +242,17 @@ public class PlaceMarker extends Decorator implements TranslatablePiece, Recursi
 
       m.repaint();
     }
+    else if (m.getStackMetrics().isStackingEnabled() && !Boolean.TRUE.equals(marker.getProperty(Properties.NO_STACK))) {
+      c = m.placeOrMerge(marker, p);
+      final Stack parent = marker.getParent();
+      if ((parent != null) && (parent.pieceCount > 1)) {
+        if ((placement == STACK_BOTTOM) || (placement == BELOW)) {
+          final ChangeTracker ct = new ChangeTracker(parent);
+          parent.insert(marker, 0);
+          c = c.append(ct.getChangeCommand());
+        }
+      }
+    }
     else {
       c = m.placeAt(marker, p);
     }


### PR DESCRIPTION
Place Marker was placing stacking pieces "Commando" if the placing piece was non-stacking.

Bug report was here:
https://forum.vassalengine.org/t/place-marker-doesnt-stack-counters/72928