### PR TITLE
11025 - Gaurd against ClassCastException when MultiActionButtons change property values

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/module/ToolbarMenu.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/ToolbarMenu.java
@@ -284,17 +284,19 @@ public class ToolbarMenu extends AbstractToolbarItem
 
   @Override
   public void propertyChange(PropertyChangeEvent evt) {
-    final JButton b = (JButton) evt.getSource();
-    final JMenuItem mi = buttonsToMenuMap.get(b);
-    if (mi != null) {
-      if (AbstractButton.TEXT_CHANGED_PROPERTY.equals(evt.getPropertyName())) {
-        scheduleBuildMenu();
-      }
-      else if ("enabled".equals(evt.getPropertyName())) { //$NON-NLS-1$
-        mi.setEnabled(b.isEnabled());
-      }
-      else if (AbstractButton.ICON_CHANGED_PROPERTY.equals(evt.getPropertyName())) {
-        mi.setIcon(b.getIcon());
+    if (evt.getSource() instanceof JButton) {
+      final JButton b = (JButton) evt.getSource();
+      final JMenuItem mi = buttonsToMenuMap.get(b);
+      if (mi != null) {
+        if (AbstractButton.TEXT_CHANGED_PROPERTY.equals(evt.getPropertyName())) {
+          scheduleBuildMenu();
+        }
+        else if ("enabled".equals(evt.getPropertyName())) { //$NON-NLS-1$
+          mi.setEnabled(b.isEnabled());
+        }
+        else if (AbstractButton.ICON_CHANGED_PROPERTY.equals(evt.getPropertyName())) {
+          mi.setIcon(b.getIcon());
+        }
       }
     }
   }

--- a/vassal-app/src/main/java/VASSAL/build/module/ToolbarMenu.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/ToolbarMenu.java
@@ -284,6 +284,7 @@ public class ToolbarMenu extends AbstractToolbarItem
 
   @Override
   public void propertyChange(PropertyChangeEvent evt) {
+    super.propertyChange(evt);
     if (evt.getSource() instanceof JButton) {
       final JButton b = (JButton) evt.getSource();
       final JMenuItem mi = buttonsToMenuMap.get(b);


### PR DESCRIPTION
Fixes #11025 

I think that some other level of this object is *also* a PropertyChangeListener and was probably adding it in cases where the property change isn't produced by a JButton, so this one just needs to check and ignore those. 