### PR TITLE
11260 - Editor now remembers its most recent image-picking (and sound) directories separately from its memory of last save/load of games and logs

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/GameModule.java
+++ b/vassal-app/src/main/java/VASSAL/build/GameModule.java
@@ -260,6 +260,8 @@ public class GameModule extends AbstractConfigurable
   private String description = "";
   private String lastSavedConfiguration;
   private FileChooser fileChooser;
+  private FileChooser fileChooserEditorImage;
+  private FileChooser fileChooserEditorSound;
   private final MutablePropertiesContainer propsContainer = new MutablePropertiesContainer.Impl();
   private final TranslatableStringContainer transContainer = new TranslatableStringContainer.Impl();
 
@@ -1450,6 +1452,41 @@ public class GameModule extends AbstractConfigurable
 
     return fileChooser;
   }
+
+  /**
+   * @return a common FileChooser so that recent file locations
+   * can be remembered
+   */
+  public FileChooser getEditorImageChooser() {
+    if (fileChooserEditorImage == null) {
+      fileChooserEditorImage = FileChooser.createFileChooser(getPlayerWindow(),
+        getGameState().getEditorImageDirectoryPreference());
+    }
+    else {
+      fileChooserEditorImage.resetChoosableFileFilters();
+      fileChooserEditorImage.rescanCurrentDirectory();
+    }
+
+    return fileChooserEditorImage;
+  }
+
+  /**
+   * @return a common FileChooser so that recent file locations
+   * can be remembered
+   */
+  public FileChooser getEditorSoundChooser() {
+    if (fileChooserEditorSound == null) {
+      fileChooserEditorSound = FileChooser.createFileChooser(getPlayerWindow(),
+        getGameState().getEditorImageDirectoryPreference());
+    }
+    else {
+      fileChooserEditorSound.resetChoosableFileFilters();
+      fileChooserEditorSound.rescanCurrentDirectory();
+    }
+
+    return fileChooserEditorSound;
+  }
+
 
   /**
    * Provides access to the Game Module's toolbar.

--- a/vassal-app/src/main/java/VASSAL/build/module/GameState.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/GameState.java
@@ -116,6 +116,8 @@ public class GameState implements CommandEncoder {
   protected String lastSave;
   protected File lastSaveFile = null;
   protected DirectoryConfigurer savedGameDirectoryPreference;
+  protected DirectoryConfigurer editorImageDirectoryPreference;
+  protected DirectoryConfigurer editorSoundDirectoryPreference;
   protected String loadComments;
   protected boolean loadingInBackground = false;
   private boolean fastForwarding = false;
@@ -1510,5 +1512,21 @@ public class GameState implements CommandEncoder {
       GameModule.getGameModule().getPrefs().addOption(null, savedGameDirectoryPreference);
     }
     return savedGameDirectoryPreference;
+  }
+
+  public DirectoryConfigurer getEditorImageDirectoryPreference() {
+    if (editorImageDirectoryPreference == null) {
+      editorImageDirectoryPreference = new DirectoryConfigurer("editorImageDir", null); //NON-NLS
+      GameModule.getGameModule().getPrefs().addOption(null, editorImageDirectoryPreference);
+    }
+    return editorImageDirectoryPreference;
+  }
+
+  public DirectoryConfigurer getEditorSoundDirectoryPreference() {
+    if (editorSoundDirectoryPreference == null) {
+      editorSoundDirectoryPreference = new DirectoryConfigurer("editorSoundDir", null); //NON-NLS
+      GameModule.getGameModule().getPrefs().addOption(null, editorSoundDirectoryPreference);
+    }
+    return editorSoundDirectoryPreference;
   }
 }

--- a/vassal-app/src/main/java/VASSAL/configure/IconConfigurer.java
+++ b/vassal-app/src/main/java/VASSAL/configure/IconConfigurer.java
@@ -18,16 +18,6 @@
 
 package VASSAL.configure;
 
-import java.awt.Component;
-import java.awt.Dimension;
-import java.io.File;
-
-import javax.swing.Icon;
-import javax.swing.ImageIcon;
-import javax.swing.JButton;
-import javax.swing.JLabel;
-import javax.swing.JPanel;
-
 import VASSAL.build.GameModule;
 import VASSAL.i18n.Resources;
 import VASSAL.tools.filechooser.FileChooser;
@@ -35,8 +25,16 @@ import VASSAL.tools.filechooser.ImageFileFilter;
 import VASSAL.tools.imageop.ImageOp;
 import VASSAL.tools.imageop.Op;
 import VASSAL.tools.imageop.OwningOpMultiResolutionImage;
-
 import net.miginfocom.swing.MigLayout;
+
+import javax.swing.Icon;
+import javax.swing.ImageIcon;
+import javax.swing.JButton;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import java.awt.Component;
+import java.awt.Dimension;
+import java.io.File;
 
 public class IconConfigurer extends Configurer {
   private JPanel controls;
@@ -132,7 +130,7 @@ public class IconConfigurer extends Configurer {
   }
 
   private void selectImage() {
-    final FileChooser fc = GameModule.getGameModule().getFileChooser();
+    final FileChooser fc = GameModule.getGameModule().getEditorImageChooser();
     fc.setFileFilter(new ImageFileFilter());
 
     if (fc.showOpenDialog(getControls()) != FileChooser.APPROVE_OPTION) {

--- a/vassal-app/src/main/java/VASSAL/configure/ImageSelector.java
+++ b/vassal-app/src/main/java/VASSAL/configure/ImageSelector.java
@@ -24,11 +24,8 @@ import VASSAL.tools.image.LabelUtils;
 import VASSAL.tools.image.MultiResolutionRenderedImage;
 import VASSAL.tools.imageop.Op;
 import VASSAL.tools.imageop.OpIcon;
-
-import java.awt.Component;
-import java.awt.Dimension;
-import java.awt.event.ItemEvent;
-import java.awt.event.ItemListener;
+import net.miginfocom.swing.MigLayout;
+import org.apache.commons.lang3.ArrayUtils;
 
 import javax.swing.BorderFactory;
 import javax.swing.DefaultComboBoxModel;
@@ -38,10 +35,10 @@ import javax.swing.JButton;
 import javax.swing.JComboBox;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
-
-import net.miginfocom.swing.MigLayout;
-
-import org.apache.commons.lang3.ArrayUtils;
+import java.awt.Component;
+import java.awt.Dimension;
+import java.awt.event.ItemEvent;
+import java.awt.event.ItemListener;
 
 /**
  * Allows a user to select from the images currently available in a module, or
@@ -191,7 +188,7 @@ public class ImageSelector extends Configurer implements ItemListener {
 
   private void pickImage() {
     final GameModule gm = GameModule.getGameModule();
-    final FileChooser fc = gm.getFileChooser();
+    final FileChooser fc = gm.getEditorImageChooser();
     fc.setFileFilter(new ImageFileFilter());
 
     if (fc.showOpenDialog(gm.getPlayerWindow()) == FileChooser.APPROVE_OPTION && fc.getSelectedFile().exists()) {

--- a/vassal-app/src/main/java/VASSAL/configure/SoundConfigurer.java
+++ b/vassal-app/src/main/java/VASSAL/configure/SoundConfigurer.java
@@ -27,15 +27,14 @@ import VASSAL.tools.URLUtils;
 import VASSAL.tools.filechooser.AudioFileFilter;
 import VASSAL.tools.filechooser.FileChooser;
 
+import javax.swing.JButton;
+import javax.swing.JTextField;
 import java.awt.Component;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URL;
-
-import javax.swing.JButton;
-import javax.swing.JTextField;
 
 /**
  * Configurer for specifying a Clip. This class is intended to allow
@@ -162,7 +161,7 @@ public class SoundConfigurer extends Configurer {
   }
 
   public void chooseClip() {
-    final FileChooser fc = GameModule.getGameModule().getFileChooser();
+    final FileChooser fc = GameModule.getGameModule().getEditorSoundChooser();
     fc.setFileFilter(new AudioFileFilter());
 
     if (fc.showOpenDialog(getControls()) != FileChooser.APPROVE_OPTION) {

--- a/vassal-app/src/main/java/VASSAL/counters/ImagePicker.java
+++ b/vassal-app/src/main/java/VASSAL/counters/ImagePicker.java
@@ -17,13 +17,15 @@
  */
 package VASSAL.counters;
 
