### PR TITLE
Make visual gap in stack when dragging piece into expanded stack.

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/module/map/PieceMover.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/PieceMover.java
@@ -96,6 +96,8 @@ import java.awt.event.MouseListener;
 import java.awt.event.MouseMotionListener;
 import java.awt.geom.AffineTransform;
 import java.awt.image.BufferedImage;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
@@ -860,7 +862,7 @@ public class PieceMover extends AbstractBuildable
    * <br>(1) Moves each piece in the {@link DragBuffer} to its proper destination,
    * based on the mouse having been released at point "p" (if multiple pieces
    * were being dragged after being e.g. band-selected, each individual piece's
-   * destination point will vary with the piece's offset from the anhor point
+   * destination point will vary with the piece's offset from the anchor point
    * that started the drag). This also involves removing each piece from any
    * stacks/decks it was part of, and possibly removing it from its old map if
    * it is changing maps.
@@ -1313,6 +1315,8 @@ public class PieceMover extends AbstractBuildable
    */
   @Override
   public void mouseDragged(MouseEvent e) {
+    // FDL: I would prefer to execute the make-stack-gap logic here, since it would be targeted at the appropriate
+    // window/map, but this method is called unreliably (MacOS).
     if (!breachedThreshold && (dragBegin != null)) {
       final Point pt = map.componentToMap(e.getPoint());
       if (map.mapToComponent(Math.abs(pt.x - dragBegin.x)) > GlobalOptions.getInstance().getDragThreshold() ||
@@ -1321,7 +1325,6 @@ public class PieceMover extends AbstractBuildable
       }
     }
   }
