### PR TITLE
Fix Deck refreshing when running Game Refresher

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/module/GameRefresher.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/GameRefresher.java
@@ -662,7 +662,7 @@ public final class GameRefresher implements CommandEncoder, GameComponent {
     // Load the new pieces back into the Deck in the same order
     final DrawPile target = DrawPile.findDrawPile(deck.getDeckName());
     for (final GamePiece piece : pieces) {
-      command.append(target.addToContents(piece));
+      command.append(target.addToContents(piece, false));
     }
 
   }

--- a/vassal-app/src/main/java/VASSAL/build/module/GameRefresher.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/GameRefresher.java
@@ -660,9 +660,8 @@ public final class GameRefresher implements CommandEncoder, GameComponent {
     }
 
     // Load the new pieces back into the Deck in the same order
-    final DrawPile target = DrawPile.findDrawPile(deck.getDeckName());
     for (final GamePiece piece : pieces) {
-      command.append(target.addToContents(piece, false));
+      command.append(deck.getMap().placeOrMerge(piece, deck.getPosition()));
     }
 
   }

--- a/vassal-app/src/main/java/VASSAL/build/module/map/DrawPile.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/DrawPile.java
@@ -1002,12 +1002,16 @@ public class DrawPile extends SetupStack implements PropertySource, PropertyName
   }
 
   public Command addToContents(GamePiece p) {
+    return addToContents(p, true);
+  }
+
+  public Command addToContents(GamePiece p, boolean checkAccessibility) {
     // If the piece is already in the Deck, do nothing
     if (myDeck != null && myDeck.indexOf(p) >= 0) {
       return new NullCommand();
     }
     // Don't add to decks we don't have access to
-    if ((myDeck != null) && !myDeck.isAccessible()) {
+    if ((myDeck != null) && checkAccessibility && !myDeck.isAccessible()) {
       return new NullCommand();
     }
     // Merge it in


### PR DESCRIPTION
1. Fix access issue when refreshing Decks with new 'ownership' feature. Symptom is Deck disappears on refresh.
2. Fix issue where all cards from duplicately named Decks in module end up in the first defined Deck after refresh.