### PR TITLE
10772 Allow module images to have English localizations

### DIFF
--- a/vassal-app/src/main/java/VASSAL/i18n/I18nResourcePathFinder.java
+++ b/vassal-app/src/main/java/VASSAL/i18n/I18nResourcePathFinder.java
@@ -46,7 +46,7 @@ public class I18nResourcePathFinder implements ResourcePathFinder {
     if (images == null) {
       images = archive.getImageNameSet(true, true);
     }
-    if (images != null && !language.equals("en")) {
+    if (images != null) {
       path = DataArchive.IMAGE_DIR;
       path = path.substring(0, path.length() - 1);
       path = path + "_" + language + "/" + name;


### PR DESCRIPTION
The code that localizes images makes the assumption that the base language of the module is always English, so does not check if the is an English alternate for an image in the images_en folder. 