### PR TITLE
Global Key Command fastmatch for Mats fixed to avoid certain trait-order bugs

### DIFF
--- a/vassal-app/src/main/java/VASSAL/counters/GlobalCommand.java
+++ b/vassal-app/src/main/java/VASSAL/counters/GlobalCommand.java
@@ -438,18 +438,21 @@ public class GlobalCommand implements Auditable {
       else if (target.fastMatchLocation && target.targetType == GlobalCommandTarget.Target.CURMAT) {
         if (curPiece instanceof Decorator) {
           // First check if we are a mat
-          GamePiece matPiece = Decorator.getDecorator(curPiece, Mat.class);
+          GamePiece matPiece = Decorator.getDecorator(Decorator.getOutermost(curPiece), Mat.class);
           if (matPiece == null) {
             // Otherwise check if we're a cargo that's currently ON a mat.
-            final MatCargo cargo = (MatCargo)Decorator.getDecorator(curPiece, MatCargo.class);
+            final MatCargo cargo = (MatCargo)Decorator.getDecorator(Decorator.getOutermost(curPiece), MatCargo.class);
             if (cargo != null) {
               matPiece = cargo.getMat();
             }
           }
           if (matPiece != null) {
             final Mat mat = (Mat)Decorator.getDecorator(matPiece, Mat.class);
-            final List<GamePiece> pieces = new ArrayList<>(mat.getContents());
-            pieces.add(0, mat);
+            final List<GamePiece> pieces = new ArrayList<>();
+            for (final GamePiece p : mat.getContents()) {
+              pieces.add(Decorator.getOutermost(p));
+            }
+            pieces.add(0, Decorator.getOutermost(matPiece));
 
             for (final GamePiece gamePiece : pieces) {
               // If a property-based Fast Match is specified, we eliminate non-matchers of that first.


### PR DESCRIPTION
It appears that the Fast Match setting for Mats/Mat-Cargo was subject to malfunctions based on sometimes passing "only part of the piece" (i.e. not passing the outermost trait) to matches