### PR TITLE
DrawingMouseoverIndex correctly returned as string. Console now displays null valued properties instead of NPE

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/GameModule.java
+++ b/vassal-app/src/main/java/VASSAL/build/GameModule.java
@@ -2072,7 +2072,7 @@ public class GameModule extends AbstractConfigurable
       return CounterDetailViewer.isDrawingMouseOver();
     }
     else if (DRAWING_MOUSEOVER_INDEX_PROPERTY.equals(key)) {
-      return CounterDetailViewer.isDrawingMouseOver() ? 2 : 1;
+      return String.valueOf(CounterDetailViewer.isDrawingMouseOver() ? 2 : 1);
     }
 
     //BR// MapName_isVisible property for each map window

--- a/vassal-app/src/main/java/VASSAL/build/GameModule.java
+++ b/vassal-app/src/main/java/VASSAL/build/GameModule.java
@@ -2072,7 +2072,7 @@ public class GameModule extends AbstractConfigurable
       return CounterDetailViewer.isDrawingMouseOver();
     }
     else if (DRAWING_MOUSEOVER_INDEX_PROPERTY.equals(key)) {
-      return String.valueOf(CounterDetailViewer.isDrawingMouseOver() ? 2 : 1);
+      return CounterDetailViewer.isDrawingMouseOver() ? "2" : "1";
     }
 
     //BR// MapName_isVisible property for each map window

--- a/vassal-app/src/main/java/VASSAL/build/module/Console.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/Console.java
@@ -173,7 +173,7 @@ public class Console {
         show("[" + property + "]: " + propValue.getPropertyValue());
       }
       else {
-        final String propVal = (String)GameModule.getGameModule().getProperty(property);
+        final String propVal = String.valueOf(GameModule.getGameModule().getProperty(property));
         if (propVal != null) {
           show("[" + property + "]: " + propVal);
         }


### PR DESCRIPTION
Fixes a minor goof in 3.6-beta7 and one other minor console thing that has existed for a while.

(1) DrawingMouseoverIndex was returning an integer. This _ironically_ made it not work when offered to the Embellishment's Follows-Expression field -- it would have an expression evaluation error! So now it returns the "number" in a String, the way Vassal apparently wants it. This made it work as a valid property to pass to Follows Expression Value.

(2) The Console's "property show" was throwing if it was asked to show a non-string property value