### PR TITLE
Auto-select contents of Edit boxes when they get focus

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/module/map/Zoomer.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/Zoomer.java
@@ -36,26 +36,6 @@ import VASSAL.tools.LaunchButton;
 import VASSAL.tools.NamedKeyStroke;
 import VASSAL.tools.swing.SwingUtils;
 
-import java.awt.BorderLayout;
-import java.awt.Component;
-import java.awt.Dimension;
-import java.awt.Frame;
-import java.awt.GridBagConstraints;
-import java.awt.GridBagLayout;
-import java.awt.Insets;
-import java.awt.Point;
-import java.awt.Rectangle;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
-import java.awt.event.MouseWheelEvent;
-import java.awt.event.MouseWheelListener;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
-
 import javax.swing.AbstractListModel;
 import javax.swing.Box;
 import javax.swing.BoxLayout;
@@ -83,6 +63,25 @@ import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
 import javax.swing.event.DocumentEvent;
 import javax.swing.event.DocumentListener;
+import java.awt.BorderLayout;
+import java.awt.Component;
+import java.awt.Dimension;
+import java.awt.Frame;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.awt.Insets;
+import java.awt.Point;
+import java.awt.Rectangle;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.event.MouseWheelEvent;
+import java.awt.event.MouseWheelListener;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
 
 /**
  * Controls the zooming in/out of a {@link Map} window.
@@ -429,6 +428,18 @@ public class Zoomer extends AbstractConfigurable implements GameComponent {
       levelField = new JTextField(8);
       levelField.setMaximumSize(new Dimension(
         Integer.MAX_VALUE, levelField.getPreferredSize().height));
+
+      // Edit box selects all text when first focused
+      levelField.addFocusListener(new java.awt.event.FocusAdapter() {
+        public void focusGained(java.awt.event.FocusEvent evt) {
+          SwingUtilities.invokeLater(new Runnable() {
+            @Override
+            public void run() {
+              levelField.selectAll();
+            }
+          });
+        }
+      });
 
       // validator for the level entry field
       levelField.getDocument().addDocumentListener(new DocumentListener() {

--- a/vassal-app/src/main/java/VASSAL/configure/BeanShellExpressionConfigurer.java
+++ b/vassal-app/src/main/java/VASSAL/configure/BeanShellExpressionConfigurer.java
@@ -17,13 +17,14 @@
  */
 package VASSAL.configure;
 
+import VASSAL.counters.EditablePiece;
+import VASSAL.counters.GamePiece;
+import VASSAL.i18n.Resources;
+import VASSAL.script.expression.FunctionBuilder;
+import VASSAL.tools.icon.IconFactory;
+import VASSAL.tools.icon.IconFamily;
 import bsh.BeanShellExpressionValidator;
-
-import java.awt.Component;
-import java.awt.event.KeyAdapter;
-import java.awt.event.KeyEvent;
-import java.awt.image.BufferedImage;
-import java.util.List;
+import net.miginfocom.swing.MigLayout;
 
 import javax.swing.BoxLayout;
 import javax.swing.Icon;
@@ -34,14 +35,11 @@ import javax.swing.JPanel;
 import javax.swing.JPopupMenu;
 import javax.swing.JTextField;
 import javax.swing.SwingUtilities;
