### PR TITLE
HexGridNumbering subclasses can be imported w/o crashing

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/module/map/boardPicker/board/mapgrid/HexGridNumbering.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/boardPicker/board/mapgrid/HexGridNumbering.java
@@ -289,7 +289,7 @@ public class HexGridNumbering extends RegularGridNumbering {
 
   @Override
   protected JComponent getGridVisualizer() {
-    if (visualizer == null) {
+    if ((visualizer == null) && (grid != null)) {
       visualizer = new JPanel() {
         private static final long serialVersionUID = 1L;
 

--- a/vassal-app/src/main/java/VASSAL/build/module/map/boardPicker/board/mapgrid/RegularGridNumbering.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/boardPicker/board/mapgrid/RegularGridNumbering.java
@@ -401,7 +401,10 @@ public abstract class RegularGridNumbering extends AbstractConfigurable implemen
     for (final String value : s) {
       c.getConfigurer(value).addPropertyChangeListener(evt -> visualizer.repaint());
     }
-    ((Container) c.getControls()).add(getGridVisualizer(), "span 2, align left");
+    final JComponent gridVisualizer = getGridVisualizer();
+    if (gridVisualizer != null) {
+      ((Container) c.getControls()).add(gridVisualizer, "span 2, align left"); //NON-NLS
+    }
     return c;
   }
 


### PR DESCRIPTION
Fixes #9262 

HexGridNumbering subclasses can now be imported w/o crashing -- they just won't show their full configurer during the initial import. But no further need to hand-edit them into the buildfile.