### PR TITLE
10762 - Fix sum() collision with beanshell for e.g. Rollovers, etc by introducing sumProperties() alternative

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/module/properties/SumProperties.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/properties/SumProperties.java
@@ -39,8 +39,8 @@ public class SumProperties implements PropertySource {
   public Object getProperty(Object key) {
     Object value = null;
     final String keyString = key.toString();
-    if (keyString.startsWith("sum(") && keyString.endsWith(")")) { //NON-NLS
-      final String propertyName = keyString.substring(4, keyString.length() - 1);
+    if ((keyString.startsWith("sum(") || keyString.startsWith("sumProperties(")) && keyString.endsWith(")")) { //NON-NLS
+      final String propertyName = keyString.substring(keyString.startsWith("sum(") ? 4 : 14, keyString.length() - 1); // NON-NLS
       int sum = 0;
       boolean indeterminate = false;
       for (final GamePiece p : pieces) {

--- a/vassal-doc/src/main/readme-referencemanual/ReferenceManual/MouseOver.adoc
+++ b/vassal-doc/src/main/readme-referencemanual/ReferenceManual/MouseOver.adoc
@@ -49,7 +49,7 @@ Otherwise, it will display only if 1 or 2 pieces have been included via the sett
 
 *Summary text above pieces:*::  A <<MessageFormat.adoc#top,Message Format>> specifying the text to display above the drawn pieces in the viewer.
 In addition to standard <<Properties.adoc#top,Properties>>, you can include $countPieces$ to count the pieces included in the display. You can also include a property with the name _sum(propertyName)_ where _propertyName_ is a property defined on a Game Piece.
-The sum of the numeric values of this property for all included pieces will be substituted. **Note:** If you are using a Beanshell expression here instead of just substitution with $..$ then for _sum_ you will need to use the Beanshell version of sum as documented in <<Expressions.adoc#top, Expressions>>.
+The sum of the numeric values of this property for all included pieces will be substituted. **Note:** If you are using a Beanshell expression here instead of just substitution with $..$ then for _sum_ you will need to use _sumProperties_ as Beanshell has its own separate sum keyword as documented in <<Expressions.adoc#top, Expressions>>.
 
 *Text below each piece:*::  A <<MessageFormat.adoc#top,Message Format>> specifying the text to display below each included piece.
 


### PR DESCRIPTION
Rollovers (and maybe other things) use the SumProperties class which allow $..$ substitution of a simple `$sum(propertyName)$` into the expression. But if Beanshell is used this local sum() quasi-property collides with the sum() we've built into Beanshell. 

So I've introduced an alternate syntax sumProperties() for folks to use inside their Beanshells. 