### PR TITLE
Editor: Don't close window when moving Map or other components relative to Map

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/module/Map.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/Map.java
@@ -1027,11 +1027,6 @@ public class Map extends AbstractToolbarItem implements GameComponent, MouseList
     final GameModule g = GameModule.getGameModule();
     g.getGameState().removeGameComponent(this);
 
-    final Window w = SwingUtilities.getWindowAncestor(theMap);
-    if (w != null) {
-      w.dispose();
-    }
-
     g.getToolBar().remove(getLaunchButton());
     idMgr.remove(this);
     if (picker != null) {

--- a/vassal-app/src/main/java/VASSAL/configure/ConfigureTree.java
+++ b/vassal-app/src/main/java/VASSAL/configure/ConfigureTree.java
@@ -1059,7 +1059,7 @@ public class ConfigureTree extends JTree implements PropertyChangeListener, Mous
     final ArrayList<Configurable> moveToBack = new ArrayList<>();
     for (int i = index; i < oldContents.length; ++i) {
       try {
-        oldContents[i].removeFrom(parent);
+        //oldContents[i].removeFrom(parent);
         parent.remove(oldContents[i]);
       }
       // FIXME: review error message
@@ -1068,7 +1068,7 @@ public class ConfigureTree extends JTree implements PropertyChangeListener, Mous
           "Illegal configuration", JOptionPane.ERROR_MESSAGE); //NON-NLS
         for (int j = index; j < i; ++j) {
           parent.add(oldContents[j]);
-          oldContents[j].addTo(parent);
+          //oldContents[j].addTo(parent);
         }
         return false;
       }
@@ -1093,7 +1093,7 @@ public class ConfigureTree extends JTree implements PropertyChangeListener, Mous
 
     for (final Configurable c : moveToBack) {
       parent.add(c);
-      c.addTo(parent);
+      //c.addTo(parent);
     }
 
     notifyStateChanged(true);

--- a/vassal-app/src/main/java/VASSAL/configure/ConfigureTree.java
+++ b/vassal-app/src/main/java/VASSAL/configure/ConfigureTree.java
@@ -1059,7 +1059,6 @@ public class ConfigureTree extends JTree implements PropertyChangeListener, Mous
     final ArrayList<Configurable> moveToBack = new ArrayList<>();
     for (int i = index; i < oldContents.length; ++i) {
       try {
-        //oldContents[i].removeFrom(parent);
         parent.remove(oldContents[i]);
       }
       // FIXME: review error message
@@ -1068,7 +1067,6 @@ public class ConfigureTree extends JTree implements PropertyChangeListener, Mous
           "Illegal configuration", JOptionPane.ERROR_MESSAGE); //NON-NLS
         for (int j = index; j < i; ++j) {
           parent.add(oldContents[j]);
-          //oldContents[j].addTo(parent);
         }
         return false;
       }
@@ -1093,7 +1091,6 @@ public class ConfigureTree extends JTree implements PropertyChangeListener, Mous
 
     for (final Configurable c : moveToBack) {
       parent.add(c);
-      //c.addTo(parent);
     }
 
     notifyStateChanged(true);


### PR DESCRIPTION
Don't close map window when Map is removed from parent. This prevents the window from closing when the ConfigureTree is reordered in the Editor.