### PR TITLE
10838 - Password stuff! 

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/GameModule.java
+++ b/vassal-app/src/main/java/VASSAL/build/GameModule.java
@@ -268,6 +268,12 @@ public class GameModule extends AbstractConfigurable
 
   private boolean matSupport = false; // If no Mats exist in the module, we don't need to spend any time doing mat-related calculations during moves/selects
 
+  private ToggleablePasswordConfigurer passwordConfigurer;
+
+  public ToggleablePasswordConfigurer getPasswordConfigurer() {
+    return passwordConfigurer;
+  }
+
   /**
    * @return True if there are any Mat or MatCargo objects in the module
    */
@@ -713,12 +719,12 @@ public class GameModule extends AbstractConfigurable
     fullName.addPropertyChangeListener(evt -> idChangeSupport.firePropertyChange(evt));
     final TextConfigurer profile = new TextConfigurer(GameModule.PERSONAL_INFO, Resources.getString("Prefs.personal_info"), "");   //$NON-NLS-1$ //$NON-NLS-2$
     profile.addPropertyChangeListener(evt -> idChangeSupport.firePropertyChange(evt));
-    final ToggleablePasswordConfigurer user = new ToggleablePasswordConfigurer(GameModule.SECRET_NAME, Resources.getString("Prefs.password_label"), ""); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-    user.addPropertyChangeListener(evt -> GameModule.setUserId((String) evt.getNewValue()));
+    passwordConfigurer = new ToggleablePasswordConfigurer(GameModule.SECRET_NAME, Resources.getString("Prefs.password_label"), ""); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+    passwordConfigurer.addPropertyChangeListener(evt -> GameModule.setUserId((String) evt.getNewValue()));
     getPrefs().addOption(Resources.getString("Prefs.personal_tab"), fullName);   //$NON-NLS-1$ //$NON-NLS-2$
-    getPrefs().addOption(Resources.getString("Prefs.personal_tab"), user);   //$NON-NLS-1$ //$NON-NLS-2$
+    getPrefs().addOption(Resources.getString("Prefs.personal_tab"), passwordConfigurer);   //$NON-NLS-1$ //$NON-NLS-2$
     getPrefs().addOption(Resources.getString("Prefs.personal_tab"), profile);  //$NON-NLS-1$
