### PR TITLE
Report exceptions thrown while loading modules

### DIFF
--- a/vassal-app/src/main/java/VASSAL/launch/Launcher.java
+++ b/vassal-app/src/main/java/VASSAL/launch/Launcher.java
@@ -91,7 +91,6 @@ public abstract class Launcher {
 
     createMenuManager();
 
-
     final SimpleRunnableFuture<Void> fut = new SimpleRunnableFuture() {
       @Override
       public void run() {
@@ -162,6 +161,9 @@ public abstract class Launcher {
           )
         );
         System.exit(1);
+      }
+      else {
+        throw new RuntimeException(e);
       }
     }
   }


### PR DESCRIPTION
Exceptions thrown when launching are bugs. Don't swallow the exceptions.