### PR TITLE
12077 - ObscuredToOthers can be counted on to be 'false' for pieces that don't even have a Mask property

### DIFF
--- a/vassal-app/src/main/java/VASSAL/counters/BasicPiece.java
+++ b/vassal-app/src/main/java/VASSAL/counters/BasicPiece.java
@@ -310,6 +310,9 @@ public class BasicPiece extends AbstractImageFinder implements TranslatablePiece
     else if (Properties.VISIBLE_STATE.equals(key)) {
       return "";
     }
+    else if (Properties.OBSCURED_TO_OTHERS.equals(key)) {
+      return false;
+    }
 
     // Check for a property in the scratch-pad properties
     Object prop = props == null ? null : props.get(key);


### PR DESCRIPTION
@riverwanderer I think what was going on in 12077 might have involved ObscuredToOthers, which I think is the only thing you were using "unary !" with. This actually also does MOST of the thing you'd requested in some other item -- gives pieces a "false" to return if they don't have a Mask property. 