### PR TITLE
Misc property lookup optimizations

### DIFF
--- a/vassal-app/src/main/java/VASSAL/counters/Decorator.java
+++ b/vassal-app/src/main/java/VASSAL/counters/Decorator.java
@@ -162,14 +162,14 @@ public abstract class Decorator extends AbstractImageFinder implements EditableP
     else if (Properties.KEY_COMMANDS.equals(key)) {
       return getKeyCommands();
     }
-    else if (Properties.INNER.equals(key)) {
-      return piece;
-    }
     else if (Properties.VISIBLE_STATE.equals(key)) {
       return myGetState() + piece.getProperty(key);
     }
     else if (Properties.SELECTED.equals(key)) {
       return selected;
+    }
+    else if (Properties.INNER.equals(key)) {
+      return piece;
     }
     else {
       return piece.getProperty(key);

--- a/vassal-app/src/main/java/VASSAL/counters/Decorator.java
+++ b/vassal-app/src/main/java/VASSAL/counters/Decorator.java
@@ -156,14 +156,14 @@ public abstract class Decorator extends AbstractImageFinder implements EditableP
    */
   @Override
   public Object getProperty(Object key) {
-    if (Properties.KEY_COMMANDS.equals(key)) {
-      return getKeyCommands();
-    }
-    else if (Properties.INNER.equals(key)) {
+    if (Properties.INNER.equals(key)) {
       return piece;
     }
     else if (Properties.OUTER.equals(key)) {
       return dec;
+    }
+    else if (Properties.KEY_COMMANDS.equals(key)) {
+      return getKeyCommands();
     }
     else if (Properties.VISIBLE_STATE.equals(key)) {
       return myGetState() + piece.getProperty(key);
@@ -519,9 +519,14 @@ public abstract class Decorator extends AbstractImageFinder implements EditableP
    * @return the outermost Decorator/Trait of this piece, i.e. the entire logical Game Piece with all traits
    */
   public static GamePiece getOutermost(GamePiece p) {
-    while (p.getProperty(Properties.OUTER) != null) {
-      p = (GamePiece) p.getProperty(Properties.OUTER);
-    }
+    Object next;
+    //BR// This figures prominently enough in our profiler reports that the slightly awkward look is worth not calling getProperty twice per object.
+    do {
+      next = p.getProperty(Properties.OUTER);
+      if (next != null) {
+        p = (GamePiece)next;
+      }
+    } while (next != null);
     return p;
   }
 

--- a/vassal-app/src/main/java/VASSAL/counters/Decorator.java
+++ b/vassal-app/src/main/java/VASSAL/counters/Decorator.java
@@ -156,11 +156,11 @@ public abstract class Decorator extends AbstractImageFinder implements EditableP
    */
   @Override
   public Object getProperty(Object key) {
-    if (Properties.INNER.equals(key)) {
-      return piece;
-    }
-    else if (Properties.OUTER.equals(key)) {
+    if (Properties.OUTER.equals(key)) {
       return dec;
+    }
+    else if (Properties.INNER.equals(key)) {
+      return piece;
     }
     else if (Properties.KEY_COMMANDS.equals(key)) {
       return getKeyCommands();

--- a/vassal-app/src/main/java/VASSAL/counters/Decorator.java
+++ b/vassal-app/src/main/java/VASSAL/counters/Decorator.java
@@ -159,11 +159,11 @@ public abstract class Decorator extends AbstractImageFinder implements EditableP
     if (Properties.OUTER.equals(key)) {
       return dec;
     }
-    else if (Properties.INNER.equals(key)) {
-      return piece;
-    }
     else if (Properties.KEY_COMMANDS.equals(key)) {
       return getKeyCommands();
+    }
+    else if (Properties.INNER.equals(key)) {
+      return piece;
     }
     else if (Properties.VISIBLE_STATE.equals(key)) {
       return myGetState() + piece.getProperty(key);

--- a/vassal-app/src/main/java/VASSAL/script/ExpressionInterpreter.java
+++ b/vassal-app/src/main/java/VASSAL/script/ExpressionInterpreter.java
@@ -452,14 +452,7 @@ public class ExpressionInterpreter extends AbstractInterpreter implements Loopab
         final Object prop = ps.getProperty(property);
         if (prop != null) {
           final String s1 = prop.toString();
-          if (NumberUtils.isParsable(s1)) {
-            try {
-              result += Integer.parseInt(s1);
-            }
-            catch (NumberFormatException ignored) {
-              // Anything at all goes wrong trying to add the property, just ignore it and treat as 0
-            }
-          }
+          result += NumberUtils.toInt(s1, 0);
         }
       }
       else {
@@ -467,15 +460,7 @@ public class ExpressionInterpreter extends AbstractInterpreter implements Loopab
           final Object prop = gamePiece.getProperty(property);
           if (prop != null) {
             final String s1 = prop.toString();
-            if (NumberUtils.isParsable(s1)) {
-              try {
-                result +=
-                  Integer.parseInt(s1);
-              }
-              catch (NumberFormatException ignored) {
-                // Anything at all goes wrong trying to add the property, just ignore it and treat as 0
-              }
-            }
+            result += NumberUtils.toInt(s1, 0);
           }
         }
       }
@@ -580,14 +565,7 @@ public class ExpressionInterpreter extends AbstractInterpreter implements Loopab
                 final Object prop = gamePiece.getProperty(property);
                 if (prop != null) {
                   final String s1 = prop.toString();
-                  if (NumberUtils.isParsable(s1)) {
-                    try {
-                      result += Integer.parseInt(s1);
-                    }
-                    catch (NumberFormatException e) {
-                      //
-                    }
-                  }
+                  result += NumberUtils.toInt(s1, 0);
                 }
               }
             }
@@ -595,14 +573,7 @@ public class ExpressionInterpreter extends AbstractInterpreter implements Loopab
               final Object prop = piece.getProperty(property);
               if (prop != null) {
                 final String s1 = prop.toString();
-                if (NumberUtils.isParsable(s1)) {
-                  try {
-                    result += Integer.parseInt(s1);
-                  }
-                  catch (NumberFormatException e) {
-                    //
-                  }
-                }
+                result += NumberUtils.toInt(s1, 0);
               }
             }
           }

--- a/vassal-app/src/main/java/VASSAL/script/ExpressionInterpreter.java
+++ b/vassal-app/src/main/java/VASSAL/script/ExpressionInterpreter.java
@@ -456,7 +456,7 @@ public class ExpressionInterpreter extends AbstractInterpreter implements Loopab
             try {
               result += Integer.parseInt(s1);
             }
-            catch (Exception ignored) {
+            catch (NumberFormatException ignored) {
               // Anything at all goes wrong trying to add the property, just ignore it and treat as 0
             }
           }
@@ -472,7 +472,7 @@ public class ExpressionInterpreter extends AbstractInterpreter implements Loopab
                 result +=
                   Integer.parseInt(s1);
               }
-              catch (Exception ignored) {
+              catch (NumberFormatException ignored) {
                 // Anything at all goes wrong trying to add the property, just ignore it and treat as 0
               }
             }
@@ -536,7 +536,7 @@ public class ExpressionInterpreter extends AbstractInterpreter implements Loopab
                 }
               }
             }
