### PR TITLE
12032 - Mark-When-Moved trait can be configured to only flag when piece changes LocationName or Mat. Similarly Map auto-report can be configured to ignore same-location movements.

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/GameModule.java
+++ b/vassal-app/src/main/java/VASSAL/build/GameModule.java
@@ -128,7 +128,6 @@ import VASSAL.tools.menu.MenuItemProxy;
 import VASSAL.tools.menu.MenuManager;
 import VASSAL.tools.swing.SwingUtils;
 import VASSAL.tools.version.VersionUtils;
-
 import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -136,6 +135,13 @@ import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
+import javax.swing.AbstractAction;
+import javax.swing.JComponent;
+import javax.swing.JFrame;
+import javax.swing.JOptionPane;
+import javax.swing.JPanel;
+import javax.swing.JToolBar;
+import javax.swing.KeyStroke;
 import java.awt.Container;
 import java.awt.Rectangle;
 import java.awt.event.ActionEvent;
@@ -160,14 +166,6 @@ import java.util.Deque;
 import java.util.List;
 import java.util.Objects;
 import java.util.Random;
-
-import javax.swing.AbstractAction;
-import javax.swing.JComponent;
-import javax.swing.JFrame;
-import javax.swing.JOptionPane;
-import javax.swing.JPanel;
-import javax.swing.JToolBar;
-import javax.swing.KeyStroke;
 
 import static VASSAL.preferences.Prefs.MAIN_WINDOW_HEIGHT;
 import static VASSAL.preferences.Prefs.MAIN_WINDOW_REMEMBER;
@@ -279,6 +277,7 @@ public class GameModule extends AbstractConfigurable
   private final TranslatableStringContainer transContainer = new TranslatableStringContainer.Impl();
 
   private boolean matSupport = false; // If no Mats exist in the module, we don't need to spend any time doing mat-related calculations during moves/selects
+  private boolean trueMovedSupport = false; // If not ignore-small-moves traits exist in the module, we don't need to spend any time doing related calculations
 
   private final DeckManager deckMgr = new DeckManager();
 
@@ -305,6 +304,21 @@ public class GameModule extends AbstractConfigurable
   public void setMatSupport(boolean matSupport) {
     this.matSupport = matSupport;
   }
