### PR TITLE
Apparently stack name can be null sometimes during initial adding-to-module

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/module/map/SetupStack.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/SetupStack.java
@@ -406,7 +406,7 @@ public class SetupStack extends AbstractConfigurable implements GameComponent, U
     final Configurable[] configurables = getConfigureComponents();
     for (final Configurable c : configurables) {
       final String cName = c.getConfigureName();
-      if (!cName.isEmpty()) {
+      if ((cName != null) && !cName.isEmpty()) {
         return cName;
       }
     }


### PR DESCRIPTION
Hooray for things being null and getting checked for that

(No issue number needed, I think I introduced this in code checked in after 3.6.5 -- HOORAY ME!!!)