### PR TITLE
11918 - Startup GKC that fires when player joins or changes sides

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/module/PlayerRoster.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/PlayerRoster.java
@@ -37,7 +37,18 @@ import VASSAL.tools.LaunchButton;
 import VASSAL.tools.NamedKeyStroke;
 import VASSAL.tools.SequenceEncoder;
 import VASSAL.tools.swing.FlowLabel;
+import net.miginfocom.swing.MigLayout;
+import org.netbeans.spi.wizard.WizardController;
+import org.w3c.dom.Attr;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NamedNodeMap;
+import org.w3c.dom.NodeList;
 
+import javax.swing.JLabel;
+import javax.swing.JOptionPane;
+import javax.swing.JPanel;
+import javax.swing.SwingUtilities;
 import java.awt.Component;
 import java.beans.PropertyChangeListener;
 import java.io.IOException;
@@ -45,20 +56,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
-
-import javax.swing.JLabel;
-import javax.swing.JOptionPane;
-import javax.swing.JPanel;
-import javax.swing.SwingUtilities;
-
-import net.miginfocom.swing.MigLayout;
-
-import org.netbeans.spi.wizard.WizardController;
-import org.w3c.dom.Attr;
-import org.w3c.dom.Document;
-import org.w3c.dom.Element;
-import org.w3c.dom.NamedNodeMap;
-import org.w3c.dom.NodeList;
 
 /**
  * Maintains a list of players involved in the current game
@@ -299,6 +296,8 @@ public class PlayerRoster extends AbstractToolbarItem implements CommandEncoder,
 
     newSide = getMySide();
     fireSideChange(mySide, newSide);
+
+    GameModule.getGameModule().getGameState().doStartupGlobalKeyCommands(true);
   }
 
   protected void fireSideChange(String oldSide, String newSide) {

--- a/vassal-app/src/main/java/VASSAL/build/module/StartupGlobalKeyCommand.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/StartupGlobalKeyCommand.java
@@ -45,10 +45,11 @@ import java.util.List;
  *
  */
 public class StartupGlobalKeyCommand extends GlobalKeyCommand implements GameComponent, CommandEncoder, UniqueIdManager.Identifyable {
-  public static final String WHEN_TO_APPLY                 = "whenToApply";          //NON-NLS
-  public static final String APPLY_FIRST_LAUNCH_OF_SESSION = "firstLaunchOfSession"; //NON-NLS
-  public static final String APPLY_EVERY_LAUNCH_OF_SESSION = "everyLaunchOfSession"; //NON-NLS
-  public static final String APPLY_START_OF_GAME_ONLY      = "startOfGameOnly";      //NON-NLS
+  public static final String WHEN_TO_APPLY                   = "whenToApply";          //NON-NLS
+  public static final String APPLY_FIRST_LAUNCH_OF_SESSION   = "firstLaunchOfSession"; //NON-NLS
+  public static final String APPLY_EVERY_LAUNCH_OF_SESSION   = "everyLaunchOfSession"; //NON-NLS
+  public static final String APPLY_START_OF_GAME_ONLY        = "startOfGameOnly";      //NON-NLS
+  public static final String APPLY_START_GAME_OR_SIDE_CHANGE = "sideChange";           //NON-NLS
 
   private static final char DELIMITER = '\t'; //$NON-NLS-1$
   public static final String COMMAND_PREFIX = "SGKC" + DELIMITER; //NON-NLS-1$
@@ -64,7 +65,7 @@ public class StartupGlobalKeyCommand extends GlobalKeyCommand implements GameCom
   public static class Prompt extends TranslatableStringEnum {
     @Override
     public String[] getValidValues(AutoConfigurable target) {
-      return new String[]{ APPLY_FIRST_LAUNCH_OF_SESSION, APPLY_EVERY_LAUNCH_OF_SESSION, APPLY_START_OF_GAME_ONLY };
+      return new String[]{ APPLY_FIRST_LAUNCH_OF_SESSION, APPLY_EVERY_LAUNCH_OF_SESSION, APPLY_START_OF_GAME_ONLY, APPLY_START_GAME_OR_SIDE_CHANGE };
     }
 
     @Override
@@ -72,7 +73,8 @@ public class StartupGlobalKeyCommand extends GlobalKeyCommand implements GameCom
       return new String[] {
         "Editor.StartupGlobalKeyCommand.first_launch_of_session",
         "Editor.StartupGlobalKeyCommand.every_launch_of_session",
-        "Editor.StartupGlobalKeyCommand.start_of_game_only"
+        "Editor.StartupGlobalKeyCommand.start_of_game_only",
+        "Editor.StartupGlobalKeyCommand.start_or_side_change"
       };
     }
   }