-    GameModule.setUserId(user.getValueString());
+    GameModule.setUserId(passwordConfigurer.getValueString());
   }
 
   /**

--- a/vassal-app/src/main/java/VASSAL/build/module/PlayerRoster.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/PlayerRoster.java
@@ -478,6 +478,13 @@ public class PlayerRoster extends AbstractToolbarItem implements CommandEncoder,
       availableSides.toArray(new String[0]));
     sideConfig.setValue(translatedObserver);
 
+    // If they have a non-blank password already, then we just return the side-picking controls
+    final String pwd = (String)GameModule.getGameModule().getPrefs().getValue(GameModule.SECRET_NAME);
+    if ((pwd != null) && !pwd.isBlank()) {
+      return sideConfig.getControls();
+    }
+
+    // Or, if they haven't set a password yet, we plead with them to set one.
     final JPanel panel = new JPanel();
     panel.add(sideConfig.getControls());
     final JLabel message = new JLabel("You have not yet set your password. Proper function of VASSAL requires a non-blank password.");

--- a/vassal-app/src/main/java/VASSAL/build/module/PlayerRoster.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/PlayerRoster.java
@@ -44,7 +44,9 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
+import javax.swing.JLabel;
 import javax.swing.JOptionPane;
+import javax.swing.JPanel;
 
 import org.w3c.dom.Attr;
 import org.w3c.dom.Document;
@@ -475,7 +477,16 @@ public class PlayerRoster extends AbstractToolbarItem implements CommandEncoder,
       Resources.getString("PlayerRoster.join_game_as"), //$NON-NLS-1$
       availableSides.toArray(new String[0]));
     sideConfig.setValue(translatedObserver);
-    return sideConfig.getControls();
+
+    final JPanel panel = new JPanel();
+    panel.add(sideConfig.getControls());
+    final JLabel message = new JLabel("You have not yet set your password. Proper function of VASSAL requires a non-blank password.");
+    panel.add(message);
+
+    final JLabel label = new JLabel("Please set your password: ");
+    panel.add(label);
+    panel.add(GameModule.getGameModule().getPasswordConfigurer().getControls());
+    return panel;
   }
 
   /**

--- a/vassal-app/src/main/java/VASSAL/build/module/PlayerRoster.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/PlayerRoster.java
@@ -35,6 +35,7 @@ import VASSAL.tools.DataArchive;
 import VASSAL.tools.LaunchButton;
 import VASSAL.tools.NamedKeyStroke;
 import VASSAL.tools.SequenceEncoder;
+import VASSAL.tools.swing.FlowLabel;
 
 import java.awt.Component;
 import java.beans.PropertyChangeListener;
@@ -47,6 +48,8 @@ import java.util.Objects;
 import javax.swing.JLabel;
 import javax.swing.JOptionPane;
 import javax.swing.JPanel;
+
+import net.miginfocom.swing.MigLayout;
 
 import org.w3c.dom.Attr;
 import org.w3c.dom.Document;
@@ -485,14 +488,19 @@ public class PlayerRoster extends AbstractToolbarItem implements CommandEncoder,
     }
 
     // Or, if they haven't set a password yet, we plead with them to set one.
-    final JPanel panel = new JPanel();
-    panel.add(sideConfig.getControls());
-    final JLabel message = new JLabel("You have not yet set your password. Proper function of VASSAL requires a non-blank password.");
-    panel.add(message);
+    final JPanel panel = new JPanel(new MigLayout("ins 0", "[]", "[]para[]rel[]"));
+    panel.add(sideConfig.getControls(), "wrap");
 
-    final JLabel label = new JLabel("Please set your password: ");
-    panel.add(label);
-    panel.add(GameModule.getGameModule().getPasswordConfigurer().getControls());
+    final FlowLabel message = new FlowLabel("<html><b>You have not yet set your password. Proper function of VASSAL requires a non-blank password.</b></html>");
+    panel.add(message, "wrap");
+
+    final JLabel label = new JLabel("Please set your password:");
+    panel.add(label, "split 2");
+
+    final Component pwc = GameModule.getGameModule().getPasswordConfigurer().getControls();
+    label.setLabelFor(pwc);
+    panel.add(pwc);
+
     return panel;
   }
 

--- a/vassal-app/src/main/java/VASSAL/build/module/PlayerRoster.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/PlayerRoster.java
@@ -641,9 +641,9 @@ public class PlayerRoster extends AbstractToolbarItem implements CommandEncoder,
       availableNames.get(0)
     );
 
-    final int index = availableNames.indexOf(choice);
-    if (index > 0) {
-      claimSlot(indices.get(index));
+    final int pick = availableNames.indexOf(choice);
+    if ((pick >= 0) && (pick < indices.size())) {
+      claimSlot(indices.get(pick));
     }
   }
 

--- a/vassal-app/src/main/java/VASSAL/build/module/PlayerRoster.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/PlayerRoster.java
@@ -276,6 +276,7 @@ public class PlayerRoster extends AbstractToolbarItem implements CommandEncoder,
     c.execute();
 
     remove(GameModule.getActiveUserId());
+    GameModule.setTempUserId(null); // If we were using a temp user id, stop using it now
 
     final Add a = new Add(this, me.playerId, me.playerName, me.side);
     a.execute();

--- a/vassal-app/src/main/java/VASSAL/build/module/WizardSupport.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/WizardSupport.java
@@ -225,7 +225,7 @@ public class WizardSupport {
 
 
   public InitialWelcomeSteps createInitialWelcomeSteps() {
-    if (!isRealName()) {
+    if (!isRealName() || !isNonBlankPassword()) {
       return new InitialWelcomeSteps(new String[]{ACTION_KEY, InitialWelcomeSteps.NAME_STEP},
         new String[]{Resources.getString("WizardSupport.WizardSupport.EnterName"), Resources.getString("WizardSupport.WizardSupport.SelectPlayMode")}); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
     }
@@ -245,6 +245,19 @@ public class WizardSupport {
   private boolean isRealName() {
     final String name = (String)GameModule.getGameModule().getPrefs().getValue(GameModule.REAL_NAME);
     return name != null && !name.isBlank() && !name.equals(Resources.getString("Prefs.newbie"));
+  }
+
+
+  /**
+   * Returns true if user has supplied a real password for current GameModule.
+   *
+   * Test's whether GameModule.SECRET_NAME is non-empty
+   *
+   * @return <code>true</code> if user supplied a real password
+   */
+  private boolean isNonBlankPassword() {
+    final String pwd = (String)GameModule.getGameModule().getPrefs().getValue(GameModule.SECRET_NAME);
+    return (pwd != null) && !pwd.isBlank();
   }
 
 

