### PR TITLE
11545 - Description of Prototype will auto-include any BasicName

### DIFF
--- a/vassal-app/src/main/java/VASSAL/configure/ConfigureTree.java
+++ b/vassal-app/src/main/java/VASSAL/configure/ConfigureTree.java
@@ -43,6 +43,7 @@ import VASSAL.build.module.properties.GlobalTranslatableMessage;
 import VASSAL.build.module.properties.ZoneProperty;
 import VASSAL.build.widget.CardSlot;
 import VASSAL.build.widget.PieceSlot;
+import VASSAL.counters.BasicPiece;
 import VASSAL.counters.Decorator;
 import VASSAL.counters.EditablePiece;
 import VASSAL.counters.GamePiece;
@@ -2403,6 +2404,13 @@ public class ConfigureTree extends JTree implements PropertyChangeListener, Mous
           final String desc = ((ComponentDescription) c).getDescription();
           if ((desc != null) && !desc.isEmpty()) {
             description += " - " + desc;
+          }
+        }
+
+        if (c instanceof PrototypeDefinition) {
+          final String basicName = (String)((PrototypeDefinition) c).getPiece().getProperty(BasicPiece.BASIC_NAME);
+          if ((basicName != null) && !basicName.isEmpty()) {
+            description += " - " + basicName;
           }
         }
       }


### PR DESCRIPTION
If a prototype definition includes a "BasicName" trait, then it will be auto-displayed as part of the "description" of the prototype when viewed in the editor. (That way if a BasicName trait is used, it becomes part of the normal description of the prototype/piece without the string needing to be manually copied somewhere else -- "duplication of code") 

![image](https://user-images.githubusercontent.com/3742246/175836285-13259f99-3879-44e4-859c-29c62f51eb4a.png)
