### PR TITLE
11348 - Polygon Editor improvements (move whole shape, tab between points)

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/module/map/boardPicker/board/mapgrid/PolygonEditor.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/boardPicker/board/mapgrid/PolygonEditor.java
@@ -518,7 +518,12 @@ public class PolygonEditor extends JPanel {
         break;
       case KeyEvent.VK_TAB:
         if ((polygon != null) && (polygon.npoints > 0)) {
-          selected = (selected + 1) % polygon.npoints;
+          if (e.isShiftDown()) {
+            selected = (selected + polygon.npoints - 1) % polygon.npoints;
+          }
+          else {
+            selected = (selected + 1) % polygon.npoints;
+          }
         }
         updateAllCoords();
         repaint();

--- a/vassal-app/src/main/java/VASSAL/build/module/map/boardPicker/board/mapgrid/Zone.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/boardPicker/board/mapgrid/Zone.java
@@ -779,11 +779,13 @@ public class Zone extends AbstractConfigurable implements GridContainer, Mutable
 
       frame.setLayout(new BoxLayout(frame.getContentPane(), BoxLayout.Y_AXIS));
       final JPanel labels = new JPanel();
-      labels.setLayout(new GridLayout(3, 2));
+      labels.setLayout(new GridLayout(4, 2));
       labels.add(new JLabel(Resources.getString("Editor.Zone.drag_to_create_initial_shape")));
       labels.add(new JLabel(Resources.getString("Editor.Zone.right_click_to_add_point")));
       labels.add(new JLabel(Resources.getString("Editor.Zone.left_drag_to_move_points")));
       labels.add(new JLabel(Resources.getString("Editor.Zone.del_to_remove_points")));
+      labels.add(new JLabel(Resources.getString("Editor.Zone.shift_drag_to_move_whole_shape")));
+      labels.add(new JLabel(Resources.getString("Editor.Zone.arrow_keys_adjust_position")));
       warning.setForeground(Color.red);
       warning.setVisible(false);
       labels.add(warning);

--- a/vassal-app/src/main/resources/VASSAL/i18n/Editor.properties
+++ b/vassal-app/src/main/resources/VASSAL/i18n/Editor.properties
@@ -2156,7 +2156,9 @@ Editor.Zone.define_shape=Define shape
 Editor.Zone.drag_to_create_initial_shape=Drag to create rectangle
 Editor.Zone.right_click_to_add_point=Right click to add points
 Editor.Zone.left_drag_to_move_points=Drag points to move
-Editor.Zone.del_to_remove_points=DEL to remove points
+Editor.Zone.del_to_remove_points=DEL to remove points, TAB changes selection, ESC deselects all
+Editor.Zone.shift_drag_to_move_whole_shape=Shift+Drag to move whole shape
+Editor.Zone.arrow_keys_adjust_position=Arrow keys adjust position (Shift = faster)
 Editor.Zone.set_coordinates_directly=Set coordinates directly
 Editor.Zone.enter_points_instructions=Enter x,y coordinates of polygon vertices,\nseparated by spaces
 Editor.Zone.delete_all_points=Delete all points


### PR DESCRIPTION
* If SHIFT held down, moves whole shape instead of just one vertex
* If no vertex selected, then arrow keys likewise move whole shape
* TAB between selected vertices
* ESC deselects

Added info on these features to the window legend