### PR TITLE
Show an error dialog if reading a corrupted prefs file

### DIFF
--- a/vassal-app/src/main/java/VASSAL/preferences/Prefs.java
+++ b/vassal-app/src/main/java/VASSAL/preferences/Prefs.java
@@ -180,7 +180,15 @@ public class Prefs implements Closeable {
       try (FileLock lock = ch.lock()) {
         final InputStream in = new BufferedInputStream(Channels.newInputStream(ch));
         storedValues.clear();
-        storedValues.load(in);
+        try {
+          storedValues.load(in);
+        }
+        catch (IllegalArgumentException e) {
+          // This happens if we have a corrupted prefs file, which is not
+          // a very friendly exception for Properties.load() to throw when
+          // doing I/O.
+          throw new IOException("Corrupted prefs file", e);
+        }
       }
     }
     catch (FileNotFoundException | NoSuchFileException e) {


### PR DESCRIPTION
Catch IllegalArgumentException thrown by Properties.load() when reading a corrupted prefs file and wrap in an IOException so we can show an error dialog. (Previously, a corrupted global prefs file could stop the Module Manager from opening and give the user no clue as to why.)