### PR TITLE
10835 - Clear Temp User Id when changing sides

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/module/PlayerRoster.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/PlayerRoster.java
@@ -641,9 +641,9 @@ public class PlayerRoster extends AbstractToolbarItem implements CommandEncoder,
       availableNames.get(0)
     );
 
-    final int index = availableNames.indexOf(choice);
-    if (index > 0) {
-      claimSlot(indices.get(index));
+    final int pick = availableNames.indexOf(choice);
+    if ((pick >= 0) && (pick < indices.size())) {
+      claimSlot(indices.get(pick));
     }
   }
 

--- a/vassal-app/src/main/java/VASSAL/build/module/PlayerRoster.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/PlayerRoster.java
@@ -276,6 +276,7 @@ public class PlayerRoster extends AbstractToolbarItem implements CommandEncoder,
     c.execute();
 
     remove(GameModule.getActiveUserId());
+    GameModule.setTempUserId(null); // If we were using a temp user id, stop using it now
 
     final Add a = new Add(this, me.playerId, me.playerName, me.side);
     a.execute();

--- a/vassal-app/src/main/resources/VASSAL/i18n/VASSAL.properties
+++ b/vassal-app/src/main/resources/VASSAL/i18n/VASSAL.properties
@@ -940,7 +940,7 @@ PlayerRoster.current_password=Current Password
 PlayerRoster.empty_password=Empty Password
 PlayerRoster.quoted_password="%1$s"
 PlayerRoster.pick_an_occupied_side=Your password profile matches several active players. Claim which side?
-
+PlayerRoster.none_of_the_above=(None of these are my side)
 
 #PlayerWindow
 


### PR DESCRIPTION
When a player retires from a side, clear any "temp user id" they were using to claim that side (e.g. if they were given the chance to match to a blank password or something). This ensures that they will claim their own new side with their correct password rather than (ack!) the temporary blank password. 

I also needed to introduce a "Remove"-player-from-roster for  this. 

Likewise, I made it so if the first player into the game happens to be a Blank Password person, it doesn't auto-force the next player to start the game into that slot -- instead it "offers it". 

Eventually (for perhaps 3.6.1) we can consider additional flow-improvement measures including:
(1) We can halt players with blank passwords and force them to pick a password before continuing (since they can still auto-match their existing games, and this then prevents them from being a _constant_ problem in this department)
(2) Once players pick real passwords, we could actually _write_ their new passwords into the game state (overwriting their blank password), rather than letting the game limp along with a blank password