### PR TITLE
BoundsTracker - Track bounds and repaint just for the regions of added pieces; rather than the whole map.

### DIFF
--- a/vassal-app/src/main/java/VASSAL/counters/BoundsTracker.java
+++ b/vassal-app/src/main/java/VASSAL/counters/BoundsTracker.java
@@ -18,11 +18,11 @@
 package VASSAL.counters;
 
 import java.awt.Rectangle;
+import java.util.ArrayList;
 import java.util.List;
-import java.util.LinkedList;
 
 import VASSAL.build.module.Map;
-import VASSAL.tools.lang.Pair;
+import org.apache.commons.lang3.tuple.Pair;
 
 /**
  * Records the bounding boxes of GamePieces.  Use addPiece() to
@@ -31,10 +31,10 @@ import VASSAL.tools.lang.Pair;
  * added pieces belonged.
  */
 public class BoundsTracker {
-  private final List<Pair<Rectangle, Map>> regions;
+  private final List<Pair<Map, Rectangle>> regions;
 
   public BoundsTracker() {
-    regions = new LinkedList<>();
+    regions = new ArrayList<>();
   }
 
   public void clear() {
@@ -45,13 +45,13 @@ public class BoundsTracker {
     if (p.getMap() != null) {
       final Rectangle region = p.boundingBox();
       region.translate(p.getPosition().x, p.getPosition().y);
-      regions.add(new Pair<>(region, p.getMap()));
+      regions.add(Pair.of(p.getMap(), region));
     }
   }
 
   public void repaint() {
-    for (final Pair<Rectangle, Map> rmPair : regions) {
-      rmPair.second.repaint(rmPair.first);
+    for (final Pair<Map, Rectangle> mrPair : regions) {
+      mrPair.getLeft().repaint(mrPair.getRight());
     }
   }
 }

--- a/vassal-app/src/main/java/VASSAL/counters/BoundsTracker.java
+++ b/vassal-app/src/main/java/VASSAL/counters/BoundsTracker.java
@@ -17,10 +17,12 @@
  */
 package VASSAL.counters;
 
-import java.util.HashSet;
-import java.util.Set;
+import java.awt.Rectangle;
+import java.util.List;
+import java.util.LinkedList;
 
 import VASSAL.build.module.Map;
+import VASSAL.tools.lang.Pair;
 
 /**
  * Records the bounding boxes of GamePieces.  Use addPiece() to
@@ -29,25 +31,27 @@ import VASSAL.build.module.Map;
  * added pieces belonged.
  */
 public class BoundsTracker {
-  private final Set<Map> maps;
+  private final List<Pair<Rectangle, Map>> regions;
 
   public BoundsTracker() {
-    maps = new HashSet<>();
+    regions = new LinkedList<>();
   }
 
   public void clear() {
-    maps.clear();
+    regions.clear();
   }
 
   public void addPiece(GamePiece p) {
     if (p.getMap() != null) {
-      maps.add(p.getMap());
+      final Rectangle region = p.boundingBox();
+      region.translate(p.getPosition().x, p.getPosition().y);
+      regions.add(new Pair<>(region, p.getMap()));
     }
   }
 
   public void repaint() {
-    for (final Map m : maps) {
-      m.repaint();
+    for (final Pair<Rectangle, Map> rmPair : regions) {
+      rmPair.second.repaint(rmPair.first);
     }
   }
 }


### PR DESCRIPTION
BoundsTracker was always repainting the entire map. This change has BoundsTracker repaint just the regions of the map that the added Pieces report.

### Discussion

**User Impact**
I don't know the general user impact of this fix. BoundsTracker is not used that many places. 

**Why this PR?**
I am working on a "stack slots" feature and was using BoundsTracker to track changes to the stack. The feature repaints the screen frequently in the case where you're "scrubbing" a piece over an expanded stack and slots are appearing/disappearing rapidly. 

The code was performing in a slow and glitchy way.

When I made the adjustment in this PR, the code performed quickly again.

So, in the case where you're using BoundsTracker and calling repaint often, there would be a big benefit in this adjustment.

**Risks**
This code likely exposes new bugs because it requires that (a) BoundsTracker is used properly, and (b) `Piece.getBoundingBox()` accurately contains all things within the piece/stack/deck.

**In closing**
I can work around not having this PR accepted because I can do my own bounds tracking quite easily without the use of this class.

But, on the other hand, after doing some more general Vassal perf testing, I have a strong hunch that using region updates  in more places (rather than full map updates) could very well result in big performance gains. In order to do this, bounds tracking and getBoundingBox will both need to be done properly, so getting the kinks worked out here might be a step in that direction.

**Discussion in Discord**
There is a discussion of additional related ideas in Discord, Development/General channel, Sunday June 20 4:00 UTC.