### PR TITLE
11303 - Preference to control drag-at-edge scroll rate, plus Amazing New Default Powers

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/module/Map.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/Map.java
@@ -981,7 +981,7 @@ public class Map extends AbstractToolbarItem implements GameComponent, MouseList
 
     // To establish initial defaults, check to see if module designer has overridden the "default defaults" with Global Properties
     final Object delayProp = g.getProperty(DEFAULT_EDGE_SCROLL_DELAY_PROPERTY);
-    final int delayDefault = (delayProp instanceof String) ? NumberUtils.toInt((String)delayProp) : PREFERRED_EDGE_SCROLL_DELAY_STANDARD_DEFAULT;
+    final int delayDefault = (delayProp instanceof String) ? NumberUtils.toInt((String)delayProp) : PREFERRED_EDGE_SCROLL_DELAY;
 
     g.getPrefs().addOption(
       Resources.getString("Prefs.general_tab"), //$NON-NLS-1$
@@ -2122,7 +2122,7 @@ public class Map extends AbstractToolbarItem implements GameComponent, MouseList
   protected static final String DEFAULT_EDGE_SCROLL_ZONE_PROPERTY  = "Map.defaultEdgeScrollZone";  //NON-NLS
   protected static final String DEFAULT_EDGE_SCROLL_RATE_PROPERTY  = "Map.defaultEdgeScrollRate";  //NON-NLS
 
-  public static final int PREFERRED_EDGE_SCROLL_DELAY_STANDARD_DEFAULT = 200;
+  public static final int PREFERRED_EDGE_SCROLL_DELAY = 200;
   public static final String PREFERRED_EDGE_DELAY = "PreferredEdgeDelay"; //$NON-NLS-1$
 
   /** The width of the hot zone for triggering autoscrolling. */

--- a/vassal-app/src/main/java/VASSAL/build/module/Map.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/Map.java
@@ -2207,7 +2207,7 @@ public class Map extends AbstractToolbarItem implements GameComponent, MouseList
       public void timingEvent(float fraction) {
         // Constant velocity along each axis, 0.5px/ms default
         final long t1 = System.currentTimeMillis();
-        final int dt = (int)((t1 - t0) * NumberUtils.max(EDGE_SCROLL_RATE, 0.01));
+        final int dt = (int)((t1 - t0) * Math.max(EDGE_SCROLL_RATE, 0.01));
         t0 = t1;
 
         scroll(sx * dt, sy * dt);

--- a/vassal-app/src/main/java/VASSAL/build/module/Map.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/Map.java
@@ -83,6 +83,7 @@ import VASSAL.configure.CompoundValidityChecker;
 import VASSAL.configure.ConfigureTree;
 import VASSAL.configure.Configurer;
 import VASSAL.configure.ConfigurerFactory;
+import VASSAL.configure.DoubleConfigurer;
 import VASSAL.configure.IconConfigurer;
 import VASSAL.configure.IntConfigurer;
 import VASSAL.configure.MandatoryComponent;
@@ -127,6 +128,7 @@ import VASSAL.tools.swing.SplitPane;
 import VASSAL.tools.swing.SwingUtils;
 import net.miginfocom.swing.MigLayout;
 import org.apache.commons.lang3.SystemUtils;
+import org.apache.commons.lang3.math.NumberUtils;
 import org.jdesktop.animation.timing.Animator;
 import org.jdesktop.animation.timing.TimingTargetAdapter;
 import org.w3c.dom.Element;
@@ -283,6 +285,7 @@ public class Map extends AbstractToolbarItem implements GameComponent, MouseList
   protected String description;
 
   private IntConfigurer preferredScrollConfig;
+  private DoubleConfigurer preferredScrollRateConfig;
 
   public Map() {
     getView();
@@ -976,22 +979,30 @@ public class Map extends AbstractToolbarItem implements GameComponent, MouseList
       }
     });
 
+    // To establish initial defaults, check to see if module designer has overridden the "default defaults" with Global Properties
+    final Object delayProp = g.getProperty(DEFAULT_EDGE_SCROLL_DELAY_PROPERTY);
+    final int delayDefault = (delayProp instanceof String) ? NumberUtils.toInt((String)delayProp) : PREFERRED_EDGE_SCROLL_DELAY_STANDARD_DEFAULT;
+
     g.getPrefs().addOption(
       Resources.getString("Prefs.general_tab"), //$NON-NLS-1$
       new IntConfigurer(
         PREFERRED_EDGE_DELAY,
         Resources.getString("Map.scroll_delay_preference"), //$NON-NLS-1$
-        PREFERRED_EDGE_SCROLL_DELAY
+        delayDefault
       )
     );
 
     g.addSideChangeListenerToPlayerRoster(this);
 
