### PR TITLE
11127 - Don't throw exception if there's a drive letter in a filename

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/GameModule.java
+++ b/vassal-app/src/main/java/VASSAL/build/GameModule.java
@@ -126,7 +126,6 @@ import VASSAL.tools.menu.MenuManager;
 import VASSAL.tools.swing.SwingUtils;
 import VASSAL.tools.version.VersionUtils;
 import org.apache.commons.codec.digest.DigestUtils;
-import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.LoggerFactory;
@@ -1495,7 +1494,7 @@ public class GameModule extends AbstractConfigurable
       return Resources.getString(key + "_title", nameString, "", Info.getVersion());  //NON-NLS-1$
     }
     else {
-      return Resources.getString(key + "_title_" + gameFileMode, nameString, moduleVersion ? gameFile : FilenameUtils.removeExtension(removePrefix(gameFile)), Info.getVersion()); //NON-NLS-1$
+      return Resources.getString(key + "_title_" + gameFileMode, nameString, gameFile, Info.getVersion()); //NON-NLS-1$
     }
   }
 

--- a/vassal-app/src/main/java/VASSAL/build/GameModule.java
+++ b/vassal-app/src/main/java/VASSAL/build/GameModule.java
@@ -17,10 +17,6 @@
  */
 package VASSAL.build;
 
-import static VASSAL.preferences.Prefs.MAIN_WINDOW_HEIGHT;
-import static VASSAL.preferences.Prefs.MAIN_WINDOW_REMEMBER;
-import static VASSAL.preferences.Prefs.MAIN_WINDOW_WIDTH;
-
 import VASSAL.Info;
 import VASSAL.build.module.BasicCommandEncoder;
 import VASSAL.build.module.BasicLogger;
@@ -129,7 +125,20 @@ import VASSAL.tools.image.tilecache.ImageTileDiskCache;
 import VASSAL.tools.menu.MenuManager;
 import VASSAL.tools.swing.SwingUtils;
 import VASSAL.tools.version.VersionUtils;
+import org.apache.commons.codec.digest.DigestUtils;
+import org.apache.commons.io.FilenameUtils;
+import org.apache.commons.lang3.ArrayUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.LoggerFactory;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
 
+import javax.swing.JComponent;
+import javax.swing.JFrame;
+import javax.swing.JOptionPane;
+import javax.swing.JPanel;
+import javax.swing.JToolBar;
+import javax.swing.KeyStroke;
 import java.awt.Container;
 import java.awt.Rectangle;
 import java.awt.event.KeyEvent;
@@ -152,20 +161,9 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Random;
 
-import javax.swing.JComponent;
-import javax.swing.JFrame;
-import javax.swing.JOptionPane;
-import javax.swing.JPanel;
-import javax.swing.JToolBar;
-import javax.swing.KeyStroke;
-
-import org.apache.commons.codec.digest.DigestUtils;
-import org.apache.commons.io.FilenameUtils;
-import org.apache.commons.lang3.ArrayUtils;
-import org.apache.commons.lang3.StringUtils;
-import org.slf4j.LoggerFactory;
-import org.w3c.dom.Document;
-import org.w3c.dom.Element;
+import static VASSAL.preferences.Prefs.MAIN_WINDOW_HEIGHT;
+import static VASSAL.preferences.Prefs.MAIN_WINDOW_REMEMBER;
+import static VASSAL.preferences.Prefs.MAIN_WINDOW_WIDTH;
 
 /**
  * The GameModule class is the base class for a VASSAL module.  It is
@@ -1463,6 +1461,17 @@ public class GameModule extends AbstractConfigurable
     return frame.getToolBar();
   }
 
+
+  /**
+   * Removes any windows drive letter prefix from a filename, to keep stupid FileUtils from throwing a stupid exception.
+   * @param fileName filename
+   * @return filename w/o any prefix (e.g. "C:")
+   */
+  private String removePrefix(String fileName) {
+    final int index = fileName.indexOf(':');
+    return (index < 0) ? fileName : fileName.substring(index);
+  }
+
   /**
    * Returns an appropriate Title Bar string for a window, based on the module name,
    * the last read/written game file, and the manner of interaction with it.
@@ -1486,7 +1495,7 @@ public class GameModule extends AbstractConfigurable
       return Resources.getString(key + "_title", nameString, "", Info.getVersion());  //NON-NLS-1$
     }
     else {
-      return Resources.getString(key + "_title_" + gameFileMode, nameString, moduleVersion ? gameFile : FilenameUtils.removeExtension(gameFile), Info.getVersion()); //NON-NLS-1$
+      return Resources.getString(key + "_title_" + gameFileMode, nameString, moduleVersion ? gameFile : FilenameUtils.removeExtension(removePrefix(gameFile)), Info.getVersion()); //NON-NLS-1$
     }
   }
 

--- a/vassal-app/src/main/java/VASSAL/build/GameModule.java
+++ b/vassal-app/src/main/java/VASSAL/build/GameModule.java
@@ -1469,7 +1469,7 @@ public class GameModule extends AbstractConfigurable
    */
   private String removePrefix(String fileName) {
     final int index = fileName.indexOf(':');
-    return (index < 0) ? fileName : fileName.substring(index);
+    return (index < 0) ? fileName : fileName.substring(index + 1);
   }
 
   /**

--- a/vassal-app/src/main/java/VASSAL/build/GameModule.java
+++ b/vassal-app/src/main/java/VASSAL/build/GameModule.java
@@ -1460,17 +1460,6 @@ public class GameModule extends AbstractConfigurable
     return frame.getToolBar();
   }
 
-
-  /**
-   * Removes any windows drive letter prefix from a filename, to keep stupid FileUtils from throwing a stupid exception.
-   * @param fileName filename
-   * @return filename w/o any prefix (e.g. "C:")
-   */
-  private String removePrefix(String fileName) {
-    final int index = fileName.indexOf(':');
-    return (index < 0) ? fileName : fileName.substring(index + 1);
-  }
-
   /**
    * Returns an appropriate Title Bar string for a window, based on the module name,
    * the last read/written game file, and the manner of interaction with it.


### PR DESCRIPTION
Fixes #11127 

It's insane that FilenameUtils 
(a) understands drive letter prefixes, where they are, etc
(b) but throws an exception if one's part of a string passed into the filename
(c) but DOESN'T provide a way to extract the non-prefix part of a path+filename in order to use the things w/o the stupid exception.