### PR TITLE
11929 - Show translated module name and descriptions in Module Manager

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/module/metadata/AbstractMetaData.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/metadata/AbstractMetaData.java
@@ -43,6 +43,7 @@ import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 
 import VASSAL.i18n.Resources;
+import VASSAL.tools.version.VersionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
@@ -101,6 +102,13 @@ public abstract class AbstractMetaData {
   protected static final String BUILDFILE_MODULE_ELEMENT1 = "VASSAL.launch.BasicModule"; //NON-NLS
   protected static final String BUILDFILE_MODULE_ELEMENT2 = "VASSAL.build.GameModule"; //NON-NLS
   protected static final String BUILDFILE_EXTENSION_ELEMENT = "VASSAL.build.module.ModuleExtension"; //NON-NLS
+
+  // Vassal versions prior to 3.6.11 reversed the language and translated details in the metadata
+  protected static final String BUG_11929_VASSAL_FIX_VERSION = "3.6.11";
+
+  public static boolean isPreBug11929(String version) {
+    return VersionUtils.compareVersions(VersionUtils.truncateToIncrementalVersion(version), BUG_11929_VASSAL_FIX_VERSION) < 0;
+  }
 
   protected String version;
   protected String vassalVersion;
@@ -462,7 +470,13 @@ public abstract class AbstractMetaData {
           setDescription(new Attribute(DESCRIPTION_ELEMENT, value));
         }
         else {
-          descriptionAttr.addTranslation(language, value);
+          // Modules saved prior to 3.6.11 have the language and the translation reversed
+          if (isPreBug11929(getVassalVersion())) {
+            descriptionAttr.addTranslation(value, language);
+          }
+          else {
+            descriptionAttr.addTranslation(language, value);
+          }
         }
       }
       else if (DATE_SAVED_ELEMENT.equals(qName)) {

--- a/vassal-app/src/main/java/VASSAL/build/module/metadata/AbstractMetaData.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/metadata/AbstractMetaData.java
@@ -42,6 +42,7 @@ import javax.xml.transform.TransformerFactoryConfigurationError;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 
+import VASSAL.i18n.Resources;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
@@ -365,7 +366,7 @@ public abstract class AbstractMetaData {
      * @return translated value
      */
     public String getLocalizedValue() {
-      final String lang = Locale.getDefault().getLanguage();
+      final String lang = Resources.getLocale().getLanguage(); // Use the current Vassal language, not the default Local language
       final String tx = translations.get(lang);
       return tx == null ? getValue() : tx;
     }
@@ -391,8 +392,8 @@ public abstract class AbstractMetaData {
 
       for (final Map.Entry<String, String> en : translations.entrySet()) {
         e = doc.createElement(prefix);
-        e.setAttribute(LANG_ATTR, en.getValue());
-        e.appendChild(doc.createTextNode(en.getKey()));
+        e.setAttribute(LANG_ATTR, en.getKey());
+        e.appendChild(doc.createTextNode(en.getValue()));
         root.appendChild(e);
       }
     }

--- a/vassal-app/src/main/java/VASSAL/build/module/metadata/ModuleMetaData.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/metadata/ModuleMetaData.java
@@ -161,7 +161,13 @@ public class ModuleMetaData extends AbstractMetaData {
           nameAttr = new Attribute(NAME_ELEMENT, accumulator.toString().trim());
         }
         else {
-          nameAttr.addTranslation(language, accumulator.toString().trim());
+          // Modules saved prior to 3.6.11 have the language and the translation reversed
+          if (isPreBug11929(getVassalVersion())) {
+            nameAttr.addTranslation(accumulator.toString().trim(), language);
+          }
+          else {
+            nameAttr.addTranslation(language, accumulator.toString().trim());
+          }
         }
       }
       else {


### PR DESCRIPTION
Turns out I had already solved this, except for 2 bugs which meant that it had never work!