### PR TITLE
Reinstate removal of module tile cache when a module is removed from the Module Manager

### DIFF
--- a/vassal-app/src/main/java/VASSAL/launch/AbstractLaunchAction.java
+++ b/vassal-app/src/main/java/VASSAL/launch/AbstractLaunchAction.java
@@ -114,6 +114,13 @@ public abstract class AbstractLaunchAction extends AbstractAction {
   }
 
   /**
+   * @return <code>true</code> iff any files are in use
+   */
+  public static boolean anyInUse() {
+    return useTracker.anyInUse();
+  }
+
+  /**
    * @param file the file to check
    * @return <code>true</code> iff the file is in use
    */

--- a/vassal-app/src/main/java/VASSAL/launch/ModuleManagerWindow.java
+++ b/vassal-app/src/main/java/VASSAL/launch/ModuleManagerWindow.java
@@ -1610,7 +1610,9 @@ public class ModuleManagerWindow extends JFrame {
         @Override
         public void actionPerformed(ActionEvent e) {
           removeModule(file);
-          //cleanupTileCache();  // Sometimes they might have another copy of same module in the list, and ended up with TileNotFound exceptions
+          if (!AbstractLaunchAction.anyInUse()) {
+            cleanupTileCache();
+          }
         }
       });
 

--- a/vassal-app/src/main/java/VASSAL/launch/UseTracker.java
+++ b/vassal-app/src/main/java/VASSAL/launch/UseTracker.java
@@ -30,6 +30,13 @@ public class UseTracker {
   private final PropertyChangeSupport pcs = new PropertyChangeSupport(this);
 
   /**
+   * @return <code>true</code> iff any files are in use
+   */
+  public synchronized boolean anyInUse() {
+    return !using.isEmpty();
+  }
+
+  /**
    * @param file the file to check
    * @return <code>true</code> iff the file is in use
    */


### PR DESCRIPTION
Reinstate removal of module tile cache when a module is removed from the Module Manager, but only if no modules are open, to guard against deletion of an in-use cache.