### PR TITLE
12041 - Rollover border color of 'no color' did not save to file, nor copy correctly

### DIFF
--- a/vassal-app/src/main/java/VASSAL/configure/ColorConfigurer.java
+++ b/vassal-app/src/main/java/VASSAL/configure/ColorConfigurer.java
@@ -83,7 +83,7 @@ public class ColorConfigurer extends Configurer {
 
   public static String colorToString(Color c) {
     if (c == null) {
-      return "null"; //NON-NLS
+      return ""; 
     }
     else if (c.getTransparency() == c.OPAQUE) {
       return c.getRed() + ","

--- a/vassal-app/src/main/java/VASSAL/configure/ColorConfigurer.java
+++ b/vassal-app/src/main/java/VASSAL/configure/ColorConfigurer.java
@@ -17,16 +17,15 @@
  */
 package VASSAL.configure;
 
-import java.awt.Color;
-import java.util.NoSuchElementException;
-import java.util.StringTokenizer;
-
-import javax.swing.JColorChooser;
-import javax.swing.JPanel;
-
 import VASSAL.build.BadDataReport;
 import VASSAL.tools.ColorButton;
 import VASSAL.tools.ErrorDialog;
+
+import javax.swing.JColorChooser;
+import javax.swing.JPanel;
+import java.awt.Color;
+import java.util.NoSuchElementException;
+import java.util.StringTokenizer;
 
 /**
  * Configurer for {@link Color} values.
@@ -84,7 +83,7 @@ public class ColorConfigurer extends Configurer {
 
   public static String colorToString(Color c) {
     if (c == null) {
-      return null;
+      return "null"; //NON-NLS
     }
     else if (c.getTransparency() == c.OPAQUE) {
       return c.getRed() + ","


### PR DESCRIPTION
#Fixes 12041

When color configurer was translating "no color" as null. Which worked okay in traits, but in attributes it meant our XML code didn't actually write/copy a record for that attribute. 

Worked around by returning the string "null" instead, which the configurer's StringToColor already turns back into a real `null`