--- a/vassal-app/src/main/java/VASSAL/launch/LoadModuleAction.java
+++ b/vassal-app/src/main/java/VASSAL/launch/LoadModuleAction.java
@@ -95,8 +95,8 @@ public class LoadModuleAction extends GameModuleAction {
       module.getPlayerWindow().setVisible(true);
 
       // prompt for username and password if wizard is off
-      // but no username is set
-      if (!isRealName()) {
+      // but no username is set, or password is blank
+      if (!isRealName() || !isNonBlankPassword()) {
         new UsernameAndPasswordDialog(module.getPlayerWindow()).setVisible(true);
       }
     }
@@ -114,4 +114,15 @@ public class LoadModuleAction extends GameModuleAction {
     return name != null && !name.isBlank() && !name.equals(Resources.getString("Prefs.newbie"));
   }
 
+  /**
+   * Returns true if user has supplied a real password for current GameModule.
+   *
+   * Test's whether GameModule.SECRET_NAME is non-empty
+   *
+   * @return <code>true</code> if user supplied a real password
+   */
+  private boolean isNonBlankPassword() {
+    final String pwd = (String)GameModule.getGameModule().getPrefs().getValue(GameModule.SECRET_NAME);
+    return (pwd != null) && !pwd.isBlank();
+  }
 }

--- a/vassal-app/src/main/resources/VASSAL/i18n/VASSAL.properties
+++ b/vassal-app/src/main/resources/VASSAL/i18n/VASSAL.properties
@@ -940,7 +940,7 @@ PlayerRoster.current_password=Current Password
 PlayerRoster.empty_password=Empty Password
 PlayerRoster.quoted_password="%1$s"
 PlayerRoster.pick_an_occupied_side=Your password profile matches several active players. Claim which side?
-
+PlayerRoster.none_of_the_above=(None of these are my side)
 
 #PlayerWindow
 

--- a/vassal-app/src/main/resources/VASSAL/i18n/VASSAL.properties
+++ b/vassal-app/src/main/resources/VASSAL/i18n/VASSAL.properties
@@ -941,6 +941,9 @@ PlayerRoster.empty_password=Empty Password
 PlayerRoster.quoted_password="%1$s"
 PlayerRoster.pick_an_occupied_side=Your password profile matches several active players. Claim which side?
 PlayerRoster.none_of_the_above=(None of these are my side)
+PlayerRoster.need_non_blank_password=<html><b>You have not yet set your password. Proper function of VASSAL requires a non-blank password.</b></html>
+PlayerRoster.please_set_your_password=Please set your password:
+PlayerRoster.failed_pref_write=Failed to write module preferences: %1$s
 
 #PlayerWindow
 


### PR DESCRIPTION
When picking a side in a new game, if the password is currently blank, provide an opportunity to correct that. 

This (alas) doesn't _block_ the ability to leave the field blank, as the "GameSetupSteps" part of the Wizard doesn't seem to utilize the "setProblem" thing that blocks forward progress. 

But if I _do_ set my password in this dialog, it sets it in my preferences and then leaves me alone in the future about my password.

Note -- this PR builds on #10835, and includes everything that's in that.

![image](https://user-images.githubusercontent.com/3742246/143919523-f0b3355a-7c99-4399-8e4c-33f741f6e028.png)
