### PR TITLE
10903 - Incredibly, stacking units placed by At-Start stacks didn't allow Action Buttons on said pieces to function until the piece was moved

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/module/map/SetupStack.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/SetupStack.java
@@ -266,6 +266,11 @@ public class SetupStack extends AbstractConfigurable implements GameComponent, U
         }
       }
       map.placeAt(s, p);
+
+      // Tell any *stacked* pieces what map they are on. 
+      for (final GamePiece piece : s.asList()) {
+        piece.setMap(map);
+      }
     }
   }
 


### PR DESCRIPTION
... because setMap() was never actually called for those pieces. 

So let's call it now -- WHAT COULD GO WRONG?!?!?!?!

It is conceivable that this will fix other subtle bugs about some pieces not realizing what map they were on until they were moved for the first time. Or I suppose it could expose NEW AMAZING BUGS where we used to somehow depend on that behavior. 

https://forum.vassalengine.org/t/version-3-6-1-cant-get-and-action-button-trait/73208/7