### PR TITLE
Get the CloseWindow event to look at other ways of reopening the window apart from the button

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/module/Map.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/Map.java
@@ -2866,7 +2866,11 @@ public class Map extends AbstractToolbarItem implements GameComponent, MouseList
             topWindow.addWindowListener(new WindowAdapter() {
               @Override
               public void windowClosing(WindowEvent e) {
-                if (useLaunchButtonEdit) {
+                // If there is no way of reopening the window,
+                // we close the game. Otherwise just the window.
+                // But there are three ways of reopening it:
+                // Button, the toggle hot key, the show hot key
+                if (useLaunchButtonEdit || !getAttributeValueString(HOTKEY).isEmpty() || !getAttributeValueString(SHOW_KEY).isEmpty()) {
                   topWindow.setVisible(false);
                 }
                 else {


### PR DESCRIPTION
Bug: https://github.com/vassalengine/vassal/issues/11597

Problem with map that don't have a launch button (but do have a hotkey). When you try to close them, VASSAL tries to close the game rather than simply hiding the window.