-            catch (Exception ignored) {
+            catch (NumberFormatException ignored) {
               // Anything at all goes wrong trying to read the property, just ignore it and treat as 0
             }
           }

--- a/vassal-app/src/main/java/VASSAL/script/ExpressionInterpreter.java
+++ b/vassal-app/src/main/java/VASSAL/script/ExpressionInterpreter.java
@@ -44,6 +44,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.math.NumberUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -448,21 +449,33 @@ public class ExpressionInterpreter extends AbstractInterpreter implements Loopab
     if (ps instanceof GamePiece) {
       final Stack s = ((GamePiece) ps).getParent();
       if (s == null) {
-        try {
-          result += Integer.parseInt(ps.getProperty(property).toString());
-        }
-        catch (Exception ignored) {
-          // Anything at all goes wrong trying to add the property, just ignore it and treat as 0
+        final Object prop = ps.getProperty(property);
+        if (prop != null) {
+          final String s1 = prop.toString();
+          if (NumberUtils.isParsable(s1)) {
+            try {
+              result += Integer.parseInt(s1);
+            }
+            catch (Exception ignored) {
+              // Anything at all goes wrong trying to add the property, just ignore it and treat as 0
+            }
+          }
         }
       }
       else {
         for (final GamePiece gamePiece : s.asList()) {
-          try {
-            result +=
-              Integer.parseInt(gamePiece.getProperty(property).toString());
-          }
-          catch (Exception ignored) {
-            // Anything at all goes wrong trying to add the property, just ignore it and treat as 0
+          final Object prop = gamePiece.getProperty(property);
+          if (prop != null) {
+            final String s1 = prop.toString();
+            if (NumberUtils.isParsable(s1)) {
+              try {
+                result +=
+                  Integer.parseInt(s1);
+              }
+              catch (Exception ignored) {
+                // Anything at all goes wrong trying to add the property, just ignore it and treat as 0
+              }
+            }
           }
         }
       }
@@ -495,9 +508,12 @@ public class ExpressionInterpreter extends AbstractInterpreter implements Loopab
             result++;
           }
           else {
-            final String val = ps.getProperty(property).toString();
-            if (!"".equals(val)) {
-              result++;
+            final Object prop = ps.getProperty(property);
+            if (prop != null) {
+              final String val = prop.toString();
+              if (!"".equals(val)) {
+                result++;
+              }
             }
           }
         }
@@ -512,9 +528,12 @@ public class ExpressionInterpreter extends AbstractInterpreter implements Loopab
         else {
           for (final GamePiece gamePiece: s.asList()) {
             try {
-              final String val = gamePiece.getProperty(property).toString();
-              if (!"".equals(val)) {
-                result++;
+              final Object prop = gamePiece.getProperty(property);
+              if (prop != null) {
+                final String val = prop.toString();
+                if (!"".equals(val)) {
+                  result++;
+                }
               }
             }
             catch (Exception ignored) {
@@ -558,20 +577,32 @@ public class ExpressionInterpreter extends AbstractInterpreter implements Loopab
             if (piece instanceof Stack) {
               final Stack s = (Stack) piece;
               for (final GamePiece gamePiece : s.asList()) {
-                try {
-                  result += Integer.parseInt(gamePiece.getProperty(property).toString());
-                }
-                catch (NumberFormatException e) {
-                  //
+                final Object prop = gamePiece.getProperty(property);
+                if (prop != null) {
+                  final String s1 = prop.toString();
+                  if (NumberUtils.isParsable(s1)) {
+                    try {
+                      result += Integer.parseInt(s1);
+                    }
+                    catch (NumberFormatException e) {
+                      //
+                    }
+                  }
                 }
               }
             }
             else {
-              try {
-                result += Integer.parseInt(piece.getProperty(property).toString());
-              }
-              catch (NumberFormatException e) {
-                //
+              final Object prop = piece.getProperty(property);
+              if (prop != null) {
+                final String s1 = prop.toString();
+                if (NumberUtils.isParsable(s1)) {
+                  try {
+                    result += Integer.parseInt(s1);
+                  }
+                  catch (NumberFormatException e) {
+                    //
+                  }
+                }
               }
             }
           }

--- a/vassal-app/src/main/java/VASSAL/script/ExpressionInterpreter.java
+++ b/vassal-app/src/main/java/VASSAL/script/ExpressionInterpreter.java
@@ -488,22 +488,17 @@ public class ExpressionInterpreter extends AbstractInterpreter implements Loopab
     if (ps instanceof GamePiece) {
       final Stack s = ((GamePiece) ps).getParent();
       if (s == null) {        
-        try {
-          if ("".equals(property)) {
-            result++;
-          }
-          else {
-            final Object prop = ps.getProperty(property);
-            if (prop != null) {
-              final String val = prop.toString();
-              if (!"".equals(val)) {
-                result++;
-              }
+        if ("".equals(property)) {
+          result++;
+        }
+        else {
+          final Object prop = ps.getProperty(property);
+          if (prop != null) {
+            final String val = prop.toString();
+            if (!"".equals(val)) {
+              result++;
             }
           }
-        }
-        catch (Exception ignored) {
-          // Anything at all goes wrong trying to read the property, just ignore it and treat as 0
         }
       }
       else {
@@ -512,17 +507,12 @@ public class ExpressionInterpreter extends AbstractInterpreter implements Loopab
         }
         else {
           for (final GamePiece gamePiece: s.asList()) {
-            try {
-              final Object prop = gamePiece.getProperty(property);
-              if (prop != null) {
-                final String val = prop.toString();
-                if (!"".equals(val)) {
-                  result++;
-                }
+            final Object prop = gamePiece.getProperty(property);
+            if (prop != null) {
+              final String val = prop.toString();
+              if (!"".equals(val)) {
+                result++;
               }
-            }
-            catch (NumberFormatException ignored) {
-              // Anything at all goes wrong trying to read the property, just ignore it and treat as 0
             }
           }
         }


### PR DESCRIPTION
(1) moved INNER and OUTER to the top of the properties check list for Decorator, since they're asked for the most
(2) Adjusted Decorator.getOutermost() to not call getProperty twice for the same thing
(3) Adjusted the ExpressionInterpreter to avoid throwing scads of NPE / NumberFormat exceptions when a piece doesn't have a particular property

None of these make the code _look_ any better but they run faster.