### PR TITLE
11356 - SetupStack can match literal grid names even if Zone only reports Zone name (e.g. uses $name$ as Location Format)

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/module/map/SetupStack.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/SetupStack.java
@@ -875,7 +875,7 @@ public class SetupStack extends AbstractConfigurable implements GameComponent, U
         // Update the Component configurer to reflect the change
         xConfig.setValue(String.valueOf(myStack.pos.x));
         yConfig.setValue(String.valueOf(myStack.pos.y));
-        if (locationConfig != null) { // DrawPile's do not have a location
+        if ((locationConfig != null) && !useGridLocation) { // DrawPile's do not have a location. And don't need to change location if it's fixed to a grid location.
           updateLocation();
           locationConfig.setValue(location);
         }

--- a/vassal-app/src/main/java/VASSAL/build/module/map/SetupStack.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/SetupStack.java
@@ -32,6 +32,7 @@ import VASSAL.build.module.documentation.HelpFile;
 import VASSAL.build.module.map.boardPicker.Board;
 import VASSAL.build.module.map.boardPicker.board.MapGrid;
 import VASSAL.build.module.map.boardPicker.board.MapGrid.BadCoords;
+import VASSAL.build.module.map.boardPicker.board.ZonedGrid;
 import VASSAL.build.widget.PieceSlot;
 import VASSAL.command.Command;
 import VASSAL.configure.AutoConfigurer;
@@ -195,10 +196,20 @@ public class SetupStack extends AbstractConfigurable implements GameComponent, U
   // only update the position if we're using the location name
   protected void updatePosition() {
     if (isUseGridLocation() && location != null && !location.equals("")) {
+      final MapGrid grid = getConfigureBoard(true).getGrid();
       try {
-        pos = getConfigureBoard(true).getGrid().getLocation(location);
+        pos = grid.getLocation(location);
       }
       catch (final BadCoords e) {
+        // Allow SetupStacks to match literal grid location names in Irregular/Region grids even if Zone configured to only use/report Zone's name
+        if (grid instanceof ZonedGrid) {
+          final Point p = ((ZonedGrid) grid).getRegionLocation(location);
+          if (p != null) {
+            pos = p;
+            return;
+          }
+        }
+
         ErrorDialog.dataWarning(new BadDataReport(this, "Error.setup_stack_position_error", location, e));
       }
     }
@@ -211,10 +222,19 @@ public class SetupStack extends AbstractConfigurable implements GameComponent, U
         report.addWarning(getConfigureName() + Resources.getString("SetupStack.null_location")); //NON-NLS
       }
       else {
+        final MapGrid grid = getConfigureBoard(true).getGrid();
         try {
-          getConfigureBoard(true).getGrid().getLocation(location);
+          grid.getLocation(location);
         }
         catch (final BadCoords e) {
+          // Allow SetupStacks to match literal grid location names in Irregular/Region grids even if Zone configured to only use/report Zone's name
+          if (grid instanceof ZonedGrid) {
+            final Point p = ((ZonedGrid) grid).getRegionLocation(location);
+            if (p != null) {
+              return;
+            }
+          }
+
           String msg = "Bad location name " + location + " in " + getConfigureName();  //NON-NLS
           if (e.getMessage() != null) {
             msg += ":  " + e.getMessage();

--- a/vassal-app/src/main/java/VASSAL/build/module/map/boardPicker/board/ZonedGrid.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/boardPicker/board/ZonedGrid.java
@@ -17,6 +17,21 @@
  */
 package VASSAL.build.module.map.boardPicker.board;
 
+import VASSAL.build.AbstractConfigurable;
+import VASSAL.build.Buildable;
+import VASSAL.build.module.Map;
+import VASSAL.build.module.documentation.HelpFile;
+import VASSAL.build.module.map.boardPicker.Board;
+import VASSAL.build.module.map.boardPicker.board.mapgrid.GridContainer;
+import VASSAL.build.module.map.boardPicker.board.mapgrid.GridNumbering;
+import VASSAL.build.module.map.boardPicker.board.mapgrid.Zone;
+import VASSAL.build.module.map.boardPicker.board.mapgrid.ZoneHighlight;
+import VASSAL.build.module.map.boardPicker.board.mapgrid.ZonedGridHighlighter;
+import VASSAL.configure.Configurer;
+import VASSAL.i18n.Resources;
+import org.apache.commons.lang3.tuple.Pair;
+import org.w3c.dom.Element;
+
 import java.awt.Dimension;
 import java.awt.Graphics;
 import java.awt.Graphics2D;
@@ -30,23 +45,6 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
-
-import org.apache.commons.lang3.tuple.Pair;
-
-import org.w3c.dom.Element;
-
-import VASSAL.build.AbstractConfigurable;
-import VASSAL.build.Buildable;
-import VASSAL.build.module.Map;
-import VASSAL.build.module.documentation.HelpFile;
-import VASSAL.build.module.map.boardPicker.Board;
-import VASSAL.build.module.map.boardPicker.board.mapgrid.GridContainer;
-import VASSAL.build.module.map.boardPicker.board.mapgrid.GridNumbering;
-import VASSAL.build.module.map.boardPicker.board.mapgrid.Zone;
-import VASSAL.build.module.map.boardPicker.board.mapgrid.ZoneHighlight;
-import VASSAL.build.module.map.boardPicker.board.mapgrid.ZonedGridHighlighter;
-import VASSAL.configure.Configurer;
-import VASSAL.i18n.Resources;
 
 /**
  * Map Grid that contains any number of {@link VASSAL.build.module.map.boardPicker.board.mapgrid.Zone}s against a background {@link MapGrid}
@@ -239,6 +237,16 @@ public class ZonedGrid extends AbstractConfigurable implements GeometricGrid, Gr
       return background.getLocation(location);
     else
       throw new BadCoords();
+  }
+
+  public Point getRegionLocation(String location) {
+    for (final Zone zone : zones) {
+      final Point p = zone.getRegionLocation(location);
+      if (p != null && zone.contains(p)) {
+        return p;
+      }
+    }
+    return null;
   }
 
   @Override

--- a/vassal-app/src/main/java/VASSAL/build/module/map/boardPicker/board/mapgrid/Zone.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/boardPicker/board/mapgrid/Zone.java
@@ -28,6 +28,7 @@ import VASSAL.build.module.map.boardPicker.Board;
 import VASSAL.build.module.map.boardPicker.board.HexGrid;
 import VASSAL.build.module.map.boardPicker.board.MapGrid;
 import VASSAL.build.module.map.boardPicker.board.MapGrid.BadCoords;
+import VASSAL.build.module.map.boardPicker.board.Region;
 import VASSAL.build.module.map.boardPicker.board.RegionGrid;
 import VASSAL.build.module.map.boardPicker.board.SquareGrid;
 import VASSAL.build.module.map.boardPicker.board.ZonedGrid;
@@ -370,6 +371,17 @@ public class Zone extends AbstractConfigurable implements GridContainer, Mutable
       }
       return p;
     }
+  }
+
+  public Point getRegionLocation(String location) {
+    final MapGrid g = getGrid();
+    if (g instanceof RegionGrid) {
+      final Region r = ((RegionGrid) g).findRegion(location);
+      if (r != null) {
+        return new Point(r.getOrigin());
+      }
+    }
+    return null;
   }
 
   public String locationName(Point p) {


### PR DESCRIPTION
SetupStack has a "Use grid location" checkbox, but *unlike* the Send To Location trait it *cannot* send to the name of a grid location in an Irregular Grid (aka "RegionGrid") if the Zone for the grid is set up to use only the zone name (e.g. "$name$" instead of "$gridLocation$").

This is super irritating because it is often desirable to define explicit send-points inside of a larger region (which we can already do with Send To Location) even if the larger region (zone) just reports its zone name as the location name. 

This change allows SetupStack to participate in the goodness -- it will now perform a complete search the old way like before, but if it comes to the point where it finds nothing and was literally just going to throw an exception and print an error message, it will instead first scan the list of literal gridLocation names and match those as well. 

This change affects only SetupStack, does not affect the internal complicated codepaths for "getLocation" -- there is no need to change those because again SendToLocation (the other main customer for such things) already features a way to get around this. 