+
+  /**
+   * @return True if there are any ignore-small-moves traits in the module
+   */
+  public boolean isTrueMovedSupport() {
+    return trueMovedSupport;
+  }
+
+  /**
+   * @param fancyMoveSupport true if a ignore-small-moves trait exists in the module
+   */
+  public void setTrueMovedSupport(boolean trueMovedSupport) {
+    this.trueMovedSupport = trueMovedSupport;
+  }
+
 
   private final PropertyChangeListener repaintOnPropertyChange =
     evt -> {

--- a/vassal-app/src/main/java/VASSAL/build/module/Map.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/Map.java
@@ -267,6 +267,7 @@ public class Map extends AbstractToolbarItem implements GameComponent, MouseList
   protected boolean allowMultiple = false;
   protected VisibilityCondition visibilityCondition;
   protected DragGestureListener dragGestureListener;
+  protected boolean onlyReportChangedLocation = false;
   protected String moveWithinFormat;
   protected String moveToFormat;
   protected String createFormat;
@@ -374,6 +375,13 @@ public class Map extends AbstractToolbarItem implements GameComponent, MouseList
   }
 
   /**
+   * @return true if auto-reporting moves should only happen if location changed
+   */
+  public boolean isOnlyReportChangedLocation() {
+    return onlyReportChangedLocation;
+  }
+
+  /**
    * Global Change Reporting control - used by Global Key Commands (see {@link GlobalCommand}) to
    * temporarily disable reporting while they run, if their "Suppress individual reports" option is selected.
    * @param b true to turn global change reporting on, false to turn it off.
@@ -409,6 +417,7 @@ public class Map extends AbstractToolbarItem implements GameComponent, MouseList
   public static final String ICON = "icon"; //$NON-NLS-1$
   public static final String HOTKEY = "hotkey"; //$NON-NLS-1$
   public static final String SUPPRESS_AUTO = "suppressAuto"; //$NON-NLS-1$
+  public static final String ONLY_REPORT_CHANGED_LOCATION = "onlyReportChangedLocation"; //NON-NLS
   public static final String MOVE_WITHIN_FORMAT = "moveWithinFormat"; //$NON-NLS-1$
   public static final String MOVE_TO_FORMAT = "moveToFormat"; //$NON-NLS-1$
   public static final String CREATE_FORMAT = "createFormat"; //$NON-NLS-1$
@@ -545,6 +554,12 @@ public class Map extends AbstractToolbarItem implements GameComponent, MouseList
         moveWithinFormat = ""; //$NON-NLS-1$
       }
     }
+    else if (ONLY_REPORT_CHANGED_LOCATION.equals(key)) {
+      if (value instanceof String) {
+        value = Boolean.valueOf((String) value);
+      }
+      onlyReportChangedLocation = (Boolean) value;
+    }
     else if (MOVE_WITHIN_FORMAT.equals(key)) {
       moveWithinFormat = (String) value;
     }
@@ -653,6 +668,9 @@ public class Map extends AbstractToolbarItem implements GameComponent, MouseList
     }
     else if (USE_LAUNCH_BUTTON.equals(key)) {
       return String.valueOf(useLaunchButtonEdit);
+    }
+    else if (ONLY_REPORT_CHANGED_LOCATION.equals(key)) {
+      return String.valueOf(onlyReportChangedLocation);
     }
     else if (MOVE_WITHIN_FORMAT.equals(key)) {
       return getMoveWithinFormat();
@@ -3355,6 +3373,7 @@ public class Map extends AbstractToolbarItem implements GameComponent, MouseList
       Resources.getString("Editor.Map.toggle_key"),
       Resources.getString("Editor.Map.show_key"),
       Resources.getString("Editor.Map.hide_key"),
+      Resources.getString("Editor.Map.only_report_changed_location"),
       Resources.getString("Editor.Map.report_move_within"), //$NON-NLS-1$
       Resources.getString("Editor.Map.report_move_to"), //$NON-NLS-1$
       Resources.getString("Editor.Map.report_created"), //$NON-NLS-1$
@@ -3394,6 +3413,7 @@ public class Map extends AbstractToolbarItem implements GameComponent, MouseList
       HOTKEY,
       SHOW_KEY,
       HIDE_KEY,
+      ONLY_REPORT_CHANGED_LOCATION,
       MOVE_WITHIN_FORMAT,
       MOVE_TO_FORMAT,
       CREATE_FORMAT,
@@ -3434,6 +3454,7 @@ public class Map extends AbstractToolbarItem implements GameComponent, MouseList
       NamedKeyStroke.class,
       NamedKeyStroke.class,
       NamedKeyStroke.class,
+      Boolean.class,
       MoveWithinFormatConfig.class,
       MoveToFormatConfig.class,
       CreateFormatConfig.class,

--- a/vassal-app/src/main/java/VASSAL/build/module/Map.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/Map.java
@@ -367,6 +367,13 @@ public class Map extends AbstractToolbarItem implements GameComponent, MouseList
   }
 
   /**
+   * @return true if the map marks pieces as moved
+   */
+  public boolean isMarkMoved() {
+    return !markMovedOption.equals(GlobalOptions.NEVER);
+  }
+
+  /**
    * Global Change Reporting control - used by Global Key Commands (see {@link GlobalCommand}) to
    * temporarily disable reporting while they run, if their "Suppress individual reports" option is selected.
    * @param b true to turn global change reporting on, false to turn it off.

--- a/vassal-app/src/main/java/VASSAL/build/module/map/MovementReporter.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/MovementReporter.java
@@ -181,7 +181,7 @@ public class MovementReporter {
       final Map fromMap = Map.getMapById(ms.getOldMapId());
       final Map toMap = Map.getMapById(ms.getNewMapId());
       format.clearProperties();
-      String sourceFieldKey;
+      final String sourceFieldKey;
       if (fromMap == null) {
         format.setFormat(toMap.getCreateFormat());
         sourceFieldKey = "Editor.Map.report_created";
@@ -198,10 +198,18 @@ public class MovementReporter {
         break;
       }
       format.setProperty(Map.PIECE_NAME, ms.getPieceName());
-      format.setProperty(Map.LOCATION, getLocation(toMap, ms.getNewPosition()));
+      final String loc = getLocation(toMap, ms.getNewPosition());
+      format.setProperty(Map.LOCATION, loc);
       if (fromMap != null) {
         format.setProperty(Map.OLD_MAP, fromMap.getLocalizedConfigureName());
-        format.setProperty(Map.OLD_LOCATION, getLocation(fromMap, ms.getOldPosition()));
+        final String oldLoc = getLocation(fromMap, ms.getOldPosition());
+        format.setProperty(Map.OLD_LOCATION, oldLoc);
+
+        if ((toMap == fromMap) && toMap.isOnlyReportChangedLocation()) {
+          if (loc.equals(oldLoc)) {
+            continue;
+          }
+        }
       }
       format.setProperty(Map.MAP_NAME, toMap.getLocalizedConfigureName());
 

--- a/vassal-app/src/main/java/VASSAL/counters/Deck.java
+++ b/vassal-app/src/main/java/VASSAL/counters/Deck.java
@@ -1829,7 +1829,7 @@ public class Deck extends Stack implements PlayerRoster.SideChangeListener {
         // Prepare the piece for move, writing "old location" properties and unlinking from any deck
         c = p.prepareMove(c, false);
         c = c.append(target.addToContents(p));
-        c = p.finishMove(c, false, false);
+        c = p.finishMove(c, false, false, false);
       }
     }
     return c;
@@ -1928,7 +1928,7 @@ public class Deck extends Stack implements PlayerRoster.SideChangeListener {
       c = c.append(target.addToContents(piece));
 
       // Finish up after piece's move. Apply afterburner key if that option is selected
-      c = piece.finishMove(c, dkc.isApplyOnMove() && (map != null), false);
+      c = piece.finishMove(c, dkc.isApplyOnMove() && (map != null), false, false);
       if (dkc.isApplyOnMove() && (map != null)) {
         map.repaint();
       }

--- a/vassal-app/src/main/java/VASSAL/counters/Footprint.java
+++ b/vassal-app/src/main/java/VASSAL/counters/Footprint.java
@@ -37,6 +37,7 @@ import VASSAL.tools.SequenceEncoder;
 import VASSAL.tools.image.ImageUtils;
 import VASSAL.tools.image.LabelUtils;
 
+import javax.swing.KeyStroke;
 import java.awt.AlphaComposite;
 import java.awt.BasicStroke;
 import java.awt.Color;
@@ -57,8 +58,6 @@ import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
-
-import javax.swing.KeyStroke;
 
 /**
  * Displays a movement trail indicating where a piece has been moved
@@ -244,7 +243,7 @@ public class Footprint extends MovementMarkable {
 
   @Override
   public void setProperty(Object key, Object val) {
-    if (Properties.MOVED.equals(key)) {
+    if (Properties.MOVED.equals(key) || Properties.MAYBE_MOVED.equals(key)) {
       setMoved(Boolean.TRUE.equals(val));
       piece.setProperty(key, val); // Pass on to MovementMarkable
       myBoundingBox = null;

--- a/vassal-app/src/main/java/VASSAL/counters/FreeRotator.java
+++ b/vassal-app/src/main/java/VASSAL/counters/FreeRotator.java
@@ -509,7 +509,7 @@ public class FreeRotator extends Decorator
     c = c.append(map.placeOrMerge(Decorator.getOutermost(gp), dest));
 
     // Post move actions -- find a new mat if needed, and apply any afterburner apply-on-move key
-    c = finishMove(c, true, !cargoFollowup);
+    c = finishMove(c, true, !cargoFollowup, true);
 
     return c;
   }

--- a/vassal-app/src/main/java/VASSAL/counters/GamePiece.java
+++ b/vassal-app/src/main/java/VASSAL/counters/GamePiece.java
@@ -223,7 +223,16 @@ public interface GamePiece extends PropertySource {
     return c;
   }
 
+  default Command checkTrueMoved() {
+    GameModule.getGameModule().warn("GamePiece#checkTrueMove called by Deck or Stack"); //NON-NLS
+    return null;
+  }
+
   default Command finishMove(Command c, boolean afterburner, boolean findmat) {
+    return finishMove(c, afterburner, findmat, false);
+  }
+
+  default Command finishMove(Command c, boolean afterburner, boolean findmat, boolean markMoved) {
     GameModule.getGameModule().warn("GamePiece#finishMove called by Deck or Stack"); //NON-NLS
     return c;
   }

--- a/vassal-app/src/main/java/VASSAL/counters/Properties.java
+++ b/vassal-app/src/main/java/VASSAL/counters/Properties.java
@@ -126,6 +126,9 @@ public interface Properties {
   /** Return Boolean.TRUE if this piece has been moved */
   String MOVED = "Moved"; // NON-NLS
 
