### PR TITLE
11911 - Debug window shows board-relative coordinates if they are different from the map-relative ones

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/module/Map.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/Map.java
@@ -2090,7 +2090,7 @@ public class Map extends AbstractToolbarItem implements GameComponent, MouseList
   @Override
   public void mouseMoved(MouseEvent e) {
     final DebugControls dc = GameModule.getGameModule().getDebugControls();
-    dc.setCursorLocation(componentToMap(e.getPoint()));
+    dc.setCursorLocation(componentToMap(e.getPoint()), this);
   }
 
   /**
@@ -2103,7 +2103,7 @@ public class Map extends AbstractToolbarItem implements GameComponent, MouseList
   @Override
   public void mouseDragged(MouseEvent e) {
     final DebugControls dc = GameModule.getGameModule().getDebugControls();
-    dc.setCursorLocation(componentToMap(e.getPoint()));
+    dc.setCursorLocation(componentToMap(e.getPoint()), this);
 
     if (!SwingUtils.isContextMouseButtonDown(e)) {
       scrollAtEdge(e.getPoint(), SCROLL_ZONE);

--- a/vassal-app/src/main/java/VASSAL/build/module/map/PieceMover.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/PieceMover.java
@@ -18,8 +18,6 @@
  */
 package VASSAL.build.module.map;
 
-import static VASSAL.build.module.Map.MAP_NAME;
-
 import VASSAL.build.AbstractBuildable;
 import VASSAL.build.Buildable;
 import VASSAL.build.GameModule;
@@ -64,7 +62,14 @@ import VASSAL.tools.NamedKeyStroke;
 import VASSAL.tools.image.ImageUtils;
 import VASSAL.tools.imageop.Op;
 import VASSAL.tools.swing.SwingUtils;
+import org.apache.commons.lang3.SystemUtils;
 
+import javax.swing.ImageIcon;
+import javax.swing.JLabel;
+import javax.swing.JLayeredPane;
+import javax.swing.JRootPane;
+import javax.swing.KeyStroke;
+import javax.swing.SwingUtilities;
 import java.awt.AlphaComposite;
 import java.awt.Color;
 import java.awt.Component;
