### PR TITLE
Use piece as property source in auto-move-report where possible

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/module/map/MovementReporter.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/MovementReporter.java
@@ -205,9 +205,9 @@ public class MovementReporter {
       }
       format.setProperty(Map.MAP_NAME, toMap.getLocalizedConfigureName());
 
-      final List<GamePiece> pieces = ms.getPieces();
+      final GamePiece piece = ms.getFirstPiece();
 
-      final String moveText = format.getLocalizedText(((pieces != null) && !pieces.isEmpty()) ? pieces.get(0) : toMap, toMap, sourceFieldKey);
+      final String moveText = format.getLocalizedText((piece != null) ? piece : toMap, toMap, sourceFieldKey);
 
       if (moveText.length() > 0) {
         c = c.append(new Chatter.DisplayText(GameModule.getGameModule().getChatter(), "* " + moveText));
@@ -315,8 +315,11 @@ public class MovementReporter {
       return oldPosition;
     }
 
-    public List<GamePiece> getPieces() {
-      return new ArrayList<>(pieces);
+    public GamePiece getFirstPiece() {
+      if (pieces.isEmpty()) {
+        return null;
+      }
+      return pieces.get(0);
     }
 
     @Override

--- a/vassal-app/src/main/java/VASSAL/build/module/map/MovementReporter.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/MovementReporter.java
@@ -207,7 +207,7 @@ public class MovementReporter {
 
       final List<GamePiece> pieces = ms.getPieces();
 
-      final String moveText = format.getLocalizedText(((pieces != null) && !pieces.isEmpty()) ? pieces.get(0) : toMap, sourceFieldKey);
+      final String moveText = format.getLocalizedText(((pieces != null) && !pieces.isEmpty()) ? pieces.get(0) : toMap, toMap, sourceFieldKey);
 
       if (moveText.length() > 0) {
         c = c.append(new Chatter.DisplayText(GameModule.getGameModule().getChatter(), "* " + moveText));

--- a/vassal-app/src/main/java/VASSAL/build/module/map/MovementReporter.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/MovementReporter.java
@@ -205,7 +205,9 @@ public class MovementReporter {
       }
       format.setProperty(Map.MAP_NAME, toMap.getLocalizedConfigureName());
 
-      final String moveText = format.getLocalizedText(toMap, sourceFieldKey);
+      final List<GamePiece> pieces = ms.getPieces();
+
+      final String moveText = format.getLocalizedText(((pieces != null) && !pieces.isEmpty()) ? pieces.get(0) : toMap, sourceFieldKey);
 
       if (moveText.length() > 0) {
         c = c.append(new Chatter.DisplayText(GameModule.getGameModule().getChatter(), "* " + moveText));
@@ -311,6 +313,10 @@ public class MovementReporter {
 
     public Point getOldPosition() {
       return oldPosition;
+    }
+
+    public List<GamePiece> getPieces() {
+      return new ArrayList<>(pieces);
     }
 
     @Override


### PR DESCRIPTION
Benkyo was trying to do a property computation in map auto-move-reporting that seemed reasonable, except strangely the movement reports use the Map rather than the GamePiece as the property source, so he couldn't use the piece properties.

This makes use of the piece as the property source. Since it has already been moved to the target (destination) map by the time the movement report is called, those properties remain in scope.