### PR TITLE
11178 - Omit empty lines in non-blank property setting prompts

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/module/GlobalOptions.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/GlobalOptions.java
@@ -148,7 +148,7 @@ public class GlobalOptions extends AbstractConfigurable implements ComponentDesc
   private String inventoryVisibleToAll = ALWAYS; // Inventory can see private windows -> default to on
   private String sendToLocationMoveTrails = NEVER; // Send-to-Location generates movement trails (default to off)
   private boolean storeLeadingZeroIntegersAsStrings = false; // Store integers with leading zeroes as String internally
-  private boolean purgeBlankPropertyPrompts = false; // Purge blank property prompts
+  private boolean purgeBlankPropertyPrompts = true; // Purge blank property prompts
 
   // Configurable prompt string for unmask-my-pieces
   private String promptString = Resources.getString("GlobalOptions.opponents_can_unmask_my_pieces");

--- a/vassal-app/src/main/java/VASSAL/build/module/GlobalOptions.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/GlobalOptions.java
@@ -95,6 +95,7 @@ public class GlobalOptions extends AbstractConfigurable implements ComponentDesc
   public static final String INVENTORY_VISIBLE_TO_ALL = "inventoryForAll"; //NON-NLS
   public static final String SEND_TO_LOCATION_MOVE_TRAILS = "sendToLocationMoveTrails"; //NON-NLS
   public static final String STORE_LEADING_ZERO_INTEGERS_AS_STRINGS = "storeLeadingZeroIntegersAsStrings"; //NON-NLS
+  public static final String PURGE_BLANK_PROPERTY_PROMPTS = "purgeBlankPropertyPrompts"; //NON-NLS
 
   // Hybrid preference settings
   public static final String ALWAYS = "Always"; //$NON-NLS-1$
@@ -147,6 +148,7 @@ public class GlobalOptions extends AbstractConfigurable implements ComponentDesc
   private String inventoryVisibleToAll = ALWAYS; // Inventory can see private windows -> default to on
   private String sendToLocationMoveTrails = NEVER; // Send-to-Location generates movement trails (default to off)
   private boolean storeLeadingZeroIntegersAsStrings = false; // Store integers with leading zeroes as String internally
+  private boolean purgeBlankPropertyPrompts = false; // Purge blank property prompts
 
   // Configurable prompt string for unmask-my-pieces
   private String promptString = Resources.getString("GlobalOptions.opponents_can_unmask_my_pieces");
@@ -465,7 +467,8 @@ public class GlobalOptions extends AbstractConfigurable implements ComponentDesc
       Resources.getString("Editor.GlobalOption.hot_keys_on_closed_windows"), //NON-NLS
       Resources.getString("Editor.GlobalOption.inventory_visible_to_all"),
       Resources.getString("Editor.GlobalOption.send_to_location_movement_trails"),
-      Resources.getString("Editor.GlobalOption.leading_zero_integer_strings")
+      Resources.getString("Editor.GlobalOption.leading_zero_integer_strings"),
+      Resources.getString("Editor.GlobalOption.purge_blank_property_prompts")
     };
   }
 
@@ -485,7 +488,8 @@ public class GlobalOptions extends AbstractConfigurable implements ComponentDesc
         HOTKEYS_ON_CLOSED_WINDOWS,
         INVENTORY_VISIBLE_TO_ALL,
         SEND_TO_LOCATION_MOVE_TRAILS,
-        STORE_LEADING_ZERO_INTEGERS_AS_STRINGS
+        STORE_LEADING_ZERO_INTEGERS_AS_STRINGS,
+        PURGE_BLANK_PROPERTY_PROMPTS
       )
     );
 
@@ -509,6 +513,7 @@ public class GlobalOptions extends AbstractConfigurable implements ComponentDesc
       PromptOnOff.class,
       PromptOnOff.class,
       PromptOnOff.class,
+      Boolean.class,
       Boolean.class
     };
   }
@@ -640,6 +645,9 @@ public class GlobalOptions extends AbstractConfigurable implements ComponentDesc
     else if (STORE_LEADING_ZERO_INTEGERS_AS_STRINGS.equals(key)) {
       return String.valueOf(storeLeadingZeroIntegersAsStrings);
     }
