### PR TITLE
Reinstate AbstractBuildable.getComponents()

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/AbstractBuildable.java
+++ b/vassal-app/src/main/java/VASSAL/build/AbstractBuildable.java
@@ -136,6 +136,15 @@ public abstract class AbstractBuildable extends AbstractImageFinder implements B
 
   /**
    * @return all build components that are an instance of the given class
+   * @deprecated Use {@link #getComponentsOf(Class)} instead.
+   */
+  @Deprecated(since = "2020-08-06", forRemoval = true)
+  public <T> Enumeration<T> getComponents(Class<T> target) {
+    return Collections.enumeration(getComponentsOf(target));
+  }
+
+  /**
+   * @return all build components that are an instance of the given class
    */
   public <T> List<T> getComponentsOf(Class<T> target) {
     final ArrayList<T> l = new ArrayList<>();

--- a/vassal-app/src/main/resources/removed
+++ b/vassal-app/src/main/resources/removed
@@ -1,5 +1,4 @@
 VASSAL.build.AbstractBuildable.getAllDescendantComponents(java.lang.Class)	3.6.0
-VASSAL.build.AbstractBuildable.getComponents(java.lang.Class)	3.6.0
 VASSAL.build.GameModule.compareVersions(java.lang.String, java.lang.String)	3.6.0
 VASSAL.build.GameModule.fireKeyStroke(javax.swing.KeyStroke)	3.6.0
 VASSAL.build.GameModule.getFileDialog()	3.6.0


### PR DESCRIPTION
Reinstate AbstractBuildable.getComponents(), since we're getting bug reports about it. (The dependency checker doesn't find that it's deprecated because it's attributed to the leaf class, not to AbstractBuildable...)