-
-import VASSAL.counters.EditablePiece;
-import VASSAL.counters.GamePiece;
-import VASSAL.i18n.Resources;
-import VASSAL.script.expression.FunctionBuilder;
-import VASSAL.tools.icon.IconFactory;
-import VASSAL.tools.icon.IconFamily;
-import net.miginfocom.swing.MigLayout;
+import java.awt.Component;
+import java.awt.event.KeyAdapter;
+import java.awt.event.KeyEvent;
+import java.awt.image.BufferedImage;
+import java.util.List;
 
 /**
  * A Configurer for Java Expressions
@@ -174,6 +172,19 @@ public class BeanShellExpressionConfigurer extends StringConfigurer {
           updateParentBuilder();
         }
       });
+
+      // Edit box selects all text when first focused
+      nameField.addFocusListener(new java.awt.event.FocusAdapter() {
+        public void focusGained(java.awt.event.FocusEvent evt) {
+          SwingUtilities.invokeLater(new Runnable() {
+            @Override
+            public void run() {
+              nameField.selectAll();
+            }
+          });
+        }
+      });
+
       panel.add(validator);
       panel.add(extraDetails);
       expressionPanel.add(panel, "grow"); // NON-NLS

--- a/vassal-app/src/main/java/VASSAL/configure/FileConfigurer.java
+++ b/vassal-app/src/main/java/VASSAL/configure/FileConfigurer.java
@@ -23,15 +23,15 @@ import VASSAL.preferences.Prefs;
 import VASSAL.tools.ArchiveWriter;
 import VASSAL.tools.filechooser.FileChooser;
 
-import java.awt.Component;
-import java.io.File;
-
 import javax.swing.JButton;
 import javax.swing.JFrame;
 import javax.swing.JPanel;
 import javax.swing.JTextField;
+import javax.swing.SwingUtilities;
 import javax.swing.event.DocumentEvent;
 import javax.swing.event.DocumentListener;
+import java.awt.Component;
+import java.io.File;
 
 /**
  * A Configurer for java.io.File values
@@ -127,6 +127,19 @@ public class FileConfigurer extends Configurer {
 
       tf = new JTextField(getValueString());
       tf.setEditable(editable);
+      if (editable) {
+        // Edit box selects all text when first focused
+        tf.addFocusListener(new java.awt.event.FocusAdapter() {
+          public void focusGained(java.awt.event.FocusEvent evt) {
+            SwingUtilities.invokeLater(new Runnable() {
+              @Override
+              public void run() {
+                tf.selectAll();
+              }
+            });
+          }
+        });
+      }
       tf.setMaximumSize(new java.awt.Dimension(tf.getMaximumSize().width,
                                                tf.getPreferredSize().height));
       tf.getDocument().addDocumentListener(new DocumentListener() {

--- a/vassal-app/src/main/java/VASSAL/configure/ListKeyCommandsDialog.java
+++ b/vassal-app/src/main/java/VASSAL/configure/ListKeyCommandsDialog.java
@@ -49,6 +49,7 @@ import javax.swing.JScrollPane;
 import javax.swing.JTable;
 import javax.swing.JTextField;
 import javax.swing.RowFilter;
+import javax.swing.SwingUtilities;
 import javax.swing.event.DocumentEvent;
 import javax.swing.event.DocumentListener;
 import javax.swing.table.AbstractTableModel;
@@ -86,6 +87,18 @@ public class ListKeyCommandsDialog extends JDialog {
     this.owner = owner;
 
     final JTextField filter = new JTextField(25);
+
+    // Edit box selects all text when first focused
+    filter.addFocusListener(new java.awt.event.FocusAdapter() {
+      public void focusGained(java.awt.event.FocusEvent evt) {
+        SwingUtilities.invokeLater(new Runnable() {
+          @Override
+          public void run() {
+            filter.selectAll();
+          }
+        });
+      }
+    });
 
     tmod = new MyTableModel(rows);
     final JTable table = new JTable(tmod) {

--- a/vassal-app/src/main/java/VASSAL/configure/NamedHotKeyConfigurer.java
+++ b/vassal-app/src/main/java/VASSAL/configure/NamedHotKeyConfigurer.java
@@ -23,15 +23,7 @@ import VASSAL.tools.NamedKeyStroke;
 import VASSAL.tools.icon.IconFactory;
 import VASSAL.tools.icon.IconFamily;
 import VASSAL.tools.swing.SwingUtils;
-
-import java.awt.Color;
-import java.awt.Component;
-import java.awt.Dimension;
-import java.awt.Graphics;
-import java.awt.event.FocusEvent;
-import java.awt.event.FocusListener;
-import java.awt.event.KeyAdapter;
-import java.awt.event.KeyEvent;
+import net.miginfocom.swing.MigLayout;
 
 import javax.swing.JButton;
 import javax.swing.JComponent;
@@ -40,13 +32,20 @@ import javax.swing.JLayer;
 import javax.swing.JPanel;
 import javax.swing.JTextField;
 import javax.swing.KeyStroke;
+import javax.swing.SwingUtilities;
 import javax.swing.plaf.LayerUI;
 import javax.swing.text.AbstractDocument;
 import javax.swing.text.AttributeSet;
 import javax.swing.text.BadLocationException;
 import javax.swing.text.DocumentFilter;
-
-import net.miginfocom.swing.MigLayout;
+import java.awt.Color;
+import java.awt.Component;
+import java.awt.Dimension;
+import java.awt.Graphics;
+import java.awt.event.FocusEvent;
+import java.awt.event.FocusListener;
+import java.awt.event.KeyAdapter;
+import java.awt.event.KeyEvent;
 
 /**
  * A configurer for Configuring Key Strokes. It allows the entry of either
@@ -207,6 +206,18 @@ public class NamedHotKeyConfigurer extends Configurer implements FocusListener {
       keyName.setText(getValueNamedKeyStroke() == null ? null : getValueNamedKeyStroke().getName());
       ((AbstractDocument) keyName.getDocument()).setDocumentFilter(new KeyNameFilter());
       keyName.addFocusListener(this);
+
+      // Edit box selects all text when first focused
+      keyName.addFocusListener(new java.awt.event.FocusAdapter() {
+        public void focusGained(java.awt.event.FocusEvent evt) {
+          SwingUtilities.invokeLater(new Runnable() {
+            @Override
+            public void run() {
+              keyName.selectAll();
+            }
+          });
+        }
+      });
 
       final JPanel panel = new JPanel(new MigLayout("ins 0", "[fill,grow]0[]0[fill,grow]0[]")); // NON-NLS
 

--- a/vassal-app/src/main/java/VASSAL/configure/StringConfigurer.java
+++ b/vassal-app/src/main/java/VASSAL/configure/StringConfigurer.java
@@ -17,19 +17,19 @@
  */
 package VASSAL.configure;
 
