### PR TITLE
Action Buttons now respect rotation. Also fixed a bug in getOuter()

### DIFF
--- a/vassal-app/src/main/java/VASSAL/counters/ActionButton.java
+++ b/vassal-app/src/main/java/VASSAL/counters/ActionButton.java
@@ -40,6 +40,8 @@ import java.awt.Rectangle;
 import java.awt.Shape;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
+import java.awt.geom.AffineTransform;
+import java.awt.geom.Point2D;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -323,7 +325,35 @@ public class ActionButton extends Decorator implements EditablePiece, Loopable {
         }
         else if (piece instanceof ActionButton) {
           final ActionButton action = (ActionButton) piece;
-          if (action.stroke != null && action.stroke.getKeyStroke() != null && action.bounds.contains(point)) {
+
+          // Handle rotation of the piece, movement is relative to the current facing of the unit.
+          // Traverse any traits outward from this trait (ones that could rotate this trait),
+          // and find out what the cumulative rotation is
+          Decorator rotateTrait = action.getOuter();
+          double cumulative = 0.0;
+          while (rotateTrait != null) {
+            if (rotateTrait instanceof FreeRotator) {
+              cumulative += ((FreeRotator)rotateTrait).getAngleInRadians();
+            }
+            else if (rotateTrait instanceof MatCargo) {
+              cumulative += ((MatCargo)rotateTrait).getMatAngleInRadians();
+            }
+            rotateTrait = rotateTrait.getOuter();
+          }
+
+          final Shape shape;
+          // If rotated, apply the rotation
+          if (cumulative != 0.0) {
+            shape = AffineTransform.getRotateInstance(cumulative,
+              0,
+              0)
+              .createTransformedShape(action.bounds);
+          }
+          else {
+            shape = action.bounds;
+          }
+
+          if (action.stroke != null && action.stroke.getKeyStroke() != null && shape.contains(point)) {
             // Save state prior to command
             p.setProperty(Properties.SNAPSHOT, ((PropertyExporter) p).getProperties());
             try {

--- a/vassal-app/src/main/java/VASSAL/counters/ActionButton.java
+++ b/vassal-app/src/main/java/VASSAL/counters/ActionButton.java
@@ -41,7 +41,6 @@ import java.awt.Shape;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.awt.geom.AffineTransform;
-import java.awt.geom.Point2D;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;

--- a/vassal-app/src/main/java/VASSAL/counters/Decorator.java
+++ b/vassal-app/src/main/java/VASSAL/counters/Decorator.java
@@ -296,7 +296,8 @@ public abstract class Decorator extends AbstractImageFinder implements EditableP
   /** @return next piece "outward" (away from BasicPiece) in the trait list. This method is required
    * by {@link Obscurable} to handle masking of getProperty calls. */
   public Decorator getOuter() {
-    return dec;
+    // We have to call getProperty rather than reference "dec", because SetGlobalProperty has a useless-but-overriding member.
+    return (Decorator)getProperty(Properties.OUTER);
   }
 
   /**

--- a/vassal-app/src/main/java/VASSAL/counters/FreeRotator.java
+++ b/vassal-app/src/main/java/VASSAL/counters/FreeRotator.java
@@ -203,6 +203,8 @@ public class FreeRotator extends Decorator
     return useUnrotatedShape ? 0.0 : validAngles[angleIndex];
   }
 
+  // These are deprecated and also don't work because MatCargo also rotates things
+  @Deprecated
   public double getCumulativeAngle() {
     double angle = getAngle();
     // Add cumulative angle of any other FreeRotator trait in this piece
@@ -213,6 +215,8 @@ public class FreeRotator extends Decorator
     return angle;
   }
 
+  // These are deprecated and also don't work because MatCargo also rotates things
+  @Deprecated
   public double getCumulativeAngleInRadians() {
     return -PI_180 * getCumulativeAngle();
   }

--- a/vassal-app/src/main/java/VASSAL/counters/FreeRotator.java
+++ b/vassal-app/src/main/java/VASSAL/counters/FreeRotator.java
@@ -204,7 +204,7 @@ public class FreeRotator extends Decorator
   }
 
   // These are deprecated and also don't work because MatCargo also rotates things
-  @Deprecated
+  @Deprecated (since = "2021-11-20", forRemoval = true)
   public double getCumulativeAngle() {
     double angle = getAngle();
     // Add cumulative angle of any other FreeRotator trait in this piece
@@ -216,7 +216,7 @@ public class FreeRotator extends Decorator
   }
 
   // These are deprecated and also don't work because MatCargo also rotates things
-  @Deprecated
+  @Deprecated (since = "2021-11-20", forRemoval = true)
   public double getCumulativeAngleInRadians() {
     return -PI_180 * getCumulativeAngle();
   }

--- a/vassal-app/src/main/java/VASSAL/counters/MatCargo.java
+++ b/vassal-app/src/main/java/VASSAL/counters/MatCargo.java
@@ -419,6 +419,10 @@ public class MatCargo extends Decorator implements TranslatablePiece {
     return mrot == null ? 0.0 : mrot.getAngle();
   }
 
+  public double getMatAngleInRadians() {
+    return -PI_180 * getMatAngle();
+  }
+
   /**
    * If we're maintaining facing to our Mat, rotate our graphics as appropriate to account for that when drawing
    */


### PR DESCRIPTION
Fixes #6075 

Also, getOuter() was failing if it happened upon a Set Global Property trait specifically. That's now fixed.

I have a rectangular button in Almoravid and I checked rotating it e.g. 45 degrees, and now you have to click exactly in the boundaries of the visible button (whereas before you had to click inside where you knew the pre-rotated shape would have been)

ALSO -- The get-cumulative-angle method in FreeRotator was ignoring MatCargo. Fortunately it was only called in Move-Fixed-Distance (Translate.java). So now... maybe it's fixed? (Merged this in from 10791 because there was shared code)