### PR TITLE
tweak to allow designer control of TC backwards function when disabled

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/module/turn/TurnTracker.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/turn/TurnTracker.java
@@ -1020,9 +1020,9 @@ public class TurnTracker extends TurnComponent implements CommandEncoder, GameCo
     }
 
     protected void doPrev() {
-        captureState();          
-        prev();
-        save();
+      captureState();
+      prev();
+      save();
     }
 
     protected void initComponents() {

--- a/vassal-app/src/main/java/VASSAL/build/module/turn/TurnTracker.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/turn/TurnTracker.java
@@ -1020,11 +1020,9 @@ public class TurnTracker extends TurnComponent implements CommandEncoder, GameCo
     }
 
     protected void doPrev() {
-      if (!fwdOnly) {                // FWD_ONLY start wrap - only the "if"
-        captureState();           // standard code
+        captureState();          
         prev();
         save();
-      }                            // FWD_ONLY end wrap
     }
 
     protected void initComponents() {


### PR DESCRIPTION
This adjustment to the disabled TurnCounter "-" behavior allows the designer to maintain control if desired. Previously, the "-" button functionality was observed to be able to be overridden by HotKeys and could lead to accidental player control and was therefore bypassed. However, there are valid use cases where the designer would need to exercise the "-" function while denying it to the player. The bypass is therefore removed in this adjustment, returning control to the designer. 