### PR TITLE
11540 - Display translated Basic Piece/Basic Name in Scrollable lists in Game Piece Palette

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/Widget.java
+++ b/vassal-app/src/main/java/VASSAL/build/Widget.java
@@ -183,8 +183,10 @@ public abstract class Widget extends AbstractConfigurable implements ComponentDe
         final String localizedName = slot.getLocalizedConfigureName();
         setText((localizedName == null || localizedName.isBlank()) ? slot.getConfigureName() : localizedName);
       }
-      else if (value instanceof Configurable) {
-        setText(((Configurable) value).getConfigureName());
+      else if (value instanceof AbstractConfigurable) {
+        final AbstractConfigurable c = (AbstractConfigurable) value;
+        final String localizedName = c.getLocalizedConfigureName();
+        setText((localizedName == null || localizedName.isBlank()) ? c.getConfigureName() : localizedName);
       }
       return this;
     }

--- a/vassal-app/src/main/java/VASSAL/build/Widget.java
+++ b/vassal-app/src/main/java/VASSAL/build/Widget.java
@@ -19,8 +19,10 @@ package VASSAL.build;
 
 import VASSAL.build.module.ChartWindow;
 import VASSAL.build.module.documentation.HelpFile;
+import VASSAL.build.widget.PieceSlot;
 import VASSAL.configure.ComponentDescription;
 import VASSAL.i18n.Localization;
+
 import org.w3c.dom.Attr;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -174,8 +176,16 @@ public abstract class Widget extends AbstractConfigurable implements ComponentDe
       boolean cellHasFocus) {
 
       super.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus);
-      if (value instanceof Configurable)
+      if (value instanceof PieceSlot) {
+        // PieceSlot names are exposed in the Player in Scrollable Lists.
+        // PieceSlot names are not translated as such, they are based on the translation of the contained piece
+        final PieceSlot slot = (PieceSlot) value;
+        final String localizedName = slot.getLocalizedConfigureName();
+        setText((localizedName == null || localizedName.isBlank()) ? slot.getConfigureName() : localizedName);
+      }
+      else if (value instanceof Configurable) {
         setText(((Configurable) value).getConfigureName());
+      }
       return this;
     }
   }

--- a/vassal-app/src/main/java/VASSAL/build/module/PieceWindow.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/PieceWindow.java
@@ -286,8 +286,6 @@ public class PieceWindow extends Widget implements UniqueIdManager.Identifyable 
       }
       GameModule.getGameModule().getToolBar().add(launch);
     }
-
-    setAttributeTranslatable(NAME, false);
   }
 
   @Override

--- a/vassal-app/src/main/java/VASSAL/build/widget/PieceSlot.java
+++ b/vassal-app/src/main/java/VASSAL/build/widget/PieceSlot.java
@@ -42,6 +42,7 @@ import VASSAL.counters.PieceDefiner;
 import VASSAL.counters.PlaceMarker;
 import VASSAL.counters.Properties;
 import VASSAL.i18n.ComponentI18nData;
+import VASSAL.i18n.Localization;
 import VASSAL.i18n.Resources;
 import VASSAL.search.ImageSearchTarget;
 import VASSAL.tools.ErrorDialog;