-
 
   /**
    * Moves the group of dragged (in the DragBuffer) pieces to the target point (p).
@@ -1981,7 +1984,83 @@ public class PieceMover extends AbstractBuildable
 
         final DebugControls dc = GameModule.getGameModule().getDebugControls();
         dc.setCursorLocation(pt);
+
+        if ((System.currentTimeMillis() - dmmThrottleMs) > 200) {
+          dmmThrottleMs = System.currentTimeMillis();
+          makeStackGap(map, pt);
+        }
       }
+    }
+
+    private long dmmThrottleMs = 0; // used by dragMouseMoved to throttle calls to dragMouseMovedThrottled
+    private Stack stackWihGap = null; // represents the stack that is currently displaying a gap
+
+    // FDL: This is of course a temporary method to help me see what is happening.
+    private void logConsole(String s) {
+      DateTimeFormatter dtf = DateTimeFormatter.ofPattern("HH:mm:ss.SSS");
+      LocalDateTime now = LocalDateTime.now();
+      System.out.println(dtf.format(now) + ": " + s);
+    }
+
+    // NOTE: This currently only works when dragging within the same map. I'm not sure the best way to handle dragging
+    // from one map to another, but I am guessing that the associated PieceMover should signal in some way that it is
+    // the current one being dragged-over.
+    private void makeStackGap(Map map, Point location) {
+      logConsole("makeStackGap");
+
+      PieceMover pieceMover = map.getPieceMover();
+
+      ////////////////////////////////////////////////
+      // 1. get piece being dragged
+      final List<GamePiece> draggedPieces = new ArrayList<>();
+      final PieceIterator it = DragBuffer.getBuffer().getIterator();
+      while (it.hasMoreElements()) {
+        final GamePiece piece = it.nextPiece();
+        if (piece.getProperty(MatCargo.IS_CARGO) == null && piece.getProperty(Mat.MAT_ID) == null) {
+          draggedPieces.add(piece);
+        }
+      }
+
+      if (draggedPieces.size() != 1) {
+        return;
+      }
+
+      final GamePiece draggedPiece = draggedPieces.get(0);
+      logConsole("piece being dragged: " + draggedPiece.getName());
+
+      ////////////////////////////////////////////////
+      // 2. check if piece intersects another piece
+      MatCargo currentCargo = (MatCargo) Decorator.getDecorator(draggedPiece, MatCargo.class);
+      Mat currentMat = (Mat) Decorator.getDecorator(draggedPiece, Mat.class);;
+
+      int exSepX = Integer.parseInt((String)map.getStackMetrics().getAttributeValueString(StackMetrics.EXSEP_X));
+      int exSepY = Integer.parseInt((String)map.getStackMetrics().getAttributeValueString(StackMetrics.EXSEP_Y));
+
+      // This is a hack so we can see if we are below the stack (allowing us to insert at bottom of stack).
+      // Note: This doesn't work, since both StackMetrics and the display logic not set up to handle the bottom piece
+      // of a stack being offset.
+      location.translate(-exSepX, -exSepY);
+
+      GamePiece targetPiece = map.findAnyPiece(
+        location, pieceMover.getDropTargetSelector(draggedPiece, currentCargo, currentMat));
+
+      final BoundsTracker tracker = new BoundsTracker();
+      final Stack targetStack = targetPiece != null ? targetPiece.getParent() : null;
+      if (targetPiece != null && targetStack != null && targetStack.isExpanded()) {
+        targetStack.insertGapAtPosition = targetStack.indexOf(targetPiece);
+        stackWihGap = targetStack;
+        logConsole("We can merge with: " + targetPiece.getName() +
+                ", index: " + targetStack.indexOf(targetPiece) +
+                ", insert-at-gap: " + targetStack.insertGapAtPosition);
+        tracker.addPiece(targetPiece);
+        tracker.addPiece(targetStack);
+      } else if(stackWihGap != null) {
+        logConsole("Clearing gap");
+        stackWihGap.insertGapAtPosition = -1;
+        tracker.addPiece(stackWihGap);
+        stackWihGap = null;
+      }
+      tracker.repaint();
     }
 
     protected Point lastDragLocation = new Point();
@@ -2017,6 +2096,12 @@ public class PieceMover extends AbstractBuildable
       final DropTargetListener forward = getListener(e);
       if (forward != null) {
         forward.drop(e);
+      }
+
+      if (stackWihGap != null) {
+        logConsole("Clearing gap");
+        stackWihGap.insertGapAtPosition = -1;
+        stackWihGap = null;
       }
     }
 

--- a/vassal-app/src/main/java/VASSAL/build/module/map/PieceMover.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/PieceMover.java
@@ -1997,8 +1997,8 @@ public class PieceMover extends AbstractBuildable
 
     // FDL: This is of course a temporary method to help me see what is happening.
     private void logConsole(String s) {
-      DateTimeFormatter dtf = DateTimeFormatter.ofPattern("HH:mm:ss.SSS");
-      LocalDateTime now = LocalDateTime.now();
+      final DateTimeFormatter dtf = DateTimeFormatter.ofPattern("HH:mm:ss.SSS");
+      final LocalDateTime now = LocalDateTime.now();
       System.out.println(dtf.format(now) + ": " + s);
     }
 
@@ -2008,7 +2008,7 @@ public class PieceMover extends AbstractBuildable
     private void makeStackGap(Map map, Point location) {
       logConsole("makeStackGap");
 
-      PieceMover pieceMover = map.getPieceMover();
+      final PieceMover pieceMover = map.getPieceMover();
 
       ////////////////////////////////////////////////
       // 1. get piece being dragged
@@ -2030,18 +2030,18 @@ public class PieceMover extends AbstractBuildable
 
       ////////////////////////////////////////////////
       // 2. check if piece intersects another piece
-      MatCargo currentCargo = (MatCargo) Decorator.getDecorator(draggedPiece, MatCargo.class);
-      Mat currentMat = (Mat) Decorator.getDecorator(draggedPiece, Mat.class);;
+      final MatCargo currentCargo = (MatCargo) Decorator.getDecorator(draggedPiece, MatCargo.class);
+      final Mat currentMat = (Mat) Decorator.getDecorator(draggedPiece, Mat.class);
 
-      int exSepX = Integer.parseInt((String)map.getStackMetrics().getAttributeValueString(StackMetrics.EXSEP_X));
-      int exSepY = Integer.parseInt((String)map.getStackMetrics().getAttributeValueString(StackMetrics.EXSEP_Y));
+      final int exSepX = Integer.parseInt((String)map.getStackMetrics().getAttributeValueString(StackMetrics.EXSEP_X));
+      final int exSepY = Integer.parseInt((String)map.getStackMetrics().getAttributeValueString(StackMetrics.EXSEP_Y));
 
       // This is a hack so we can see if we are below the stack (allowing us to insert at bottom of stack).
       // Note: This doesn't work, since both StackMetrics and the display logic not set up to handle the bottom piece
       // of a stack being offset.
       location.translate(-exSepX, -exSepY);
 
-      GamePiece targetPiece = map.findAnyPiece(
+      final GamePiece targetPiece = map.findAnyPiece(
         location, pieceMover.getDropTargetSelector(draggedPiece, currentCargo, currentMat));
 
       final BoundsTracker tracker = new BoundsTracker();
@@ -2054,7 +2054,8 @@ public class PieceMover extends AbstractBuildable
                 ", insert-at-gap: " + targetStack.insertGapAtPosition);
         tracker.addPiece(targetPiece);
         tracker.addPiece(targetStack);
-      } else if(stackWihGap != null) {
+      }
+      else if (stackWihGap != null) {
         logConsole("Clearing gap");
         stackWihGap.insertGapAtPosition = -1;
         tracker.addPiece(stackWihGap);

--- a/vassal-app/src/main/java/VASSAL/build/module/map/StackMetrics.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/StackMetrics.java
@@ -45,6 +45,7 @@ import VASSAL.configure.ColorConfigurer;
 import VASSAL.configure.HotKeyConfigurer;
 import VASSAL.configure.VisibilityCondition;
 import VASSAL.counters.BasicPiece;
+import VASSAL.counters.DragBuffer;
 import VASSAL.counters.GamePiece;
 import VASSAL.counters.Highlighter;
 import VASSAL.counters.PieceFilter;
@@ -248,7 +249,9 @@ public class StackMetrics extends AbstractConfigurable {
    * Different instances of StackMetrics may render a {@link Stack}
    * in different ways.  The default algorithm is: If not expanded,
    * all but the top visible GamePiece is drawn as a white square
-   * with size given by {@link GamePiece#getShape}.  The
+   * with size given by {@link GamePiece#getShape}.
+   *
+   * FDL: Is this still true? >> The
    * separation between GamePieces is given by {@link
    * #relativePosition}
    *
@@ -257,6 +260,7 @@ public class StackMetrics extends AbstractConfigurable {
    * drawn in front of other GamePieces, even those above them in
    * the stack.
    */
