### PR TITLE
11160 - Prevent At-Start Stacks from creating additional spurious pieces on main map

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/module/map/SetupStack.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/SetupStack.java
@@ -465,11 +465,6 @@ public class SetupStack extends AbstractConfigurable implements GameComponent, U
         slot.clearCache(); //BR// Always rebuild piece at beginning - we might be starting a new game in Editor after changing prototypes
         GamePiece p = slot.getPiece();
 
-        Map map = p.getMap();
-        if (map != null) {
-          map = null;
-        }
-
         if (p != null) { // In case slot fails to "build the piece", which is a possibility.
           p = PieceCloner.getInstance().clonePiece(p);
           GameModule.getGameModule().getGameState().addPiece(p);

--- a/vassal-app/src/main/java/VASSAL/build/module/map/SetupStack.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/SetupStack.java
@@ -18,6 +18,53 @@
 
 package VASSAL.build.module.map;
 
+import VASSAL.build.AbstractConfigurable;
+import VASSAL.build.AbstractFolder;
+import VASSAL.build.AutoConfigurable;
+import VASSAL.build.BadDataReport;
+import VASSAL.build.Buildable;
+import VASSAL.build.Configurable;
+import VASSAL.build.GameModule;
+import VASSAL.build.module.GameComponent;
+import VASSAL.build.module.Map;
+import VASSAL.build.module.NewGameIndicator;
+import VASSAL.build.module.documentation.HelpFile;
+import VASSAL.build.module.map.boardPicker.Board;
+import VASSAL.build.module.map.boardPicker.board.MapGrid;
+import VASSAL.build.module.map.boardPicker.board.MapGrid.BadCoords;
+import VASSAL.build.widget.PieceSlot;
+import VASSAL.command.Command;
+import VASSAL.configure.AutoConfigurer;
+import VASSAL.configure.Configurer;
+import VASSAL.configure.TranslatableStringEnum;
+import VASSAL.configure.ValidationReport;
+import VASSAL.configure.VisibilityCondition;
+import VASSAL.counters.GamePiece;
+import VASSAL.counters.PieceCloner;
+import VASSAL.counters.Properties;
+import VASSAL.counters.Stack;
+import VASSAL.i18n.ComponentI18nData;
+import VASSAL.i18n.Resources;
+import VASSAL.tools.AdjustableSpeedScrollPane;
+import VASSAL.tools.ErrorDialog;
+import VASSAL.tools.UniqueIdManager;
+import VASSAL.tools.image.ImageUtils;
+import VASSAL.tools.menu.MenuManager;
+import VASSAL.tools.swing.SwingUtils;
+import org.apache.commons.lang3.SystemUtils;
+
+import javax.swing.Box;
+import javax.swing.ImageIcon;
+import javax.swing.JButton;
+import javax.swing.JCheckBox;
+import javax.swing.JFrame;
+import javax.swing.JLabel;
+import javax.swing.JLayeredPane;
+import javax.swing.JPanel;
+import javax.swing.JPopupMenu;
+import javax.swing.JRootPane;
+import javax.swing.JScrollPane;
+import javax.swing.SwingUtilities;
 import java.awt.AlphaComposite;
 import java.awt.BorderLayout;
 import java.awt.Color;
@@ -62,55 +109,6 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.stream.Collectors;
-
-import javax.swing.Box;
-import javax.swing.ImageIcon;
-import javax.swing.JButton;
-import javax.swing.JCheckBox;
-import javax.swing.JFrame;
-import javax.swing.JLabel;
-import javax.swing.JLayeredPane;
-import javax.swing.JPanel;
-import javax.swing.JPopupMenu;
-import javax.swing.JRootPane;
-import javax.swing.JScrollPane;
-import javax.swing.SwingUtilities;
-
-import org.apache.commons.lang3.SystemUtils;
-
-import VASSAL.build.AbstractConfigurable;
-import VASSAL.build.AbstractFolder;
-import VASSAL.build.AutoConfigurable;
-import VASSAL.build.BadDataReport;
-import VASSAL.build.Buildable;
-import VASSAL.build.Configurable;
-import VASSAL.build.GameModule;
-import VASSAL.build.module.GameComponent;
-import VASSAL.build.module.Map;
-import VASSAL.build.module.NewGameIndicator;
-import VASSAL.build.module.documentation.HelpFile;
-import VASSAL.build.module.map.boardPicker.Board;
-import VASSAL.build.module.map.boardPicker.board.MapGrid;
-import VASSAL.build.module.map.boardPicker.board.MapGrid.BadCoords;
-import VASSAL.build.widget.PieceSlot;
-import VASSAL.command.Command;
-import VASSAL.configure.AutoConfigurer;
-import VASSAL.configure.Configurer;
-import VASSAL.configure.TranslatableStringEnum;
-import VASSAL.configure.ValidationReport;
-import VASSAL.configure.VisibilityCondition;
-import VASSAL.counters.GamePiece;
-import VASSAL.counters.PieceCloner;
-import VASSAL.counters.Properties;
-import VASSAL.counters.Stack;
-import VASSAL.i18n.ComponentI18nData;
-import VASSAL.i18n.Resources;
-import VASSAL.tools.AdjustableSpeedScrollPane;
-import VASSAL.tools.ErrorDialog;
-import VASSAL.tools.UniqueIdManager;
-import VASSAL.tools.image.ImageUtils;
-import VASSAL.tools.menu.MenuManager;
-import VASSAL.tools.swing.SwingUtils;
 
 /**
  * This is the "At-Start Stack" component, which initializes a Map or Board with a specified stack.
@@ -466,6 +464,12 @@ public class SetupStack extends AbstractConfigurable implements GameComponent, U
         final PieceSlot slot = (PieceSlot) configurable;
         slot.clearCache(); //BR// Always rebuild piece at beginning - we might be starting a new game in Editor after changing prototypes
         GamePiece p = slot.getPiece();
+
+        Map map = p.getMap();
+        if (map != null) {
+          map = null;
+        }
+
         if (p != null) { // In case slot fails to "build the piece", which is a possibility.
           p = PieceCloner.getInstance().clonePiece(p);
           GameModule.getGameModule().getGameState().addPiece(p);

--- a/vassal-app/src/main/java/VASSAL/build/widget/PieceSlot.java
+++ b/vassal-app/src/main/java/VASSAL/build/widget/PieceSlot.java
@@ -47,7 +47,13 @@ import VASSAL.search.ImageSearchTarget;
 import VASSAL.tools.ErrorDialog;
 import VASSAL.tools.image.LabelUtils;
 import VASSAL.tools.swing.SwingUtils;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
 
+import javax.swing.JPanel;
+import javax.swing.JPopupMenu;
+import javax.swing.event.PopupMenuEvent;
+import javax.swing.event.PopupMenuListener;
 import java.awt.Color;
 import java.awt.Component;
 import java.awt.Dimension;
@@ -66,14 +72,6 @@ import java.awt.event.MouseListener;
 import java.awt.geom.AffineTransform;
 import java.awt.image.BufferedImage;
 import java.util.Collection;
-
-import javax.swing.JPanel;
-import javax.swing.JPopupMenu;
-import javax.swing.event.PopupMenuEvent;
-import javax.swing.event.PopupMenuListener;
-
-import org.w3c.dom.Document;
-import org.w3c.dom.Element;
 
 /**
  * A Component that displays a GamePiece.
@@ -232,6 +230,13 @@ public class PieceSlot extends Widget implements MouseListener, KeyListener {
       else {
         c = comm.getTarget();
         c.setState(comm.getState());
+
+        //BR// A slot's piece should NOT come attached to a map.
+        final Map map = c.getMap();
+        if (map != null) {
+          map.removePiece(c);
+          c.setMap(null);
+        }
 
         final Dimension size = panel.getSize();
         c.setPosition(new Point(size.width / 2, size.height / 2));


### PR DESCRIPTION
Somehow the pieces in his PieceSlot for his setupstack already thought they were *on a map*, but of course pieces in Piece Slots are supposed to be the "Platonic Forms Of Their Pieces". 

I can only suppose that some weird thing had happened in the past (direct xml file editing? something else?) that made just a few of his pieces have pieceslots that were somehow attached to a map. And so what he was seeing was the actual Platonic Form of his pieces!!! 

The reason it showed up _now_ was that I had it rebuilding SetupStacks "for safety" whenever game is set up (previously you could get zany results from multiple runs of game in one Player window, plus also more importantly this makes prototype editing more stable)

I've patched it by just making sure those things aren't allowed to be "on a map" at the time they're recreated. 