### PR TITLE
Minor fixups in ConfigureTree menu -- no Changelist Entry needed

### DIFF
--- a/vassal-app/src/main/java/VASSAL/configure/ConfigureTree.java
+++ b/vassal-app/src/main/java/VASSAL/configure/ConfigureTree.java
@@ -508,9 +508,15 @@ public class ConfigureTree extends JTree implements PropertyChangeListener, Mous
       addAction(popup, buildImportTreeAction(target));
     }
 
-    popup.addSeparator();
-    addAction(popup, buildOpenPiecesAction(target));
-    addAction(popup, buildEditPiecesAction(target));
+    final Action aOpen = buildOpenPiecesAction(target);
+    final Action aEdit = buildEditPiecesAction(target);
+
+    if ((aOpen != null) || (aEdit != null)) {
+      popup.addSeparator();
+    }
+
+    addAction(popup, aOpen);
+    addAction(popup, aEdit);
 
     return popup;
   }
@@ -658,18 +664,14 @@ public class ConfigureTree extends JTree implements PropertyChangeListener, Mous
 
 
   protected Action buildImportTreeAction(final Configurable target) {
-    Action a = null;
-    if (getTreeNode(target).getParent() != null) {
-      a = new AbstractAction(Resources.getString("Editor.ConfigureTree.import_object")) {
-        private static final long serialVersionUID = 1L;
+    return new AbstractAction(Resources.getString("Editor.ConfigureTree.import_object")) {
+      private static final long serialVersionUID = 1L;
 
-        @Override
-        public void actionPerformed(ActionEvent e) {
-          importTreeBranch(target);
-        }
-      };
-    }
-    return a;
+      @Override
+      public void actionPerformed(ActionEvent e) {
+        importTreeBranch(target);
+      }
+    };
   }
 
 


### PR DESCRIPTION
* It was printing an extra separator when nothing was displayed on the other side
* It wasn't allowing imports to the root element, which should be allowed (only exports of the root node are disallowed)
(Thx @riverwanderer for testing and calling this to my attention)