+  // FDL: Does this method get called?
   public void draw(Stack stack, Graphics g, int x, int y, Component obs, double zoom) {
     final Highlighter highlighter = stack.getMap() == null ? BasicPiece.getHighlighter() : stack.getMap().getHighlighter();
     final Point[] positions = new Point[stack.getPieceCount()];
@@ -324,9 +328,11 @@ public class StackMetrics extends AbstractConfigurable {
         final Point pt = map.mapToDrawing(positions[index], os_scale);
         if (bounds == null || isVisible(region, bounds[index])) {
           if (stack.isExpanded() || !e.hasMoreElements()) {
+            // FDL: expanded stack draw.
             next.draw(g, pt.x, pt.y, view, zoom);
           }
           else {
+            // FDL: unexpanded stack draw.
             drawUnexpanded(next, g, pt.x, pt.y, view, zoom);
           }
         }
@@ -388,9 +394,9 @@ public class StackMetrics extends AbstractConfigurable {
   /**
    * Fill the argument arrays with the positions, selection bounds and bounding boxes of the pieces in the argument stack
    * @param parent The parent Stack
-   * @param positions If non-null will contain a {@link Point} giving the position of each piece in <code>parent</code>
-   * @param shapes If non-null will contain a {@link Shape} giving the shape of for each piece in <code>parent</code>
-   * @param boundingBoxes If non-null will contain a {@link Rectangle} giving the bounding box for each piece in <code>parent</code>
+   * @param positions If non-null will be filled with a {@link Point} giving the position of each piece in <code>parent</code>
+   * @param shapes If non-null will be filled with a {@link Shape} giving the shape of for each piece in <code>parent</code>
+   * @param boundingBoxes If non-null will be filled with a {@link Rectangle} giving the bounding box for each piece in <code>parent</code>
    * @param x the x-location of the parent
    * @param y the y-location of the parent
    * @return the number of pieces processed in the stack
@@ -406,11 +412,14 @@ public class StackMetrics extends AbstractConfigurable {
     if (shapes != null) {
       count = Math.min(count, shapes.length);
     }
-    final int dx = parent.isExpanded() ? exSepX : unexSepX;
-    final int dy = parent.isExpanded() ? exSepY : unexSepY;
     Point currentPos = null, nextPos;
     Rectangle currentSelBounds = null, nextSelBounds;
     for (int index = 0; index < count; ++index) {
+      final int xOffset = parent.insertGapAtPosition == index ? exSepX : 0;
+      final int yOffset = parent.insertGapAtPosition == index ? exSepY : 0;
+      final int dx = parent.isExpanded() ? exSepX + xOffset : unexSepX;
+      final int dy = parent.isExpanded() ? exSepY + yOffset : unexSepY;
+
       final GamePiece child = parent.getPieceAt(index);
       if (Boolean.TRUE.equals(child.getProperty(Properties.INVISIBLE_TO_ME))) {
         final Rectangle blank = new Rectangle(x, y, 0, 0);

--- a/vassal-app/src/main/java/VASSAL/build/module/map/StackMetrics.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/StackMetrics.java
@@ -45,7 +45,6 @@ import VASSAL.configure.ColorConfigurer;
 import VASSAL.configure.HotKeyConfigurer;
 import VASSAL.configure.VisibilityCondition;
 import VASSAL.counters.BasicPiece;
-import VASSAL.counters.DragBuffer;
 import VASSAL.counters.GamePiece;
 import VASSAL.counters.Highlighter;
 import VASSAL.counters.PieceFilter;

--- a/vassal-app/src/main/java/VASSAL/counters/Stack.java
+++ b/vassal-app/src/main/java/VASSAL/counters/Stack.java
@@ -77,6 +77,8 @@ public class Stack extends AbstractImageFinder implements GamePiece, StateMergea
   protected int layer = LAYER_NOT_SET; // Visual layer for this stack. Once the first piece is added, it is bound permanently.
   private boolean expanded = false;    // Is stack currently visually expanded by the player (for easier viewing, and/or to drag individual pieces)
 
+  public int insertGapAtPosition = -1;
+
   private String id;
 
   private static StackMetrics defaultMetrics;


### PR DESCRIPTION
### Overview

This PR is an exploration of a new feature whereby a user can drag a pice (or stack) into the middle of another piece (or stack) and see a visual gap where the piece would drop into the stack if dropped.

**Drag piece into expanded stack**
![image](https://user-images.githubusercontent.com/153073/173289218-ed3350b2-afca-427f-bca1-61f806be66c9.png)

More discussion here:
https://forum.vassalengine.org/t/ux-improvement-stack-management-feature-idea/74661/2

**I'm just at the very early stages of learning the Vassal codebase, so this is merely an exploration at this point. Ideally it will grow into something that can be usability tested in order to find out if such a feature is desirable.**

### Current Progress

* You can drag a single piece into an already-expanded stack.
* You cannot yet drag a stack
* You cannot yet insert into the bottom of a stack
* You cannot yet insert underneath an individual piece
* You must move one piece initially before the code will work (haven't looked into why yet).

### Next up / Q's

* Is it correct to detect piece collision from a throttled `AbstractDragHandler::dragMouseMoved`?

* I’m currently using `map.pickAnyPiece` to decide if a piece overlaps with a stack. This has the benefit of not having to write something new. And it could work for a usability test. But, it doesn’t give exactly what I want (I want piece collision). I’d be happy to implement something else, but just wanted to check that my thinking is correct and that I didn’t miss something elsewhere in the codebase that does this (or something similar). I didn’t see any collision detection code.

* Figure out how to drop a piece underneath a stack. I think this will require that a stack to be able to render the bottom piece offset, which looks like it will require a code change.
