### PR TITLE
11986 - Add missing Section size symbol to NATO markers

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/module/gamepieceimage/Symbol.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/gamepieceimage/Symbol.java
@@ -185,6 +185,8 @@ public class Symbol {
       new SizeOption(SZ_INSTALLATION, Resources.getString("Editor.Symbol.Size.installation"), 1, INSTALLATION_SYMBOL),
       new SizeOption(SZ_TEAM, Resources.getString("Editor.Symbol.Size.team"), 1, TEAM_SYMBOL),
       new SizeOption(SZ_SQUAD, Resources.getString("Editor.Symbol.Size.squad"), 1, SQUAD_SYMBOL),
+      // Note: Platoon and Section constants reversed due to earlier error. Maintain this switch for compatibility
+      new SizeOption(SZ_PLATOON, Resources.getString("Editor.Symbol.Size.section"), 2, SQUAD_SYMBOL),
       new SizeOption(SZ_SECTION, Resources.getString("Editor.Symbol.Size.platoon"), 3, SQUAD_SYMBOL),
       new SizeOption(SZ_ECHELON, Resources.getString("Editor.Symbol.Size.echelon"), 4, SQUAD_SYMBOL),
       new SizeOption(SZ_COMPANY, Resources.getString("Editor.Symbol.Size.company"), 1, COMPANY_SYMBOL),

--- a/vassal-app/src/main/resources/VASSAL/i18n/Editor.properties
+++ b/vassal-app/src/main/resources/VASSAL/i18n/Editor.properties
@@ -1947,6 +1947,7 @@ Editor.Symbol.Size.installation=Installation
 Editor.Symbol.Size.team=Team
 Editor.Symbol.Size.squad=Squad
 Editor.Symbol.Size.platoon=Platoon
+Editor.Symbol.Size.section=Section
 Editor.Symbol.Size.echelon=Echelon
 Editor.Symbol.Size.company=Company
 Editor.Symbol.Size.battalion=Battalion


### PR DESCRIPTION
Extremely minor change, would be good for 3.6.12