### PR TITLE
11919 - Allow DEL/BACKSPACE to be mapped as a hotkey

### DIFF
--- a/vassal-app/src/main/java/VASSAL/configure/NamedHotKeyConfigurer.java
+++ b/vassal-app/src/main/java/VASSAL/configure/NamedHotKeyConfigurer.java
@@ -415,7 +415,13 @@ public class NamedHotKeyConfigurer extends Configurer implements FocusListener {
         switch (e.getKeyCode()) {
         case KeyEvent.VK_DELETE:
         case KeyEvent.VK_BACK_SPACE:
-          setValue(NamedKeyStroke.NULL_KEYSTROKE);
+          // Allow mapping of Delete
+          if (getValue().equals(NamedKeyStroke.NULL_KEYSTROKE) || e.isShiftDown() || e.isControlDown() || e.isMetaDown() || e.isAltDown()) {
+            setValue(NamedKeyStroke.of(SwingUtils.convertKeyEvent(e)));
+          }
+          else {
+            setValue(NamedKeyStroke.NULL_KEYSTROKE);
+          }
           break;
         case KeyEvent.VK_SHIFT:
         case KeyEvent.VK_CONTROL:

--- a/vassal-app/src/main/java/VASSAL/configure/NamedHotKeyConfigurer.java
+++ b/vassal-app/src/main/java/VASSAL/configure/NamedHotKeyConfigurer.java
@@ -376,7 +376,13 @@ public class NamedHotKeyConfigurer extends Configurer implements FocusListener {
       switch (e.getKeyCode()) {
       case KeyEvent.VK_DELETE:
       case KeyEvent.VK_BACK_SPACE:
-        setValue(NamedKeyStroke.NULL_KEYSTROKE);
+        // Allow mapping of Delete
+        if (getValue().equals(NamedKeyStroke.NULL_KEYSTROKE) || e.isShiftDown() || e.isControlDown() || e.isMetaDown() || e.isAltDown()) {
+          setValue(NamedKeyStroke.of(SwingUtils.convertKeyEvent(e)));
+        }
+        else {
+          setValue(NamedKeyStroke.NULL_KEYSTROKE);
+        }
         break;
       case KeyEvent.VK_SHIFT:
       case KeyEvent.VK_CONTROL:

--- a/vassal-app/src/main/java/VASSAL/configure/NamedHotKeyConfigurer.java
+++ b/vassal-app/src/main/java/VASSAL/configure/NamedHotKeyConfigurer.java
@@ -24,6 +24,7 @@ import VASSAL.tools.icon.IconFactory;
 import VASSAL.tools.icon.IconFamily;
 import VASSAL.tools.swing.SwingUtils;
 import net.miginfocom.swing.MigLayout;
+import org.apache.commons.lang3.SystemUtils;
 
 import javax.swing.JButton;
 import javax.swing.JComponent;
@@ -410,20 +411,22 @@ public class NamedHotKeyConfigurer extends Configurer implements FocusListener {
     @Override
     public void keyReleased(KeyEvent e) {
       // reportKeyEvent("KEY_RELEASED", e); // NON-NLS
-      switch (e.getKeyCode()) {
-      case KeyEvent.VK_DELETE:
-      case KeyEvent.VK_BACK_SPACE:
-        setValue(NamedKeyStroke.NULL_KEYSTROKE);
-        break;
-      case KeyEvent.VK_SHIFT:
-      case KeyEvent.VK_CONTROL:
-      case KeyEvent.VK_META:
-      case KeyEvent.VK_ALT:
-      case KeyEvent.VK_ALT_GRAPH:
-      case KeyEvent.VK_UNDEFINED:
-        break;
-      default:
-        setValue(NamedKeyStroke.of(SwingUtils.convertKeyEvent(e)));
+      if (SystemUtils.IS_OS_MAC) {
+        switch (e.getKeyCode()) {
+        case KeyEvent.VK_DELETE:
+        case KeyEvent.VK_BACK_SPACE:
+          setValue(NamedKeyStroke.NULL_KEYSTROKE);
+          break;
+        case KeyEvent.VK_SHIFT:
+        case KeyEvent.VK_CONTROL:
+        case KeyEvent.VK_META:
+        case KeyEvent.VK_ALT:
+        case KeyEvent.VK_ALT_GRAPH:
+        case KeyEvent.VK_UNDEFINED:
+          break;
+        default:
+          setValue(NamedKeyStroke.of(SwingUtils.convertKeyEvent(e)));
+        }
       }
     }
   }

--- a/vassal-app/src/main/java/VASSAL/tools/NamedKeyStroke.java
+++ b/vassal-app/src/main/java/VASSAL/tools/NamedKeyStroke.java
@@ -127,7 +127,7 @@ public class NamedKeyStroke {
     if (o instanceof NamedKeyStroke) {
       return Objects.equals(stroke, ((NamedKeyStroke) o).stroke);
     }
-    if (stroke == null) {
+    else if (stroke == null) {
       return false;
     }
     // checking for parameter being a completely unrelated class to this class

--- a/vassal-app/src/main/java/VASSAL/tools/NamedKeyStroke.java
+++ b/vassal-app/src/main/java/VASSAL/tools/NamedKeyStroke.java
@@ -127,10 +127,12 @@ public class NamedKeyStroke {
     if (o instanceof NamedKeyStroke) {
       return Objects.equals(stroke, ((NamedKeyStroke) o).stroke);
     }
+    if (stroke == null) {
+      return false;
+    }
     // checking for parameter being a completely unrelated class to this class
     // deliberate misuse of equals()
     else if (o instanceof KeyStroke) {
-      if (stroke == null) return false;
       final int code = stroke.getKeyCode();
       // Either DEL or BACKSPACE matches to either
       if ((code == VK_DELETE) || (code == VK_BACK_SPACE)) {

--- a/vassal-app/src/main/java/VASSAL/tools/NamedKeyStroke.java
+++ b/vassal-app/src/main/java/VASSAL/tools/NamedKeyStroke.java
@@ -130,15 +130,14 @@ public class NamedKeyStroke {
     // checking for parameter being a completely unrelated class to this class
     // deliberate misuse of equals()
     else if (o instanceof KeyStroke) {
-      if (stroke != null) {
-        final int code = stroke.getKeyCode();
-        // Either DEL or BACKSPACE matches to either
-        if ((code == VK_DELETE) || (code == VK_BACK_SPACE)) {
-          final KeyStroke k = (KeyStroke) o;
-          if ((k.getKeyCode() == VK_DELETE) || (k.getKeyCode() == VK_BACK_SPACE)) {
-            return o.equals(KeyStroke.getKeyStroke(VK_DELETE, k.getModifiers(), k.isOnKeyRelease())) ||
-                   o.equals(KeyStroke.getKeyStroke(VK_BACK_SPACE, k.getModifiers(), k.isOnKeyRelease()));
-          }
+      if (stroke == null) return false;
+      final int code = stroke.getKeyCode();
+      // Either DEL or BACKSPACE matches to either
+      if ((code == VK_DELETE) || (code == VK_BACK_SPACE)) {
+        final KeyStroke k = (KeyStroke) o;
+        if ((k.getKeyCode() == VK_DELETE) || (k.getKeyCode() == VK_BACK_SPACE)) {
+          return o.equals(KeyStroke.getKeyStroke(VK_DELETE, k.getModifiers(), k.isOnKeyRelease())) ||
+                 o.equals(KeyStroke.getKeyStroke(VK_BACK_SPACE, k.getModifiers(), k.isOnKeyRelease()));
         }
       }
       return o.equals(stroke);

--- a/vassal-app/src/main/java/VASSAL/tools/NamedKeyStroke.java
+++ b/vassal-app/src/main/java/VASSAL/tools/NamedKeyStroke.java
@@ -130,13 +130,15 @@ public class NamedKeyStroke {
     // checking for parameter being a completely unrelated class to this class
     // deliberate misuse of equals()
     else if (o instanceof KeyStroke) {
-      final int code = stroke.getKeyCode();
-      // Either DEL or BACKSPACE matches to either
-      if ((code == VK_DELETE) || (code == VK_BACK_SPACE)) {
-        final KeyStroke k = (KeyStroke)o;
-        if ((k.getKeyCode() == VK_DELETE) || (k.getKeyCode() == VK_BACK_SPACE)) {
-          return o.equals(KeyStroke.getKeyStroke(VK_DELETE, k.getModifiers(), k.isOnKeyRelease())) ||
-                 o.equals(KeyStroke.getKeyStroke(VK_BACK_SPACE, k.getModifiers(), k.isOnKeyRelease()));
+      if (stroke != null) {
+        final int code = stroke.getKeyCode();
+        // Either DEL or BACKSPACE matches to either
+        if ((code == VK_DELETE) || (code == VK_BACK_SPACE)) {
+          final KeyStroke k = (KeyStroke) o;
+          if ((k.getKeyCode() == VK_DELETE) || (k.getKeyCode() == VK_BACK_SPACE)) {
+            return o.equals(KeyStroke.getKeyStroke(VK_DELETE, k.getModifiers(), k.isOnKeyRelease())) ||
+                   o.equals(KeyStroke.getKeyStroke(VK_BACK_SPACE, k.getModifiers(), k.isOnKeyRelease()));
+          }
         }
       }
       return o.equals(stroke);

--- a/vassal-app/src/main/java/VASSAL/tools/NamedKeyStroke.java
+++ b/vassal-app/src/main/java/VASSAL/tools/NamedKeyStroke.java
@@ -18,6 +18,12 @@
 
 package VASSAL.tools;
 
+import VASSAL.build.module.KeyNamer;
+import VASSAL.tools.concurrent.ConcurrentSoftHashMap;
+import VASSAL.tools.swing.SwingUtils;
+import org.apache.commons.lang3.tuple.Pair;
+
+import javax.swing.KeyStroke;
 import java.awt.event.KeyEvent;
 import java.util.Map;
 import java.util.Objects;
@@ -31,6 +37,8 @@ import org.apache.commons.lang3.tuple.Pair;
 import VASSAL.build.module.KeyNamer;
 import VASSAL.tools.concurrent.ConcurrentSoftHashMap;
 import VASSAL.tools.swing.SwingUtils;
+import static java.awt.event.KeyEvent.VK_BACK_SPACE;
+import static java.awt.event.KeyEvent.VK_DELETE;
 
 /**
  * A NamedKeyStroke is a KeyStroke with a name given by the module developer.
@@ -130,6 +138,15 @@ public class NamedKeyStroke {
     // checking for parameter being a completely unrelated class to this class
     // deliberate misuse of equals()
     else if (o instanceof KeyStroke) {
+      final int code = stroke.getKeyCode();
+      // Either DEL or BACKSPACE matches to either
+      if ((code == VK_DELETE) || (code == VK_BACK_SPACE)) {
+        final KeyStroke k = (KeyStroke)o;
+        if ((k.getKeyCode() == VK_DELETE) || (k.getKeyCode() == VK_BACK_SPACE)) {
+          return o.equals(KeyStroke.getKeyStroke(VK_DELETE, k.getModifiers(), k.isOnKeyRelease())) ||
+                 o.equals(KeyStroke.getKeyStroke(VK_BACK_SPACE, k.getModifiers(), k.isOnKeyRelease()));
+        }
+      }
       return o.equals(stroke);
     }
 

--- a/vassal-app/src/main/java/VASSAL/tools/NamedKeyStroke.java
+++ b/vassal-app/src/main/java/VASSAL/tools/NamedKeyStroke.java
@@ -134,15 +134,16 @@ public class NamedKeyStroke {
     // deliberate misuse of equals()
     else if (o instanceof KeyStroke) {
       final int code = stroke.getKeyCode();
-      // Either DEL or BACKSPACE matches to either
-      if ((code == VK_DELETE) || (code == VK_BACK_SPACE)) {
+
+      if (code == VK_DELETE || code == VK_BACK_SPACE) {
         final KeyStroke k = (KeyStroke) o;
-        if ((k.getKeyCode() == VK_DELETE) || (k.getKeyCode() == VK_BACK_SPACE)) {
-          return o.equals(KeyStroke.getKeyStroke(VK_DELETE, stroke.getModifiers())) ||
-                 o.equals(KeyStroke.getKeyStroke(VK_BACK_SPACE, stroke.getModifiers()));
-        }
+        final int k_code = k.getKeyCode();
+        // Either DEL or BACKSPACE matches to either
+        return (k_code == VK_DELETE || k_code == VK_BACK_SPACE) && k.getModifiers() == stroke.getModifiers();
       }
-      return o.equals(stroke);
+      else {
+        return o.equals(stroke);
+      }
     }
 
     return false;

--- a/vassal-app/src/main/java/VASSAL/tools/NamedKeyStroke.java
+++ b/vassal-app/src/main/java/VASSAL/tools/NamedKeyStroke.java
@@ -21,6 +21,7 @@ package VASSAL.tools;
 import VASSAL.build.module.KeyNamer;
 import VASSAL.tools.concurrent.ConcurrentSoftHashMap;
 import VASSAL.tools.swing.SwingUtils;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.commons.lang3.tuple.Pair;
 
 import javax.swing.KeyStroke;
@@ -28,15 +29,6 @@ import java.awt.event.KeyEvent;
 import java.util.Map;
 import java.util.Objects;
 
-import javax.swing.KeyStroke;
-
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-
-import org.apache.commons.lang3.tuple.Pair;
-
-import VASSAL.build.module.KeyNamer;
-import VASSAL.tools.concurrent.ConcurrentSoftHashMap;
-import VASSAL.tools.swing.SwingUtils;
 import static java.awt.event.KeyEvent.VK_BACK_SPACE;
 import static java.awt.event.KeyEvent.VK_DELETE;
 

--- a/vassal-app/src/main/java/VASSAL/tools/NamedKeyStroke.java
+++ b/vassal-app/src/main/java/VASSAL/tools/NamedKeyStroke.java
@@ -138,8 +138,8 @@ public class NamedKeyStroke {
       if ((code == VK_DELETE) || (code == VK_BACK_SPACE)) {
         final KeyStroke k = (KeyStroke) o;
         if ((k.getKeyCode() == VK_DELETE) || (k.getKeyCode() == VK_BACK_SPACE)) {
-          return o.equals(KeyStroke.getKeyStroke(VK_DELETE, stroke.getModifiers(), stroke.isOnKeyRelease())) ||
-                 o.equals(KeyStroke.getKeyStroke(VK_BACK_SPACE, stroke.getModifiers(), stroke.isOnKeyRelease()));
+          return o.equals(KeyStroke.getKeyStroke(VK_DELETE, stroke.getModifiers())) ||
+                 o.equals(KeyStroke.getKeyStroke(VK_BACK_SPACE, stroke.getModifiers()));
         }
       }
       return o.equals(stroke);

--- a/vassal-app/src/main/java/VASSAL/tools/NamedKeyStroke.java
+++ b/vassal-app/src/main/java/VASSAL/tools/NamedKeyStroke.java
@@ -138,8 +138,8 @@ public class NamedKeyStroke {
       if ((code == VK_DELETE) || (code == VK_BACK_SPACE)) {
         final KeyStroke k = (KeyStroke) o;
         if ((k.getKeyCode() == VK_DELETE) || (k.getKeyCode() == VK_BACK_SPACE)) {
-          return o.equals(KeyStroke.getKeyStroke(VK_DELETE, k.getModifiers(), k.isOnKeyRelease())) ||
-                 o.equals(KeyStroke.getKeyStroke(VK_BACK_SPACE, k.getModifiers(), k.isOnKeyRelease()));
+          return o.equals(KeyStroke.getKeyStroke(VK_DELETE, stroke.getModifiers(), k.isOnKeyRelease())) ||
+                 o.equals(KeyStroke.getKeyStroke(VK_BACK_SPACE, stroke.getModifiers(), k.isOnKeyRelease()));
         }
       }
       return o.equals(stroke);

--- a/vassal-app/src/main/java/VASSAL/tools/NamedKeyStroke.java
+++ b/vassal-app/src/main/java/VASSAL/tools/NamedKeyStroke.java
@@ -138,8 +138,8 @@ public class NamedKeyStroke {
       if ((code == VK_DELETE) || (code == VK_BACK_SPACE)) {
         final KeyStroke k = (KeyStroke) o;
         if ((k.getKeyCode() == VK_DELETE) || (k.getKeyCode() == VK_BACK_SPACE)) {
-          return o.equals(KeyStroke.getKeyStroke(VK_DELETE, stroke.getModifiers(), k.isOnKeyRelease())) ||
-                 o.equals(KeyStroke.getKeyStroke(VK_BACK_SPACE, stroke.getModifiers(), k.isOnKeyRelease()));
+          return o.equals(KeyStroke.getKeyStroke(VK_DELETE, stroke.getModifiers(), stroke.isOnKeyRelease())) ||
+                 o.equals(KeyStroke.getKeyStroke(VK_BACK_SPACE, stroke.getModifiers(), stroke.isOnKeyRelease()));
         }
       }
       return o.equals(stroke);


### PR DESCRIPTION
Current implementation may not allow Mac to *bind* DEL/Backspace as a hotkey, but it will still successfully match DEL/Backspace for any module where it HAS been bound. 

To work fully right, Mac version will need either:
(a) exactly this
(b) Or possibly be told to ignore Backspace/Delete on the keyPressed side of things
(c) Or possibly be told to ignore Backspace/Delete on the keyReleased side of things
(d) Or possibly (but unlikely) something even more crazy/stupid