### PR TITLE
Prevent Save Game from clobbering log being replayed 

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/module/GameState.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/GameState.java
@@ -127,6 +127,10 @@ public class GameState implements CommandEncoder {
     loadingInBackground = b;
   }
 
+  void setLastSaveFile(File f) {
+    lastSaveFile = f;
+  }
+
   //public GameState() {}
 
   /**
@@ -1046,7 +1050,12 @@ public class GameState implements CommandEncoder {
           else {
             msg = Resources.getString("GameState.loaded", shortName); //$NON-NLS-1$
           }
+
           g.setGameFile(shortName, GameModule.GameFileMode.LOADED_GAME);
+
+          if (((BasicLogger) g.getLogger()).isReplaying()) {
+            lastSaveFile = null;
+          }
         }
         else {
           msg = Resources.getString("GameState.cancel_load", shortName);
@@ -1140,6 +1149,10 @@ public class GameState implements CommandEncoder {
                 msg = Resources.getString("GameState.loaded", shortName); //$NON-NLS-1$
               }
               g.setGameFile(shortName, GameModule.GameFileMode.LOADED_GAME);
+
+              if (((BasicLogger) g.getLogger()).isReplaying()) {
+                lastSaveFile = null;
+              }
             }
             else {
               msg = Resources.getString("GameState.invalid_savefile", shortName);  //$NON-NLS-1$

--- a/vassal-app/src/main/java/VASSAL/build/module/GameState.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/GameState.java
@@ -662,8 +662,6 @@ public class GameState implements CommandEncoder {
           loadGameInBackground(f);
         }
       }
-
-      lastSaveFile = f;
     }
     catch (IOException e) {
       ReadErrorDialog.error(e, f);

--- a/vassal-app/src/main/java/VASSAL/build/module/WizardSupport.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/WizardSupport.java
@@ -692,9 +692,15 @@ public class WizardSupport {
                 new SavedGameLoader(controller, settings, new BufferedInputStream(Files.newInputStream(f.toPath())), POST_LOAD_GAME_WIZARD, f) {
                   @Override
                   public void run() {
-                    GameModule.getGameModule().getFileChooser().setSelectedFile(f); //BR// When loading a saved game from Wizard, put it appropriately into the "default" for the next save/load/etc.
-                    GameModule.getGameModule().setGameFile(f.getName(), GameModule.GameFileMode.LOADED_GAME); //BR// ... aaaand put it in the app window description.
+                    final GameModule g = GameModule.getGameModule();
+                    g.getFileChooser().setSelectedFile(f); //BR// When loading a saved game from Wizard, put it appropriately into the "default" for the next save/load/etc.
+                    g.setGameFile(f.getName(), GameModule.GameFileMode.LOADED_GAME); //BR// ... aaaand put it in the app window description.
                     super.run();
+
+                    g.getGameState().setLastSaveFile(
+                      ((BasicLogger) g.getLogger()).isReplaying() ? null : f
+                    );
+
                     processing.remove(f);
                   }
                 }.start();


### PR DESCRIPTION
Set lastSaveFile to null if we're replaying a log, to prevent Save Game from clobbering the log.