### PR TITLE
11099 Correct HexGrid range between points within a hex

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/module/map/boardPicker/board/HexGrid.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/boardPicker/board/HexGrid.java
@@ -724,7 +724,7 @@ public class HexGrid extends AbstractConfigurable
 
     final VASSAL.build.module.Map m = getContainer().getBoard().getMap();
 
-    // Snap the pounts to the HexGrid before calculating range
+    // Snap the points to the HexGrid before calculating range. Note: snap via the Map to get correct handling of board offets.
     final Point pp1 = m.snapTo(p1);
     final Point pp2 = m.snapTo(p2);
 

--- a/vassal-app/src/main/java/VASSAL/build/module/map/boardPicker/board/HexGrid.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/boardPicker/board/HexGrid.java
@@ -722,9 +722,17 @@ public class HexGrid extends AbstractConfigurable
   @Override
   public int range(Point p1, Point p2) {
 
-    final Hex h1 = OffsetCoord.qoffsetToCube(OffsetCoord.ODD, new OffsetCoord(getRawColumn(p1), getRawRow(p1)));
-    final Hex h2 = OffsetCoord.qoffsetToCube(OffsetCoord.ODD, new OffsetCoord(getRawColumn(p2), getRawRow(p2)));
+    final VASSAL.build.module.Map m = getContainer().getBoard().getMap();
 
+    // Snap the pounts to the HexGrid before calculating range
+    final Point pp1 = m.snapTo(p1);
+    final Point pp2 = m.snapTo(p2);
+
+    // Create two Hex Coordinate references
+    final Hex h1 = OffsetCoord.qoffsetToCube(OffsetCoord.ODD, new OffsetCoord(getRawColumn(pp1), getRawRow(pp1)));
+    final Hex h2 = OffsetCoord.qoffsetToCube(OffsetCoord.ODD, new OffsetCoord(getRawColumn(pp2), getRawRow(pp2)));
+
+    // And return the difference
     return h1.distance(h2);
   }
 


### PR DESCRIPTION
The range in hexes between 2 points that are not in the centres of hexes can be out by 1 hex. In the worst case, 2 the hex range between two non-central points in the same hex can be 1 instead of 0. This affects the range displayed by the LOS thread and also the GKC range check.