### PR TITLE
12084 - Help menu shows module-specific help items before generic Vassal ones

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/module/Documentation.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/Documentation.java
@@ -41,6 +41,10 @@ import java.net.MalformedURLException;
  * Represents the <code>Help</code> menu of the controls window
  */
 public class Documentation extends AbstractConfigurable {
+
+  public static final String INTRO_FILE = "/help/Intro.html"; //NON-NLS
+  public static final String INTRO_FILENAME = "Intro.html"; //NON-NLS
+
   public JMenu getHelpMenu() {
     final JMenuBar mb = MenuManager.getInstance().getMenuBarFor(
       GameModule.getGameModule().getPlayerWindow());
@@ -61,9 +65,9 @@ public class Documentation extends AbstractConfigurable {
       final HelpFile intro = new HelpFile();
       intro.setAttribute(HelpFile.TITLE,
         Resources.getString("Documentation.quick_start")); //$NON-NLS-1$
-      intro.setAttribute(HelpFile.FILE, "/help/Intro.html"); //$NON-NLS-1$
+      intro.setAttribute(HelpFile.FILE, INTRO_FILE); //$NON-NLS-1$
       intro.setAttribute(HelpFile.TYPE, HelpFile.RESOURCE);
-      intro.setAttribute(HelpFile.VASSAL_DOC, true);
+      intro.setAttribute(HelpFile.VASSAL_DOC, HelpFile.VASSAL_SECTION);
       intro.addTo(this);
       add(intro);
     }

--- a/vassal-app/src/main/java/VASSAL/build/module/Documentation.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/Documentation.java
@@ -30,14 +30,12 @@ import VASSAL.configure.Configurer;
 import VASSAL.i18n.Resources;
 import VASSAL.tools.ErrorDialog;
 import VASSAL.tools.menu.MenuManager;
-
-import java.io.File;
-import java.net.MalformedURLException;
+import org.w3c.dom.Element;
 
 import javax.swing.JMenu;
 import javax.swing.JMenuBar;
-
-import org.w3c.dom.Element;
+import java.io.File;
+import java.net.MalformedURLException;
 
 /**
  * Represents the <code>Help</code> menu of the controls window
@@ -65,6 +63,7 @@ public class Documentation extends AbstractConfigurable {
         Resources.getString("Documentation.quick_start")); //$NON-NLS-1$
       intro.setAttribute(HelpFile.FILE, "/help/Intro.html"); //$NON-NLS-1$
       intro.setAttribute(HelpFile.TYPE, HelpFile.RESOURCE);
+      intro.setAttribute(HelpFile.VASSAL_DOC, true);
       intro.addTo(this);
       add(intro);
     }

--- a/vassal-app/src/main/java/VASSAL/build/module/documentation/HelpFile.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/documentation/HelpFile.java
@@ -17,18 +17,6 @@
  */
 package VASSAL.build.module.documentation;
 
-import java.awt.Dialog;
-import java.awt.event.ActionEvent;
-import java.io.File;
-import java.io.IOException;
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.util.Collection;
-import java.util.List;
-
-import javax.swing.AbstractAction;
-import javax.swing.Action;
-
 import VASSAL.build.AbstractConfigurable;
 import VASSAL.build.Buildable;
 import VASSAL.build.GameModule;
@@ -41,6 +29,17 @@ import VASSAL.tools.URLUtils;
 import VASSAL.tools.menu.MenuItemProxy;
 import VASSAL.tools.menu.MenuManager;
 
+import javax.swing.AbstractAction;
+import javax.swing.Action;
+import java.awt.Dialog;
+import java.awt.event.ActionEvent;
+import java.io.File;
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.Collection;
+import java.util.List;
+
 /**
  * Places an entry in the <code>Help</code> menu.  Selecting the entry
  * displays a window with stored text on it.
@@ -50,6 +49,7 @@ public class HelpFile extends AbstractConfigurable {
   public static final String FILE = "fileName"; //$NON-NLS-1$
   public static final String TYPE = "fileType"; //$NON-NLS-1$
   private static final String IMAGE = "image"; //$NON-NLS-1$
+  public static final String VASSAL_DOC = "vassalDoc"; //NON-NLS
 
   public static final String ARCHIVE_ENTRY = "archive"; //$NON-NLS-1$
   public static final String RESOURCE = "resource"; //$NON-NLS-1$
@@ -62,6 +62,7 @@ public class HelpFile extends AbstractConfigurable {
   protected String fileName;
   protected Action launch;
   protected String fileType = ARCHIVE_ENTRY;
+  protected Boolean vassalDoc = false;
 
   public static String getConfigureTypeName() {
     return Resources.getString("Editor.HelpFile.component_type");
@@ -189,7 +190,8 @@ public class HelpFile extends AbstractConfigurable {
       TITLE,
       FILE,
       IMAGE,
-      TYPE
+      TYPE,
+      VASSAL_DOC
     };
   }
 
@@ -203,6 +205,9 @@ public class HelpFile extends AbstractConfigurable {
     }
     else if (TYPE.equals(key)) {
       return fileType;
+    }
+    else if (VASSAL_DOC.equals(key)) {
+      return String.valueOf(vassalDoc);
     }
     return null;
   }
@@ -226,6 +231,14 @@ public class HelpFile extends AbstractConfigurable {
     }
     else if (TYPE.equals(key)) {
       fileType = (String) val;
+    }
+    else if (VASSAL_DOC.equals(key)) {
+      if (val instanceof String) {
+        vassalDoc = "true".equals(val); //NON-NLS
+      }
+      else {
+        vassalDoc = (Boolean) val;
+      }
     }
   }
 
@@ -255,14 +268,14 @@ public class HelpFile extends AbstractConfigurable {
   @Override
   public void addTo(Buildable b) {
     launchItem = new MenuItemProxy(launch);
-    MenuManager.getInstance().addToSection("Documentation.Module", launchItem); //NON-NLS
+    MenuManager.getInstance().addToSection(vassalDoc ? "Documentation.VASSAL" : "Documentation.Module", launchItem); //NON-NLS
     launch.setEnabled(true);
   }
 
   @Override
   public void removeFrom(Buildable b) {
     MenuManager.getInstance()
-               .removeFromSection("Documentation.Module", launchItem); //NON-NLS
+               .removeFromSection(vassalDoc ? "Documentation.VASSAL" : "Documentation.Module", launchItem); //NON-NLS
     launch.setEnabled(false);
   }
 

--- a/vassal-app/src/main/java/VASSAL/launch/PlayerWindow.java
+++ b/vassal-app/src/main/java/VASSAL/launch/PlayerWindow.java
@@ -125,7 +125,6 @@ public class PlayerWindow extends JFrame {
     helpMenu.add(mm.addMarker("Documentation.Module.end"));  //NON-NLS
 
     helpMenu.add(mm.addMarker("Documentation.VASSAL.start"));  //NON-NLS
-    //helpMenu.add(mm.addKey("General.help"));
     helpMenu.add(mm.addKey("Help.user_guide"));
     helpMenu.addSeparator();
     helpMenu.add(mm.addMarker("Documentation.VASSAL.end"));  //NON-NLS
@@ -165,16 +164,6 @@ public class PlayerWindow extends JFrame {
 
     toolsMenu.add(debugCheckbox);
     DebugControls.setCheckBox(debugCheckbox);
-
-    // This file doesn't have particularly useful information, and the weird entry ("Help"???) was cluttering the Help menu.
-    //try {
-    //  final URL url = new File(Documentation.getDocumentationBaseDir(),
-    //                           "README.html").toURI().toURL();
-    //  mm.addAction("General.help", new ShowHelpAction(url, null));
-    //}
-    //catch (MalformedURLException e) {
-    //  ErrorDialog.bug(e);
-    //}
 
     try {
       final URL url = new File(Documentation.getDocumentationBaseDir(),

--- a/vassal-app/src/main/java/VASSAL/launch/PlayerWindow.java
+++ b/vassal-app/src/main/java/VASSAL/launch/PlayerWindow.java
@@ -166,14 +166,15 @@ public class PlayerWindow extends JFrame {
     toolsMenu.add(debugCheckbox);
     DebugControls.setCheckBox(debugCheckbox);
 
-    try {
-      final URL url = new File(Documentation.getDocumentationBaseDir(),
-                               "README.html").toURI().toURL();
-      mm.addAction("General.help", new ShowHelpAction(url, null));
-    }
-    catch (MalformedURLException e) {
-      ErrorDialog.bug(e);
-    }
+    // This file doesn't have particularly useful information, and the weird entry ("Help"???) was cluttering the Help menu.
+    //try {
+    //  final URL url = new File(Documentation.getDocumentationBaseDir(),
+    //                           "README.html").toURI().toURL();
+    //  mm.addAction("General.help", new ShowHelpAction(url, null));
+    //}
+    //catch (MalformedURLException e) {
+    //  ErrorDialog.bug(e);
+    //}
 
     try {
       final URL url = new File(Documentation.getDocumentationBaseDir(),

--- a/vassal-app/src/main/java/VASSAL/launch/PlayerWindow.java
+++ b/vassal-app/src/main/java/VASSAL/launch/PlayerWindow.java
@@ -121,14 +121,14 @@ public class PlayerWindow extends JFrame {
     // FIXME: setting mnemonic from first letter could cause collisions in some languages
     helpMenu.setMnemonic(Resources.getString("General.help.shortcut").charAt(0));
 
-    helpMenu.add(mm.addMarker("Documentation.VASSAL.start"));  //NON-NLS
-    helpMenu.add(mm.addKey("General.help"));
-    helpMenu.add(mm.addKey("Help.user_guide"));
-    helpMenu.add(mm.addMarker("Documentation.VASSAL.end"));  //NON-NLS
-
-    helpMenu.addSeparator();
     helpMenu.add(mm.addMarker("Documentation.Module.start"));  //NON-NLS
     helpMenu.add(mm.addMarker("Documentation.Module.end"));  //NON-NLS
+
+    helpMenu.add(mm.addMarker("Documentation.VASSAL.start"));  //NON-NLS
+    //helpMenu.add(mm.addKey("General.help"));
+    helpMenu.add(mm.addKey("Help.user_guide"));
+    helpMenu.addSeparator();
+    helpMenu.add(mm.addMarker("Documentation.VASSAL.end"));  //NON-NLS
 
     helpMenu.add(mm.addKey("Documentation.about_module"));
 

--- a/vassal-app/src/main/resources/VASSAL/i18n/Editor.properties
+++ b/vassal-app/src/main/resources/VASSAL/i18n/Editor.properties
@@ -939,6 +939,9 @@ Editor.GridEditor.does_not_look=Does not look like a %1$s!
 # HelpFile
 Editor.HelpFile.component_type=Plain Text Help File
 Editor.HelpFile.text_file=Text File
+Editor.HelpFile.display_with_vassal_section=Section of help menu
+Editor.HelpFile.user_section=User Section
+Editor.HelpFile.vassal_section=VASSAL Section
 
 # Hex Grid
 Editor.HexGrid.sideways=Sideways (hexrows go horizontal)

--- a/vassal-app/src/main/resources/VASSAL/i18n/VASSAL.properties
+++ b/vassal-app/src/main/resources/VASSAL/i18n/VASSAL.properties
@@ -613,7 +613,7 @@ Dice.random_text_too_few_faces=Random Text Button [%1$s] has too few faces for r
 
 # Documentation
 Documentation.about_module=About Module
-Documentation.quick_start=Quick Start
+Documentation.quick_start=Vassal Quick Start
 
 # Editor
 Editor.app_name=Editor
@@ -784,7 +784,7 @@ GpIdChecker.place_replace_trait=Place/Replace Trait %1$s
 
 # Help Window
 Help.error_log=Show Error Log
-Help.user_guide=User's Guide
+Help.user_guide=Vassal User's Guide
 
 # IconFamily
 Icon.extra_small=Extra Small


### PR DESCRIPTION
Basically if a module designer goes to the trouble of making some specific help for the module, then that is the stuff that ought to be at the top of the help menu.

I based this on 3.6.15 since it could go there. But it could also be punted into 3.7 if we're not looking for more, or not looking for trouble, or whatever.