### PR TITLE
11524 - Option to 'always use format' on text label (even if label is blank)

### DIFF
--- a/vassal-app/src/main/java/VASSAL/counters/Labeler.java
+++ b/vassal-app/src/main/java/VASSAL/counters/Labeler.java
@@ -44,7 +44,15 @@ import VASSAL.tools.imageop.ImageOp;
 import VASSAL.tools.imageop.Op;
 import VASSAL.tools.imageop.ScaledImagePainter;
 import VASSAL.tools.swing.SwingUtils;
+import net.miginfocom.swing.MigLayout;
+import org.apache.commons.lang3.SystemUtils;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 
+import javax.swing.JLabel;
+import javax.swing.JOptionPane;
+import javax.swing.JPanel;
+import javax.swing.KeyStroke;
+import javax.swing.plaf.basic.BasicHTML;
 import java.awt.Color;
 import java.awt.Component;
 import java.awt.Dimension;
@@ -66,17 +74,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.function.DoubleConsumer;
-
-import javax.swing.JLabel;
-import javax.swing.JOptionPane;
-import javax.swing.JPanel;
-import javax.swing.KeyStroke;
-import javax.swing.plaf.basic.BasicHTML;
-
-import net.miginfocom.swing.MigLayout;
-
-import org.apache.commons.lang3.SystemUtils;
-import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 /**
  * d/b/a "Text Label"
@@ -117,6 +114,7 @@ public class Labeler extends Decorator implements TranslatablePiece, Loopable {
   protected String propertyName;
   protected KeyCommand menuKeyCommand;
   protected String description = "";
+  protected boolean alwaysUseFormat;
 
   private Point position = null; // Label position cache
 
@@ -152,6 +150,7 @@ public class Labeler extends Decorator implements TranslatablePiece, Loopable {
     rotateDegrees = st.nextInt(0);
     propertyName = st.nextToken("TextLabel"); // NON-NLS
     description = st.nextToken("");
+    alwaysUseFormat = st.nextBoolean(false);
   }
 
   /*
@@ -207,7 +206,8 @@ public class Labeler extends Decorator implements TranslatablePiece, Loopable {
       .append(font.getStyle())
       .append(rotateDegrees)
       .append(propertyName)
-      .append(description);
+      .append(description)
+      .append(alwaysUseFormat);
     return ID + se.getValue();
   }
 
@@ -224,7 +224,7 @@ public class Labeler extends Decorator implements TranslatablePiece, Loopable {
   @Override
   public String getName() {
     String result = "";
-    if (label.length() == 0) {
+    if ((label.length() == 0) && !alwaysUseFormat) {
       result =  piece.getName();
     }
     else {
@@ -254,7 +254,7 @@ public class Labeler extends Decorator implements TranslatablePiece, Loopable {
 
   @Override
   public String getLocalizedName() {
-    if (label.length() == 0) {
+    if ((label.length() == 0) && !alwaysUseFormat) {
       return piece.getLocalizedName();
     }
     else {
@@ -802,6 +802,7 @@ public class Labeler extends Decorator implements TranslatablePiece, Loopable {
     if (! Objects.equals(rotateDegrees, l.rotateDegrees)) return false;
     if (! Objects.equals(propertyName, l.propertyName)) return false;
     if (! Objects.equals(description, l.description)) return false;
+    if (! Objects.equals(alwaysUseFormat, l.alwaysUseFormat)) return false;
 
     // Check State
     return Objects.equals(label, l.label);
@@ -835,6 +836,7 @@ public class Labeler extends Decorator implements TranslatablePiece, Loopable {
     private final BooleanConfigurer bold, italic;
     private final StringConfigurer propertyNameConfig;
     private final StringConfigurer descConfig;
+    private final BooleanConfigurer alwaysUseFormatConfig;
 
     public Ed(Labeler l) {
       controls = new TraitConfigPanel();
@@ -851,6 +853,9 @@ public class Labeler extends Decorator implements TranslatablePiece, Loopable {
       format.setValue(l.nameFormat.getFormat()); // NON-NLS
       format.setHintKey("Editor.TextLabel.name_format_hint");
       controls.add("Editor.TextLabel.name_format", format); //NON-NLS
+
+      alwaysUseFormatConfig = new BooleanConfigurer(l.alwaysUseFormat);
+      controls.add("Editor.TextLabel.always_use_format", alwaysUseFormatConfig);
 
       command = new StringConfigurer(l.menuCommand);
       command.setHintKey("Editor.menu_command_hint");
@@ -995,7 +1000,8 @@ public class Labeler extends Decorator implements TranslatablePiece, Loopable {
 
       se.append(i.toString())
         .append(propertyNameConfig.getValueString())
-        .append(descConfig.getValueString());
+        .append(descConfig.getValueString())
+        .append(alwaysUseFormatConfig.getValueString());
 
       return ID + se.getValue();
     }

--- a/vassal-app/src/main/resources/VASSAL/i18n/Editor.properties
+++ b/vassal-app/src/main/resources/VASSAL/i18n/Editor.properties
@@ -2024,6 +2024,7 @@ Editor.TextLabel.rotate_text_degrees=Rotate text (degrees)
 Editor.TextLabel.change_label=Change label
 Editor.TextLabel.change_label_command=Change label command
 Editor.TextLabel.property_name_hint=Property name that will expose the Label Text for this trait
+Editor.TextLabel.always_use_format=Use name format even when label is empty
 
 # ToolbarMenu
 Editor.ToolbarMenu.component_type=Toolbar Menu

--- a/vassal-doc/src/main/readme-referencemanual/ReferenceManual/Label.adoc
+++ b/vassal-doc/src/main/readme-referencemanual/ReferenceManual/Label.adoc
@@ -37,7 +37,9 @@ with a line break +
 and [red]#different# [blue]#colors#
 ****
 
-*Name format:*::  A <<MessageFormat.adoc#top,Message Format>> that specifies how the name of this piece will be reported: _pieceName_ is the name of the piece excluding the label, _label_ is the value of the label text (including, unfortunately, HTML tags). If the label is empty, then the default name of the piece is always used. *Note:* the _$pieceName$_ reference here works differently from the PieceName property (see <<BasicPiece.adoc#top, Basic Piece>>). PieceName (with the capital P) is used to retrieve the full name of the piece as evaluated via this _Name Format_ field, and thus cannot be referenced in this field as it would produce an infinite loop. For this reason, in this field only, all attempts to reference _PieceName_ are automatically assumed to be references to _pieceName_.
+*Name format:*::  A <<MessageFormat.adoc#top,Message Format>> that specifies how the name of this piece will be reported: _pieceName_ is the name of the piece excluding the label, _label_ is the value of the label text (including, unfortunately, HTML tags). If the label is empty, then the default name of the piece is always used unless the _Use name format even when label is empty_ checkbox is selected. *Note:* the _$pieceName$_ reference here works differently from the PieceName property (see <<BasicPiece.adoc#top, Basic Piece>>). PieceName (with the capital P) is used to retrieve the full name of the piece as evaluated via this _Name Format_ field, and thus cannot be referenced in this field as it would produce an infinite loop. For this reason, in this field only, all attempts to reference _PieceName_ are automatically assumed to be references to _pieceName_.
+
+*Use name format even when label is empty:*:: If selected, the _Name format_ will be evaluated even when the label is empty. Otherwise when the label is empty the default name of the piece is used.
 
 *Menu command:*::  If not blank, gives the text of the corresponding menu item in the piece's right-click context menu, selection of which will result in the text of the label being updated.
 


### PR DESCRIPTION
Heretofore, a TextLabel where the label is currently empty/blank did not run its Name Format evaluation (just left the name of the piece alone). 

However I have discovered some situations where I want to change the name of a piece based on a property, and using a "dummy" text label that otherwise doesn't display (just runs its name format) is presently the only workaround available (besides typing the name of every piece a whole extra time in a whole different place, effectively "duplicating code"). So this checkbox allows me to use TextLabel as a workaround. 