@@ -192,14 +193,20 @@ public class PieceSlot extends Widget implements MouseListener, KeyListener {
 
   /**
    * Return defined GamePiece with prototypes fully expanded.
-   *
+   * Do NOT cache the expanded piece unless Translation is complete, it may change under us.
    * @return expanded piece
    */
   protected GamePiece getExpandedPiece() {
     if (expanded == null) {
       final GamePiece p = getPiece();
       if (p != null) {  // Possible when PlaceMarker is building
-        expanded = PieceCloner.getInstance().clonePiece(p);
+        if (Localization.getInstance().isTranslationComplete()) {
+          expanded = PieceCloner.getInstance().clonePiece(p);
+          return expanded;
+        }
+        else {
+          return PieceCloner.getInstance().clonePiece(p);
+        }
       }
     }
     return expanded;

--- a/vassal-app/src/main/java/VASSAL/build/widget/PieceSlot.java
+++ b/vassal-app/src/main/java/VASSAL/build/widget/PieceSlot.java
@@ -594,6 +594,12 @@ public class PieceSlot extends Widget implements MouseListener, KeyListener {
   }
 
   @Override
+  public String getLocalizedConfigureName() {
+    final String translatedName = Decorator.getOutermost(getExpandedPiece()).getLocalizedName();
+    return (translatedName == null || translatedName.isBlank()) ? super.getLocalizedConfigureName() : translatedName;
+  }
+
+  @Override
   public HelpFile getHelpFile() {
     return HelpFile.getReferenceManualPage("GamePiece.html"); //NON-NLS
   }

--- a/vassal-app/src/main/java/VASSAL/build/widget/TabWidget.java
+++ b/vassal-app/src/main/java/VASSAL/build/widget/TabWidget.java
@@ -107,12 +107,10 @@ public class TabWidget extends Widget
    * Shouldn't be necessary, but there's a bug in JTabbedPane with HTML items. Doing this (unsetting and then resetting each title) seems to clear up the problem.
    */
   private void refreshTabs() {
-    int index = 0;
-    for (final Widget w : widgets) {
+    for (int index = 0; index < tab.getTabCount(); index++) {
       final String currentTitle = tab.getTitleAt(index); // The current title may be a translation
       tab.setTitleAt(index, "");
       tab.setTitleAt(index, currentTitle);
-      index++;
     }
   }
 

--- a/vassal-app/src/main/java/VASSAL/build/widget/TabWidget.java
+++ b/vassal-app/src/main/java/VASSAL/build/widget/TabWidget.java
@@ -109,8 +109,9 @@ public class TabWidget extends Widget
   private void refreshTabs() {
     int index = 0;
     for (final Widget w : widgets) {
+      final String currentTitle = tab.getTitleAt(index); // The current title may be a translation
       tab.setTitleAt(index, "");
-      tab.setTitleAt(index, w.getConfigureName());
+      tab.setTitleAt(index, currentTitle);
       index++;
     }
   }

--- a/vassal-app/src/main/java/VASSAL/build/widget/TabWidget.java
+++ b/vassal-app/src/main/java/VASSAL/build/widget/TabWidget.java
@@ -107,10 +107,14 @@ public class TabWidget extends Widget
    * Shouldn't be necessary, but there's a bug in JTabbedPane with HTML items. Doing this (unsetting and then resetting each title) seems to clear up the problem.
    */
   private void refreshTabs() {
-    for (int index = 0; index < tab.getTabCount(); index++) {
-      final String currentTitle = tab.getTitleAt(index); // The current title may be a translation
+    int index = 0;
+    for (final Widget w : widgets) {
+      final String currentTitle = tab.getTitleAt(index);
       tab.setTitleAt(index, "");
-      tab.setTitleAt(index, currentTitle);
+      // In Play mode, the title may have been translated, so need to keep the existing title
+      // In Edit mode, the title will not have been set yet, so need to reset it to the actual title
+      tab.setTitleAt(index, currentTitle.isEmpty() ? w.getConfigureName() : currentTitle);
+      index++;
     }
   }
 

--- a/vassal-app/src/main/java/VASSAL/i18n/Localization.java
+++ b/vassal-app/src/main/java/VASSAL/i18n/Localization.java
@@ -164,6 +164,9 @@ public class Localization extends Language {
       translatableItems.clear();
       GameModule.getGameModule().initFrameTitle();
     }
+    else {
+      translationComplete = true; // Ensure Translation marked complete even if no actual translation took place
+    }
   }
 
   /**


### PR DESCRIPTION
Combined Translation fixes

- Translated Tabs in GamePiece palette no longer lose translation when a new tab is selected.
- Piece names in Scrollable Lists in Game Piece palette are now shown correctly translated.
- Sub-Widget names in Scrollable Lists in Game Piece palette are now shown correctly translated.
- Game Piece palette window name can now be translated.