### PR TITLE
11861 - Editing PropertySheet trait shouldn't wipe its state

### DIFF
--- a/vassal-app/src/main/java/VASSAL/counters/PieceDefiner.java
+++ b/vassal-app/src/main/java/VASSAL/counters/PieceDefiner.java
@@ -1146,7 +1146,9 @@ public class PieceDefiner extends JPanel {
       if (c != null) {
         p.mySetType(c.getType());
         if (p instanceof Decorator) {
-          ((Decorator) p).mySetState(c.getState());
+          if (!(p instanceof PropertySheet)) {
+            ((Decorator) p).mySetState(c.getState());
+          }
         }
         else {
           p.setState(c.getState());


### PR DESCRIPTION
Fixes #11861 

@BrentEaston See what you think -- a short version of what's described in the attached issue is that when you edit the PropertySheet *trait* in the piece definer, it wipes all the contents you've put into the state (the values of the properties themselves), because the way only way to preload values into the properties is to use the edit-the-preview-piece power in the PieceDefiner, and normally PieceDefiner effectively wipes the state of any individual trait that gets edited. 

My proposed fix is just to exempt PropertySheet from that wiping behavior -- an edited PropertySheet trait will just keep its current state. I don't think this can cause any particular harm, and even if maybe the results aren't perfect if you delete a property at least this improves the most common case?

(EDIT: See #11861 for discussion of what happened on testing. Not sure where to go with it...)