### PR TITLE
12067 - The BLACK BOOK OF EXPORT -- Editor allows import/export of groups of items as XML files (eg to transfer between modules)

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/AbstractBuildable.java
+++ b/vassal-app/src/main/java/VASSAL/build/AbstractBuildable.java
@@ -195,7 +195,7 @@ public abstract class AbstractBuildable extends AbstractImageFinder implements B
 
 
   @Override
-  public Element getBuildElement(org.w3c.dom.Document doc) {
+  public Element getBuildElement(Document doc) {
     final Element el = doc.createElement(getClass().getName());
     final String[] names = getAttributeNames();
     for (final String name : names) {

--- a/vassal-app/src/main/java/VASSAL/build/AbstractBuildable.java
+++ b/vassal-app/src/main/java/VASSAL/build/AbstractBuildable.java
@@ -25,16 +25,16 @@ import VASSAL.i18n.Translatable;
 import VASSAL.script.expression.Auditable;
 import VASSAL.search.AbstractImageFinder;
 import VASSAL.search.ImageSearchTarget;
+import org.w3c.dom.Attr;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NamedNodeMap;
 
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.List;
-
-import org.w3c.dom.Attr;
-import org.w3c.dom.Element;
-import org.w3c.dom.NamedNodeMap;
 
 /**
  * Abstract implementation of the {@link Buildable} interface. To make a Buildable component, in other words a component
@@ -183,6 +183,16 @@ public abstract class AbstractBuildable extends AbstractImageFinder implements B
       }
     }
   }
+
+  /**
+   * @return an XML element that can be used to {@link Buildable#build} the object.
+   */
+  public String buildString() {
+    final Document doc = Builder.createNewDocument();
+    doc.appendChild(getBuildElement(doc));
+    return Builder.toString(doc);
+  }
+
 
   @Override
   public Element getBuildElement(org.w3c.dom.Document doc) {

--- a/vassal-app/src/main/java/VASSAL/build/GameModule.java
+++ b/vassal-app/src/main/java/VASSAL/build/GameModule.java
@@ -2175,15 +2175,6 @@ public class GameModule extends AbstractConfigurable
 
 
   /**
-   * @return an XML element that can be used to {@link Buildable#build} the module object.
-   */
-  private String buildString() {
-    final Document doc = Builder.createNewDocument();
-    doc.appendChild(getBuildElement(doc));
-    return Builder.toString(doc);
-  }
-
-  /**
    * Gets the value of a module level global property -- this includes identification information for the
    * local player as well as the contents of any Global Property objects defined at module level in the Module.
    * @param key identifies the global property to be returned

--- a/vassal-app/src/main/java/VASSAL/build/module/ModuleExtension.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/ModuleExtension.java
@@ -39,17 +39,10 @@ import VASSAL.tools.ArchiveWriter;
 import VASSAL.tools.DataArchive;
 import VASSAL.tools.swing.SwingUtils;
 import VASSAL.tools.version.VersionUtils;
-
-import java.awt.event.ActionEvent;
-import java.io.BufferedInputStream;
-import java.io.ByteArrayInputStream;
-import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.net.URL;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.NoSuchFileException;
-import java.util.UUID;
+import net.miginfocom.swing.MigLayout;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.w3c.dom.Document;
 
 import javax.swing.AbstractAction;
 import javax.swing.Action;
@@ -60,12 +53,16 @@ import javax.swing.JDialog;
 import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import javax.swing.JTextField;
-
-import net.miginfocom.swing.MigLayout;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.w3c.dom.Document;
+import java.awt.event.ActionEvent;
+import java.io.BufferedInputStream;
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.NoSuchFileException;
+import java.util.UUID;
 
 /**
  * An optional extension to a GameModule
@@ -416,6 +413,7 @@ public class ModuleExtension extends AbstractBuildable implements GameComponent,
     return name;
   }
 
+  @Override
   public String buildString() {
     final Document doc = Builder.createNewDocument();
     doc.appendChild(getBuildElement(doc));

--- a/vassal-app/src/main/java/VASSAL/build/module/ModuleExtension.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/ModuleExtension.java
@@ -412,14 +412,7 @@ public class ModuleExtension extends AbstractBuildable implements GameComponent,
     }
     return name;
   }
-
-  @Override
-  public String buildString() {
-    final Document doc = Builder.createNewDocument();
-    doc.appendChild(getBuildElement(doc));
-    return Builder.toString(doc);
-  }
-
+  
   protected void write(boolean saveAs) throws IOException {
     vassalVersionCreated = Info.getVersion();
     if (archive instanceof ArchiveWriter) {

--- a/vassal-app/src/main/java/VASSAL/build/module/folder/PrototypeFolder.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/folder/PrototypeFolder.java
@@ -33,8 +33,9 @@ public class PrototypeFolder extends AbstractFolder {
   public void add(Buildable b) {
     super.add(b);
     if (b instanceof PrototypeDefinition) {
-      final PrototypesContainer protos = (PrototypesContainer)getNonFolderAncestor();
-      if (protos != null) {
+      final Buildable ancestor = getNonFolderAncestor();
+      if (ancestor instanceof PrototypesContainer) {
+        final PrototypesContainer protos = (PrototypesContainer) ancestor;
         protos.addDefinition((PrototypeDefinition) b);
       }
     }

--- a/vassal-app/src/main/java/VASSAL/build/module/map/CounterDetailViewer.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/CounterDetailViewer.java
@@ -269,12 +269,12 @@ public class CounterDetailViewer extends AbstractConfigurable implements Drawabl
       b = ((AbstractFolder)b).getNonFolderAncestor();
     }
 
-    map = (Map) b;
     // Can happen during copy/paste operation of a CounterDetailViewer inside a folder. Means we will redo this operation in post-paste-fixups.
-    if (map == null) {
+    if (!(b instanceof Map)) {
       return;
     }
 
+    map = (Map) b;
     view = map.getView();
     map.addDrawComponent(this);
     final String keyDesc = hotkey == null ? "" : "(" + HotKeyConfigurer.getString(hotkey) + ")"; //NON-NLS

--- a/vassal-app/src/main/java/VASSAL/configure/ConfigureTree.java
+++ b/vassal-app/src/main/java/VASSAL/configure/ConfigureTree.java
@@ -563,6 +563,7 @@ public class ConfigureTree extends JTree implements PropertyChangeListener, Mous
       }
       else {
         GameModule.getGameModule().warn(Resources.getString("Editor.ConfigureTree.import_invalid_file"));
+        ErrorDialog.show("Error.import_invalid_file", b.toString());
         return false;
       }
 
@@ -578,7 +579,9 @@ public class ConfigureTree extends JTree implements PropertyChangeListener, Mous
         insert(target, (Configurable)b, getTreeNode(target).getChildCount());
       }
       else {
-        GameModule.getGameModule().warn(Resources.getString("Editor.ConfigureTree.import_not_allowed"));
+        GameModule.getGameModule().warn(Resources.getString("Editor.ConfigureTree.import_not_allowed", b.toString()));
+        ErrorDialog.show("Error.import_not_allowed", b.toString());
+        return false;
       }
     }
     catch (ParserConfigurationException | SAXException e) {

--- a/vassal-app/src/main/java/VASSAL/configure/ConfigureTree.java
+++ b/vassal-app/src/main/java/VASSAL/configure/ConfigureTree.java
@@ -2801,7 +2801,7 @@ public class ConfigureTree extends JTree implements PropertyChangeListener, Mous
       catch (UnsupportedFlavorException ufe) {
         logger.error("Unsupported Flavor: " + ufe.getMessage()); //NON-NLS
       }
-      catch (java.io.IOException ioe) {
+      catch (IOException ioe) {
         logger.error("I/O error: " + ioe.getMessage()); //NON-NLS
       }
       catch (InvalidDnDOperationException id) {

--- a/vassal-app/src/main/java/VASSAL/configure/ConfigureTree.java
+++ b/vassal-app/src/main/java/VASSAL/configure/ConfigureTree.java
@@ -779,9 +779,11 @@ public class ConfigureTree extends JTree implements PropertyChangeListener, Mous
 
     // PrototypeFolder needs any prototype children added to the main prototype definition list
     if (target instanceof PrototypeFolder) {
-      final PrototypesContainer protos = (PrototypesContainer)(((PrototypeFolder)target).getNonFolderAncestor());
-      if (protos != null) {
-        for (final PrototypeDefinition child : ((PrototypeFolder) target).getAllDescendantComponentsOf(PrototypeDefinition.class)) {
+      final PrototypeFolder folder = (PrototypeFolder)target;
+      final Buildable ancestor = folder.getNonFolderAncestor();
+      if (ancestor instanceof PrototypesContainer) {
+        final PrototypesContainer protos = (PrototypesContainer)ancestor;
+        for (final PrototypeDefinition child : folder.getAllDescendantComponentsOf(PrototypeDefinition.class)) {
           protos.addDefinition(child);
         }
       }

--- a/vassal-app/src/main/resources/VASSAL/i18n/Editor.properties
+++ b/vassal-app/src/main/resources/VASSAL/i18n/Editor.properties
@@ -432,6 +432,12 @@ Editor.ConfigureTree.java_name=Enter fully-qualified name of Java class to impor
 Editor.ConfigureTree.paste=Paste
 Editor.ConfigureTree.delete=Delete
 Editor.ConfigureTree.edit=Edit
+Editor.ConfigureTree.import_object=Import from XML...
+Editor.ConfigureTree.export_object=Export as XML...
+Editor.ConfigureTree.export_exists=File Exists
+Editor.ConfigureTree.export_overwrite=Overwrite %1$s?
+Editor.ConfigureTree.import_invalid_file=?<b>File did not contain a known valid VASSAL element.
+Editor.ConfigureTree.import_not_allowed=The selected item is not allowed to contain the imported item (%1$s) as a child.
 
 # CounterDetailViewer
 Editor.CounterDetailViewer.top_layer=from top-most layer only

--- a/vassal-app/src/main/resources/VASSAL/i18n/VASSAL.properties
+++ b/vassal-app/src/main/resources/VASSAL/i18n/VASSAL.properties
@@ -225,6 +225,14 @@ Error.not_a_configurable_title=Class Is Not A Configurable
 Error.not_a_configurable_heading=Class Is Not A Configurable
 Error.not_a_configurable_message=The class %1$s which you attempted to import does not implement the Configurable interface. Only classes which are Configurables may be imported this way.
 
+Error.import_invalid_file_title=No Known VASSAL Configurable Found
+Error.import_invalid_file_heading=No Known VASSAL Configurable Found
+Error.import_invalid_file_message=The class %1$s which you attempted to import does not implement the Configurable interface. Only classes which are Configurables may be imported this way.
+
+Error.import_not_allowed_title=Cannot import file to selected location
+Error.import_not_allowed_heading=Cannot import file to selected location
+Error.import_not_allowed_message=The class %1$s which you attempted to import is not allowed as a type of child for the currently selected object.
+
 Error.not_a_gamepiece_title=Invalid GamePiece
 Error.not_a_gamepiece_heading=Invalid GamePiece
 Error.not_a_gamepiece_message=The class %1$s which you attempted to import does not implement the GamePiece interface. Only classes which are GamePieces may be imported this way.


### PR DESCRIPTION
Appears on Editor menu when right-clicking any editor item

Exports selected object "and all of its children" to an XML file

XML file can then be imported to become the child of whatever is selected at the time of import.

GO FORTH AND SIN NO MORE!!!