### PR TITLE
11069 - Fix crash in Load Deck when an invalid deck file selected in file picker

### DIFF
--- a/vassal-app/src/main/java/VASSAL/counters/Deck.java
+++ b/vassal-app/src/main/java/VASSAL/counters/Deck.java
@@ -1508,11 +1508,13 @@ public class Deck extends Stack implements PlayerRoster.SideChangeListener {
 
   protected void doLoadDeck() {
     Command c = loadDeck();
-    if (!c.isNull() && Map.isChangeReportingEnabled()) {
-      c = c.append(reportCommand(loadReport, Resources.getString(Resources.LOAD)));
+    if (c != null) {
+      if (!c.isNull() && Map.isChangeReportingEnabled()) {
+        c = c.append(reportCommand(loadReport, Resources.getString(Resources.LOAD)));
+      }
+      gameModule.sendAndLog(c);
+      repaintMap();
     }
-    gameModule.sendAndLog(c);
-    repaintMap();
   }
 
   protected KeyCommand[] getKeyCommands() {


### PR DESCRIPTION
Fixes #11069 

The inner loadDeck() method can return null if the user picks a file that is not recognized as a deck.