-import java.awt.Color;
-import java.awt.Component;
-import java.awt.Dimension;
-
-import java.awt.Graphics;
-import java.awt.event.FocusListener;
 import javax.swing.JComponent;
 import javax.swing.JLayer;
 import javax.swing.JPanel;
 import javax.swing.JTextField;
+import javax.swing.SwingUtilities;
 import javax.swing.event.DocumentEvent;
 import javax.swing.event.DocumentListener;
 import javax.swing.plaf.LayerUI;
+import java.awt.Color;
+import java.awt.Component;
+import java.awt.Dimension;
+import java.awt.Graphics;
+import java.awt.event.FocusListener;
 
 /**
  * A Configurer for String values
@@ -110,6 +110,18 @@ public class StringConfigurer extends Configurer {
         nameField.getPreferredSize().height
       ));
       nameField.setText(getValueString());
+
+      // Edit box selects all text when first focused
+      nameField.addFocusListener(new java.awt.event.FocusAdapter() {
+        public void focusGained(java.awt.event.FocusEvent evt) {
+          SwingUtilities.invokeLater(new Runnable() {
+            @Override
+            public void run() {
+              nameField.selectAll();
+            }
+          });
+        }
+      });
 
       final LayerUI<JTextField> layerUI = new ConfigLayerUI(this);
       final JLayer<JTextField> layer = new JLayer<>(nameField, layerUI);


### PR DESCRIPTION
In the "making things work like good/normal UI" department along the lines of the Enter/ESC stuff -- this will now automatically select the contents of most edit boxes when the edit boxes gain focus (so when you tab to a field or click in it, you can immediately type a replacement value for the text without having to manually backspace over it all). This is "fairly normal app behavior". 