### PR TITLE
Dereference symbolic link to executable before attemping to find install dir

### DIFF
--- a/dist/VASSAL.sh
+++ b/dist/VASSAL.sh
@@ -15,8 +15,10 @@ if [ ! -x "$JAVA" ]; then
   exit 1
 fi
 
-# Find absolute path where VASSAL is installed
-INSTALL_DIR=$(cd "$(dirname "$0")"; pwd)
+# Dereference any possible symbolic link to executable script, then find
+# absolute path where VASSAL is installed 
+EXEC_PATH=$(readlink "$0")
+INSTALL_DIR=$(dirname ${EXEC_PATH})
 
 # Check that java is new enough
 if ! "$JAVA" -classpath "$INSTALL_DIR"/lib/Vengine.jar VASSAL.launch.JavaVersionChecker 2>/dev/null ; then

--- a/dist/VASSAL.sh
+++ b/dist/VASSAL.sh
@@ -17,7 +17,7 @@ fi
 
 # Dereference any possible symbolic link to executable script, then find
 # absolute path where VASSAL is installed 
-EXEC_PATH=$(readlink "$0")
+EXEC_PATH=$(realpath "$0")
 INSTALL_DIR=$(dirname ${EXEC_PATH})
 
 # Check that java is new enough


### PR DESCRIPTION
On Linux, I have noticed that VASSAL will not start if the executable script (VASSAL.sh) is run through a symbolic link. 

To reproduce the issue, unpack VASSAL into any location (I used /opt in my case), then create a symbolic link to `/opt/<VASSAL FOLDER/VASSAL.sh`, e.g. with the latest version:
```sh
ln -s /opt/VASSAL-3.6.7/VASSAL.sh vassal
```
Then call the symbolic link:
```sh
./vassal
```
You will get the following error:
```
Error: java is too old to run this version of Vassal. Please use Java 11 or later.
```
I noticed it because I was running java 11.0.8 so the error message could not be possibly correct.

The reason for this behavior is that the executable script (VASSAL.sh) will attempt to identify the installation directory a combination of `which` and `dirname`, but this will work only if calling VASSAL.sh directly, not if (like in my case) one calls a symbolic link to it. 

This commit should fix that by attempting to dereference any symbolic link prior to using dirname.