### PR TITLE
Add AOE bounds to `boundingBox()` method.

### DIFF
--- a/vassal-app/src/main/java/VASSAL/counters/AreaOfEffect.java
+++ b/vassal-app/src/main/java/VASSAL/counters/AreaOfEffect.java
@@ -168,11 +168,10 @@ public class AreaOfEffect extends Decorator implements TranslatablePiece, MapSha
 
   @Override
   public Rectangle boundingBox() {
-    // TODO: Need the context of the parent Component, because the transparency is only drawn
-    // on a Map.View object.  Because this context is not known, the bounding box returned by
-    // this method does not encompass the bounds of the transparency.  The result of this is
-    // that portions of the transparency will not be drawn after scrolling the Map window.
-    return piece.boundingBox();
+    final int radius = getRadius();
+    final Rectangle r = new Rectangle(-radius, -radius, radius * 2, radius * 2);
+    r.add(piece.boundingBox());
+    return r;
   }
 
   @Override

--- a/vassal-app/src/main/java/VASSAL/counters/AreaOfEffect.java
+++ b/vassal-app/src/main/java/VASSAL/counters/AreaOfEffect.java
@@ -168,9 +168,16 @@ public class AreaOfEffect extends Decorator implements TranslatablePiece, MapSha
 
   @Override
   public Rectangle boundingBox() {
-    final int radius = getRadius();
-    final Rectangle r = new Rectangle(-radius, -radius, radius * 2, radius * 2);
-    r.add(piece.boundingBox());
+    final Rectangle r = piece.boundingBox();
+
+    final Area a = getArea();
+    if (a != null) {
+      final Rectangle aoeBounds = getArea().getBounds();
+      final Point mapPosition = getPosition();
+      aoeBounds.translate(-mapPosition.x, -mapPosition.y);
+      r.add(aoeBounds);
+    }
+
     return r;
   }
 


### PR DESCRIPTION
There is a bug related to boundstracking reported by @Amàndil Eremanth.

The code fix in this PR makes sense to me and should fix the issue. 

**Bug repro steps**
Use 3.6.8 build (from master ok).

1. Load up his module
2. New Game
3. Select "Jugador 1"
4. Select "Adoquinado 1"
5. Click "EJERCITOS" button.
6. Select "Sauron" and drag piece to map
7. Click on piece to select.
8. Move mouse off to the side (away from where the AOE will appear).
9. Click `M` on the keyboard to display the AOE.

You'll see that AEO is only partially displayed (only within the bounding box of the piece).

