### PR TITLE
Optimization: Check for possible keystrokes in Restrict Commands before evaluating match epression

### DIFF
--- a/vassal-app/src/main/java/VASSAL/counters/RestrictCommands.java
+++ b/vassal-app/src/main/java/VASSAL/counters/RestrictCommands.java
@@ -110,21 +110,21 @@ public class RestrictCommands extends Decorator implements EditablePiece {
     return null;
   }
 
+
   /*
    * Cancel execution of watched KeyStrokes
    */
   @Override
   public Command keyEvent(KeyStroke stroke) {
-    if (!matchesFilter()) {
-      return super.keyEvent(stroke);
-    }
-    else {
-      for (final NamedKeyStroke watchKey : watchKeys) {
-        if (watchKey.equals(stroke)) {
+    for (final NamedKeyStroke watchKey : watchKeys) {
+      if (watchKey.equals(stroke)) {
+        if (matchesFilter()) {
           return null;
         }
+        break;
       }
     }
+
     return super.keyEvent(stroke);
   }
 


### PR DESCRIPTION
They were evaluating the full beanshell even if the key being passed through wasn't the key they were restricting.