@@ -102,14 +107,7 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 
-import javax.swing.ImageIcon;
-import javax.swing.JLabel;
-import javax.swing.JLayeredPane;
-import javax.swing.JRootPane;
-import javax.swing.KeyStroke;
-import javax.swing.SwingUtilities;
-
-import org.apache.commons.lang3.SystemUtils;
+import static VASSAL.build.module.Map.MAP_NAME;
 
 /**
  * PieceMover handles the "Drag and Drop" of pieces and stacks, onto or within a Map window. It implements
@@ -1983,7 +1981,7 @@ public class PieceMover extends AbstractBuildable
         pt = map.componentToMap(pt);
 
         final DebugControls dc = GameModule.getGameModule().getDebugControls();
-        dc.setCursorLocation(pt);
+        dc.setCursorLocation(pt, map);
       }
     }
 

--- a/vassal-app/src/main/java/VASSAL/tools/DebugControls.java
+++ b/vassal-app/src/main/java/VASSAL/tools/DebugControls.java
@@ -90,24 +90,19 @@ public class DebugControls extends AbstractBuildable implements ActionListener {
     return cursorLocation;
   }
 
+  private Point getBoardLocation(Point pt, Map map) {
+    if (map == null) return pt;
+    final Board b = map.findBoard(pt);
+    if (b == null) return pt;
+    final Rectangle r = b.bounds();
+    final Point bp = new Point(pt);
+    bp.translate(-r.x, -r.y);
+    return bp;
+  }
+
   public void setCursorLocation(Point pt, Map map) {
     cursorLocation = pt;
-
-    if (map != null) {
-      final Board b = map.findBoard(pt);
-      if (b != null) {
-        final Rectangle r = b.bounds();
-        final Point bp = new Point(pt);
-        bp.translate(-r.x, -r.y);
-        cursorLocationBoard = bp;
-      }
-      else {
-        cursorLocationBoard = pt;
-      }
-    }
-    else {
-      cursorLocationBoard = pt;
-    }
+    cursorLocationBoard = getBoardLocation(pt, map);
 
     updateCoords();
     updateSelected();
@@ -198,24 +193,10 @@ public class DebugControls extends AbstractBuildable implements ActionListener {
     selectedNameLabel.setText(piece.getName());
     selectedCoordsLabel.setText(piece.getPosition().x + "," + piece.getPosition().y);
 
-    final Map map = piece.getMap();
-    if (map != null) {
-      final Point pt = piece.getPosition();
-      final Board b = map.findBoard(pt);
-      if (b != null) {
-        final Rectangle r = b.bounds();
-        final Point bp = new Point(pt);
-        bp.translate(-r.x, -r.y);
-        if (!bp.equals(pt)) {
-          selectedCoordsBoardLabel.setText(bp.x + "," + bp.y);
-        }
-        else {
-          selectedCoordsBoardLabel.setText("");
-        }
-      }
-      else {
-        selectedCoordsBoardLabel.setText("");
-      }
+    final Point pt = piece.getPosition();
+    final Point bp = getBoardLocation(pt, piece.getMap());
+    if (!bp.equals(pt)) {
+      selectedCoordsBoardLabel.setText(bp.x + "," + bp.y);
     }
     else {
       selectedCoordsBoardLabel.setText("");

--- a/vassal-app/src/main/java/VASSAL/tools/DebugControls.java
+++ b/vassal-app/src/main/java/VASSAL/tools/DebugControls.java
@@ -21,6 +21,8 @@ import VASSAL.build.AbstractBuildable;
 import VASSAL.build.Buildable;
 import VASSAL.build.GameModule;
 import VASSAL.build.module.GlobalOptions;
+import VASSAL.build.module.Map;
+import VASSAL.build.module.map.boardPicker.Board;
 import VASSAL.configure.IconConfigurer;
 import VASSAL.configure.NamedHotKeyConfigurer;
 import VASSAL.counters.GamePiece;
@@ -49,6 +51,7 @@ import java.awt.BorderLayout;
 import java.awt.Component;
 import java.awt.Container;
 import java.awt.Point;
+import java.awt.Rectangle;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.net.URL;
@@ -63,11 +66,13 @@ public class DebugControls extends AbstractBuildable implements ActionListener {
   protected SplitPane splitPane;
 
   protected Point cursorLocation;
+  protected Point cursorLocationBoard;
 
   protected JLabel cursorCoordsLabel;
 
   protected FlowLabel selectedNameLabel;
   protected JLabel selectedCoordsLabel;
+  protected JLabel selectedCoordsBoardLabel;
 
   //protected JLabel heapSizeLabel;
   //protected JLabel heapMaxLabel;
@@ -85,10 +90,31 @@ public class DebugControls extends AbstractBuildable implements ActionListener {
     return cursorLocation;
   }
 
-  public void setCursorLocation(Point pt) {
+  public void setCursorLocation(Point pt, Map map) {
     cursorLocation = pt;
+
+    if (map != null) {
+      final Board b = map.findBoard(pt);
+      if (b != null) {
+        final Rectangle r = b.bounds();
+        final Point bp = new Point(pt);
+        bp.translate(-r.x, -r.y);
+        cursorLocationBoard = bp;
+      }
+      else {
+        cursorLocationBoard = pt;
+      }
+    }
+    else {
+      cursorLocationBoard = pt;
+    }
+
     updateCoords();
     updateSelected();
+  }
+
+  public void setCursorLocation(Point pt) {
+    setCursorLocation(pt, null);
   }
 
   public DebugControls() {
@@ -109,8 +135,10 @@ public class DebugControls extends AbstractBuildable implements ActionListener {
     final Box selectedBox = Box.createVerticalBox();
     selectedNameLabel = new FlowLabel("");
     selectedCoordsLabel = new JLabel("");
+    selectedCoordsBoardLabel = new JLabel("");
     selectedBox.add(selectedNameLabel);
     selectedBox.add(selectedCoordsLabel);
+    selectedBox.add(selectedCoordsBoardLabel);
 
     leftBox.add(cursorBox);
     leftBox.add(Box.createVerticalStrut(10));
@@ -151,7 +179,8 @@ public class DebugControls extends AbstractBuildable implements ActionListener {
   }
 
   private void updateCoords() {
-    cursorCoordsLabel.setText(Resources.getString("Debug.cursor", cursorLocation.x, cursorLocation.y));
+    cursorCoordsLabel.setText(Resources.getString("Debug.cursor", cursorLocation.x, cursorLocation.y) +
+      (!cursorLocationBoard.equals(cursorLocation) ? "  " + Resources.getString("Debug.cursor_board", cursorLocationBoard.x, cursorLocationBoard.y) : ""));
   }
 
 
@@ -160,6 +189,7 @@ public class DebugControls extends AbstractBuildable implements ActionListener {
     if (selected.isEmpty()) {
       selectedNameLabel.setText("");
       selectedCoordsLabel.setText("");
+      selectedCoordsBoardLabel.setText("");
       return;
     }
 
@@ -167,6 +197,29 @@ public class DebugControls extends AbstractBuildable implements ActionListener {
 
     selectedNameLabel.setText(piece.getName());
     selectedCoordsLabel.setText(piece.getPosition().x + "," + piece.getPosition().y);
+
+    final Map map = piece.getMap();
+    if (map != null) {
+      final Point pt = piece.getPosition();
+      final Board b = map.findBoard(pt);
+      if (b != null) {
+        final Rectangle r = b.bounds();
+        final Point bp = new Point(pt);
+        bp.translate(-r.x, -r.y);
+        if (!bp.equals(pt)) {
+          selectedCoordsBoardLabel.setText(bp.x + "," + bp.y);
+        }
+        else {
+          selectedCoordsBoardLabel.setText("");
+        }
+      }
+      else {
+        selectedCoordsBoardLabel.setText("");
+      }
+    }
+    else {
+      selectedCoordsBoardLabel.setText("");
+    }
   }
 
 

--- a/vassal-app/src/main/resources/VASSAL/i18n/VASSAL.properties
+++ b/vassal-app/src/main/resources/VASSAL/i18n/VASSAL.properties
@@ -545,6 +545,7 @@ Debug.debug_controls_button_icon=Debug window button icon
 Debug.debug_controls_hotkey=Debug window hotkey
 Debug.debug_controls_tooltip=Opens module debug window showing live cursor X,Y information
 Debug.cursor=Cursor: %1$s,%2$s
+Debug.cursor_board= (Board: %1$s,%2$s)
 Debug.show_debug_window=Show Debug Window
 
 # Deck


### PR DESCRIPTION
Noticed the need for this while I was working on Imperial Struggle module. Doesn't display the extra stuff on e.g. maps-that-only-have-one-board, so most people won't see anything extra/spurious/new

![image](https://user-images.githubusercontent.com/3742246/213550537-56c11192-44f2-4e44-9d9b-d8e0af641c35.png)
