### PR TITLE
Duplicating a prototype no longer disables that prototype until next module reload

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/module/PrototypesContainer.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/PrototypesContainer.java
@@ -96,6 +96,19 @@ public class PrototypesContainer extends AbstractConfigurable {
     return Resources.getString("Editor.PrototypesContainer.component_type"); //$NON-NLS-1$
   }
 
+
+  private void rebuildPrototypeMap(AbstractBuildable target) {
+    for (final Buildable b : target.getBuildables()) {
+      if (b instanceof PrototypeDefinition) {
+        addDefinition((PrototypeDefinition)b);
+      }
+      else if (b instanceof AbstractBuildable) {
+        rebuildPrototypeMap((AbstractBuildable)b);
+      }
+    }
+  }
+
+
   public void addDefinition(PrototypeDefinition def) {
     definitions.put(def.getConfigureName(), def);
     def.addPropertyChangeListener(evt -> {
@@ -103,6 +116,10 @@ public class PrototypesContainer extends AbstractConfigurable {
         definitions.remove(evt.getOldValue());
         definitions.put((String) evt.getNewValue(),
           (PrototypeDefinition) evt.getSource());
+
+        // When a prototype is renamed we need to rebuild the prototype map, so that if there was a duplicate of the same name it will re-establish its presence
+        definitions.clear();
+        rebuildPrototypeMap(GameModule.getGameModule());
       }
     });
   }

--- a/vassal-app/src/main/java/VASSAL/build/module/PrototypesContainer.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/PrototypesContainer.java
@@ -113,10 +113,6 @@ public class PrototypesContainer extends AbstractConfigurable {
     definitions.put(def.getConfigureName(), def);
     def.addPropertyChangeListener(evt -> {
       if (Configurable.NAME_PROPERTY.equals(evt.getPropertyName())) {
-        definitions.remove(evt.getOldValue());
-        definitions.put((String) evt.getNewValue(),
-          (PrototypeDefinition) evt.getSource());
-
         // When a prototype is renamed we need to rebuild the prototype map, so that if there was a duplicate of the same name it will re-establish its presence
         definitions.clear();
         rebuildPrototypeMap(GameModule.getGameModule());

--- a/vassal-app/src/main/java/VASSAL/build/module/map/CounterDetailViewer.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/CounterDetailViewer.java
@@ -196,7 +196,7 @@ public class CounterDetailViewer extends AbstractConfigurable implements Drawabl
   protected FormattedString counterReportFormat = new FormattedString(""); //NON-NLS
   protected FormattedString emptyHexReportFormat = new FormattedString("$" + BasicPiece.LOCATION_NAME + "$"); //NON-NLS
   protected String version = ""; //NON-NLS
-  protected Color fgColor;
+  protected Color fgColor = Color.black;
   protected Color bgColor;
   protected int fontSize = 9;
   protected Font font = new Font("Dialog", Font.PLAIN, fontSize); //NON-NLS

--- a/vassal-app/src/main/java/VASSAL/build/module/map/CounterDetailViewer.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/CounterDetailViewer.java
@@ -196,7 +196,7 @@ public class CounterDetailViewer extends AbstractConfigurable implements Drawabl
   protected FormattedString counterReportFormat = new FormattedString(""); //NON-NLS
   protected FormattedString emptyHexReportFormat = new FormattedString("$" + BasicPiece.LOCATION_NAME + "$"); //NON-NLS
   protected String version = ""; //NON-NLS
-  protected Color fgColor = Color.black;
+  protected Color fgColor;
   protected Color bgColor;
   protected int fontSize = 9;
   protected Font font = new Font("Dialog", Font.PLAIN, fontSize); //NON-NLS


### PR DESCRIPTION
This one could be 3.6.14 if desired

Two prototypes w/ the same name will still only have one of them "found", but this solves the problem where when duplicating a prototype (either by copy/paste or the duplicate option) you ended up temporarily with two of the same name, and even when you renamed the new one to some new name it made the prototype container "forget about" the original prototype until you reloaded the module.