+  /** Write-only -- sets MOVED but only if ignore-same-location isn't checked in the trait */
+  String MAYBE_MOVED = "MaybeMoved"; //NON-NLS
+
   /** Used to store a duplicate of the target piece at some point in time */
   String SNAPSHOT = "snapshot"; // NON-NLS
 

--- a/vassal-app/src/main/java/VASSAL/counters/ReturnToDeck.java
+++ b/vassal-app/src/main/java/VASSAL/counters/ReturnToDeck.java
@@ -183,7 +183,7 @@ public class ReturnToDeck extends Decorator implements TranslatablePiece {
       final Map m = pile.getMap();
 
       // Post move actions -- apply any afterburner apply-on-move key (but only if the piece was actually moved)
-      comm = finishMove(comm, (m != null && m.getMoveKey() != null && (m != preMap || !getPosition().equals(prePos))), false);
+      comm = finishMove(comm, (m != null && m.getMoveKey() != null && (m != preMap || !getPosition().equals(prePos))), false, false);
 
       if (m != null) {
         m.repaint();

--- a/vassal-app/src/main/java/VASSAL/counters/SendToLocation.java
+++ b/vassal-app/src/main/java/VASSAL/counters/SendToLocation.java
@@ -543,7 +543,7 @@ public class SendToLocation extends Decorator implements TranslatablePiece {
         map.repaint();
 
         // Complete the move, finding new mat if needed and applying map afterburner key
-        c = finishMove(c, true, true);
+        c = finishMove(c, true, true, GlobalOptions.getInstance().isSendToLocationMoveTrails());
       }
     }
     else {
@@ -562,7 +562,7 @@ public class SendToLocation extends Decorator implements TranslatablePiece {
         dest = backPoint;
 
         // Complete the move, finding new mat if needed and applying map afterburner key
-        c = finishMove(c, true, true);
+        c = finishMove(c, true, true, GlobalOptions.getInstance().isSendToLocationMoveTrails());
 
         if (oldMap != null && oldMap != backMap) {
           oldMap.repaint();
@@ -600,7 +600,7 @@ public class SendToLocation extends Decorator implements TranslatablePiece {
             c = c.append(map.placeOrMerge(piece, pt));
 
             // Complete the move, applying map afterburner key
-            c = piece.finishMove(c, true, false);
+            c = piece.finishMove(c, true, false, GlobalOptions.getInstance().isSendToLocationMoveTrails());
           }
         }
       }

--- a/vassal-app/src/main/java/VASSAL/counters/Translate.java
+++ b/vassal-app/src/main/java/VASSAL/counters/Translate.java
@@ -326,7 +326,7 @@ public class Translate extends Decorator implements TranslatablePiece {
     c = c.append(map.placeOrMerge(Decorator.getOutermost(this), dest));
 
     // Post move actions -- find a new mat if needed, and apply any afterburner apply-on-move key
-    c = finishMove(c, true, true);
+    c = finishMove(c, true, true, true);
 
     return c;
   }

--- a/vassal-app/src/main/resources/VASSAL/i18n/Editor.properties
+++ b/vassal-app/src/main/resources/VASSAL/i18n/Editor.properties
@@ -1432,7 +1432,9 @@ Editor.MoveFixedDistance.additional_offset_upwards=Additional offset upwards
 
 # MovementMarkable
 Editor.MovementMarkable.marker_image=Marker image
-Editor.MovementMarkable.default_command=Mark Moved
+Editor.MovementMarkable.default_command=Toggle whether piece marked as moved
+Editor.MovementMarkable.default_command_true=Mark piece as moved
+Editor.MovementMarkable.default_command_false=Mark piece as unmoved
 Editor.MovementMarkable.trait_description=Mark When Moved
 Editor.MovementMarkable.mark_moved_command=Mark Moved command
 Editor.MovementMarkable.horizontal_offset=Horizontal offset
@@ -1440,6 +1442,12 @@ Editor.MovementMarkable.vertical_offset=Vertical offset
 Editor.MovementMarkable.enable_text=You must enable the "Mark Pieces that Move" option in one or more Map Windows
 Editor.MovementMarkable.option_not_enabled=Option not enabled
 Editor.MovementMarkable.ignore_same_location=Ignore moves which don't change either Location Name or Mat
+Editor.MovementMarkable.menu_command=Menu Command to toggle
+Editor.MovementMarkable.menu_command_true=Menu Command to mark as moved
+Editor.MovementMarkable.menu_command_false=Menu  Command to mark as unmoved
+Editor.MovementMarkable.key_command=Key Command to toggle
+Editor.MovementMarkable.key_command_true=Key Command to mark as moved
+Editor.MovementMarkable.key_command_false=Key Command to mark as unmoved
 
 # Multi Action Button
 Editor.MultiActionButton.buttons=Button names

--- a/vassal-app/src/main/resources/VASSAL/i18n/Editor.properties
+++ b/vassal-app/src/main/resources/VASSAL/i18n/Editor.properties
@@ -1438,6 +1438,7 @@ Editor.MovementMarkable.horizontal_offset=Horizontal offset
 Editor.MovementMarkable.vertical_offset=Vertical offset
 Editor.MovementMarkable.enable_text=You must enable the "Mark Pieces that Move" option in one or more Map Windows
 Editor.MovementMarkable.option_not_enabled=Option not enabled
+Editor.MovementMarkable.ignore_same_location=Ignore moves which don't change either Location Name or Mat
 
 # Multi Action Button
 Editor.MultiActionButton.buttons=Button names

--- a/vassal-app/src/main/resources/VASSAL/i18n/Editor.properties
+++ b/vassal-app/src/main/resources/VASSAL/i18n/Editor.properties
@@ -1227,6 +1227,7 @@ Editor.Map.bc_selected_counter=Border color for selected counters
 Editor.Map.bt_selected_counter=Border thickness for selected counters
 Editor.Map.show_hide=Include toolbar button to show/hide
 Editor.Map.show_hide_first=Include toolbar button to show/hide (Docking state won't change until module restarted)
+Editor.Map.only_report_changed_location=Only auto-report move "within this map" if piece's Location Name changed
 Editor.Map.report_move_within=Auto-report format for movement within this map
 Editor.Map.report_move_to=Auto-report format for movement to this map
 Editor.Map.report_created=Auto-report format for units created in this map

--- a/vassal-doc/src/main/readme-referencemanual/ReferenceManual/Map.adoc
+++ b/vassal-doc/src/main/readme-referencemanual/ReferenceManual/Map.adoc
@@ -68,6 +68,8 @@ NOTE: changing this option will not take effect until the module has been reload
 
 NOTE: The following reports are separate from, and in addition to, any reports the piece itself generates with <<ReportChanges.adoc#top,Report Action>> traits in response to the Key Command applied by the bottom field.
 
+*Only auto-report move "within this map" if piece's Location Name changed:*::  If selected, then movement "within this map" will only be auto-reported if the piece's LocationName property is changed by the move.
+
 *Auto-report format for movement within this map:*::  A <<MessageFormat.adoc#top,Message Format>> that will be used to automatically report movement of pieces completely within this map window: _$pieceName$_ is the name of the piece being moved, _$location$_ is the location to which the piece is being moved (in the format specified below), _$previousLocation$_ is the location from which the piece is being moved.
 
 *Auto-report format for movement to this map:*::  A <<MessageFormat.adoc#top,Message Format>> that will be used to report movement of pieces to this map window from another map window: In addition to the properties noted for the above item, _$previousMap$_ is the name of the map from which the piece is being moved.

--- a/vassal-doc/src/main/readme-referencemanual/ReferenceManual/MarkMoved.adoc
+++ b/vassal-doc/src/main/readme-referencemanual/ReferenceManual/MarkMoved.adoc
@@ -41,7 +41,7 @@ SEE ALSO: <<MovementTrail.adoc#top,Movement Trails>>)
 
 *Key command to mark as unmoved:*:: <<NamedKeyCommand.adoc#top,Keystroke or Named Command>> to force the piece's moved status to _false_ and clear any Movement Trails.
 
-*Ignore moves which don't change either Location Name or Mat:*:: If checked, then don't the piece as moved if neither its Location Name nor its mat changed as a result of its move. This can be used to ignore insignificant moves (e.g. a couple pixels in an area movement game).
+*Ignore moves which don't change either Location Name or Mat:*:: If checked, then don't mark the piece as moved if neither its Location Name nor its mat changed as a result of its move. This can be used to ignore insignificant moves (e.g. a couple pixels in an area movement game).
 
 *Marker Image:*:: Use the _Select_ button to load a new image or the _Default_ button to return to the default image.
 

--- a/vassal-doc/src/main/readme-referencemanual/ReferenceManual/MarkMoved.adoc
+++ b/vassal-doc/src/main/readme-referencemanual/ReferenceManual/MarkMoved.adoc
@@ -33,6 +33,8 @@ SEE ALSO: <<MovementTrail.adoc#top,Movement Trails>>)
 
 *Key command:*:: <<NamedKeyCommand.adoc#top,Keystroke or Named Command>> to clear the piece's move history (setting _Moved_ property back to _false_ and clearing any <<MovementTrail.adoc#top,Movement Trails>>).
 
+*Ignore moves which don't change either Location Name or Mat:*:: If checked, then don't the piece as moved if neither its Location Name nor its mat changed as a result of its move. This can be used to ignore insignificant moves (e.g. a couple pixels in an area movement game).
+
 *Marker Image:*:: Use the _Select_ button to load a new image or the _Default_ button to return to the default image.
 
 *Horizontal Offset:*:: Specify how many pixels to the right of the center of the piece to display the moved marker.

--- a/vassal-doc/src/main/readme-referencemanual/ReferenceManual/MarkMoved.adoc
+++ b/vassal-doc/src/main/readme-referencemanual/ReferenceManual/MarkMoved.adoc
@@ -29,9 +29,17 @@ SEE ALSO: <<MovementTrail.adoc#top,Movement Trails>>)
 |
 *Description:*:: A short description of this trait for your own reference.
 
-*Menu command:*:: Right-click context menu item that will clear the piece's move history (setting _Moved_ property back to _false_ and clearing any <<MovementTrail.adoc#top,Movement Trails>>). If this item is left blank, no context menu entry will appear but the move history can still be cleared with the Key Command, below.
+*Menu command to toggle:*:: Right-click context menu item that will toggle the moved status (flipping _Moved_ property between _true_ and _false_ and clearing any <<MovementTrail.adoc#top,Movement Trails>> if set to false). If this item is left blank, no context menu entry will appear but the flag can still be toggled with the key command, below.
 
-*Key command:*:: <<NamedKeyCommand.adoc#top,Keystroke or Named Command>> to clear the piece's move history (setting _Moved_ property back to _false_ and clearing any <<MovementTrail.adoc#top,Movement Trails>>).
+*Key command to toggle:*:: <<NamedKeyCommand.adoc#top,Keystroke or Named Command>> to toggle the piece's moved status (flipping _Moved_ property between _true_ and _false_ and clearing any <<MovementTrail.adoc#top,Movement Trails>> if set to false).
+
+*Menu command to mark as moved:*:: Context menu item that will force the piece's moved status to _true_.
+
+*Key command to mark as moved:*:: <<NamedKeyCommand.adoc#top,Keystroke or Named Command>> to force the piece's moved status to _true_.
+
+*Menu command to mark as unmoved:*:: Context menu item that will force the piece's moved status to _false_ and clear any Movement Trails.
+
+*Key command to mark as unmoved:*:: <<NamedKeyCommand.adoc#top,Keystroke or Named Command>> to force the piece's moved status to _false_ and clear any Movement Trails.
 
 *Ignore moves which don't change either Location Name or Mat:*:: If checked, then don't the piece as moved if neither its Location Name nor its mat changed as a result of its move. This can be used to ignore insignificant moves (e.g. a couple pixels in an area movement game).
 


### PR DESCRIPTION
Per this forum thread: https://forum.vassalengine.org/t/mark-when-moved-enhancement/74042

Ironically the auto-report thing part of this is the first thing I ever wanted to change about Vassal -- if it already had this I might never have started down That Fateful Road. And yet I never got around to actually changing it until now...

