### PR TITLE
6195 - Don't thrash Deck properties when just rearranging order

### DIFF
--- a/vassal-app/src/main/java/VASSAL/counters/Deck.java
+++ b/vassal-app/src/main/java/VASSAL/counters/Deck.java
@@ -436,7 +436,7 @@ public class Deck extends Stack implements PlayerRoster.SideChangeListener {
    */
   @Override
   protected void insertPieceAt(GamePiece p, int index, boolean suppressDeckCounts) {
-    super.insertPieceAt(p, index);
+    super.insertPieceAt(p, index, suppressDeckCounts);
     if (!suppressDeckCounts) {
       updateCounts(p, true);
       fireNumCardsProperty();
@@ -464,7 +464,7 @@ public class Deck extends Stack implements PlayerRoster.SideChangeListener {
     if (!suppressDeckCounts) {
       updateCounts(index);
     }
-    super.removePieceAt(index);
+    super.removePieceAt(index, suppressDeckCounts);
     if (!suppressDeckCounts) {
       fireNumCardsProperty();
       if (hotkeyOnEmpty && emptyKey != null && startCount > 0 && pieceCount == 0) {

--- a/vassal-app/src/main/java/VASSAL/counters/Deck.java
+++ b/vassal-app/src/main/java/VASSAL/counters/Deck.java
@@ -425,10 +425,24 @@ public class Deck extends Stack implements PlayerRoster.SideChangeListener {
    */
   @Override
   protected void insertPieceAt(GamePiece p, int index) {
-    super.insertPieceAt(p, index);
-    updateCounts(p, true);
-    fireNumCardsProperty();
+    insertPieceAt(p, index, false);
   }
+
+  /**
+   * Inserts a piece into a specific position into the Deck (counting down from the top)
+   * @param p Piece to insert
+   * @param index "How many cards down into the Deck" to put it.
+   * @param suppressDeckCounts true if ONLY the Stack part of the operation should be performed (we're just rearranging deck order and so don't want extra property updates). Ignored at Stack level.
+   */
+  @Override
+  protected void insertPieceAt(GamePiece p, int index, boolean suppressDeckCounts) {
+    super.insertPieceAt(p, index);
+    if (!suppressDeckCounts) {
+      updateCounts(p, true);
+      fireNumCardsProperty();
+    }
+  }
+
 
   /**
    * Removes a piece from a specific location in the deck
@@ -436,14 +450,29 @@ public class Deck extends Stack implements PlayerRoster.SideChangeListener {
    */
   @Override
   protected void removePieceAt(int index) {
+    removePieceAt(index, false);
+  }
+
+  /**
+   * Removes a piece from a specific location in the deck
+   * @param index Piece to remove, counting down from the top
+   * @param suppressDeckCounts true if deck counts & firing last card keystroke should be suppressed (because we're actually just rearranging deck order)
+   */
+  @Override
+  protected void removePieceAt(int index, boolean suppressDeckCounts) {
     final int startCount = pieceCount;
-    updateCounts(index);
+    if (!suppressDeckCounts) {
+      updateCounts(index);
+    }
     super.removePieceAt(index);
-    fireNumCardsProperty();
-    if (hotkeyOnEmpty && emptyKey != null && startCount > 0 && pieceCount == 0) {
-      gameModule.fireKeyStroke(emptyKey);
+    if (!suppressDeckCounts) {
+      fireNumCardsProperty();
+      if (hotkeyOnEmpty && emptyKey != null && startCount > 0 && pieceCount == 0) {
+        gameModule.fireKeyStroke(emptyKey);
+      }
     }
   }
+
 
   /**
    * Removes all pieces from the Deck.

--- a/vassal-app/src/main/java/VASSAL/counters/Stack.java
+++ b/vassal-app/src/main/java/VASSAL/counters/Stack.java
@@ -154,10 +154,21 @@ public class Stack extends AbstractImageFinder implements GamePiece, StateMergea
     }
   }
 
+
+
+
   /**
    * @param index Index of piece to remove from the stack
    */
   protected void removePieceAt(int index) {
+    removePieceAt(index, false);
+  }
+
+  /**
+   * @param index Index of piece to remove from the stack
+   * @param suppressDeckCounts true if this is should not update deck counts nor fire last-card-in-deck (ignored in a mere Stack)
+   */
+  protected void removePieceAt(int index, boolean suppressDeckCounts) {
     if (index >= 0 && index < pieceCount) {
       pieceCount--;
       for (int i = index; i < pieceCount; ++i) {
@@ -166,6 +177,7 @@ public class Stack extends AbstractImageFinder implements GamePiece, StateMergea
       expanded = expanded && pieceCount > 1;
     }
   }
+
 
   /**
    * Perform some action on a GamePiece that has just been removed this Stack
@@ -182,6 +194,17 @@ public class Stack extends AbstractImageFinder implements GamePiece, StateMergea
    * @param index place to insert it
    */
   protected void insertPieceAt(GamePiece p, int index) {
+    insertPieceAt(p, index, false);
+  }
+
+
+  /**
+   * Insert a piece at a particular point in the stack
+   * @param p piece to insert
+   * @param index place to insert it
+   * @param suppressDeckCounts true if ONLY the Stack part of the operation should be performed (we're just rearranging deck order and so don't want extra property updates). Ignored at Stack level.
+   */
+  protected void insertPieceAt(GamePiece p, int index, boolean suppressDeckCounts) {
     if (index < 0) {
       index = 0;
     }
@@ -202,6 +225,7 @@ public class Stack extends AbstractImageFinder implements GamePiece, StateMergea
     contents[index] = p;
     pieceCount++;
   }
+
 
   /**
    * Marks the stack as empty
@@ -306,12 +330,12 @@ public class Stack extends AbstractImageFinder implements GamePiece, StateMergea
     if (index >= 0) {
       final boolean origExpanded = isExpanded(); // Bug #2766794
       if (pos > index) {
-        insertPieceAt(p, pos + 1);
-        removePieceAt(index);
+        insertPieceAt(p, pos + 1, true);
+        removePieceAt(index, true);
       }
       else {
-        removePieceAt(index);
-        insertPieceAt(p, pos);
+        removePieceAt(index, true);
+        insertPieceAt(p, pos, true);
       }
       setExpanded(origExpanded);
     }


### PR DESCRIPTION
Fixes #6195

Couple of things -- I ran through this bug in 3.6 and was not able to reproduce the effects. I even put a breakpoint on the deck out-of-cards thing to see if it was getting fired extra times. I'm not sure _when_ this problem stopped happening (I couldn't find a smoking gun in the git history), but anyway I could not reproduce it from the demo module.

However there is some stuff where deck properties could be getting updated extra times when merely rearranging the order of the deck, so I've provided a PR to address that. 