### PR TITLE
11957 - Spaces in GKC reports made consistent with all other reports

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/module/map/DeckGlobalKeyCommand.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/DeckGlobalKeyCommand.java
@@ -292,7 +292,7 @@ public class DeckGlobalKeyCommand extends MassKeyCommand {
       final String reportText = reportFormat.getText(source, (Auditable) this, "Editor.report_format");
       Command c;
       if (reportText.length() > 0) {
-        c = new Chatter.DisplayText(GameModule.getGameModule().getChatter(), "*" + reportText);
+        c = new Chatter.DisplayText(GameModule.getGameModule().getChatter(), "* " + reportText);
         c.execute();
       }
       else {

--- a/vassal-app/src/main/java/VASSAL/counters/GlobalCommand.java
+++ b/vassal-app/src/main/java/VASSAL/counters/GlobalCommand.java
@@ -248,7 +248,7 @@ public class GlobalCommand implements Auditable {
       final String reportText = reportFormat.getLocalizedText(source, owner, "Editor.report_format");
       if (reportText.length() > 0) {
         command = new Chatter.DisplayText(
-          GameModule.getGameModule().getChatter(), "*" + reportText); //NON-NLS
+          GameModule.getGameModule().getChatter(), "* " + reportText); //NON-NLS
         command.execute();
       }
 


### PR DESCRIPTION
In every other type of report (e.g. Report traits, DoActionButtons, etc) the report is formatted beginning "* " (a space after the asterisk). But for GKCs it is oddly not, leading to SLOPPY OUTPUT. 

This fixes them to be consistent with the other reports.