### PR TITLE
12061 - Fixed bug with pasting invalid/incomplete regex expressions

### DIFF
--- a/vassal-app/src/main/java/VASSAL/script/ExpressionInterpreter.java
+++ b/vassal-app/src/main/java/VASSAL/script/ExpressionInterpreter.java
@@ -330,7 +330,8 @@ public class ExpressionInterpreter extends AbstractInterpreter implements Loopab
 
       try {
         eval(MAGIC1 + "=" + MAGIC2 + "(" + argList.toString() + ")");
-        result = get(MAGIC1).toString();
+        final Object magic1 = get(MAGIC1);
+        result = (magic1 == null) ? "" : magic1.toString();
       }
       catch (EvalError e) {
         final String s = e.getRawMessage();


### PR DESCRIPTION
Fixes #12061 
Fixes #12062

It appears that by pasting a sufficiently incorrect/incomplete regex expression, you can make Beanshell's eval thing return a null. So in the tradition of beanshell expressions I've made that quietly fail returning a "" the way it does with other exceptions.