-import java.awt.BorderLayout;
-import java.awt.Dimension;
-import java.awt.Font;
-import java.awt.event.ItemEvent;
-import java.awt.event.ItemListener;
-import java.awt.event.MouseEvent;
-import java.awt.event.MouseListener;
+import VASSAL.build.GameModule;
+import VASSAL.i18n.Resources;
+import VASSAL.tools.ScrollPane;
+import VASSAL.tools.filechooser.FileChooser;
+import VASSAL.tools.filechooser.ImageFileFilter;
+import VASSAL.tools.imageop.Op;
+import VASSAL.tools.imageop.OpIcon;
+import VASSAL.tools.swing.SwingUtils;
+import org.apache.commons.lang3.ArrayUtils;
 
 import javax.swing.BoxLayout;
 import javax.swing.DefaultComboBoxModel;
@@ -32,17 +34,13 @@ import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 import javax.swing.JTextArea;
-
-import org.apache.commons.lang3.ArrayUtils;
-
-import VASSAL.i18n.Resources;
-import VASSAL.build.GameModule;
-import VASSAL.tools.ScrollPane;
-import VASSAL.tools.filechooser.FileChooser;
-import VASSAL.tools.filechooser.ImageFileFilter;
-import VASSAL.tools.imageop.Op;
-import VASSAL.tools.imageop.OpIcon;
-import VASSAL.tools.swing.SwingUtils;
+import java.awt.BorderLayout;
+import java.awt.Dimension;
+import java.awt.Font;
+import java.awt.event.ItemEvent;
+import java.awt.event.ItemListener;
+import java.awt.event.MouseEvent;
+import java.awt.event.MouseListener;
 
 public class ImagePicker extends JPanel
                          implements MouseListener, ItemListener {
@@ -166,7 +164,7 @@ public class ImagePicker extends JPanel
 
   public void pickImage() {
     final GameModule gm = GameModule.getGameModule();
-    final FileChooser fc = gm.getFileChooser();
+    final FileChooser fc = gm.getEditorImageChooser();
     fc.setFileFilter(new ImageFileFilter());
 
     if (fc.showOpenDialog(this) == FileChooser.APPROVE_OPTION

--- a/vassal-app/src/main/java/VASSAL/tools/icon/IconFamily.java
+++ b/vassal-app/src/main/java/VASSAL/tools/icon/IconFamily.java
@@ -641,7 +641,7 @@ public class IconFamily extends AbstractConfigurable {
     }
 
     protected void selectImage() {
-      final FileChooser fc = GameModule.getGameModule().getFileChooser();
+      final FileChooser fc = GameModule.getGameModule().getEditorImageChooser();
       fc.setFileFilter(new FamilyImageFilter(family.getName()));
       fc.setSelectedFile(new File(family.getName() + ".*")); //$NON-NLS-1$
       if (fc.showOpenDialog(getControls()) != FileChooser.APPROVE_OPTION) {


### PR DESCRIPTION
So for example if you are going back and forth between playing a game (loading log files) while editing some other module, you won't keep being asked to pick a saved game from your art directory or vice versa.