### PR TITLE
11073 - Fix situation where Send-to-Location throws exceptions when it can't find target counters

### DIFF
--- a/vassal-app/src/main/java/VASSAL/counters/SendToLocation.java
+++ b/vassal-app/src/main/java/VASSAL/counters/SendToLocation.java
@@ -538,6 +538,12 @@ public class SendToLocation extends Decorator implements TranslatablePiece {
         }
         c = c.append(map.placeOrMerge(outer, dest));
 
+        // The map field might change or even become null through the apply-key processes below, so we schedule our repaints now based on our current information.
+        if (oldMap != null && oldMap != map) {
+          oldMap.repaint();
+        }
+        map.repaint();
+
         // If a cargo piece has been "sent", find it a new Mat if needed.
         c = MatCargo.findNewMat(c, outer);
 
@@ -549,11 +555,6 @@ public class SendToLocation extends Decorator implements TranslatablePiece {
         if (parent != null) {
           c = c.append(parent.pieceRemoved(outer));
         }
-
-        if (oldMap != null && oldMap != map) {
-          oldMap.repaint();
-        }
-        map.repaint();
       }
     }
     else {


### PR DESCRIPTION
The "map" field is not e.g. where the piece is, it's just where the SendToLocation trait thinks its target is. And since we have "send to target counter" with filters, it is possible for there to be no valid target, so map can be null. And in this particular case we were inside a "if (map != null)" so it looked like map couldn't be null, except the apply-on-move key can change that situation by changing what matches filters, etc. So I've moved the reference up above the place where it can change, since repaint is just a "schedule this" call anyway.