### PR TITLE
11963 - SendToLocation, Can Rotate, and MoveFixedDistance were all unlinking from deck/stack at wrong time, causing buggy behavior in some instances especially involving decks

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/module/map/PieceMover.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/PieceMover.java
@@ -772,6 +772,9 @@ public class PieceMover extends AbstractBuildable
    * @return Command encapsulating anything this method did, for replay in log file or on other clients
    */
   protected Command movedPiece(GamePiece p, Point loc) {
+    // Make sure we don't end up sending I'm-empty commands from decks that were emptied by other players (e.g. online or log-step)
+    Deck.clearEmptyDecksList();
+
     Command c = new NullCommand();
     c = c.append(setOldLocations(p));
     if (!loc.equals(p.getPosition())) {

--- a/vassal-app/src/main/java/VASSAL/build/module/map/PieceMover.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/PieceMover.java
@@ -1172,6 +1172,9 @@ public class PieceMover extends AbstractBuildable
       comm = comm.append(applyKeyAfterMove(allDraggedPieces, map.getMoveKey()));
     }
 
+    // If we emptied any decks, let them send their I-am-empty key commands
+    Deck.checkEmptyDecks();
+
     // Repaint any areas of the map window changed by our move
     tracker.repaint();
 

--- a/vassal-app/src/main/java/VASSAL/build/module/map/PieceMover.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/PieceMover.java
@@ -1176,7 +1176,7 @@ public class PieceMover extends AbstractBuildable
     }
 
     // If we emptied any decks, let them send their I-am-empty key commands
-    Deck.checkEmptyDecks();
+    comm = Deck.checkEmptyDecks(comm);
 
     // Repaint any areas of the map window changed by our move
     tracker.repaint();

--- a/vassal-app/src/main/java/VASSAL/build/module/map/deck/DeckSendKeyCommand.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/deck/DeckSendKeyCommand.java
@@ -27,27 +27,27 @@ import VASSAL.script.expression.FormattedStringExpression;
 import VASSAL.tools.FormattedString;
 import VASSAL.tools.NamedKeyStroke;
 import VASSAL.tools.NamedKeyStrokeListener;
+import org.apache.commons.lang3.ArrayUtils;
 
 import java.awt.event.ActionEvent;
 import java.util.Collections;
 import java.util.List;
 
