### PR TITLE
Documentation updates for DrawingMouseover / DrawingMouseover Index

### DIFF
--- a/vassal-doc/src/main/readme-referencemanual/ReferenceManual/BasicPiece.adoc
+++ b/vassal-doc/src/main/readme-referencemanual/ReferenceManual/BasicPiece.adoc
@@ -57,6 +57,8 @@ If the piece is in a <<ZonedGrid.adoc#top,Zone>> in a Multi-Zone Grid, then whet
 * _Selected_ contains _true_ when the piece has been selected with the mouse
 * _PieceId_ contains a string that uniquely defines the source of the piece.
 All pieces sourced from the same <<PieceWindow.adoc#top,Game Piece Palette>> slot will have the same PieceId string.
+* _DrawingMouseover_ contains _true_ when a <<MouseOver.adoc#top, Mouseover Stack Viewer>> is currently being drawn, and contains _false_ otherwise.
+* _DrawingMouseoverIndex_ contains 2 when a <<MouseOver.adoc#top, Mouseover Stack Viewer>> is currently being drawn, and contains 1 otherwise. This can be used e.g. in the _Follows Expression_ field of a <<Layer.adoc#top, Layer trait>> to draw a different image for the Mouseover than is normally used when drawing the piece on the map.
 
 The following <<Properties.adoc#top,Properties>> are defined after a piece is moved, either manually by drag-and-drop movement or by a <<SendToLocation.adoc#top,Send To Location>> trait:
 

--- a/vassal-doc/src/main/readme-referencemanual/ReferenceManual/MouseOver.adoc
+++ b/vassal-doc/src/main/readme-referencemanual/ReferenceManual/MouseOver.adoc
@@ -7,7 +7,9 @@
 '''''
 
 === Mouse-over Stack Viewer
+A Mouseover Stack Viewer displays a "rollover" or "tooltip" for a stack when the mouse cursor is moved over it, after a specified delay. The tooltip can be configured to include images and/or display descriptive text about the pieces in the stack. Note that a "stack" for this purpose can consist of a single piece or multiple pieces, or even a deck.
 
+Occasionally pieces will want to "draw themselves differently" inside of a Mouseover Stack Viewer. For this purpose they can check the property `DrawingMouseover` in e.g. a Calculated Property or a Label's "Follows Expression Value" field. Alternatively the property `DrawingMouseoverIndex` will contain 2 while drawing the mouseover, 1 otherwise; this can be useful as an index for a Follows Expression layer because it avoids the substantial performance cost of a full Beanshell expression e.g. `{ DrawingMouseover ? 2 : 1 }`.
 
 [width="100%",cols="50%a,^50%a",]
 |===

--- a/vassal-doc/src/main/readme-referencemanual/ReferenceManual/Properties.adoc
+++ b/vassal-doc/src/main/readme-referencemanual/ReferenceManual/Properties.adoc
@@ -67,6 +67,8 @@ the level in a <<Layer.adoc#Properties,Layer)>> you can use _<_, _\<=_, _>_, and
 |*CurrentY* |<<BasicPiece#top,Basic Piece>>|Current Y-coordinate of the piece.
 |*CurrentZone* |<<BasicPiece#top,Basic Piece>>|Current Zone name if the current map has a <<ZonedGrid.adoc#top,multi-zoned grid>>, or "" if the piece is not in any zone, or not on a map.
 |*DeckName* |<<BasicPiece#top,Basic Piece>>|Current Deck name if stacked in a <<Deck.adoc#top,Deck>>, or "" if not in a Deck.
+|*DrawingMouseover* |<<BasicPiece#top,Basic Piece>>|"true" when a <<MouseOver.adoc#top, Mouseover Stack Viewer>> is currently being drawn, "false" otherwise.
+|*DrawingMouseoverIndex* |<<BasicPiece#top,Basic Piece>>|2 when a <<MouseOver.adoc#top, Mouseover Stack Viewer>> is currently being drawn, 1 otherwise.
 |*IgnoreGrid* |<<NonStacking.adoc#top,Does not stack>> |"true" if this piece ignores the map grid when moving.
 |*Immobile* |<<NonStacking.adoc#top,Does not stack>> |"true" if this piece cannot be moved by drag and drop.
 |*Invisible* |<<Hideable.adoc#top,Invisible>> |"true" if this piece is invisible to the current player.


### PR DESCRIPTION
These were somehow only documented in the Designer's Guide.

So now they are added to the online docs in various places.