### PR TITLE
10774 - Validation messages when Movement Trail traits placed inside of Rotate, Pivot, or Mat Cargo

### DIFF
--- a/vassal-app/src/main/java/VASSAL/counters/Footprint.java
+++ b/vassal-app/src/main/java/VASSAL/counters/Footprint.java
@@ -17,6 +17,7 @@
  */
 package VASSAL.counters;
 
+import VASSAL.build.BadDataReport;
 import VASSAL.build.module.Map;
 import VASSAL.build.module.documentation.HelpFile;
 import VASSAL.command.ChangeTracker;
@@ -29,6 +30,7 @@ import VASSAL.configure.NamedHotKeyConfigurer;
 import VASSAL.configure.StringConfigurer;
 import VASSAL.i18n.PieceI18nData;
 import VASSAL.i18n.Resources;
+import VASSAL.tools.ErrorDialog;
 import VASSAL.tools.NamedKeyStroke;
 import VASSAL.tools.SequenceEncoder;
 import VASSAL.tools.image.ImageUtils;
@@ -144,6 +146,7 @@ public class Footprint extends MovementMarkable {
         pointList.add(new Point(x, y));
       }
     }
+    requireNoOuterRotate();
   }
 
   @Override
@@ -270,6 +273,7 @@ public class Footprint extends MovementMarkable {
    */
   @Override
   public void setMoved(boolean justMoved) {
+    requireNoOuterRotate();
     if (justMoved) {
       recordCurrentPosition();
       final Map map = getMap();
@@ -718,6 +722,23 @@ public class Footprint extends MovementMarkable {
     }
 
     return null;
+  }
+
+  /**
+   * Displays a Bad Module Data warning if a movement trails trait is found inside of a rotation trait
+   */
+  public void requireNoOuterRotate() {
+    Decorator piece = getOuter();
+    while (piece != null) {
+      if ((piece instanceof FreeRotator) || (piece instanceof Pivot) || ((piece instanceof MatCargo) && (((MatCargo)piece).maintainRelativeFacing))) {
+        String name = getName();
+        if ((name == null) || name.isEmpty()) {
+          name = Resources.getString("Decorator.prototype");
+        }
+        ErrorDialog.dataWarning(new BadDataReport(Resources.getString("Decorator.trails_inside_rotate", getBaseDescription(), piece.getBaseDescription()), name));
+      }
+      piece = piece.getOuter();
+    }
   }
 
   @Override

--- a/vassal-app/src/main/java/VASSAL/counters/Footprint.java
+++ b/vassal-app/src/main/java/VASSAL/counters/Footprint.java
@@ -117,6 +117,8 @@ public class Footprint extends MovementMarkable {
   private KeyCommand showTrailCommandOff;
   private KeyCommand showTrailCommandClear;
 
+  private boolean rotateCheckedOnMove;
+
 
   public Footprint() {
     super(Footprint.ID, null);
@@ -273,7 +275,10 @@ public class Footprint extends MovementMarkable {
    */
   @Override
   public void setMoved(boolean justMoved) {
-    requireNoOuterRotate();
+    if (!rotateCheckedOnMove) {
+      requireNoOuterRotate();
+      rotateCheckedOnMove = true;
+    }
     if (justMoved) {
       recordCurrentPosition();
       final Map map = getMap();

--- a/vassal-app/src/main/resources/VASSAL/i18n/VASSAL.properties
+++ b/vassal-app/src/main/resources/VASSAL/i18n/VASSAL.properties
@@ -550,9 +550,12 @@ Deck.not_a_saved_deck=%1$s is not a saved deck file
 Deck.load_failed_title=Load Deck Failed
 Deck.load_failed_text=Failed to load deck from %1$s. It may be incompatible with the current version of the module.
 
+# Decorator
+Decorator.prototype=Prototype
+Decorator.trails_inside_rotate=%1$s trait found above/inside a %2$s trait which could rotate it, and will probably not work properly.
+
 # Deselect
 Deselect.Deselect=Deselect
-
 
 # Dice Button
 Dice.number_of_dice=Number of dice


### PR DESCRIPTION
MOVEMENT TRAILS SHAT THE BED. NEWS AT 11.

![image](https://user-images.githubusercontent.com/3742246/142342425-75953d41-83ed-4e7a-8395-5a6a66fffbf6.png)