-import org.apache.commons.lang3.ArrayUtils;
-
 public class DeckSendKeyCommand extends AbstractDeckKeyCommand {
 
-  public static final String TARGET_DECK = "targetDeck";
-  public static final String VARIABLE_DECK = "variableDeck";
-  public static final String DECK_EXPRESSION = "deckExpression";
-  public static final String SEND_MATCHING = "sendMatching";
-  public static final String MATCH_EXPRESSION = "matchExpression";
-  public static final String LIMIT_TOTAL = "limitTotal";
-  public static final String LIMIT_EXPRESSION = "limitExpression";
-  public static final String STOP = "stop";
-  public static final String STOP_EXPRESSION = "stopExpression";
-  public static final String STOP_INCLUDE = "stopAlso";
-  public static final String ORDER = "order";
-  public static final String SENT_COUNT = "sentCount";
+  public static final String TARGET_DECK = "targetDeck"; //NON-NLS
+  public static final String VARIABLE_DECK = "variableDeck"; //NON-NLS
+  public static final String DECK_EXPRESSION = "deckExpression"; //NON-NLS
+  public static final String SEND_MATCHING = "sendMatching"; //NON-NLS
+  public static final String MATCH_EXPRESSION = "matchExpression"; //NON-NLS
+  public static final String LIMIT_TOTAL = "limitTotal"; //NON-NLS
+  public static final String LIMIT_EXPRESSION = "limitExpression"; //NON-NLS
+  public static final String STOP = "stop"; //NON-NLS
+  public static final String STOP_EXPRESSION = "stopExpression"; //NON-NLS
+  public static final String STOP_INCLUDE = "stopAlso"; //NON-NLS
+  public static final String ORDER = "order"; //NON-NLS
+  public static final String SENT_COUNT = "sentCount"; //NON-NLS
+  public static final String APPLY_ON_MOVE = "applyOnMove"; //NON-NLS
 
   private NamedKeyStrokeListener sendListener;
   private String targetDeck = "";
@@ -60,6 +60,7 @@ public class DeckSendKeyCommand extends AbstractDeckKeyCommand {
   private boolean stop = false;
   private final FormattedString stopExpresson =  new FormattedString("{}");
   private boolean stopInclude;
+  private boolean applyOnMove = false;
 
   public static String getConfigureTypeName() {
     return Resources.getString("Editor.DeckSendKeyCommand.component_type"); //$NON-NLS-1$
@@ -109,6 +110,10 @@ public class DeckSendKeyCommand extends AbstractDeckKeyCommand {
     return stopInclude;
   }
 
+  public boolean isApplyOnMove() {
+    return applyOnMove;
+  }
+
   @Override
   public String[] getAttributeNames() {
     return ArrayUtils.addAll(
@@ -122,7 +127,8 @@ public class DeckSendKeyCommand extends AbstractDeckKeyCommand {
       LIMIT_EXPRESSION,
       STOP,
       STOP_EXPRESSION,
-      STOP_INCLUDE
+      STOP_INCLUDE,
+      APPLY_ON_MOVE
     );
   }
 
@@ -140,7 +146,8 @@ public class DeckSendKeyCommand extends AbstractDeckKeyCommand {
       Resources.getString("Editor.DeckSendKeyCommand.stop"),
       Resources.getString("Editor.DeckSendKeyCommand.stop_expression"),
       Resources.getString("Editor.DeckSendKeyCommand.stop_include"),
-      Resources.getString("Editor.DeckSendKeyCommand.order")
+      Resources.getString("Editor.DeckSendKeyCommand.order"),
+      Resources.getString("Editor.DeckSendKeyCommand.apply_on_move")
     );
   }
 
@@ -157,6 +164,7 @@ public class DeckSendKeyCommand extends AbstractDeckKeyCommand {
       FormattedStringExpression.class,
       Boolean.class,
       FormattedStringExpression.class,
+      Boolean.class,
       Boolean.class
     );
   }
@@ -208,6 +216,12 @@ public class DeckSendKeyCommand extends AbstractDeckKeyCommand {
       }
       stopInclude = (Boolean) value;
     }
+    else if (APPLY_ON_MOVE.equals(key)) {
+      if (value instanceof String) {
+        value = Boolean.valueOf((String) value);
+      }
+      applyOnMove = (Boolean) value;
+    }
     else {
       super.setAttribute(key, value);
     }
@@ -244,6 +258,9 @@ public class DeckSendKeyCommand extends AbstractDeckKeyCommand {
     }
     else if (STOP_INCLUDE.equals(key)) {
       return String.valueOf(stopInclude);
+    }
+    else if (APPLY_ON_MOVE.equals(key)) {
+      return String.valueOf(applyOnMove);
     }
     else {
       return super.getAttributeValueString(key);
@@ -323,5 +340,4 @@ public class DeckSendKeyCommand extends AbstractDeckKeyCommand {
     }
     return Collections.emptyList();
   }
-
 }

