### PR TITLE
Fix bug in BoundsTracker: Not correctly tracking the redraw bounds of pieces that are within a stack

### DIFF
--- a/vassal-app/src/main/java/VASSAL/counters/BoundsTracker.java
+++ b/vassal-app/src/main/java/VASSAL/counters/BoundsTracker.java
@@ -44,9 +44,11 @@ public class BoundsTracker {
   public void addPiece(GamePiece p) {
     if (p.getMap() != null) {
       if(p.getParent() != null) {
-        // NB: We track the Stack if there is one. This is because individual pieces within a Stack do not include
-        // their stack-offsets in `boundingBox()` and so the repaint would not include these offsets. This matters
-        // for rotate-piece (for example). Note: other effects (like area-of-effect) are not offset from the Stack.
+        // NB: We track the Stack if there is one. This is because individual pieces
+        // within a Stack do not include their stack-offsets in `boundingBox()` and
+        // so the repaint would not include these offsets. This matters for
+        // rotate-piece (for example). Note: other effects (like area-of-effect) are
+        // not offset from the Stack.
         p = p.getParent();
       }
       final Rectangle region = p.boundingBox();

--- a/vassal-app/src/main/java/VASSAL/counters/BoundsTracker.java
+++ b/vassal-app/src/main/java/VASSAL/counters/BoundsTracker.java
@@ -43,6 +43,12 @@ public class BoundsTracker {
 
   public void addPiece(GamePiece p) {
     if (p.getMap() != null) {
+      if(p.getParent() != null) {
+        // NB: We track the Stack if there is one. This is because individual pieces within a Stack do not include
+        // their stack-offsets in `boundingBox()` and so the repaint would not include these offsets. This matters
+        // for rotate-piece (for example). Note: other effects (like area-of-effect) are not offset from the Stack.
+        p = p.getParent();
+      }
       final Rectangle region = p.boundingBox();
       region.translate(p.getPosition().x, p.getPosition().y);
       regions.add(Pair.of(p.getMap(), region));

--- a/vassal-app/src/main/java/VASSAL/counters/BoundsTracker.java
+++ b/vassal-app/src/main/java/VASSAL/counters/BoundsTracker.java
@@ -43,7 +43,7 @@ public class BoundsTracker {
 
   public void addPiece(GamePiece p) {
     if (p.getMap() != null) {
-      if(p.getParent() != null) {
+      if (p.getParent() != null) {
         // NB: We track the Stack if there is one. This is because individual pieces
         // within a Stack do not include their stack-offsets in `boundingBox()` and
         // so the repaint would not include these offsets. This matters for


### PR DESCRIPTION
BoundsTracker was recently updated to trigger a redraw just part of the map (rather than the entire map).

This revealed some bugs and oddities. One of these bugs/oddities was the fact that when a piece reports its bounds via `boundingBox()` it does not include its offset position in the stack. In some cases we want the offset position and in some cases not. There were a few options considered:

(1) repaint both the boundingBox of the GamePiece AND the boundingBox+stackOffset of the GamePiece.

(2) have each GamePiece report whether its draw area is offset with the stack or not, perhaps defaulting to true.   Then you could have a boundingBoxWithStackOffset() method or even boundingBox(withStackOffset: true) which would include the stack-offset when needed.

(3) track/repaint the parent stack, not the individual GamePiece.

(4) rethink everything ;)

@uckelman voted for option 3. It seems like a great option to me and it is what is implemented here.