### PR TITLE
11060 - Fixes to various Toolbar Buttons that weren't respecting the "disable-on-global-property" settings

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/AbstractToolbarItem.java
+++ b/vassal-app/src/main/java/VASSAL/build/AbstractToolbarItem.java
@@ -454,7 +454,9 @@ public abstract class AbstractToolbarItem extends AbstractConfigurable implement
    */
   @Override
   public void addTo(Buildable parent) {
-    GameModule.getGameModule().getToolBar().add(getComponent());
+    final GameModule gm = GameModule.getGameModule();
+    gm.getGameState().addGameComponent(this);
+    gm.getToolBar().add(getComponent());
   }
 
   /**
@@ -463,8 +465,10 @@ public abstract class AbstractToolbarItem extends AbstractConfigurable implement
    */
   @Override
   public void removeFrom(Buildable b) {
-    GameModule.getGameModule().getToolBar().remove(getComponent());
-    GameModule.getGameModule().getToolBar().revalidate();
+    final GameModule gm = GameModule.getGameModule();
+    gm.getToolBar().remove(getComponent());
+    gm.getToolBar().revalidate();
+    gm.getGameState().removeGameComponent(this);
   }
 
   @Override

--- a/vassal-app/src/main/java/VASSAL/build/module/Inventory.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/Inventory.java
@@ -926,6 +926,8 @@ public class Inventory extends AbstractToolbarItem
 
   @Override
   public void setup(boolean gameStarting) {
+    super.setup(gameStarting);
+
     if (!gameStarting) {
       getLaunchButton().setEnabled(false);
     }

--- a/vassal-app/src/main/java/VASSAL/build/module/Map.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/Map.java
@@ -2719,6 +2719,8 @@ public class Map extends AbstractToolbarItem implements GameComponent, MouseList
    */
   @Override
   public void setup(boolean show) {
+    super.setup(show);
+
     final GameModule g = GameModule.getGameModule();
 
     if (show) {

--- a/vassal-app/src/main/java/VASSAL/build/module/NotesWindow.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/NotesWindow.java
@@ -346,6 +346,7 @@ public class NotesWindow extends AbstractToolbarItem
 
   @Override
   public void setup(boolean show) {
+    super.setup(show);
     getLaunchButton().setEnabled(show);
     if (!show) {
       scenarioNotes.setValue(""); //$NON-NLS-1$

--- a/vassal-app/src/main/java/VASSAL/build/module/PlayerRoster.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/PlayerRoster.java
@@ -436,6 +436,7 @@ public class PlayerRoster extends AbstractToolbarItem implements CommandEncoder,
 
   @Override
   public void setup(boolean gameStarting) {
+    super.setup(gameStarting);
     if (gameStarting) {
       claimOccupiedSide();
       if (GameModule.getGameModule().isMultiPlayer()) {

--- a/vassal-app/src/main/java/VASSAL/build/module/SpecialDiceButton.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/SpecialDiceButton.java
@@ -343,6 +343,7 @@ public class SpecialDiceButton extends AbstractToolbarItem implements CommandEnc
       }
     });
     final GameModule mod = GameModule.getGameModule();
+    mod.getGameState().addGameComponent(this);
     ran = mod.getRNG();
     mod.getToolBar().add(launch);
     idMgr.add(this);
@@ -356,6 +357,7 @@ public class SpecialDiceButton extends AbstractToolbarItem implements CommandEnc
     mod.removeCommandEncoder(this);
     mod.getToolBar().remove(launch);
     mod.getToolBar().revalidate();
+    mod.getGameState().removeGameComponent(this);
   }
 
   @Override

--- a/vassal-app/src/main/java/VASSAL/build/module/ToolbarMenu.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/ToolbarMenu.java
@@ -306,6 +306,7 @@ public class ToolbarMenu extends AbstractToolbarItem
 
   @Override
   public void setup(boolean gameStarting) {
+    super.setup(gameStarting);
     // Prevent our Toolbar buttons from becoming visible on Game close/reopen
     scheduleBuildMenu();
   }

--- a/vassal-app/src/main/java/VASSAL/build/module/ToolbarMenu.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/ToolbarMenu.java
@@ -173,6 +173,7 @@ public class ToolbarMenu extends AbstractToolbarItem
       toolbar.addContainerListener(this);
       scheduleBuildMenu();
     }
+    GameModule.getGameModule().getGameState().addGameComponent(this);
   }
 
   @Override
@@ -193,6 +194,7 @@ public class ToolbarMenu extends AbstractToolbarItem
   public void removeFrom(Buildable parent) {
     toolbar.remove(getLaunchButton());
     toolbar.removeContainerListener(this);
+    GameModule.getGameModule().getGameState().removeGameComponent(this);
   }
 
   protected void buildMenu() {

--- a/vassal-app/src/main/java/VASSAL/build/module/map/ImageSaver.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/ImageSaver.java
@@ -108,6 +108,7 @@ public class ImageSaver extends AbstractToolbarItem {
   public void addTo(Buildable b) {
     map = (Map) b;
     map.getToolBar().add(getLaunchButton());
+    GameModule.getGameModule().getGameState().addGameComponent(this);
   }
 
   @Override
@@ -115,6 +116,7 @@ public class ImageSaver extends AbstractToolbarItem {
     map = (Map) b;
     map.getToolBar().remove(getLaunchButton());
     map.getToolBar().revalidate();
+    GameModule.getGameModule().getGameState().removeGameComponent(this);
   }
 
   /** @deprecated Use {@link VASSAL.build.AbstractToolbarItem.IconConfig} instead. */

--- a/vassal-app/src/main/java/VASSAL/build/module/map/LOS_Thread.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/LOS_Thread.java
@@ -238,10 +238,13 @@ public class LOS_Thread extends AbstractToolbarItem implements
       config.addPropertyChangeListener(evt -> threadColor = (Color) evt.getNewValue());
       config.fireUpdate();
     }
+
+    GameModule.getGameModule().getGameState().addGameComponent(this);
   }
 
   @Override
   public void removeFrom(Buildable b) {
+    GameModule.getGameModule().getGameState().removeGameComponent(this);
     if (b instanceof AbstractFolder) {
       b = ((AbstractFolder)b).getNonFolderAncestor();
     }

--- a/vassal-app/src/main/java/VASSAL/build/module/map/LayerControl.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/LayerControl.java
@@ -5,6 +5,7 @@ import java.util.stream.Stream;
 import VASSAL.build.AbstractToolbarItem;
 import VASSAL.build.AutoConfigurable;
 import VASSAL.build.Buildable;
+import VASSAL.build.GameModule;
 import VASSAL.build.module.Map;
 import VASSAL.build.module.documentation.HelpFile;
 import VASSAL.configure.ComponentDescription;
@@ -245,6 +246,7 @@ public class LayerControl extends AbstractToolbarItem implements ComponentDescri
     pieceLayers = (LayeredPieceCollection) parent;
     pieceLayers.getToolBar().add(getLaunchButton());
     pieceCollection = pieceLayers.getPieceCollection();
+    GameModule.getGameModule().getGameState().addGameComponent(this);
   }
 
   @Override
@@ -252,6 +254,7 @@ public class LayerControl extends AbstractToolbarItem implements ComponentDescri
     if (getMap() != null) {
       getMap().getToolBar().remove(getLaunchButton());
     }
+    GameModule.getGameModule().getGameState().removeGameComponent(this);
   }
 
   public Map getMap() {

--- a/vassal-app/src/main/java/VASSAL/build/module/map/MapShader.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/MapShader.java
@@ -634,6 +634,7 @@ public class MapShader extends AbstractToolbarItem implements GameComponent, Dra
    */
   @Override
   public void setup(boolean gameStarting) {
+    super.setup(gameStarting);
     getLaunchButton().setEnabled(gameStarting);
     if (!gameStarting) {
       boardClip = null;

--- a/vassal-app/src/main/java/VASSAL/build/module/map/MassKeyCommand.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/MassKeyCommand.java
@@ -186,6 +186,7 @@ public class MassKeyCommand extends AbstractToolbarItem
     if (parent instanceof PropertySource) {
       propertySource = (PropertySource) parent;
     }
+    GameModule.getGameModule().getGameState().addGameComponent(this);
     setAttributeTranslatable(NAME, false);
     globalCommand.setPropertySource(propertySource);
   }
@@ -529,6 +530,7 @@ public class MassKeyCommand extends AbstractToolbarItem
     if (parent instanceof ToolBarComponent) {
       ((ToolBarComponent)parent).getToolBar().remove(getLaunchButton());
     }
+    GameModule.getGameModule().getGameState().removeGameComponent(this);
   }
 
   public PieceFilter getFilter() {

--- a/vassal-app/src/main/java/VASSAL/build/module/map/PieceRecenterer.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/PieceRecenterer.java
@@ -132,6 +132,7 @@ public class PieceRecenterer extends AbstractToolbarItem implements DeckVisitor 
   public void addTo(Buildable parent) {
     map = (Map)parent;
     map.getToolBar().add(getLaunchButton());
+    GameModule.getGameModule().getGameState().addGameComponent(this);
   }
 
   @Override
@@ -156,5 +157,6 @@ public class PieceRecenterer extends AbstractToolbarItem implements DeckVisitor 
   @Override
   public void removeFrom(Buildable parent) {
     map.getToolBar().remove(getLaunchButton());
+    GameModule.getGameModule().getGameState().removeGameComponent(this);
   }
 }

--- a/vassal-app/src/main/java/VASSAL/build/module/map/TextSaver.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/TextSaver.java
@@ -87,6 +87,7 @@ public class TextSaver extends AbstractToolbarItem {
   public void addTo(Buildable b) {
     map = (Map) b;
     map.getToolBar().add(getLaunchButton());
+    GameModule.getGameModule().getGameState().addGameComponent(this);
   }
 
   @Override
@@ -94,6 +95,7 @@ public class TextSaver extends AbstractToolbarItem {
     map = (Map) b;
     map.getToolBar().remove(getLaunchButton());
     map.getToolBar().revalidate();
+    GameModule.getGameModule().getGameState().removeGameComponent(this);
   }
 
   public void apply() {

--- a/vassal-app/src/main/java/VASSAL/build/module/properties/ChangePropertyButton.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/properties/ChangePropertyButton.java
@@ -192,6 +192,7 @@ public class ChangePropertyButton extends AbstractToolbarItem implements Propert
   @Override
   public void removeFrom(Buildable parent) {
     property.getToolBar().remove(getLaunchButton());
+    GameModule.getGameModule().getGameState().removeGameComponent(this);
   }
 
   @Override
@@ -209,6 +210,7 @@ public class ChangePropertyButton extends AbstractToolbarItem implements Propert
     property = (GlobalProperty) parent;
     property.getToolBar().add(getLaunchButton());
     propChangeConfig.setName(property.getConfigureName());
+    GameModule.getGameModule().getGameState().addGameComponent(this);
   }
 
   public static String getConfigureTypeName() {


### PR DESCRIPTION
AbstractToolbarItem Buttons weren't getting added as components.

Also a bunch of them do their own bespoke addTo without calling super, so had to retrofit it in there too. 