@@ -208,7 +210,7 @@ public class StartupGlobalKeyCommand extends GlobalKeyCommand implements GameCom
         return false;
       }
     }
-    else if (APPLY_START_OF_GAME_ONLY.equals(whenToApply)) {
+    else if (APPLY_START_OF_GAME_ONLY.equals(whenToApply) || APPLY_START_GAME_OR_SIDE_CHANGE.equals(whenToApply)) {
       if (hasAppliedThisGame) {
         return false;
       }
@@ -216,6 +218,20 @@ public class StartupGlobalKeyCommand extends GlobalKeyCommand implements GameCom
 
     hasEverApplied = true;     // This one will be false again next time anything calls GameState.setup(true)
     hasAppliedThisGame = true; // This one will be remembered as part of the game state (i.e. even after loading a game)
+    apply();
+    return true;
+  }
+
+  /**
+   * Apply the command, but only if it is eligible to be applied on Player Join / Change
+   * @return true if command was applied
+   */
+  public boolean applyPlayerChange() {
+    if (!APPLY_START_GAME_OR_SIDE_CHANGE.equals(whenToApply)) {
+      return false;
+    }
+    hasEverApplied     = true;
+    hasAppliedThisGame = true;
     apply();
     return true;
   }

--- a/vassal-app/src/main/resources/VASSAL/i18n/Editor.properties
+++ b/vassal-app/src/main/resources/VASSAL/i18n/Editor.properties
@@ -1909,6 +1909,7 @@ Editor.StartupGlobalKeyCommand.when_to_apply=When To Apply
 Editor.StartupGlobalKeyCommand.first_launch_of_session=On First Game Launch/Load Of Session
 Editor.StartupGlobalKeyCommand.every_launch_of_session=On Every Game Launch/Load Of Session
 Editor.StartupGlobalKeyCommand.start_of_game_only=At Start Of Every Fresh Game Only
+Editor.StartupGlobalKeyCommand.start_or_side_change=At Start of Fresh Game or Player Join/Side-Change
 
 # String Builder
 Editor.StringBuilder.component_type=String Builder

--- a/vassal-doc/src/main/readme-referencemanual/ReferenceManual/GameModule.adoc
+++ b/vassal-doc/src/main/readme-referencemanual/ReferenceManual/GameModule.adoc
@@ -90,7 +90,6 @@ Any of them can be added by right-clicking on the _[Module]_ component in the Mo
 |===
 
 
-
 '''''
 
 ==== <<HelpMenu.adoc#top,Help Menu>>

--- a/vassal-doc/src/main/readme-referencemanual/ReferenceManual/GameModule.adoc
+++ b/vassal-doc/src/main/readme-referencemanual/ReferenceManual/GameModule.adoc
@@ -85,7 +85,7 @@ Any of them can be added by right-clicking on the _[Module]_ component in the Mo
 |<<#DiceButton,Dice Button>>|<<GamePieceImageDefinitions.adoc#top,Game Piece Image Definitions>>|<<Inventory.adoc#top,Game Piece Inventory Window>>|<<PieceWindow.adoc#top,Game Piece Palette>>|<<Prototypes.adoc#top,Game Piece Prototype Definitions>>
 |<<Map.adoc#GlobalKeyCommand,Global Key Command>>|<<GlobalOptions.adoc#top,Global Options>>|<<GlobalProperties.adoc#top,Global Properties>>|<<GlobalTranslatableMessages.adoc#top, Global Translatable Messages>>|<<HelpMenu.adoc#top,Help Menu>>
 |<<Map.adoc#top,Map Window>>|<<MultiActionButton.adoc#top,Multi-Action Button>>|<<#NotesWindow,Notes Window>>|<<PlayerHand.adoc#top,Player Hand>>|<<#PredefinedSetup,Predefined Setup>>
-|<<PrivateWindow.adoc#top,Private Window>>|<<#RandomTextButton,Random Text Button>>|<<SpecialDiceButton.adoc#top,Symbolic Dice Button>>|<<Toolbar.adoc#top,Toolbar>>|<<ToolbarMenu.adoc#top,Toolbar Menu>>
+|<<PrivateWindow.adoc#top,Private Window>>|<<#RandomTextButton,Random Text Button>>|<<#StartupGlobalKeyCommand,Startup Global Key Command>>|<<SpecialDiceButton.adoc#top,Symbolic Dice Button>>|<<Toolbar.adoc#top,Toolbar>>|<<ToolbarMenu.adoc#top,Toolbar Menu>>
 |<<TurnTracker.adoc#top,Turn Counter>>||||
 |===
 
@@ -265,6 +265,30 @@ Applies to <<GamePiece.adoc#top,Game Pieces>> on all <<Map.adoc#top,Map Windows>
 
 |image:images/GlobalKeyCommand.png[]
 |===
+
+
+[#StartupGlobalKeyCommand]
+==== Startup Global Key Command
+
+Can print a welcome message, or perform some other task that needs to be done whenever the module is started up.
+
+image:images/StartupGlobalKeyCommand.png[]
+
+An extension of <<#GlobalKeyCommand,Global Key Command>> that fires automatically upon completion of module load, once all the key listeners are started up.
+All fields behave identically to the corresponding ones in <<#GlobalKeyCommand,Global Key Command>>, except that those pertaining to the physical representation of a Toolbar button are suppressed as being inapplicable.
+
+As of VASSAL 3.6, multiple start-up global key commands _can_ be depended on to run in the order they are listed in the module.
+
+Startup Global Key Commands can be configured to any of three modes:
+
+**(1) On First Game Launch/Load Of Session**: These fire every time the _module_ starts up, regardless of whether it is to begin a new game or to load and continue an existing one.
+
+**(2) On Every Game Launch/Load Of Session**: These fire every time a game is launched or loaded during the session.
+
+**(3) At Start Of Every Fresh Game Only**: These fire only when a _new game_ is starting. If the game is saved and later restored, or is being exchanged back and forth in log form, the key command will not fire on subsequent loads. For clarity, a new game started from a <<GameModule.adoc#PredefinedSetup, Pre-defined Setup>> _does_ count as a fresh new game.
+
+**(4) At Start of Fresh Game or Player Join/Side-Change**: These fire only when a _new game_ is starting _OR_ a new player joins or changes sides.
+
 
 ==== <<Inventory.adoc#top,Game Piece Inventory Window>>
 [width="100%",cols="40%,60%",]

--- a/vassal-doc/src/main/readme-referencemanual/ReferenceManual/Map.adoc
+++ b/vassal-doc/src/main/readme-referencemanual/ReferenceManual/Map.adoc
@@ -456,6 +456,7 @@ Startup Global Key Commands can be configured to any of three modes:
 
 **(3) At Start Of Every Fresh Game Only**: These fire only when a _new game_ is starting. If the game is saved and later restored, or is being exchanged back and forth in log form, the key command will not fire on subsequent loads. For clarity, a new game started from a <<GameModule.adoc#PredefinedSetup, Pre-defined Setup>> _does_ count as a fresh new game.
 
+**(4) At Start of Fresh Game or Player Join/Side-Change**: These fire only when a _new game_ is starting _OR_ a new player joins or changes sides. 
 
 '''
 [#GlobalKeyCommand]

--- a/vassal-doc/src/main/readme-referencemanual/ReferenceManual/Map.adoc
+++ b/vassal-doc/src/main/readme-referencemanual/ReferenceManual/Map.adoc
@@ -103,7 +103,7 @@ Once you configure it, your new sub-component will appear at the bottom of the M
 |<<GamePieceLayers.adoc#top,Game Piece Layers>> |<<#GlobalKeyCommand,Global Key Command>> |<<GlobalProperties.adoc#top,Global Properties>> |<<#HidePieces,Hide Pieces Button>>
 |<<#ImageCapture,Image Capture Tool>>|<<#LastMoveHighlighter,Last Move Highlighter>> |<<#LOS,Line of Sight Thread>> |<<#MapBoards,Map Boards>> |<<#MapShading,Map Shading>>
 |<<#StackViewer,Mouse-over Stack Viewer>> |<<#OverviewWindow,Overview Window>> |<<#PieceRecenterer,Recenter Pieces Button>> |<<#StackingOptions,Stacking Options>>
-|<<#StartupGlobalKeyCommand,Startup Global Key Command>> |<<#TextCapture,Text Capture Tool>> |<<ToolbarMenu.adoc#top,Toolbar Menu>> |<<#Zoom,Zoom Capability>>
+|<<#TextCapture,Text Capture Tool>> |<<ToolbarMenu.adoc#top,Toolbar Menu>> |<<#Zoom,Zoom Capability>>
 |===
 
 '''''
@@ -433,30 +433,6 @@ This is useful for games where there are no absolute terrain features, such as s
 
 |image:images/PieceRecenterer.png[]
 |===
-
-[#StartupGlobalKeyCommand]
-
-==== Startup Global Key Command
-
-Can print a welcome message, or perform some other task that needs to be done whenever the module is started up.
-
-
-image:images/StartupGlobalKeyCommand.png[]
-
-An extension of <<#GlobalKeyCommand,Global Key Command>> that fires automatically upon completion of module load, once all the key listeners are started up.
-All fields behave identically to the corresponding ones in <<#GlobalKeyCommand,Global Key Command>>, except that those pertaining to the physical representation of a Toolbar button are suppressed as being inapplicable.
-
-As of VASSAL 3.6, multiple start-up global key commands _can_ be depended on to run in the order they are listed in the module.
-
-Startup Global Key Commands can be configured to any of three modes:
-
-**(1) On First Game Launch/Load Of Session**: These fire every time the _module_ starts up, regardless of whether it is to begin a new game or to load and continue an existing one.
-
-**(2) On Every Game Launch/Load Of Session**: These fire every time a game is launched or loaded during the session.
-
-**(3) At Start Of Every Fresh Game Only**: These fire only when a _new game_ is starting. If the game is saved and later restored, or is being exchanged back and forth in log form, the key command will not fire on subsequent loads. For clarity, a new game started from a <<GameModule.adoc#PredefinedSetup, Pre-defined Setup>> _does_ count as a fresh new game.
-
-**(4) At Start of Fresh Game or Player Join/Side-Change**: These fire only when a _new game_ is starting _OR_ a new player joins or changes sides. 
 
 '''
 [#GlobalKeyCommand]


### PR DESCRIPTION
Is this a good idea or a terrible idea? I *think* it will run once at game start (from perspective of whoever started the game) and then once whenever someone joins/changes-side (from their new side's perspective). 

I was thinking it could be used to solve the classic Vassal problem where when you start a game you have to go immediately "flip all your cards upside down" (or pieces or whatever) because them just starting upside down can't be part of the initial state because of our encoded-by-passwords method of turning things face down.  