### PR TITLE
11565 Global Option List Preferences not initialising Global Property correctly

### DIFF
--- a/vassal-app/src/main/java/VASSAL/configure/StringEnumConfigurer.java
+++ b/vassal-app/src/main/java/VASSAL/configure/StringEnumConfigurer.java
@@ -108,12 +108,7 @@ public class StringEnumConfigurer extends Configurer {
 
   @Override
   public String getValueString() {
-    if (box != null) {
-      return (String) box.getSelectedItem();
-    }
-    else {
-      return validValues.length > 0 ? validValues[0] : "";
-    }
+    return (String) value;
   }
 
   @Override

--- a/vassal-app/src/main/java/VASSAL/configure/StringEnumConfigurer.java
+++ b/vassal-app/src/main/java/VASSAL/configure/StringEnumConfigurer.java
@@ -108,7 +108,7 @@ public class StringEnumConfigurer extends Configurer {
 
   @Override
   public String getValueString() {
-    return (String) value;
+    return value == null ? "" : (String) value;
   }
 
   @Override


### PR DESCRIPTION
This was due to a subtle race condition when StringEnumConfigurers are updated, due to the way the Configurer handles user interaction in the drop-down box. The selected value can for a short term be out of step with the actual underlying value. Mostly, this doesn't matter, except it seems in the case of Global Option List preferences. Solved fairly easily by modifying getValueString() to return a value based on the underlying value, NOT the current state of the UI.