### PR TITLE
10791 - Cumulative Rotate for Move-Fixed-Distance is now correct?

### DIFF
--- a/vassal-app/src/main/java/VASSAL/counters/FreeRotator.java
+++ b/vassal-app/src/main/java/VASSAL/counters/FreeRotator.java
@@ -203,6 +203,8 @@ public class FreeRotator extends Decorator
     return useUnrotatedShape ? 0.0 : validAngles[angleIndex];
   }
 
+  // These are deprecated and also don't work because MatCargo also rotates things
+  @Deprecated
   public double getCumulativeAngle() {
     double angle = getAngle();
     // Add cumulative angle of any other FreeRotator trait in this piece
@@ -213,6 +215,8 @@ public class FreeRotator extends Decorator
     return angle;
   }
 
+  // These are deprecated and also don't work because MatCargo also rotates things
+  @Deprecated
   public double getCumulativeAngleInRadians() {
     return -PI_180 * getCumulativeAngle();
   }

--- a/vassal-app/src/main/java/VASSAL/counters/FreeRotator.java
+++ b/vassal-app/src/main/java/VASSAL/counters/FreeRotator.java
@@ -204,7 +204,7 @@ public class FreeRotator extends Decorator
   }
 
   // These are deprecated and also don't work because MatCargo also rotates things
-  @Deprecated
+  @Deprecated (since = "2021-11-20", forRemoval = true)
   public double getCumulativeAngle() {
     double angle = getAngle();
     // Add cumulative angle of any other FreeRotator trait in this piece
@@ -216,7 +216,7 @@ public class FreeRotator extends Decorator
   }
 
   // These are deprecated and also don't work because MatCargo also rotates things
-  @Deprecated
+  @Deprecated (since = "2021-11-20", forRemoval = true)
   public double getCumulativeAngleInRadians() {
     return -PI_180 * getCumulativeAngle();
   }

--- a/vassal-app/src/main/java/VASSAL/counters/MatCargo.java
+++ b/vassal-app/src/main/java/VASSAL/counters/MatCargo.java
@@ -419,6 +419,10 @@ public class MatCargo extends Decorator implements TranslatablePiece {
     return mrot == null ? 0.0 : mrot.getAngle();
   }
 
+  public double getMatAngleInRadians() {
+    return -PI_180 * getMatAngle();
+  }
+
   /**
    * If we're maintaining facing to our Mat, rotate our graphics as appropriate to account for that when drawing
    */


### PR DESCRIPTION
The get-cumulative-angle method in FreeRotator was ignoring MatCargo. Fortunately it was only called in Move-Fixed-Distance (Translate.java). So now... maybe it's fixed? LOOK CAREFULLY. 