### PR TITLE
Added diagnostic to determine what is trying to add stacks to stacks

### DIFF
--- a/vassal-app/src/main/java/VASSAL/counters/Stack.java
+++ b/vassal-app/src/main/java/VASSAL/counters/Stack.java
@@ -295,7 +295,12 @@ public class Stack extends AbstractImageFinder implements GamePiece, StateMergea
       child.getMap().removePiece(child);
     }
     child.setParent(this);
-    insertPieceAt(child, index);
+    if (child instanceof Stack) {
+      throw new IllegalStateException("Cannot insert a stack into another stack");
+    }
+    else {
+      insertPieceAt(child, index);
+    }
   }
 
   /**


### PR DESCRIPTION
See #10873 -- _something_ was adding a stack to a stack as a child. This would at least produce a stack trace in future cases (showing what code path was trying to do that), rather than the current behavior which is that the stack gets half-way inserted.