### PR TITLE
12048 - Fix bugs when deleting groups of decks/stacks from the editor

### DIFF
--- a/vassal-app/src/main/java/VASSAL/configure/ConfigureTree.java
+++ b/vassal-app/src/main/java/VASSAL/configure/ConfigureTree.java
@@ -966,7 +966,7 @@ public class ConfigureTree extends JTree implements PropertyChangeListener, Mous
                   // Child could have been already deleted or dragged elsewhere
                   final DefaultMutableTreeNode currentParent = (DefaultMutableTreeNode)getTreeNode(child).getParent();
                   if (currentParent != null) {
-                    ConfigureTree.this.remove((Configurable)currentParent.getUserObject(), child);
+                    ConfigureTree.this.delete(child);
                   }
                   dispose();
                 }
@@ -1057,7 +1057,7 @@ public class ConfigureTree extends JTree implements PropertyChangeListener, Mous
         @Override
         public void actionPerformed(ActionEvent evt) {
           final int row = selectedRow;
-          remove(parent, target);
+          delete(target);
           if (row < getRowCount()) {
             setSelectionRow(row);
           }
@@ -1110,6 +1110,30 @@ public class ConfigureTree extends JTree implements PropertyChangeListener, Mous
     }
     return canContainPiece;
   }
+
+
+  /**
+   * Delete removes an item from the tree but ALSO traverses the tree throwing all the childrens' children manually out
+   * the airlock, one by one. Lest they return and live on as zombies...
+   */
+  protected boolean delete(Configurable target) {
+    boolean result = true;
+
+    final Enumeration<?> e = getTreeNode(target).postorderEnumeration();
+    final List<DefaultMutableTreeNode> victims = new ArrayList<>();
+    while (e.hasMoreElements()) {
+      victims.add((DefaultMutableTreeNode) e.nextElement());
+    }
+
+    for (final DefaultMutableTreeNode nextChild : victims) {
+      final DefaultMutableTreeNode nextParent = (DefaultMutableTreeNode)nextChild.getParent();
+      final Configurable child  = (Configurable) nextChild.getUserObject();
+      final Configurable parent = (Configurable) nextParent.getUserObject();
+      result &= remove(parent, child);
+    }
+    return result;
+  }
+
 
   protected boolean remove(Configurable parent, Configurable child) {
     try {

--- a/vassal-app/src/main/java/VASSAL/configure/ConfigureTree.java
+++ b/vassal-app/src/main/java/VASSAL/configure/ConfigureTree.java
@@ -1126,10 +1126,7 @@ public class ConfigureTree extends JTree implements PropertyChangeListener, Mous
     }
 
     for (final DefaultMutableTreeNode nextChild : victims) {
-      final DefaultMutableTreeNode nextParent = (DefaultMutableTreeNode)nextChild.getParent();
-      final Configurable child  = (Configurable) nextChild.getUserObject();
-      final Configurable parent = (Configurable) nextParent.getUserObject();
-      result &= remove(parent, child);
+      result &= remove((Configurable) ((DefaultMutableTreeNode)nextChild.getParent()).getUserObject(), (Configurable) nextChild.getUserObject());
     }
     return result;
   }

--- a/vassal-app/src/main/java/VASSAL/configure/ConfigureTree.java
+++ b/vassal-app/src/main/java/VASSAL/configure/ConfigureTree.java
@@ -1049,7 +1049,6 @@ public class ConfigureTree extends JTree implements PropertyChangeListener, Mous
 
   protected Action buildDeleteAction(final Configurable target) {
     final DefaultMutableTreeNode targetNode = getTreeNode(target);
-    final Configurable parent = getParent(targetNode);
     if (targetNode.getParent() != null) {
       return new AbstractAction(deleteCmd) {
         private static final long serialVersionUID = 1L;

--- a/vassal-app/src/main/java/VASSAL/configure/ConfigureTree.java
+++ b/vassal-app/src/main/java/VASSAL/configure/ConfigureTree.java
@@ -1125,8 +1125,8 @@ public class ConfigureTree extends JTree implements PropertyChangeListener, Mous
       victims.add((DefaultMutableTreeNode) e.nextElement());
     }
 
-    for (final DefaultMutableTreeNode nextChild : victims) {
-      result &= remove((Configurable) ((DefaultMutableTreeNode)nextChild.getParent()).getUserObject(), (Configurable) nextChild.getUserObject());
+    for (final DefaultMutableTreeNode victim : victims) {
+      result &= remove((Configurable) ((DefaultMutableTreeNode)victim.getParent()).getUserObject(), (Configurable) victim.getUserObject());
     }
     return result;
   }

--- a/vassal-app/src/main/java/VASSAL/configure/ExtensionTree.java
+++ b/vassal-app/src/main/java/VASSAL/configure/ExtensionTree.java
@@ -17,18 +17,6 @@
  */
 package VASSAL.configure;
 
-import java.awt.Color;
-import java.awt.Component;
-import java.awt.Frame;
-import java.awt.event.ActionEvent;
-
-import javax.swing.AbstractAction;
-import javax.swing.Action;
-import javax.swing.JOptionPane;
-import javax.swing.JTree;
-import javax.swing.SwingUtilities;
-import javax.swing.tree.DefaultMutableTreeNode;
-
 import VASSAL.build.Buildable;
 import VASSAL.build.Builder;
 import VASSAL.build.Configurable;
@@ -39,6 +27,17 @@ import VASSAL.build.widget.PieceSlot;
 import VASSAL.i18n.Resources;
 import VASSAL.launch.EditorWindow;
 import VASSAL.tools.ReflectionUtils;
+
+import javax.swing.AbstractAction;
+import javax.swing.Action;
+import javax.swing.JOptionPane;
+import javax.swing.JTree;
+import javax.swing.SwingUtilities;
+import javax.swing.tree.DefaultMutableTreeNode;
+import java.awt.Color;
+import java.awt.Component;
+import java.awt.Frame;
+import java.awt.event.ActionEvent;
 
 /**
  * The configuration tree for editing a module extension
@@ -155,7 +154,7 @@ public class ExtensionTree extends ConfigureTree {
 
                 @Override
                 public void cancel() {
-                  ExtensionTree.this.remove(target, child);
+                  ExtensionTree.this.delete(child);
                   dispose();
                 }
               };


### PR DESCRIPTION
When the user deletes something in the editor (from somewhere in the tree), it handles "properly removing that thing from its parent". But any of its children/grandchildren, whether they're in folders or just other kinds of children/grandchildren/etc? Nope, never "removeFrom's" them, etc. Meaning in this case that they never generate calls to "removeGameComponent" and so until module is reloaded there are still sometimes little treacherous references to them laying around. 

I guess when actually deleting something we need to traverse the tree and manually throw each individual child out the airlock. 