### PR TITLE
Scale tiled images to target size rather than by scale factor

### DIFF
--- a/vassal-app/src/main/java/VASSAL/tools/image/ImageUtils.java
+++ b/vassal-app/src/main/java/VASSAL/tools/image/ImageUtils.java
@@ -176,6 +176,35 @@ public class ImageUtils {
     }
   }
 
+  public static BufferedImage transform(BufferedImage src,
+                                        int sw,
+                                        int sh,
+                                        RenderingHints hints) {
+    // bail on null source
+    if (src == null) return null;
+
+    // return null image if scaling makes source vanish
+    if (sw == 0 || sh == 0) {
+      return NULL_IMAGE;
+    }
+
+    // nothing to do, return source
+    if (sw == src.getWidth() && sh == src.getHeight()) {
+      return src;
+    }
+
+    // use the default hints if we weren't given any
+    if (hints == null) hints = getDefaultHints();
+
+    src = coerceToIntType(src);
+
+    final Rectangle sbox = new Rectangle(0, 0, sw, sh);
+
+    final BufferedImage dst = GeneralFilter.zoom(sbox, src, sw > src.getWidth() ? upscale : downscale);
+
+    return toCompatibleImage(dst);
+  }
+
   public static BufferedImage coerceToIntType(BufferedImage img) {
     // ensure that img is a type which GeneralFilter can handle
     switch (img.getType()) {

--- a/vassal-app/src/main/java/VASSAL/tools/imageop/ScaleOpBitmapImpl.java
+++ b/vassal-app/src/main/java/VASSAL/tools/imageop/ScaleOpBitmapImpl.java
@@ -98,15 +98,22 @@ public class ScaleOpBitmapImpl extends AbstractTiledOpImpl
    */
   @Override
   public BufferedImage eval() throws Exception {
-    return ImageUtils.transform(sop.getImage(null), scale, 0.0, hints);
+    if (size == null) {
+      fixSize();
+    }
+    return ImageUtils.transform(sop.getImage(null), size.width, size.height, hints);
   }
 
   /** {@inheritDoc} */
   @Override
   protected void fixSize() {
     if ((size = getSizeFromCache()) == null) {
-      size = ImageUtils.transform(
-        new Rectangle(sop.getSize()), scale, 0.0).getSize();
+      // We scale to a size rather than a scale factor here because this is
+      // used for sizing tiled images, and the tiles are sliced from an image
+      // already scaled to a particular size. Doing this ensures that the
+      // sum of the tiles widths and heights match the image width and height.
+      final Dimension sd = sop.getSize();
+      size = new Dimension((int)(sd.width * scale), (int)(sd.height * scale));
     }
   }
 


### PR DESCRIPTION
This ensures that the sum of tile widths and heights equals the overall image width
and height.