### PR TITLE
Reset save dialog filename after close of game

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/module/GameState.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/GameState.java
@@ -764,6 +764,7 @@ public class GameState implements CommandEncoder {
     final FileChooser fc = GameModule.getGameModule().getFileChooser();
     fc.selectDotSavFile();
     fc.addChoosableFileFilter(new LogAndSaveFileFilter());
+    fc.setSelectedFile(lastSaveFile);
 
     if (fc.showSaveDialog() != FileChooser.APPROVE_OPTION) return null;
 
@@ -1148,7 +1149,7 @@ public class GameState implements CommandEncoder {
               }
               g.setGameFile(shortName, GameModule.GameFileMode.LOADED_GAME);
 
-              if (((BasicLogger) g.getLogger()).isReplaying()) {
+              if (((BasicLogger) g.getLogger()).isReplaying() || fromPredefinedSetup) {
                 lastSaveFile = null;
               }
             }

--- a/vassal-app/src/main/java/VASSAL/build/module/GameState.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/GameState.java
@@ -764,7 +764,18 @@ public class GameState implements CommandEncoder {
     final FileChooser fc = GameModule.getGameModule().getFileChooser();
     fc.selectDotSavFile();
     fc.addChoosableFileFilter(new LogAndSaveFileFilter());
-    fc.setSelectedFile(lastSaveFile);
+
+    if (lastSaveFile != null) {
+      // if there is a lastSaveFile, use it as the default
+      fc.setSelectedFile(lastSaveFile);
+    }
+    else {
+      // otherwise, set the directory by the previous file
+      final File f = fc.getSelectedFile();
+      if (f != null && !f.isDirectory()) {
+        fc.setCurrentDirectory(f.getParentFile());
+      }
+    }
 
     if (fc.showSaveDialog() != FileChooser.APPROVE_OPTION) return null;
 


### PR DESCRIPTION
* Actaully reset the save dialog filename before showing it, as it also  hangs on to the filename. AUGH!
* Don't suggest the name of the predefined setup as a save filename.