### PR TITLE
11961 - Clear up mark-when-moved problems for modules which still had a legacy value set

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/module/GlobalOptions.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/GlobalOptions.java
@@ -738,10 +738,6 @@ public class GlobalOptions extends AbstractConfigurable implements ComponentDesc
     }
     else if (MARK_MOVED.equals(key)) {
       markMoved = (String) value;
-      if (PROMPT.equals(markMoved)) {
-        final BooleanConfigurer config = new BooleanConfigurer(MARK_MOVED, Resources.getString("GlobalOptions.mark_moved")); //$NON-NLS-1$
-        GameModule.getGameModule().getPrefs().addOption(config);
-      }
     }
     else if (PLAYER_ID_FORMAT.equals(key)) {
       playerIdFormat.setFormat((String) value);

--- a/vassal-app/src/main/java/VASSAL/build/module/map/MovementReporter.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/MovementReporter.java
@@ -137,7 +137,7 @@ public class MovementReporter {
     final Map mappy = Map.getMapById(summary.getNewMapId());
     String option = (mappy == null) ? null : mappy.getAttributeValueString(Map.MARK_MOVED);
     if (option == null) {
-      option = GlobalOptions.getInstance().getAttributeValueString(GlobalOptions.MARK_MOVED);
+      option = GlobalOptions.ALWAYS;
     }
     if (GlobalOptions.ALWAYS.equals(option)) {
       return true;

--- a/vassal-app/src/main/java/VASSAL/build/module/map/PieceMover.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/PieceMover.java
@@ -30,7 +30,6 @@ import VASSAL.build.widget.PieceSlot;
 import VASSAL.command.ChangeTracker;
 import VASSAL.command.Command;
 import VASSAL.command.NullCommand;
-import VASSAL.configure.BooleanConfigurer;
 import VASSAL.configure.NamedHotKeyConfigurer;
 import VASSAL.counters.BasicPiece;
 import VASSAL.counters.BoundsTracker;
@@ -54,7 +53,6 @@ import VASSAL.counters.PieceVisitorDispatcher;
 import VASSAL.counters.Properties;
 import VASSAL.counters.PropertyExporter;
 import VASSAL.counters.Stack;
-import VASSAL.i18n.Resources;
 import VASSAL.tools.DebugControls;
 import VASSAL.tools.FormattedString;
 import VASSAL.tools.LaunchButton;
@@ -645,12 +643,6 @@ public class PieceMover extends AbstractBuildable
    */
   protected void initButton() {
     final String value = getMarkOption();
-    if (GlobalOptions.PROMPT.equals(value)) {
-      final BooleanConfigurer config = new BooleanConfigurer(
-        Map.MARK_MOVED, Resources.getString("Editor.PieceMover.mark_moved_pieces"), Boolean.TRUE);
-      GameModule.getGameModule().getPrefs().addOption(config);
-    }
-
     if (!GlobalOptions.NEVER.equals(value)) {
       if (markUnmovedButton == null) {
         final ActionListener al = e -> {
@@ -713,12 +705,8 @@ public class PieceMover extends AbstractBuildable
    * @return Our setting w/ regard to marking pieces moved.
    */
   private String getMarkOption() {
-    String value = map.getAttributeValueString(Map.MARK_MOVED);
-    if (value == null) {
-      value = GlobalOptions.getInstance()
-                           .getAttributeValueString(GlobalOptions.MARK_MOVED);
-    }
-    return value;
+    final String value = map.getAttributeValueString(Map.MARK_MOVED);
+    return (value == null) ? GlobalOptions.ALWAYS : value;
   }
 
   @Override
@@ -841,16 +829,7 @@ public class PieceMover extends AbstractBuildable
    */
   protected boolean shouldMarkMoved() {
     final String option = getMarkOption();
-    if (GlobalOptions.ALWAYS.equals(option)) {
-      return true;
-    }
-    else if (GlobalOptions.NEVER.equals(option)) {
-      return false;
-    }
-    else {
-      return Boolean.TRUE.equals(
-        GameModule.getGameModule().getPrefs().getValue(Map.MARK_MOVED));
-    }
+    return !GlobalOptions.NEVER.equals(option);
   }
 
   /**


### PR DESCRIPTION
There was zombie code from back when (in the terrible Bad Old Days) whether to mark pieces moved was sometimes treated as a user preference (ouch! head! exploded!) 

Anyway, modules which still had "Use User Preference" set in them were sometimes still (ack) heeding the terrible advice of the user. 

Zombie, meet FLAMETHROWER!