### PR TITLE
Fix ArrayIndexOutOfBoundsException in StringEnumConfigurer

### DIFF
--- a/vassal-app/src/main/java/VASSAL/configure/StringEnumConfigurer.java
+++ b/vassal-app/src/main/java/VASSAL/configure/StringEnumConfigurer.java
@@ -108,7 +108,12 @@ public class StringEnumConfigurer extends Configurer {
 
   @Override
   public String getValueString() {
-    return box != null ? (String) box.getSelectedItem() : validValues[0];
+    if (box != null) {
+      return (String) box.getSelectedItem();
+    }
+    else {
+      return validValues.length > 0 ? validValues[0] : "";
+    }
   }
 
   @Override


### PR DESCRIPTION
validValues might be an empty array; return an empty string in that case.