### PR TITLE
10931 - Fix NPE in menu text

### DIFF
--- a/vassal-app/src/main/java/VASSAL/counters/KeyCommand.java
+++ b/vassal-app/src/main/java/VASSAL/counters/KeyCommand.java
@@ -176,6 +176,6 @@ public class KeyCommand extends AbstractAction {
 
   private static String makeMenuText(KeyStroke ks, String text) {
     return (ks != null && text != null && !text.isBlank() ?
-      text + "  " + NamedHotKeyConfigurer.getString(ks) : text).intern();
+      text + "  " + NamedHotKeyConfigurer.getString(ks) : (text == null) ? "" : text).intern();
   }
 }


### PR DESCRIPTION
Fixes #10931

@BrentEaston this actually happened down from one of your DeckSendKeyCommand thing (Hooray! Someone is using one already!!!). Possibly this patch will just fix the whole problem, but since this is a newish structural addition, could you possibly check through your various DeckSOMETHINGKey things and make sure they're all copacetic with whatever nulls they're supposed to theoretically pass/not-pass?