+    // To establish initial defaults, check to see if module designer has overridden the "default defaults" with Global Properties
+    final Object zoneProp = g.getProperty(DEFAULT_EDGE_SCROLL_ZONE_PROPERTY);
+    final int zoneDefault = (zoneProp instanceof String) ? NumberUtils.toInt((String)zoneProp) : PREFERRED_EDGE_SCROLL_ZONE_STANDARD_DEFAULT;
+
     // Create the Configurer for the Pref
     preferredScrollConfig = new IntConfigurer(
       PREFERRED_SCROLL_ZONE,
       Resources.getString("Map.scroll_zone_preference"), //$NON-NLS-1$
-      SCROLL_ZONE
+      zoneDefault
     );
 
     // Register the Pref, which copies any existing pref value into the configurer
@@ -1001,10 +1012,37 @@ public class Map extends AbstractToolbarItem implements GameComponent, MouseList
     );
 
     // Read the current value of the pref
-    SCROLL_ZONE = preferredScrollConfig.getIntValue(60);
+    SCROLL_ZONE = preferredScrollConfig.getIntValue(zoneDefault);
 
     // Listen for any changes to the pref
-    preferredScrollConfig.addPropertyChangeListener(evt -> SCROLL_ZONE = preferredScrollConfig.getIntValue(60));
+    preferredScrollConfig.addPropertyChangeListener(evt -> SCROLL_ZONE = preferredScrollConfig.getIntValue(zoneDefault));
+
+    // To establish initial defaults, check to see if module designer has overridden the "default defaults" with Global Properties
+    final Object rateProp = g.getProperty(DEFAULT_EDGE_SCROLL_RATE_PROPERTY);
+    final double rateDefault = (rateProp instanceof String) ? NumberUtils.toDouble((String)rateProp) : PREFERRED_EDGE_SCROLL_RATE_STANDARD_DEFAULT;
+
+    // Create the Configurer for the Pref
+    preferredScrollRateConfig = new DoubleConfigurer(
+      PREFERRED_EDGE_SCROLL_RATE,
+      Resources.getString("Map.scroll_rate"),
+      rateDefault
+    );
+
+    // Register the Pref, which copies any existing pref value into the configurer
+    g.getPrefs().addOption(
+      Resources.getString("Prefs.general_tab"), //$NON-NLS-1$
+      preferredScrollRateConfig
+    );
+
+    // Read the current value of the pref
+    final String setting = preferredScrollRateConfig.getValueString();
+    EDGE_SCROLL_RATE = NumberUtils.toDouble(setting);
+
+    // Listen for any changes to the pref
+    preferredScrollRateConfig.addPropertyChangeListener(evt -> {
+      final String set = preferredScrollRateConfig.getValueString();
+      EDGE_SCROLL_RATE = NumberUtils.toDouble(set);
+    });
 
     g.getPrefs().addOption(
       Resources.getString("Prefs.compatibility_tab"), //$NON-NLS-1$
@@ -2078,12 +2116,25 @@ public class Map extends AbstractToolbarItem implements GameComponent, MouseList
   /*
    * Delay before starting scroll at edge
    */
-  public static final int PREFERRED_EDGE_SCROLL_DELAY = 200;
+
+  // Module designers can define Global Properties w/ these names to set the initial defaults for their modules.
+  protected static final String DEFAULT_EDGE_SCROLL_DELAY_PROPERTY = "Map.defaultEdgeScrollDelay"; //NON-NLS
+  protected static final String DEFAULT_EDGE_SCROLL_ZONE_PROPERTY  = "Map.defaultEdgeScrollZone";  //NON-NLS
+  protected static final String DEFAULT_EDGE_SCROLL_RATE_PROPERTY  = "Map.defaultEdgeScrollRate";  //NON-NLS
+
+  public static final int PREFERRED_EDGE_SCROLL_DELAY_STANDARD_DEFAULT = 200;
   public static final String PREFERRED_EDGE_DELAY = "PreferredEdgeDelay"; //$NON-NLS-1$
 
   /** The width of the hot zone for triggering autoscrolling. */
-  public static int SCROLL_ZONE = 60;
+  public static final int PREFERRED_EDGE_SCROLL_ZONE_STANDARD_DEFAULT = 60;
+  public static int SCROLL_ZONE = PREFERRED_EDGE_SCROLL_ZONE_STANDARD_DEFAULT;
   public static final String PREFERRED_SCROLL_ZONE = "PreferredScrollZone"; //$NON-NLS-1$
+
+  /** The rate at which things scroll */
+  public static final double PREFERRED_EDGE_SCROLL_RATE_STANDARD_DEFAULT = 0.5;
+  public static double EDGE_SCROLL_RATE = PREFERRED_EDGE_SCROLL_RATE_STANDARD_DEFAULT;
+  public static final String PREFERRED_EDGE_SCROLL_RATE = "PreferredEdgeScrollRate"; //NON-NLS
+
 
   /** The horizontal component of the autoscrolling vector, -1, 0, or 1. */
   protected int sx;
@@ -2154,9 +2205,9 @@ public class Map extends AbstractToolbarItem implements GameComponent, MouseList
        */
       @Override
       public void timingEvent(float fraction) {
-        // Constant velocity along each axis, 0.5px/ms
+        // Constant velocity along each axis, 0.5px/ms default
         final long t1 = System.currentTimeMillis();
-        final int dt = (int)((t1 - t0) / 2);
+        final int dt = (int)((t1 - t0) * NumberUtils.max(EDGE_SCROLL_RATE, 0.01));
         t0 = t1;
 
         scroll(sx * dt, sy * dt);

--- a/vassal-app/src/main/resources/VASSAL/i18n/VASSAL.properties
+++ b/vassal-app/src/main/resources/VASSAL/i18n/VASSAL.properties
@@ -822,6 +822,7 @@ Main.new_module=New Module
 # Map
 Map.scroll_delay_preference=Delay scrolling when dragging at map edge (ms)
 Map.scroll_zone_preference=Distance from edge of map to begin scrolling (when dragging)
+Map.scroll_rate=Edge scroll rate (pixels per millisecond)
 Map.moving_stacks_preference=Moving stacks should pick up non-moving pieces
 Map.piece_not_on_map=Piece is not on this map
 Map.show_hide=Show/hide %1$s window"

--- a/vassal-doc/src/main/readme-referencemanual/ReferenceManual/Preferences.adoc
+++ b/vassal-doc/src/main/readme-referencemanual/ReferenceManual/Preferences.adoc
@@ -81,9 +81,11 @@ NOTE: Previous versions of VASSAL had a feature which let the value of this pref
 
 *Disable animation of map flares:*:: When checked, the Map Flares are displayed with a static image instead of an animated target image.
 
-*Delay scrolling when dragging at map edge (ms):*:: Sets the number of milliseconds of delay before scrolling the map when dragging a piece near to the edge of the view.
+*Delay scrolling when dragging at map edge (ms):*:: Sets the number of milliseconds of delay before scrolling the map when dragging a piece near to the edge of the view. The normal default is 200, but a module designer can change the default for the module by defining a Global Property named _Map.defaultEdgeScrollDelay_.
 
-*Distance from edge of map to begin scrolling (when dragging):*:: Sets how close to the edge of a Map the cursor must be before scrolling is initiated.
+*Distance from edge of map to begin scrolling (when dragging):*:: Sets how close in pixels to the edge of a Map the cursor must be before scrolling is initiated. The normal default is 60, but a module designer can change the default for the module by defining a Global Property named _Map.defaultEdgeScrollZone_.
+
+*Edge scroll rate (pixels per millisecond):*:: Sets the rate (in pixels per millisecond) map will scroll when dragging a piece at its edge. The normal default is 0.5, but a module designer can change the default for the module by defining a Global Property named _Map.defaultEdgeScrollRate_.
 
 |image:images/Preferences.png[]
 


### PR DESCRIPTION
I've continued to gradually extend the ability for module designers to set the "default-for-their-module" for various preferences via Global Properties.

![image](https://user-images.githubusercontent.com/3742246/159178572-71ec283d-8f9b-4fe9-a56a-9e507b32a555.png)