+    else if (PURGE_BLANK_PROPERTY_PROMPTS.equals(key)) {
+      return String.valueOf(purgeBlankPropertyPrompts);
+    }
     else if (INVENTORY_VISIBLE_TO_ALL.equals(key)) {
       return inventoryVisibleToAll;
     }
@@ -724,6 +732,14 @@ public class GlobalOptions extends AbstractConfigurable implements ComponentDesc
       }
       else if (value instanceof String) {
         storeLeadingZeroIntegersAsStrings = "true".equals(value); //$NON-NLS-1$
+      }
+    }
+    else if (PURGE_BLANK_PROPERTY_PROMPTS.equals(key)) {
+      if (value instanceof Boolean) {
+        purgeBlankPropertyPrompts = (Boolean) value;
+      }
+      else if (value instanceof String) {
+        purgeBlankPropertyPrompts = "true".equals(value); //NON-NLS
       }
     }
     else if (INVENTORY_VISIBLE_TO_ALL.equals(key)) {
@@ -828,6 +844,10 @@ public class GlobalOptions extends AbstractConfigurable implements ComponentDesc
 
   public boolean isStoreLeadingZeroIntegersAsStrings() {
     return storeLeadingZeroIntegersAsStrings;
+  }
+
+  public boolean isPurgeBlankPropertyPrompts() {
+    return purgeBlankPropertyPrompts;
   }
 
   /** @return whether specific hybrid preference is enabled (could be designer-forced setting, could be player preference) */

--- a/vassal-app/src/main/java/VASSAL/build/module/properties/EnumeratedPropertyPrompt.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/properties/EnumeratedPropertyPrompt.java
@@ -17,6 +17,7 @@
  */
 package VASSAL.build.module.properties;
 
+import VASSAL.build.module.GlobalOptions;
 import VASSAL.script.expression.AuditTrail;
 import VASSAL.script.expression.Expression;
 import VASSAL.script.expression.ExpressionException;
@@ -69,9 +70,11 @@ public class EnumeratedPropertyPrompt extends PropertyPrompt {
       finalValues[i] = value;
     }
 
+    final boolean purgeBlanks = GlobalOptions.getInstance().isPurgeBlankPropertyPrompts();
+
     final List<String> nonBlankValues = new ArrayList<>();
     for (final String value : finalValues) {
-      if (value.isEmpty()) continue;
+      if (purgeBlanks && value.isEmpty()) continue;
       nonBlankValues.add(value);
     }
 

--- a/vassal-app/src/main/java/VASSAL/build/module/properties/EnumeratedPropertyPrompt.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/properties/EnumeratedPropertyPrompt.java
@@ -17,11 +17,13 @@
  */
 package VASSAL.build.module.properties;
 
-import javax.swing.JOptionPane;
-
 import VASSAL.script.expression.AuditTrail;
 import VASSAL.script.expression.Expression;
 import VASSAL.script.expression.ExpressionException;
+
+import javax.swing.JOptionPane;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Prompts user to select from a list
@@ -66,8 +68,19 @@ public class EnumeratedPropertyPrompt extends PropertyPrompt {
       }
       finalValues[i] = value;
     }
+
+    final List<String> nonBlankValues = new ArrayList<>();
+    for (final String value : finalValues) {
+      if (value.isEmpty()) continue;
+      nonBlankValues.add(value);
+    }
+
+    if (nonBlankValues.isEmpty()) {
+      return oldValue;
+    }
+
     final String newValue = (String) JOptionPane.showInputDialog(
-      dialogParent.getComponent(), promptText, null, JOptionPane.QUESTION_MESSAGE, null, finalValues, oldValue);
+      dialogParent.getComponent(), promptText, null, JOptionPane.QUESTION_MESSAGE, null, nonBlankValues.toArray(new String[0]), oldValue);
     return newValue == null ? oldValue : newValue;
   }
 

--- a/vassal-app/src/main/resources/VASSAL/i18n/Editor.properties
+++ b/vassal-app/src/main/resources/VASSAL/i18n/Editor.properties
@@ -896,6 +896,7 @@ Editor.GlobalOption.hot_keys_on_closed_windows=Toolbars on closed map windows ac
 Editor.GlobalOption.inventory_visible_to_all=Inventory can see into Private Windows not accessible to current player
 Editor.GlobalOption.send_to_location_movement_trails=Send-to-Location trait generates Movement Trails
 Editor.GlobalOption.leading_zero_integer_strings=Preserve leading zeros in Integers?
