### PR TITLE
10792 - Fix NPE (Always cache bounding box)

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/module/map/SetupStack.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/SetupStack.java
@@ -628,6 +628,7 @@ public class SetupStack extends AbstractConfigurable implements GameComponent, U
     stackConfigurer = new StackConfigurer(this);
     stackConfigurer.init();
     stackConfigurer.setVisible(true);
+    stackConfigurer.cacheBoundingBox();
   }
 
   protected PieceSlot getTopPiece() {


### PR DESCRIPTION
Fixes #10792 

If the configurer had been the *primary* configurer of an earlier session, it might not have cached its bounding box.