--- a/vassal-app/src/main/java/VASSAL/counters/Deck.java
+++ b/vassal-app/src/main/java/VASSAL/counters/Deck.java
@@ -183,12 +183,17 @@ public class Deck extends Stack implements PlayerRoster.SideChangeListener {
   /**
    * If any decks want to send their I-am-empty key, send it now.
    */
-  public static void checkEmptyDecks() {
+  public static Command checkEmptyDecks(Command c) {
+    final GameModule gm = GameModule.getGameModule();
+    gm.pauseLogging();
     for (final Deck deck : deckEmptiedKeyQueue) {
       deck.sendEmptyKey();
     }
 
     deckEmptiedKeyQueue.clear();
+
+    c = c.append(gm.resumeLogging());
+    return c;
   }
 
   /**

--- a/vassal-app/src/main/java/VASSAL/counters/Deck.java
+++ b/vassal-app/src/main/java/VASSAL/counters/Deck.java
@@ -177,6 +177,27 @@ public class Deck extends Stack implements PlayerRoster.SideChangeListener {
   /** The matching DrawPile that generated this Deck */
   protected DrawPile myPile;
 
+  // List of decks who want to fire off their I-just-got-emptied key
+  protected static List<Deck> deckEmptiedKeyQueue = new ArrayList<>();
+
+  /**
+   * If any decks want to send their I-am-empty key, send it now.
+   */
+  public static void checkEmptyDecks() {
+    for (final Deck deck : deckEmptiedKeyQueue) {
+      deck.sendEmptyKey();
+    }
+
+    deckEmptiedKeyQueue.clear();
+  }
+
+  /**
+   * Sends the I-am-empty key for this deck (whether to send it was already determined when the last piece was removed)
+   */
+  protected void sendEmptyKey() {
+    gameModule.fireKeyStroke(emptyKey);
+  }
+
   /**
    * Special {@link CommandEncoder} to handle loading/saving Decks from files.
    */
@@ -469,7 +490,7 @@ public class Deck extends Stack implements PlayerRoster.SideChangeListener {
       fireNumCardsProperty();
       // Do NOT fire a Deck Empty key if it has been caused by an Undo Command
       if (hotkeyOnEmpty && emptyKey != null && startCount > 0 && pieceCount == 0 && ! GameModule.getGameModule().getBasicLogger().isUndoInProgress()) {
-        gameModule.fireKeyStroke(emptyKey);
+        deckEmptiedKeyQueue.add(this);
       }
     }
   }

--- a/vassal-app/src/main/java/VASSAL/counters/Deck.java
+++ b/vassal-app/src/main/java/VASSAL/counters/Deck.java
@@ -192,6 +192,13 @@ public class Deck extends Stack implements PlayerRoster.SideChangeListener {
   }
 
   /**
+   * Clears the list of I-am-empty decks
+   */
+  public static void clearEmptyDecksList() {
+    deckEmptiedKeyQueue.clear();
+  }
+
+  /**
    * Sends the I-am-empty key for this deck (whether to send it was already determined when the last piece was removed)
    */
   protected void sendEmptyKey() {

--- a/vassal-app/src/main/java/VASSAL/counters/Deck.java
+++ b/vassal-app/src/main/java/VASSAL/counters/Deck.java
@@ -1814,7 +1814,9 @@ public class Deck extends Stack implements PlayerRoster.SideChangeListener {
       // move cards to deck
       final int cnt = getPieceCount() - 1;
       for (int i = cnt; i >= 0; i--) {
-        c = c.append(target.addToContents(getPieceAt(i)));
+        final GamePiece p = getPieceAt(i);
+        c = c.append(pieceRemoved(p));
+        c = c.append(target.addToContents(p));
       }
     }
     return c;

--- a/vassal-app/src/main/java/VASSAL/counters/Deck.java
+++ b/vassal-app/src/main/java/VASSAL/counters/Deck.java
@@ -85,6 +85,8 @@ import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.Random;
 
+import static VASSAL.counters.Decorator.putOldProperties;
+
 /**
  * A collection of pieces that behaves like a deck, i.e.: Doesn't move.
  * Can't be expanded. Can be shuffled. Can be turned face-up and face-down.
@@ -1815,6 +1817,7 @@ public class Deck extends Stack implements PlayerRoster.SideChangeListener {
       final int cnt = getPieceCount() - 1;
       for (int i = cnt; i >= 0; i--) {
         final GamePiece p = getPieceAt(i);
+        c = c.append(putOldProperties(p));
         c = c.append(pieceRemoved(p));
         c = c.append(target.addToContents(p));
       }
@@ -1907,7 +1910,15 @@ public class Deck extends Stack implements PlayerRoster.SideChangeListener {
 
     // Send them
     for (final GamePiece piece : sending) {
+      c = c.append(putOldProperties(piece));
+      c = c.append(pieceRemoved(piece));
       c = c.append(target.addToContents(piece));
+
+      // Apply Auto-move key if that option is selected
+      if (dkc.isApplyOnMove() && (map != null)) {
+        c = c.append(piece.keyEvent(map.getMoveKey()));
+        map.repaint();
+      }
     }
 
     // And add a report

--- a/vassal-app/src/main/java/VASSAL/counters/EditablePiece.java
+++ b/vassal-app/src/main/java/VASSAL/counters/EditablePiece.java
@@ -63,6 +63,13 @@ public interface EditablePiece extends GamePiece {
     return desc;
   }
 
+  /**
+   * Centralized method for preparing a piece to move. Writes the "Old Map" properties based on its current location,
+   * optionally marks the piece as moved, and tells any deck its in that it is leaving.
+   * @param c Command to which will be appended a command for recreating anything this method does
+   * @param mark_moved If true the piece will be mark moved
+   * @return A command for recreating anything this method does, appended to the command passed
+   */
   @Override
   default Command prepareMove(Command c, boolean mark_moved) {
     final GamePiece outer = Decorator.getOutermost(this);
@@ -80,6 +87,14 @@ public interface EditablePiece extends GamePiece {
     return c;
   }
 
+  /**
+   * Centralized method for finishing up after a piece moves. Optionally finds a new mat if needed,
+   * and optionally applies any afterburner apply-on-move key for the piece's map.
+   * @param c Command to which will be appended a command for recreating anything this method does
+   * @param afterburner if true, apply the afterburner apply-on-move key for the piece's map
+   * @param findmat if true, find a new mat for this piece if needed (if this piece is cargo)
+   * @return A command for recreating anything this method does, appended to the command passed
+   */
   @Override
   default Command finishMove(Command c, boolean afterburner, boolean findmat) {
     final GamePiece outer = Decorator.getOutermost(this);

--- a/vassal-app/src/main/java/VASSAL/counters/EditablePiece.java
+++ b/vassal-app/src/main/java/VASSAL/counters/EditablePiece.java
@@ -89,7 +89,8 @@ public interface EditablePiece extends GamePiece {
 
   /**
    * Centralized method for finishing up after a piece moves. Optionally finds a new mat if needed,
-   * and optionally applies any afterburner apply-on-move key for the piece's map.
+   * and optionally applies any afterburner apply-on-move key for the piece's map. If we emptied any
+   * decks, allows them to send their I-am-empty key commands
    * @param c Command to which will be appended a command for recreating anything this method does
    * @param afterburner if true, apply the afterburner apply-on-move key for the piece's map
    * @param findmat if true, find a new mat for this piece if needed (if this piece is cargo)
@@ -110,6 +111,9 @@ public interface EditablePiece extends GamePiece {
         c = c.append(outer.keyEvent(map.getMoveKey()));
       }
     }
+
+    // If we emptied any decks, let them send their I-am-empty key commands
+    Deck.checkEmptyDecks();
 
     return c;
   }

--- a/vassal-app/src/main/java/VASSAL/counters/EditablePiece.java
+++ b/vassal-app/src/main/java/VASSAL/counters/EditablePiece.java
@@ -72,14 +72,22 @@ public interface EditablePiece extends GamePiece {
    */
   @Override
   default Command prepareMove(Command c, boolean mark_moved) {
+    // Make sure we don't send deck-is-empty hotkeys when deck is emptied by another player in an online game or by a log-step
+    Deck.clearEmptyDecksList();
+
     final GamePiece outer = Decorator.getOutermost(this);
+
+    // If selected, mark piece as moved.
     if (mark_moved) {
       final ChangeTracker tracker = new ChangeTracker(outer);
       outer.setProperty(Properties.MOVED, Boolean.TRUE);
       c = c.append(tracker.getChangeCommand());
     }
+
+    // Write the "Old Location" properties of the piece using the current location
     c = c.append(putOldProperties(this));
 
+    // Tell our stack (in case it is a deck) that we've removed a piece
     final Stack parent = outer.getParent();
     if (parent != null) {
       c = c.append(parent.pieceRemoved(outer));

--- a/vassal-app/src/main/java/VASSAL/counters/EditablePiece.java
+++ b/vassal-app/src/main/java/VASSAL/counters/EditablePiece.java
@@ -121,7 +121,7 @@ public interface EditablePiece extends GamePiece {
     }
 
     // If we emptied any decks, let them send their I-am-empty key commands
-    Deck.checkEmptyDecks();
+    c = Deck.checkEmptyDecks(c);
 
     return c;
   }

--- a/vassal-app/src/main/java/VASSAL/counters/FreeRotator.java
+++ b/vassal-app/src/main/java/VASSAL/counters/FreeRotator.java
@@ -17,10 +17,35 @@
  */
 package VASSAL.counters;
 
+import VASSAL.build.GameModule;
+import VASSAL.build.module.Map;
+import VASSAL.build.module.documentation.HelpFile;
+import VASSAL.build.module.map.Drawable;
+import VASSAL.command.ChangeTracker;
+import VASSAL.command.Command;
+import VASSAL.configure.BooleanConfigurer;
 import VASSAL.configure.FormattedExpressionConfigurer;
+import VASSAL.configure.IntConfigurer;
+import VASSAL.configure.NamedHotKeyConfigurer;
+import VASSAL.configure.StringConfigurer;
+import VASSAL.i18n.PieceI18nData;
+import VASSAL.i18n.Resources;
+import VASSAL.i18n.TranslatablePiece;
 import VASSAL.script.expression.AuditTrail;
 import VASSAL.script.expression.AuditableException;
 import VASSAL.tools.FormattedString;
+import VASSAL.tools.NamedKeyStroke;
+import VASSAL.tools.SequenceEncoder;
+import VASSAL.tools.imageop.GamePieceOp;
+import VASSAL.tools.imageop.Op;
+import VASSAL.tools.imageop.RotateScaleOp;
+import VASSAL.tools.swing.SwingUtils;
+import net.miginfocom.swing.MigLayout;
+
+import javax.swing.JComponent;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.KeyStroke;
 import java.awt.AlphaComposite;
 import java.awt.Component;
 import java.awt.Cursor;
@@ -45,32 +70,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Objects;
 import java.util.Random;
-
-import javax.swing.JComponent;
-import javax.swing.JLabel;
-import javax.swing.JPanel;
-import javax.swing.KeyStroke;
-
-import VASSAL.build.GameModule;
-import VASSAL.build.module.Map;
-import VASSAL.build.module.documentation.HelpFile;
-import VASSAL.build.module.map.Drawable;
-import VASSAL.command.ChangeTracker;
-import VASSAL.command.Command;
-import VASSAL.configure.BooleanConfigurer;
-import VASSAL.configure.IntConfigurer;
-import VASSAL.configure.NamedHotKeyConfigurer;
-import VASSAL.configure.StringConfigurer;
-import VASSAL.i18n.PieceI18nData;
-import VASSAL.i18n.Resources;
-import VASSAL.i18n.TranslatablePiece;
-import VASSAL.tools.NamedKeyStroke;
-import VASSAL.tools.SequenceEncoder;
-import VASSAL.tools.imageop.GamePieceOp;
-import VASSAL.tools.imageop.Op;
-import VASSAL.tools.imageop.RotateScaleOp;
-import VASSAL.tools.swing.SwingUtils;
-import net.miginfocom.swing.MigLayout;
 
 /**
  * d/b/a "Can Rotate"
@@ -511,6 +510,12 @@ public class FreeRotator extends Decorator
     outer.setProperty(Properties.MOVED, Boolean.TRUE);
     c = c.append(comm.getChangeCommand());
 
+    // Unlink from Parent Stack (in case it is a Deck).
+    final Stack parent = outer.getParent();
+    if (parent != null) {
+      c = c.append(parent.pieceRemoved(outer));
+    }
+
     // Move the piece
     c = c.append(map.placeOrMerge(outer, dest));
 
@@ -522,12 +527,6 @@ public class FreeRotator extends Decorator
     // Apply after Move Key
     if (map.getMoveKey() != null) {
       c = c.append(outer.keyEvent(map.getMoveKey()));
-    }
-
-    // Unlink from Parent Stack (in case it is a Deck).
-    final Stack parent = outer.getParent();
-    if (parent != null) {
-      c = c.append(parent.pieceRemoved(outer));
     }
 
     return c;

--- a/vassal-app/src/main/java/VASSAL/counters/GamePiece.java
+++ b/vassal-app/src/main/java/VASSAL/counters/GamePiece.java
@@ -17,20 +17,19 @@
  */
 package VASSAL.counters;
 
-import java.awt.Component;
-import java.awt.Graphics;
-import java.awt.Point;
-import java.awt.Rectangle;
-import java.awt.Shape;
-
-import javax.swing.KeyStroke;
-
 import VASSAL.build.module.BasicCommandEncoder;
 import VASSAL.build.module.GameState;
 import VASSAL.build.module.Map;
 import VASSAL.build.module.properties.PropertySource;
 import VASSAL.command.ChangePiece;
 import VASSAL.command.Command;
+
+import javax.swing.KeyStroke;
+import java.awt.Component;
+import java.awt.Graphics;
+import java.awt.Point;
+import java.awt.Rectangle;
+import java.awt.Shape;
 
 /**
  * Interface to deal with the behaviors of a physical component of the game, <b><i>or a Trait of one</i></b>. Although from
@@ -217,4 +216,12 @@ public interface GamePiece extends PropertySource {
    */
   @Override
   Object getProperty(Object key);
+
+  default Command prepareMove(Command c, boolean mark_moved) {
+    return c;
+  }
+
+  default Command finishMove(Command c, boolean afterburner, boolean findmat) {
+    return c;
+  }
 }

--- a/vassal-app/src/main/java/VASSAL/counters/GamePiece.java
+++ b/vassal-app/src/main/java/VASSAL/counters/GamePiece.java
@@ -17,6 +17,7 @@
  */
 package VASSAL.counters;
 
+import VASSAL.build.GameModule;
 import VASSAL.build.module.BasicCommandEncoder;
 import VASSAL.build.module.GameState;
 import VASSAL.build.module.Map;
@@ -218,10 +219,12 @@ public interface GamePiece extends PropertySource {
   Object getProperty(Object key);
 
   default Command prepareMove(Command c, boolean mark_moved) {
+    GameModule.getGameModule().warn("GamePiece#prepareMove called by Deck or Stack"); //NON-NLS
     return c;
   }
 
   default Command finishMove(Command c, boolean afterburner, boolean findmat) {
+    GameModule.getGameModule().warn("GamePiece#finishMove called by Deck or Stack"); //NON-NLS
     return c;
   }
 }

--- a/vassal-app/src/main/java/VASSAL/counters/ReturnToDeck.java
+++ b/vassal-app/src/main/java/VASSAL/counters/ReturnToDeck.java
@@ -167,6 +167,14 @@ public class ReturnToDeck extends Decorator implements TranslatablePiece {
       final Map preMap = getMap();
       final Point prePos = getPosition();
       comm = putOldProperties(this);
+
+      // Unlink from Parent Stack (in case it is a Deck).
+      final GamePiece outer = Decorator.getOutermost(this);
+      final Stack parent = outer.getParent();
+      if (parent != null) {
+        comm = comm.append(parent.pieceRemoved(outer));
+      }
+
       comm = comm.append(pile.addToContents(Decorator.getOutermost(this)));
 
       // If this piece is also loaded cargo, remove it from it's mat

--- a/vassal-app/src/main/java/VASSAL/counters/SendToLocation.java
+++ b/vassal-app/src/main/java/VASSAL/counters/SendToLocation.java
@@ -536,6 +536,11 @@ public class SendToLocation extends Decorator implements TranslatablePiece {
 
         c = tracker.getChangeCommand();
         c = c.append(putOldProperties(this));
+
+        if (parent != null) {
+          c = c.append(parent.pieceRemoved(outer));
+        }
+
         if (!Boolean.TRUE.equals(outer.getProperty(Properties.IGNORE_GRID))) {
           dest = map.snapTo(dest);
         }
@@ -554,13 +559,10 @@ public class SendToLocation extends Decorator implements TranslatablePiece {
         if (map.getMoveKey() != null) {
           c = c.append(outer.keyEvent(map.getMoveKey()));
         }
-
-        if (parent != null) {
-          c = c.append(parent.pieceRemoved(outer));
-        }
       }
     }
     else {
+      final Stack parent = outer.getParent();
       backMap = (Map) getProperty(BACK_MAP);
       final Point backPoint = (Point) getProperty(BACK_POINT);
       final ChangeTracker tracker = new ChangeTracker(this);
@@ -576,6 +578,11 @@ public class SendToLocation extends Decorator implements TranslatablePiece {
 
       if (backMap != null && backPoint != null) {
         c = c.append(putOldProperties(this));
+
+        if (parent != null) {
+          c = c.append(parent.pieceRemoved(outer));
+        }
+
         c = c.append(backMap.placeOrMerge(outer, backPoint));
         dest = backPoint;
 
@@ -620,6 +627,10 @@ public class SendToLocation extends Decorator implements TranslatablePiece {
             c = c.append(tracker.getChangeCommand());
             c = c.append(putOldProperties(piece));
 
+            if (pieceParent != null) {
+              c = c.append(pieceParent.pieceRemoved(piece));
+            }
+
             //BR// I sort of think cargo shouldn't snap when moving in lockstep with its mat.
             //BR// This may lead to the eventual conclusion that cargo pieces shouldn't snap
             //BR// even when dragged, IF they land on an eligible Mat.
@@ -631,9 +642,6 @@ public class SendToLocation extends Decorator implements TranslatablePiece {
             // Apply Auto-move key
             if (map.getMoveKey() != null) {
               c = c.append(piece.keyEvent(map.getMoveKey()));
-            }
-            if (pieceParent != null) {
-              c = c.append(pieceParent.pieceRemoved(piece));
             }
           }
         }

--- a/vassal-app/src/main/java/VASSAL/counters/Translate.java
+++ b/vassal-app/src/main/java/VASSAL/counters/Translate.java
@@ -36,7 +36,12 @@ import VASSAL.i18n.TranslatablePiece;
 import VASSAL.tools.FormattedString;
 import VASSAL.tools.NamedKeyStroke;
 import VASSAL.tools.SequenceEncoder;
+import net.miginfocom.swing.MigLayout;
 
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.KeyStroke;
+import javax.swing.SwingUtilities;
 import java.awt.Component;
 import java.awt.Graphics;
 import java.awt.Point;
@@ -49,13 +54,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
-
-import javax.swing.JLabel;
-import javax.swing.JPanel;
-import javax.swing.KeyStroke;
-import javax.swing.SwingUtilities;
-
-import net.miginfocom.swing.MigLayout;
 
 /**
  * d/b/a "Move Fixed Distance"
@@ -331,6 +329,12 @@ public class Translate extends Decorator implements TranslatablePiece {
     outer.setProperty(Properties.MOVED, Boolean.TRUE);
     c = c.append(comm.getChangeCommand());
 
+    // Unlink from Parent Stack (in case it is a Deck).
+    final Stack parent = outer.getParent();
+    if (parent != null) {
+      c = c.append(parent.pieceRemoved(outer));
+    }
+
     // Move the piece
     c = c.append(map.placeOrMerge(outer, dest));
 
@@ -340,12 +344,6 @@ public class Translate extends Decorator implements TranslatablePiece {
     // Apply after Move Key
     if (map.getMoveKey() != null) {
       c = c.append(outer.keyEvent(map.getMoveKey()));
-    }
-
-    // Unlink from Parent Stack (in case it is a Deck).
-    final Stack parent = outer.getParent();
-    if (parent != null) {
-      c = c.append(parent.pieceRemoved(outer));
     }
 
     return c;

--- a/vassal-app/src/main/resources/VASSAL/i18n/Editor.properties
+++ b/vassal-app/src/main/resources/VASSAL/i18n/Editor.properties
@@ -472,6 +472,7 @@ Editor.DeckSendKeyCommand.stop_include=Also send card that matches stop conditio
 Editor.DeckSendKeyCommand.order=Order to send cards
 Editor.DeckSendKeyCommand.error_no_target=Target Deck not found
 Editor.DeckSendKeyCommand.error_invalid_send_limit=Invalid send card limit, Sending all cards
+Editor.DeckSendKeyCommand.apply_on_move=Apply any apply-on-move key commands for destination map
 
 # Delete
 # Description of the Delete trait seen by users

--- a/vassal-doc/src/main/readme-referencemanual/ReferenceManual/DeckSendKeyCommand.adoc
+++ b/vassal-doc/src/main/readme-referencemanual/ReferenceManual/DeckSendKeyCommand.adoc
@@ -54,7 +54,9 @@ NOTE: If you add new Decks to the module, you will need to save and reload the m
 
 *Stop sending expression:*:: A <<PropertyMatchExpression.adoc#top,Property Match Expression>> that when it matches a card, no more cards will be sent to the target Deck as part of this Deck Send Command.
 
-Also send card that matches stop condition:*:: Controls whether the card that triggers the _Stop sending expression_ is sent to the target Deck or not.
+*Also send card that matches stop condition:*:: Controls whether the card that triggers the _Stop sending expression_ is sent to the target Deck or not.
+
+*Apply any apply-on-move key commands for destination map:*:: If selected, then if the destination deck's map has an apply-on-move key (aka _Key Command to apply to all units ending movement on this map_), then it will be applied to each card after it is moved to the destination. If unchecked, then no apply-on-move commands will activate.
 
 a|
 image:images/DeckSendKeyCommand.png[]


### PR DESCRIPTION
CHANGELIST for this PR should be:
11994 - Deck "send-when-empty" hotkeys no longer create extra undo steps
11963 - SendToLocation, Can Rotate, and MoveFixedDistance were all unlinking from deck/stack at wrong time, causing buggy behavior in some instances especially involving decks 
11714 - Deck's Send-when-Empty key now processes AFTER fully moving last card
11429 - Deck Empty Hotkey no longer repeats per online player instance, nor when stepping forward a log