### PR TITLE
DoActionButton claims its icon in remove-unused-images

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/module/DoActionButton.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/DoActionButton.java
@@ -756,5 +756,10 @@ public class DoActionButton extends AbstractToolbarItem
   public void addLocalImageNames(Collection<String> s) {
     final HTMLImageFinder h = new HTMLImageFinder(reportFormat.getFormat());
     h.addImageNames(s);
+
+    final String imageName = getAttributeValueString(ICON);
+    if (imageName != null) {
+      s.add(imageName);
+    }
   }
 }


### PR DESCRIPTION
They were showing up incorrectly in remove-unused-images