### PR TITLE
Player context menus: Show keyboard shortcuts right-aligned and with symbols.

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/module/map/MenuDisplayer.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/MenuDisplayer.java
@@ -31,6 +31,7 @@ import javax.swing.JMenu;
 import javax.swing.JMenuItem;
 import javax.swing.JPopupMenu;
 import javax.swing.KeyStroke;
+import javax.swing.UIManager;
 import javax.swing.event.PopupMenuEvent;
 import javax.swing.event.PopupMenuListener;
 
@@ -107,8 +108,13 @@ public class MenuDisplayer extends MouseAdapter implements Buildable {
   // This both eliminates duplicate code AND makes this critical menu-building functionality able to "play well with others".
   // Menu text & behavior can now be custom-classed without needing to override the monster that is MenuDisplayer#createPopup.
   protected static JMenuItem makeMenuItem(KeyCommand keyCommand) {
-
+    // We remember the oldAcceleratorFont so that we can set it back after creating the JMenuItem
+    Object oldAcceleratorFont = UIManager.get("MenuItem.acceleratorFont");
+    UIManager.put("MenuItem.acceleratorFont", POPUP_MENU_FONT);
     final JMenuItem item = new JMenuItem(keyCommand.isMenuSeparator() ? MenuSeparator.SEPARATOR_NAME : getMenuText(keyCommand));
+    item.setAccelerator(keyCommand.getKeyStroke());
+    UIManager.put("MenuItem.acceleratorFont", oldAcceleratorFont);
+
     item.addActionListener(keyCommand);
     item.setFont(POPUP_MENU_FONT);
     item.setEnabled(keyCommand.isEnabled());

--- a/vassal-app/src/main/java/VASSAL/build/module/map/MenuDisplayer.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/MenuDisplayer.java
@@ -36,6 +36,7 @@ import javax.swing.event.PopupMenuEvent;
 import javax.swing.event.PopupMenuListener;
 
 import VASSAL.counters.ActionButton;
+import VASSAL.tools.NamedKeyManager;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
@@ -110,9 +111,11 @@ public class MenuDisplayer extends MouseAdapter implements Buildable {
   protected static JMenuItem makeMenuItem(KeyCommand keyCommand) {
     // We remember the oldAcceleratorFont so that we can set it back after creating the JMenuItem
     final Object oldAcceleratorFont = UIManager.get("MenuItem.acceleratorFont");
-    UIManager.put("MenuItem.acceleratorFont", POPUP_MENU_FONT);
+    UIManager.put("MenuItem.acceleratorFont", POPUP_MENU_FONT); // This needs to be set prior to creating the JMenuItem
     final JMenuItem item = new JMenuItem(keyCommand.isMenuSeparator() ? MenuSeparator.SEPARATOR_NAME : getMenuText(keyCommand));
-    item.setAccelerator(keyCommand.getKeyStroke());
+    if (!NamedKeyManager.isNamed(keyCommand.getKeyStroke())) { // If the KeyStroke is named, then there is no accelerator
+      item.setAccelerator(keyCommand.getKeyStroke());
+    }
     UIManager.put("MenuItem.acceleratorFont", oldAcceleratorFont);
 
     item.addActionListener(keyCommand);

--- a/vassal-app/src/main/java/VASSAL/build/module/map/MenuDisplayer.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/MenuDisplayer.java
@@ -109,7 +109,7 @@ public class MenuDisplayer extends MouseAdapter implements Buildable {
   // Menu text & behavior can now be custom-classed without needing to override the monster that is MenuDisplayer#createPopup.
   protected static JMenuItem makeMenuItem(KeyCommand keyCommand) {
     // We remember the oldAcceleratorFont so that we can set it back after creating the JMenuItem
-    Object oldAcceleratorFont = UIManager.get("MenuItem.acceleratorFont");
+    final Object oldAcceleratorFont = UIManager.get("MenuItem.acceleratorFont");
     UIManager.put("MenuItem.acceleratorFont", POPUP_MENU_FONT);
     final JMenuItem item = new JMenuItem(keyCommand.isMenuSeparator() ? MenuSeparator.SEPARATOR_NAME : getMenuText(keyCommand));
     item.setAccelerator(keyCommand.getKeyStroke());

--- a/vassal-app/src/main/java/VASSAL/counters/KeyCommand.java
+++ b/vassal-app/src/main/java/VASSAL/counters/KeyCommand.java
@@ -24,7 +24,6 @@ import javax.swing.KeyStroke;
 
 import VASSAL.build.GameModule;
 import VASSAL.command.Command;
-import VASSAL.configure.NamedHotKeyConfigurer;
 import VASSAL.i18n.TranslatablePiece;
 import VASSAL.tools.NamedKeyStroke;
 
@@ -53,7 +52,7 @@ public class KeyCommand extends AbstractAction {
   }
 
   public KeyCommand(String name, KeyStroke key, GamePiece target, TranslatablePiece i18nPiece) {
-    super(makeMenuText(key, name));
+    super(makeMenuText(name));
     this.target = target;
     this.name = name;
     this.stroke = key;
@@ -169,12 +168,12 @@ public class KeyCommand extends AbstractAction {
       if (i18nPiece != null && GameModule.getGameModule().isLocalizationEnabled()) {
         localizedName = i18nPiece.getI18nData().translate(name);
       }
-      localizedMenuText = makeMenuText(stroke, localizedName);
+      localizedMenuText = makeMenuText(localizedName);
     }
     return localizedMenuText;
   }
 
-  private static String makeMenuText(KeyStroke ks, String text) {
+  private static String makeMenuText(String text) {
     return (text == null ? "" : text).intern();
   }
 }

--- a/vassal-app/src/main/java/VASSAL/counters/KeyCommand.java
+++ b/vassal-app/src/main/java/VASSAL/counters/KeyCommand.java
@@ -175,7 +175,6 @@ public class KeyCommand extends AbstractAction {
   }
 
   private static String makeMenuText(KeyStroke ks, String text) {
-    return (ks != null && text != null && !text.isBlank() ?
-      text + "  " + NamedHotKeyConfigurer.getString(ks) : (text == null) ? "" : text).intern();
+    return (text == null ? "" : text).intern();
   }
 }


### PR DESCRIPTION
Making this available so @uckelman can easily see the results in different modules.

Discussion here:
https://forum.vassalengine.org/t/right-justify-context-menu-commands-v3-6-8/75000/18

**IMPORTANT -- Code does not change the tooltip for menu buttons**

This code does **not** effect the display of keyboard shortcuts for the menu buttons. It does not look possible / easy to update the menu-bottons to show symbols. I think this code is an improvement on what was there previously, but perhaps introducing this mismatch between the menu-buttons and the context menus is worse.