### PR TITLE
Directly setting coordinates in Zone definer fails to create a Zone

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/module/map/boardPicker/board/mapgrid/PolygonEditor.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/boardPicker/board/mapgrid/PolygonEditor.java
@@ -217,11 +217,7 @@ public class PolygonEditor extends JPanel {
     }
   }
 
-  public static void reset(Polygon p, String pathStr) {
-    if (p == null) {
-      p = new Polygon();
-    }
-    p.reset();
+  private static void parseString(Polygon p, String pathStr) {
     final SequenceEncoder.Decoder sd = new SequenceEncoder.Decoder(pathStr, ';');
     while (sd.hasMoreTokens()) {
       final String s = sd.nextToken();
@@ -239,6 +235,24 @@ public class PolygonEditor extends JPanel {
         }
       }
     }
+  }
+
+  public static Polygon stringToPolygon(String pathStr) {
+    final Polygon p = new Polygon();
+    parseString(p, pathStr);
+    return p.npoints == 0 ? null : p;
+  }
+
+  /** @deprecated Use {@link {#stringToPolygon(String)} for parsing and
+   *  {@link #setPolygon(Polygon)} for setting the editor instead.
+   */
+  @Deprecated(since = "2021-11-29", forRemoval = true)
+  public static void reset(Polygon p, String pathStr) {
+    if (p == null) {
+      p = new Polygon();
+    }
+    p.reset();
+    parseString(p, pathStr);
     if (p.npoints == 0) {
       p = null;
     }
@@ -246,7 +260,7 @@ public class PolygonEditor extends JPanel {
 
   public static String polygonToString(Polygon p) {
     // Sometimes people delete all the points from the polygon. Because of course they do.
-    if ((p == null) || p.npoints == 0) {
+    if (p == null || p.npoints == 0) {
       return "";
     }
 

--- a/vassal-app/src/main/java/VASSAL/build/module/map/boardPicker/board/mapgrid/Zone.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/boardPicker/board/mapgrid/Zone.java
@@ -243,7 +243,7 @@ public class Zone extends AbstractConfigurable implements GridContainer, Mutable
       setConfigureName((String) val);
     }
     else if (PATH.equals(key)) {
-      PolygonEditor.reset(myPolygon, (String) val);
+      myPolygon = PolygonEditor.stringToPolygon((String) val);
     }
     else if (LOCATION_FORMAT.equals(key)) {
       locationFormat = (String) val;
@@ -733,7 +733,7 @@ public class Zone extends AbstractConfigurable implements GridContainer, Mutable
             }
           }
           newShape = buffer.toString();
-          PolygonEditor.reset(editor.getPolygon(), newShape);
+          editor.setPolygon(PolygonEditor.stringToPolygon(newShape));
           editor.repaint();
         }
       });
@@ -810,7 +810,7 @@ public class Zone extends AbstractConfigurable implements GridContainer, Mutable
     @Override
     public void setValue(String s) {
       if (editor != null) {
-        PolygonEditor.reset(editor.getPolygon(), s);
+        editor.setPolygon(PolygonEditor.stringToPolygon(s));
       }
     }
   }

--- a/vassal-app/src/main/java/VASSAL/counters/ActionButton.java
+++ b/vassal-app/src/main/java/VASSAL/counters/ActionButton.java
@@ -370,8 +370,7 @@ public class ActionButton extends Decorator implements EditablePiece, Loopable {
             }
           }
           newShape = buffer.toString();
-          final Polygon newPoly = new Polygon();
-          PolygonEditor.reset(newPoly, newShape);
+          final Polygon newPoly = PolygonEditor.stringToPolygon(newShape);
           editor.setPolygon(newPoly); // Need to send it back in this way to get our offsetView respected
           editor.repaint();
         }


### PR DESCRIPTION
PolygonEditor.reset(Polygon, String) was totally broken. Use the proper API to set the polygon on the editor.