### PR TITLE
10803 Speeds Game Refresh and general performance in modules with many maps defined

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/GameModule.java
+++ b/vassal-app/src/main/java/VASSAL/build/GameModule.java
@@ -2070,10 +2070,12 @@ public class GameModule extends AbstractConfigurable
     }
 
     //BR// MapName_isVisible property for each map window
-    for (final Map map : Map.getMapList()) {
-      if ((map.getConfigureName() + "_isVisible").equals(key) || (map.getConfigureName().replaceAll(" ", "_") + "_isVisible").equals(key)) { //NON-NLS
-        final Container tla = (map.getComponent() != null) ? ((JPanel)map.getComponent()).getTopLevelAncestor() : null;
-        return String.valueOf(tla != null && tla.isShowing());
+    if (((String)key).contains("_isVisible")) { //NON-NLS
+      for (final Map map : Map.getMapList()) {
+        if ((map.getConfigureName() + "_isVisible").equals(key) || (map.getConfigureName().replaceAll(" ", "_") + "_isVisible").equals(key)) { //NON-NLS
+          final Container tla = (map.getComponent() != null) ? ((JPanel) map.getComponent()).getTopLevelAncestor() : null;
+          return String.valueOf(tla != null && tla.isShowing());
+        }
       }
     }
 


### PR DESCRIPTION
I did a profile on this guys' huge 306mb World in Flames module where he said the Refresh Counters time had gone from "a mere 10 minutes" to more like 50 minutes. Anyway... the guys has some "interesting features" like 57 MAP WINDOWS. But anyway from watching the profiling I was able to isolate this one little place and make his module a fuckton faster. 

So it probably makes everybody's module a non-fuckton faster but still faster.

Anyway we should probably put it in 3.6-beta7 so he can try it out.