### PR TITLE
10876 - Remove unwanted nulls from Inventory

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/module/Inventory.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/Inventory.java
@@ -531,9 +531,10 @@ public class Inventory extends AbstractToolbarItem
       if (p instanceof Decorator || p instanceof BasicPiece) {
         for (final String s : groupBy) {
           if (s.length() > 0) {
-            final String prop = String.valueOf(p.getLocalizedProperty(s)); // Doesn't necessarily start as string
-            if (prop != null)
-              groups.add(prop);
+            final Object prop = p.getLocalizedProperty(s);
+            if (prop != null) {
+              groups.add(String.valueOf(prop));
+            }
           }
         }
 


### PR DESCRIPTION
This crept in when fixing the properties that weren't strings. But we don't want null ones to suddenly get reported.