### PR TITLE
10907 - Disabled Toolbar Buttons on Map Windows didn't initialize starting state properly

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/AbstractToolbarItem.java
+++ b/vassal-app/src/main/java/VASSAL/build/AbstractToolbarItem.java
@@ -171,6 +171,8 @@ public abstract class AbstractToolbarItem extends AbstractConfigurable implement
         }
       }
     }
+
+    checkDisabled();
   }
 
   /**


### PR DESCRIPTION
I think buttons that initialized based on global properties that were truly global were working okay, but buttons initialized based on global properties that were part of Map windows (and so "didn't exist" until game setup fully activated) were not initializing properly.

https://forum.vassalengine.org/t/global-key-command-disable-bug/73222/5