### PR TITLE
9118 - Fixed bug where Deck 'count expressions' wouldn't count beanshell, only old-style (now will count either)

### DIFF
--- a/vassal-app/src/main/java/VASSAL/counters/Deck.java
+++ b/vassal-app/src/main/java/VASSAL/counters/Deck.java
@@ -391,10 +391,11 @@ public class Deck extends Stack implements PlayerRoster.SideChangeListener {
     //test all the expressions for this deck
     for (int index = 0; index < countExpressions.length; index++) {
       final MutableProperty.Impl prop = expressionProperties.get(index);
-      final FormattedString formatted =
-        new FormattedString(countExpressions[index].getExpression());
-      final PieceFilter f = PropertiesPieceFilter.parse(formatted.getText((Auditable) this, "Editor.DrawPile.count_express"));
-      if (f.accept(p)) {
+      final FormattedString formatted = new FormattedString(countExpressions[index].getExpression());
+      final String evaluated = formatted.getText(p, (Auditable) this, "Editor.DrawPile.count_express");
+      // If result is "true" then there was a beanshell expression and it evaluated to true. Otherwise try old-style.
+      // We also have to check explicitly against "false" because the PropertiesPieceFilter apparently accepts that as a match - old-style expressions are so cute
+      if ("true".equals(evaluated) || (!"false".equals(evaluated) && PropertiesPieceFilter.parse(evaluated).accept(p))) { //NON-NLS
         final String mapProperty = prop.getPropertyValue();
         if (mapProperty != null) {
           int newValue = Integer.decode(mapProperty);

--- a/vassal-doc/src/main/readme-referencemanual/ReferenceManual/Deck.adoc
+++ b/vassal-doc/src/main/readme-referencemanual/ReferenceManual/Deck.adoc
@@ -153,9 +153,17 @@ These can be whatever you like and must be in the format of:
 <expression name> : <expression>
 ....
 +
+
+Examples (using old-style and new-style expressions, respectively):
++
+....
+battleships:BB=1
+cruisers:{CA==1}
+....
++
+
 For each expression, a map-level property called __<deckName>_<expression name>__ is exposed.
-The exposed value is number of pieces for which that expression evaluates to _true_.
-An example of how to do this is provided below.
+The exposed value is number of pieces for which that expression evaluates to _true_. In the above example, if the deck's _Name_ field contained _Ships_, then the properties _Ships_battleships_ and _Ships_cruisers_ would be exposed.
 
 NOTE: Currently, the only "dynamic" property which can be used in counting expressions is _playerSide_.
 Other dynamic properties will most likely not update if they change after pieces move into a deck.


### PR DESCRIPTION
Fixes #9118