+Editor.GlobalOption.purge_blank_property_prompts=Purge blank lines from dynamic/global property prompts? 
 
 # Global Properties
 Editor.GlobalProperties.component_type=Global Properties

--- a/vassal-doc/src/main/readme-referencemanual/ReferenceManual/DynamicProperty.adoc
+++ b/vassal-doc/src/main/readme-referencemanual/ReferenceManual/DynamicProperty.adoc
@@ -47,7 +47,7 @@ Maximum/Minimum constraints will be honored.
 *_Prompt user_*::::  Pop up a dialog and ask the player for a new value for the property.
 They will be prompted for a new value using the text prompt entered in the *Prompt* field.
 *_Prompt user to select from list_*::::  Similar to _Prompt User_ but displays a list of items to select from in a drop-down menu.
-The items in the list can be generated dynamically by <<Expression.adoc#top,Expressions>>.
+The items in the list can be generated dynamically by <<Expression.adoc#top,Expressions>>. If some items evaluate to a blank string, then those items are only purged from the menu if the <<GlobalOptions.adoc#purgeblanks,Purge Blanks option in Global Options>> is selected; otherwise the blank options appear.
 
 *SEE ALSO:*  <<PropertyMarker.adoc#top,Marker>>, <<SetGlobalProperty.adoc#top,Set Global Property>>
 

--- a/vassal-doc/src/main/readme-referencemanual/ReferenceManual/GlobalOptions.adoc
+++ b/vassal-doc/src/main/readme-referencemanual/ReferenceManual/GlobalOptions.adoc
@@ -38,6 +38,9 @@ It is recommended that for new modules you set this option to _Always_, as the o
 *Preserve leading zeros in Integers:*::  This option should not normally be used. It is for the specific case where you use leading zeros in Grid co-ordinates and need to maintain these leading zeros for later reporting. By default, Vassal will strip leading zeros off and convert to an integer. Enabling this option forces Vassal to keep the leading zeros and store the number 02 as the string "02", not the number 2.
 NOTE: If you later need to do arithimetic on this value in a Beanshell expression, you will have to explicitly convert it to a number using Integer.parseInt(value).
 
+[#purgeblanks]
+*Purge blank lines from dynamic/global property prompts?*:: When a <<DynamicProperty.adoc#top,Dynamic Property>> or <<SetGlobalProperty.adoc#top,Set Global Property>> trait is configured to prompt users from a list of options, if some of those options are determined by expressions which evaluate to be a blank string, then those options are omitted from the prompt if this option is selected.
+
 *Icons and hotkeys:*:: You can specify your own button icons and keyboard shortcuts for the logfile step/undo buttons and the button that shows/hides the server controls and the button that displays the Debug Window.
 
 |image:images/GlobalOptions.png[]

--- a/vassal-doc/src/main/readme-referencemanual/ReferenceManual/SetGlobalProperty.adoc
+++ b/vassal-doc/src/main/readme-referencemanual/ReferenceManual/SetGlobalProperty.adoc
@@ -56,6 +56,6 @@ To "decrement" the value, simple increment by a negative number.
 * _Prompt user:_  Pop up a dialog and ask the user for a new value for the property.
 They will be prompted for a new value using the text prompt entered in the *Prompt* field.
 * _Prompt user to select from list:_  Similar to _Prompt User_ but displays a list of items to select from in a drop-down menu.
-The items in the list can be generated dynamically by <<Expression.adoc#top,Expressions>>.
+The items in the list can be generated dynamically by <<Expression.adoc#top,Expressions>>. If some items evaluate to a blank string, then those items are only purged from the menu if the <<GlobalOptions.adoc#purgeblanks,Purge Blanks option in Global Options>> is selected; otherwise the blank options appear.
 
 *SEE ALSO:* <<PropertyMarker.adoc#top,Marker>>, <<DynamicProperty.adoc#top,Dynamic Property>>, <<Properties.adoc#top,Properties>>


### PR DESCRIPTION
Purge blank property prompts.

But could someone actually be *relying* on the ability to set a property to blank from one of these menus?