### PR TITLE
9786 - Text Label traits will respond to GameRefresher (unless trait has a manually-change-label hotkey defined)

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/GpIdChecker.java
+++ b/vassal-app/src/main/java/VASSAL/build/GpIdChecker.java
@@ -30,6 +30,7 @@ import VASSAL.counters.PieceCloner;
 import VASSAL.counters.PlaceMarker;
 import VASSAL.counters.Properties;
 import VASSAL.i18n.Resources;
+import VASSAL.tools.NamedKeyStroke;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -308,8 +309,12 @@ public class GpIdChecker {
         final String newState = findState(oldPiece, p, decoratorNew, p.getClass());
         // Do not copy the state of Marker traits, we want to see the new value from the new definition
         if (newState != null && newState.length() > 0 && !(decoratorNew instanceof Marker)) {
-          decoratorNew.mySetState(newState);
+          // Do not copy Labeler (Text Label) label state UNLESS this Text Label has the capacity to be manually updated
+          if (!(decoratorNew instanceof Labeler) || ((((Labeler)decoratorNew).getLabelKey() != null) && !NamedKeyStroke.NULL_KEYSTROKE.equals(((Labeler)decoratorNew).getLabelKey()))) {
+            decoratorNew.mySetState(newState);
+          }
         }
+
         p = decoratorNew.getInner();
       }
     }

--- a/vassal-app/src/main/java/VASSAL/counters/Labeler.java
+++ b/vassal-app/src/main/java/VASSAL/counters/Labeler.java
@@ -127,6 +127,10 @@ public class Labeler extends Decorator implements TranslatablePiece, Loopable {
     setInner(d);
   }
 
+  public NamedKeyStroke getLabelKey() {
+    return labelKey;
+  }
+
   @Override
   public void mySetType(String type) {
     commands = null;


### PR DESCRIPTION
Fixes #9786