### PR TITLE
11258 - New BasicName trait defaults to Prototype's name. Changing Prototype's name changes BasicName trait's, if identical. At-Start Stack with no name displays name of first contained piece or folder in editor.

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/module/map/SetupStack.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/SetupStack.java
@@ -328,7 +328,7 @@ public class SetupStack extends AbstractConfigurable implements GameComponent, U
   @Override
   public String getAttributeValueString(String key) {
     if (NAME.equals(key)) {
-      return getConfigureName();
+      return name;
     }
     else if (OWNING_BOARD.equals(key)) {
       return owningBoardName;
@@ -392,6 +392,25 @@ public class SetupStack extends AbstractConfigurable implements GameComponent, U
       }
       pos.y = (Integer) value;
     }
+  }
+
+  /**
+   * Setup Stacks with no name will display in editor w/ the name of something inside them that does have a name.
+   * @return Configure name of the Setup Stack
+   */
+  @Override
+  public String getConfigureName() {
+    if ((name != null) && !name.isEmpty()) {
+      return name;
+    }
+    final Configurable[] configurables = getConfigureComponents();
+    for (final Configurable c : configurables) {
+      final String cName = c.getConfigureName();
+      if (!cName.isEmpty()) {
+        return cName;
+      }
+    }
+    return name;
   }
 
   @Override

--- a/vassal-app/src/main/java/VASSAL/counters/BasicName.java
+++ b/vassal-app/src/main/java/VASSAL/counters/BasicName.java
@@ -79,6 +79,14 @@ public class BasicName extends Decorator implements TranslatablePiece {
     return super.getProperty(key);
   }
 
+  /**
+   * For editor methods to auto-set the name
+   * @param newName new name
+   */
+  public void setName(String newName) {
+    name = newName;
+  }
+
   @Override
   public Object getLocalizedProperty(Object key) {
     if (BasicPiece.BASIC_NAME.equals(key)) {

--- a/vassal-app/src/main/java/VASSAL/counters/PieceDefiner.java
+++ b/vassal-app/src/main/java/VASSAL/counters/PieceDefiner.java
@@ -32,7 +32,29 @@ import VASSAL.tools.icon.IconFactory;
 import VASSAL.tools.icon.IconFamily;
 import VASSAL.tools.image.LabelUtils;
 import VASSAL.tools.swing.SwingUtils;
+import net.miginfocom.swing.MigLayout;
 
+import javax.swing.BorderFactory;
+import javax.swing.DefaultListCellRenderer;
+import javax.swing.DefaultListModel;
+import javax.swing.DropMode;
+import javax.swing.JButton;
+import javax.swing.JComponent;
+import javax.swing.JDialog;
+import javax.swing.JLabel;
+import javax.swing.JList;
+import javax.swing.JOptionPane;
+import javax.swing.JPanel;
+import javax.swing.JScrollPane;
+import javax.swing.JSplitPane;
+import javax.swing.KeyStroke;
+import javax.swing.ListCellRenderer;
+import javax.swing.ListSelectionModel;
+import javax.swing.SwingConstants;
+import javax.swing.SwingUtilities;
+import javax.swing.TransferHandler;
+import javax.swing.plaf.SplitPaneUI;
+import javax.swing.plaf.basic.BasicSplitPaneUI;
 import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.Component;
@@ -57,30 +79,6 @@ import java.awt.event.MouseEvent;
 import java.awt.image.BufferedImage;
 import java.util.SortedMap;
 import java.util.TreeMap;
-
-import javax.swing.BorderFactory;
-import javax.swing.DefaultListCellRenderer;
-import javax.swing.DefaultListModel;
-import javax.swing.DropMode;
-import javax.swing.JButton;
-import javax.swing.JComponent;
-import javax.swing.JDialog;
-import javax.swing.JLabel;
-import javax.swing.JList;
-import javax.swing.JOptionPane;
-import javax.swing.JPanel;
-import javax.swing.JScrollPane;
-import javax.swing.JSplitPane;
-import javax.swing.KeyStroke;
-import javax.swing.ListCellRenderer;
-import javax.swing.ListSelectionModel;
-import javax.swing.SwingConstants;
-import javax.swing.SwingUtilities;
-import javax.swing.TransferHandler;
-import javax.swing.plaf.SplitPaneUI;
-import javax.swing.plaf.basic.BasicSplitPaneUI;
-
-import net.miginfocom.swing.MigLayout;
 
 /**
  * This is the GamePiece designer dialog.  It appears when you edit
@@ -136,6 +134,8 @@ public class PieceDefiner extends JPanel {
   private JLabel scaleLabel;
   private final Prefs prefs;
 
+  private String prototypeName; // If we're editing a prototype definition, this holds the name of it
+
   // A Configurer to hold the users preferred maximum split size
   private static final int MINIMUM_SPLIT_SIZE = LabelUtils.noImageBoxImage().getWidth();
   private static final int DEFAULT_MAX_SPLIT = 256;
@@ -156,6 +156,7 @@ public class PieceDefiner extends JPanel {
     availableList.setSelectedIndex(0);
     setChanged(false);
     gpidSupport = GameModule.getGameModule().getGpIdSupport();
+    prototypeName = "";
   }
 
   public PieceDefiner(String id, GpIdSupport s) {
@@ -168,6 +169,12 @@ public class PieceDefiner extends JPanel {
   public PieceDefiner(GpIdSupport s) {
     this();
     gpidSupport = s;
+  }
+
+  public void setPrototypeName(String prototypeName) {
+    if (!this.prototypeName.equals(prototypeName)) {
+      this.prototypeName = prototypeName;
+    }
   }
 
   protected int getInUseSelectedIndex() {
@@ -1037,6 +1044,14 @@ public class PieceDefiner extends JPanel {
       if (d instanceof PlaceMarker) {
         ((PlaceMarker) d).updateGpId(gpidSupport);
       }
+
+      //BR// When adding a BasicName trait to a prototype, default its name to the name of the prototype
+      if (d instanceof BasicName) {
+        if (!prototypeName.isEmpty()) {
+          ((BasicName) d).setName(prototypeName);
+        }
+      }
+
       d.setInner(inUseModel.lastElement());
       inUseModel.addElement(d);
       moveDecorator(inUseModel.size() - 1, insertIndex == -1 ? inUseModel.size() : insertIndex + 1);

--- a/vassal-app/src/main/java/VASSAL/counters/UsePrototype.java
+++ b/vassal-app/src/main/java/VASSAL/counters/UsePrototype.java
@@ -32,18 +32,17 @@ import VASSAL.tools.RecursionLimiter.Loopable;
 import VASSAL.tools.SequenceEncoder;
 import VASSAL.tools.menu.MenuScroller;
 
+import javax.swing.JButton;
+import javax.swing.JMenu;
+import javax.swing.JMenuItem;
+import javax.swing.JPopupMenu;
+import javax.swing.KeyStroke;
 import java.awt.Component;
 import java.awt.Graphics;
 import java.awt.Rectangle;
 import java.awt.Shape;
 import java.util.List;
 import java.util.Objects;
-
-import javax.swing.JButton;
-import javax.swing.JMenu;
-import javax.swing.JMenuItem;
-import javax.swing.JPopupMenu;
-import javax.swing.KeyStroke;
 
 /**
  * d/b/a "Prototype"


### PR DESCRIPTION
* New BasicName trait defaults to Prototype's name. 
* Changing Prototype's name changes BasicName trait's, if identical. 
* At-Start Stack with no name displays name of first contained piece or folder in editor.

Those things have all been driving me crazy. Now they won't. Hopefully. 