### PR TITLE
11806 NotesWindow re-open assigns focus properly to retain caret position. …

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/module/NotesWindow.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/NotesWindow.java
@@ -62,6 +62,9 @@ public class NotesWindow extends AbstractToolbarItem
   public static final String BUTTON_TEXT = "buttonText"; //NON-NLS // non-standard legacy difference from AbstractToolbarItem
   public static final String DESCRIPTION = "description"; //NON-NLS
 
+  public static final int TAB_INDEX_SCEN = 0;
+  public static final int TAB_INDEX_PUBLIC = 1;
+
   // These three identical to AbstractToolbarItem, and are only here for "clirr purposes"
   @Deprecated(since = "2020-10-21", forRemoval = true) public static final String HOT_KEY = "hotkey"; //$NON-NLS-1$
   @Deprecated(since = "2020-10-21", forRemoval = true) public static final String ICON = "icon"; //$NON-NLS-1$
@@ -72,6 +75,8 @@ public class NotesWindow extends AbstractToolbarItem
   /** @deprecated use launch from the superclass */
   @Deprecated(since = "2021-04-03", forRemoval = true)
   protected LaunchButton launch;
+
+  protected JTabbedPane tab;
 
   protected TextConfigurer scenarioNotes;
   protected TextConfigurer publicNotes;
@@ -100,7 +105,19 @@ public class NotesWindow extends AbstractToolbarItem
       "/images/notes.gif", //NON-NLS
       e -> {
         captureState();
-        frame.setVisible(!frame.isShowing());
+
+        if (!frame.isShowing()) {
+          frame.setVisible(true);
+          if (tab.getSelectedIndex() == TAB_INDEX_SCEN) {
+            scenarioNotes.requestFocus();
+          }
+          else if (tab.getSelectedIndex() == TAB_INDEX_PUBLIC) {
+            publicNotes.requestFocus();
+          }
+        }
+        else {
+          frame.setVisible(false);
+        }
       }
     ));
     launch = getLaunchButton();
@@ -180,7 +197,7 @@ public class NotesWindow extends AbstractToolbarItem
 
       scenarioNotes = new TextConfigurer(null, null);
       publicNotes = new TextConfigurer(null, null);
-      final JTabbedPane tab = new JTabbedPane();
+      tab = new JTabbedPane();
       add(tab);
 
       Box b = Box.createVerticalBox();

--- a/vassal-app/src/main/java/VASSAL/build/module/NotesWindow.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/NotesWindow.java
@@ -62,8 +62,8 @@ public class NotesWindow extends AbstractToolbarItem
   public static final String BUTTON_TEXT = "buttonText"; //NON-NLS // non-standard legacy difference from AbstractToolbarItem
   public static final String DESCRIPTION = "description"; //NON-NLS
 
-  public static final int TAB_INDEX_SCEN = 0;
-  public static final int TAB_INDEX_PUBLIC = 1;
+  static final int TAB_INDEX_SCEN = 0;
+  static final int TAB_INDEX_PUBLIC = 1;
 
   // These three identical to AbstractToolbarItem, and are only here for "clirr purposes"
   @Deprecated(since = "2020-10-21", forRemoval = true) public static final String HOT_KEY = "hotkey"; //$NON-NLS-1$

--- a/vassal-app/src/main/java/VASSAL/configure/TextConfigurer.java
+++ b/vassal-app/src/main/java/VASSAL/configure/TextConfigurer.java
@@ -21,7 +21,6 @@ import VASSAL.build.AutoConfigurable;
 import VASSAL.tools.ScrollPane;
 import VASSAL.tools.SequenceEncoder;
 import VASSAL.tools.swing.SwingUtils;
-import javax.swing.text.DefaultCaret;
 import org.apache.commons.lang3.StringUtils;
 
 import javax.swing.BoxLayout;
@@ -127,6 +126,12 @@ public class TextConfigurer extends Configurer implements ConfigurerFactory {
   }
 
   @Override
+  public void requestFocus() {
+    super.requestFocus();
+    textArea.requestFocus();
+  }
+
+  @Override
   public java.awt.Component getControls() {
     if (p == null) {
       p = new JPanel();
@@ -143,9 +148,6 @@ public class TextConfigurer extends Configurer implements ConfigurerFactory {
         }
       });
 
-      // Prevent setting the text forcing the caret to the end of the text
-      ((DefaultCaret)textArea.getCaret()).setUpdatePolicy(DefaultCaret.NEVER_UPDATE);
-      
       textArea.setText((String) getValue());
       SwingUtils.allowUndo(textArea);
       final JScrollPane scroll = new ScrollPane(textArea);


### PR DESCRIPTION
…Restored proper caret update policy.

The previous change couldn't work & broke all text configurers. 

I've reverted that part, and instead improved the focus behavior of NotesWindow (when you re-open it after having hidden it) so that it returns focus to the TextArea you had going before, thus retaining caret position (turns out, caret position always worked right if you tabbed into the window; the problem was that unless you used tab key you had to click in the text to get the focus back in there, and that usually moved your cursor somewhere irritating)