### PR TITLE
Upgrade logback

### DIFF
--- a/vassal-app/pom.xml
+++ b/vassal-app/pom.xml
@@ -36,7 +36,7 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.2.11</version>
+            <version>1.3.0-beta0</version>
         </dependency>
         <dependency>
             <groupId>com.miglayout</groupId>


### PR DESCRIPTION
A newer version of logback is required to work with SLF4J 2.0.