### PR TITLE
12100 - Text Labels support <img> tags

### DIFF
--- a/vassal-app/src/main/java/VASSAL/counters/Labeler.java
+++ b/vassal-app/src/main/java/VASSAL/counters/Labeler.java
@@ -44,7 +44,7 @@ import VASSAL.tools.imageop.AbstractTileOpImpl;
 import VASSAL.tools.imageop.ImageOp;
 import VASSAL.tools.imageop.Op;
 import VASSAL.tools.imageop.ScaledImagePainter;
-import VASSAL.tools.swing.DataArchiveHTMLEditorKit;
+import VASSAL.tools.swing.LabelerDataArchiveHTMLEditorKit;
 import VASSAL.tools.swing.SwingUtils;
 import net.miginfocom.swing.MigLayout;
 import org.apache.commons.lang3.SystemUtils;
@@ -633,7 +633,7 @@ public class Labeler extends Decorator implements TranslatablePiece, Loopable {
       // Build a JTextPane to render HTML with images
       final JTextPane tp = new JTextPane();
       tp.setContentType("text/html"); //NON-NLS
-      final DataArchiveHTMLEditorKit kit = new DataArchiveHTMLEditorKit(GameModule.getGameModule().getDataArchive());
+      final LabelerDataArchiveHTMLEditorKit kit = new LabelerDataArchiveHTMLEditorKit(GameModule.getGameModule().getDataArchive());
       tp.setEditorKit(kit);
 
       final StyleSheet style = kit.getStyleSheet();

--- a/vassal-app/src/main/java/VASSAL/counters/Labeler.java
+++ b/vassal-app/src/main/java/VASSAL/counters/Labeler.java
@@ -17,7 +17,6 @@
 package VASSAL.counters;
 
 import VASSAL.build.GameModule;
-import VASSAL.build.module.Console;
 import VASSAL.build.module.documentation.HelpFile;
 import VASSAL.command.ChangeTracker;
 import VASSAL.command.Command;
@@ -50,7 +49,6 @@ import VASSAL.tools.swing.SwingUtils;
 import net.miginfocom.swing.MigLayout;
 import org.apache.commons.lang3.SystemUtils;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
-import org.slf4j.LoggerFactory;
 
 import javax.swing.JLabel;
 import javax.swing.JOptionPane;
@@ -630,9 +628,6 @@ public class Labeler extends Decorator implements TranslatablePiece, Loopable {
       g.dispose();
       return im;
     }
-
-    private static final org.slf4j.Logger log =
-      LoggerFactory.getLogger(Console.class);
 
     protected JTextPane makePane() {
       // Build a JTextPane to render HTML with images

--- a/vassal-app/src/main/java/VASSAL/counters/Labeler.java
+++ b/vassal-app/src/main/java/VASSAL/counters/Labeler.java
@@ -17,6 +17,7 @@
 package VASSAL.counters;
 
 import VASSAL.build.GameModule;
+import VASSAL.build.module.Console;
 import VASSAL.build.module.documentation.HelpFile;
 import VASSAL.command.ChangeTracker;
 import VASSAL.command.Command;
@@ -31,6 +32,7 @@ import VASSAL.i18n.PieceI18nData;
 import VASSAL.i18n.Resources;
 import VASSAL.i18n.TranslatablePiece;
 import VASSAL.search.HTMLImageFinder;
+import VASSAL.tools.ErrorDialog;
 import VASSAL.tools.FormattedString;
 import VASSAL.tools.NamedKeyStroke;
 import VASSAL.tools.RecursionLimitException;
@@ -43,16 +45,23 @@ import VASSAL.tools.imageop.AbstractTileOpImpl;
 import VASSAL.tools.imageop.ImageOp;
 import VASSAL.tools.imageop.Op;
 import VASSAL.tools.imageop.ScaledImagePainter;
+import VASSAL.tools.swing.DataArchiveHTMLEditorKit;
 import VASSAL.tools.swing.SwingUtils;
 import net.miginfocom.swing.MigLayout;
 import org.apache.commons.lang3.SystemUtils;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.slf4j.LoggerFactory;
 
 import javax.swing.JLabel;
 import javax.swing.JOptionPane;
 import javax.swing.JPanel;
+import javax.swing.JTextPane;
 import javax.swing.KeyStroke;
 import javax.swing.plaf.basic.BasicHTML;
+import javax.swing.text.BadLocationException;
+import javax.swing.text.StyleConstants;
+import javax.swing.text.html.HTMLDocument;
+import javax.swing.text.html.StyleSheet;
 import java.awt.Color;
 import java.awt.Component;
 import java.awt.Dimension;
@@ -67,6 +76,7 @@ import java.awt.Shape;
 import java.awt.geom.AffineTransform;
 import java.awt.geom.Area;
 import java.awt.image.BufferedImage;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -607,12 +617,61 @@ public class Labeler extends Decorator implements TranslatablePiece, Loopable {
 
       // paint the foreground
       if (fg != null) {
-        final JLabel l = makeLabel();
-        l.paint(g);
+        if (txt.contains("<img")) { //NON-NLS
+          final JTextPane p = makePane();
+          p.paint(g);
+        }
+        else {
+          final JLabel l = makeLabel();
+          l.paint(g);
+        }
       }
 
       g.dispose();
       return im;
+    }
+
+    private static final org.slf4j.Logger log =
+      LoggerFactory.getLogger(Console.class);
+
+    protected JTextPane makePane() {
+      // Build a JTextPane to render HTML with images
+      final JTextPane tp = new JTextPane();
+      tp.setContentType("text/html"); //NON-NLS
+      final DataArchiveHTMLEditorKit kit = new DataArchiveHTMLEditorKit(GameModule.getGameModule().getDataArchive());
+      tp.setEditorKit(kit);
+
+      final StyleSheet style = kit.getStyleSheet();
+      style.addRule(".label" + //NON-NLS
+        " {color:" +                                                               //NON-NLS
+        String.format("#%02x%02x%02x", fg.getRed(), fg.getGreen(), fg.getBlue()) + //NON-NLS
+        "; font-family:" +                                                         //NON-NLS
+        font.getFamily() +
+        "; font-size:" +                                                           //NON-NLS
+        font.getSize() + "pt" +                                                    //NON-NLS
+        "; " +                                                                     //NON-NLS
+        ((font.isBold()) ? "font-weight:bold" : "") +                              //NON-NLS
+        "; background-color: rgba(255, 0, 0, 0.5);" +                              //NON-NLS
+        "}");                                                                      //NON-NLS
+      style.addRule(".label" + "color {color:" + String.format("#%02x%02x%02x", fg.getRed(), fg.getGreen(), fg.getBlue()) + "; }"); //NON-NLS
+
+      tp.setOpaque(false);
+      // Transparent background
+      StyleConstants.setBackground(style.getStyle(".label"), new Color(0, 0, 0, 0)); //NON-NLS
+
+      // Remove original HTML markers if present and replace wrapping a styled div, inserting into document
+      final String fixed = txt.replaceFirst("<html>", "").replaceFirst("</html>", ""); //NON-NLS
+      final HTMLDocument doc = (HTMLDocument) tp.getDocument();
+      try {
+        kit.insertHTML(doc, doc.getLength(), "<html><div class=\"label\">" + fixed + "</div></html>", 0, 0, null); //NON-NLS
+      }
+      catch (BadLocationException | IOException ble) {
+        ErrorDialog.bug(ble);
+      }
+
+      tp.setSize(tp.getPreferredSize());
+
+      return tp;
     }
 
     protected JLabel makeLabel() {

--- a/vassal-app/src/main/java/VASSAL/counters/Labeler.java
+++ b/vassal-app/src/main/java/VASSAL/counters/Labeler.java
@@ -31,7 +31,6 @@ import VASSAL.i18n.PieceI18nData;
 import VASSAL.i18n.Resources;
 import VASSAL.i18n.TranslatablePiece;
 import VASSAL.search.HTMLImageFinder;
-import VASSAL.tools.ErrorDialog;
 import VASSAL.tools.FormattedString;
 import VASSAL.tools.NamedKeyStroke;
 import VASSAL.tools.RecursionLimitException;
@@ -44,7 +43,7 @@ import VASSAL.tools.imageop.AbstractTileOpImpl;
 import VASSAL.tools.imageop.ImageOp;
 import VASSAL.tools.imageop.Op;
 import VASSAL.tools.imageop.ScaledImagePainter;
-import VASSAL.tools.swing.LabelerDataArchiveHTMLEditorKit;
+import VASSAL.tools.swing.DataArchiveTextPane;
 import VASSAL.tools.swing.SwingUtils;
 import net.miginfocom.swing.MigLayout;
 import org.apache.commons.lang3.SystemUtils;
@@ -53,13 +52,8 @@ import org.apache.commons.lang3.builder.HashCodeBuilder;
 import javax.swing.JLabel;
 import javax.swing.JOptionPane;
 import javax.swing.JPanel;
-import javax.swing.JTextPane;
 import javax.swing.KeyStroke;
 import javax.swing.plaf.basic.BasicHTML;
-import javax.swing.text.BadLocationException;
-import javax.swing.text.StyleConstants;
-import javax.swing.text.html.HTMLDocument;
-import javax.swing.text.html.StyleSheet;
 import java.awt.Color;
 import java.awt.Component;
 import java.awt.Dimension;
@@ -74,7 +68,6 @@ import java.awt.Shape;
 import java.awt.geom.AffineTransform;
 import java.awt.geom.Area;
 import java.awt.image.BufferedImage;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -616,7 +609,7 @@ public class Labeler extends Decorator implements TranslatablePiece, Loopable {
       // paint the foreground
       if (fg != null) {
         if (txt.contains("<img")) { //NON-NLS
-          final JTextPane p = makePane();
+          final DataArchiveTextPane p = new DataArchiveTextPane(txt, "label", fg, font); //NON-NLS
           p.paint(g);
         }
         else {
@@ -627,46 +620,6 @@ public class Labeler extends Decorator implements TranslatablePiece, Loopable {
 
       g.dispose();
       return im;
-    }
-
-    protected JTextPane makePane() {
-      // Build a JTextPane to render HTML with images
-      final JTextPane tp = new JTextPane();
-      tp.setContentType("text/html"); //NON-NLS
-      final LabelerDataArchiveHTMLEditorKit kit = new LabelerDataArchiveHTMLEditorKit(GameModule.getGameModule().getDataArchive());
-      tp.setEditorKit(kit);
-
-      final StyleSheet style = kit.getStyleSheet();
-      style.addRule(".label" + //NON-NLS
-        " {color:" +                                                               //NON-NLS
-        String.format("#%02x%02x%02x", fg.getRed(), fg.getGreen(), fg.getBlue()) + //NON-NLS
-        "; font-family:" +                                                         //NON-NLS
-        font.getFamily() +
-        "; font-size:" +                                                           //NON-NLS
-        font.getSize() + "pt" +                                                    //NON-NLS
-        "; " +                                                                     //NON-NLS
-        ((font.isBold()) ? "font-weight:bold" : "") +                              //NON-NLS
-        "; background-color: rgba(255, 0, 0, 0.5);" +                              //NON-NLS
-        "}");                                                                      //NON-NLS
-      style.addRule(".label" + "color {color:" + String.format("#%02x%02x%02x", fg.getRed(), fg.getGreen(), fg.getBlue()) + "; }"); //NON-NLS
-
-      tp.setOpaque(false);
-      // Transparent background
-      StyleConstants.setBackground(style.getStyle(".label"), new Color(0, 0, 0, 0)); //NON-NLS
-
-      // Remove original HTML markers if present and replace wrapping a styled div, inserting into document
-      final String fixed = txt.replaceFirst("<html>", "").replaceFirst("</html>", ""); //NON-NLS
-      final HTMLDocument doc = (HTMLDocument) tp.getDocument();
-      try {
-        kit.insertHTML(doc, doc.getLength(), "<html><div class=\"label\">" + fixed + "</div></html>", 0, 0, null); //NON-NLS
-      }
-      catch (BadLocationException | IOException ble) {
-        ErrorDialog.bug(ble);
-      }
-
-      tp.setSize(tp.getPreferredSize());
-
-      return tp;
     }
 
     protected JLabel makeLabel() {

--- a/vassal-app/src/main/java/VASSAL/tools/swing/DataArchiveHTMLEditorKit.java
+++ b/vassal-app/src/main/java/VASSAL/tools/swing/DataArchiveHTMLEditorKit.java
@@ -1,10 +1,9 @@
 package VASSAL.tools.swing;
 
-import java.net.URL;
-import java.io.InputStream;
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
+import VASSAL.Info;
+import VASSAL.tools.DataArchive;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.swing.text.AttributeSet;
 import javax.swing.text.Element;
@@ -14,12 +13,11 @@ import javax.swing.text.ViewFactory;
 import javax.swing.text.html.HTML;
 import javax.swing.text.html.HTMLEditorKit;
 import javax.swing.text.html.ImageView;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import VASSAL.Info;
-import VASSAL.tools.DataArchive;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
 /**
  * Extended HTML Editor kit to let the <src> tag display images from the
@@ -44,6 +42,7 @@ public class DataArchiveHTMLEditorKit extends HTMLEditorKit {
   private class DataArchiveImageView extends ImageView {
     public DataArchiveImageView(Element e) {
       super(e);
+      setLoadsSynchronously(true); //BR// make sure these actually load
     }
 
     @Override

--- a/vassal-app/src/main/java/VASSAL/tools/swing/DataArchiveHTMLEditorKit.java
+++ b/vassal-app/src/main/java/VASSAL/tools/swing/DataArchiveHTMLEditorKit.java
@@ -39,7 +39,7 @@ public class DataArchiveHTMLEditorKit extends HTMLEditorKit {
     return new DataArchiveHTMLFactory();
   }
 
-  private class DataArchiveImageView extends ImageView {
+  protected class DataArchiveImageView extends ImageView {
     public DataArchiveImageView(Element e) {
       super(e);
       setLoadsSynchronously(true); //BR// make sure these actually load
@@ -70,7 +70,7 @@ public class DataArchiveHTMLEditorKit extends HTMLEditorKit {
     }
   }
 
-  private class DataArchiveHTMLFactory extends HTMLFactory {
+  protected class DataArchiveHTMLFactory extends HTMLFactory {
     @Override
     public View create(Element e) {
       final AttributeSet attrs = e.getAttributes();

--- a/vassal-app/src/main/java/VASSAL/tools/swing/DataArchiveTextPane.java
+++ b/vassal-app/src/main/java/VASSAL/tools/swing/DataArchiveTextPane.java
@@ -34,6 +34,8 @@ import java.io.IOException;
  * Essentially behaves like a JLabel on steroids, the key thing being that <img> links in the HTML can access images in the module.
  */
 public class DataArchiveTextPane extends JTextPane {
+  private static final long serialVersionUID = 1L;
+
   public DataArchiveTextPane(String text, String styleName, Color color, Font font) {
 
     if ((styleName == null) || styleName.isBlank()) {

--- a/vassal-app/src/main/java/VASSAL/tools/swing/DataArchiveTextPane.java
+++ b/vassal-app/src/main/java/VASSAL/tools/swing/DataArchiveTextPane.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2023 by vassalengine.org, Brian Reynolds
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License (LGPL) as published by the Free Software Foundation.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public
+ * License along with this library; if not, copies are available
+ * at http://www.opensource.org.
+ */
+package VASSAL.tools.swing;
+
+import VASSAL.build.GameModule;
+import VASSAL.tools.ErrorDialog;
+
+import javax.swing.JTextPane;
+import javax.swing.text.BadLocationException;
+import javax.swing.text.StyleConstants;
+import javax.swing.text.html.HTMLDocument;
+import javax.swing.text.html.StyleSheet;
+import java.awt.Color;
+import java.awt.Font;
+import java.io.IOException;
+
+/**
+ * Extends JTextPane in a way that lets us put an HTML-compliant string that might access images from the vmod archive
+ *
+ * Essentially behaves like a JLabel on steroids, the key thing being that <img> links in the HTML can access images in the module.
+ */
+public class DataArchiveTextPane extends JTextPane {
+  public DataArchiveTextPane(String text, String styleName, Color color, Font font) {
+
+    if ((styleName == null) || styleName.isBlank()) {
+      styleName = "label"; //NON-NLS // just something to default to
+    }
+
+    // Build a JTextPane to render HTML with images
+    setContentType("text/html"); //NON-NLS
+    final LabelerDataArchiveHTMLEditorKit kit = new LabelerDataArchiveHTMLEditorKit(GameModule.getGameModule().getDataArchive());
+    setEditorKit(kit);
+
+    final StyleSheet style = kit.getStyleSheet();
+    style.addRule("." + styleName +
+      " {color:" +                                                                        //NON-NLS
+      String.format("#%02x%02x%02x", color.getRed(), color.getGreen(), color.getBlue()) + //NON-NLS
+      "; font-family:" +                                                                  //NON-NLS
+      font.getFamily() +
+      "; font-size:" +                                                           //NON-NLS
+      font.getSize() + "pt" +                                                    //NON-NLS
+      "; " +                                                                     //NON-NLS
+      ((font.isBold()) ? "font-weight:bold" : "") +                              //NON-NLS
+      "; background-color: rgba(255, 0, 0, 0.5);" +                              //NON-NLS
+      "}");                                                                      //NON-NLS
+    style.addRule("." + styleName + "color {color:" + String.format("#%02x%02x%02x", color.getRed(), color.getGreen(), color.getBlue()) + "; }"); //NON-NLS
+
+    setOpaque(false);
+    // Transparent background
+    StyleConstants.setBackground(style.getStyle("." + styleName), new Color(0, 0, 0, 0)); //NON-NLS
+
+    // Remove original HTML markers if present and replace wrapping a styled div, inserting into document
+    final String fixed = text.replaceFirst("<html>", "").replaceFirst("</html>", ""); //NON-NLS
+    final HTMLDocument doc = (HTMLDocument) getDocument();
+    try {
+      kit.insertHTML(doc, doc.getLength(), "<html><div class=\"" + styleName + "\">" + fixed + "</div></html>", 0, 0, null); //NON-NLS
+    }
+    catch (BadLocationException | IOException ble) {
+      ErrorDialog.bug(ble);
+    }
+
+    setSize(getPreferredSize());
+  }
+}

--- a/vassal-app/src/main/java/VASSAL/tools/swing/LabelerDataArchiveHTMLEditorKit.java
+++ b/vassal-app/src/main/java/VASSAL/tools/swing/LabelerDataArchiveHTMLEditorKit.java
@@ -1,0 +1,93 @@
+package VASSAL.tools.swing;
+
+import VASSAL.tools.DataArchive;
+
+import javax.swing.text.AttributeSet;
+import javax.swing.text.Element;
+import javax.swing.text.StyleConstants;
+import javax.swing.text.View;
+import javax.swing.text.ViewFactory;
+import javax.swing.text.html.HTML;
+import javax.swing.text.html.InlineView;
+
+/**
+ * Extended HTML Editor kit to let the <src> tag display images from the
+ * module DataArchive where no pathname is included in the image name.
+ *
+ * This version also allows the inline images to be vertically aligned w/r/t the text
+ */
+public class LabelerDataArchiveHTMLEditorKit extends DataArchiveHTMLEditorKit {
+
+  public LabelerDataArchiveHTMLEditorKit(DataArchive arch) {
+    super(arch);
+  }
+
+  float valignImages = 0.5f;
+  float valignText   = 0.5f;
+
+  public void setValignImages(float align) {
+    valignImages = align;
+  }
+
+  public void setValignText(float align) {
+    valignText = align;
+  }
+
+  @Override
+  public ViewFactory getViewFactory() {
+    return new LabelerDataArchiveHTMLFactory();
+  }
+
+  protected class LabelerInlineView extends InlineView {
+    public LabelerInlineView(Element e) {
+      super(e);
+    }
+
+    public float getAlignment(int axis) {
+      switch (axis) {
+      case View.Y_AXIS:
+        return valignText;
+      default:
+        return super.getAlignment(axis);
+      }
+    }
+  }
+
+  private class LabelerDataArchiveImageView extends DataArchiveImageView {
+    public LabelerDataArchiveImageView(Element e) {
+      super(e);
+      setLoadsSynchronously(true); //BR// make sure these actually load
+    }
+
+    public float getAlignment(int axis) {
+      switch (axis) {
+      case View.Y_AXIS:
+        return valignImages;
+      default:
+        return super.getAlignment(axis);
+      }
+    }
+  }
+
+  private class LabelerDataArchiveHTMLFactory extends DataArchiveHTMLFactory {
+    @Override
+    public View create(Element e) {
+      final AttributeSet attrs = e.getAttributes();
+      final HTML.Tag kind = (HTML.Tag) (attrs.getAttribute(StyleConstants.NameAttribute));
+
+      if (kind == HTML.Tag.CONTENT) {
+        return new LabelerInlineView(e);
+      }
+
+      if (kind == HTML.Tag.IMG) {
+        final String file = (String) attrs.getAttribute(HTML.Attribute.SRC);
+        // file may be null if invalid src file specified
+        if (file != null && !file.isBlank() && !file.contains("/")) {
+          return new LabelerDataArchiveImageView(e);
+        }
+      }
+
+      return super.create(e);
+    }
+  }
+}

--- a/vassal-app/src/main/java/VASSAL/tools/swing/LabelerDataArchiveHTMLEditorKit.java
+++ b/vassal-app/src/main/java/VASSAL/tools/swing/LabelerDataArchiveHTMLEditorKit.java
@@ -17,6 +17,7 @@ import javax.swing.text.html.InlineView;
  * This version also allows the inline images to be vertically aligned w/r/t the text
  */
 public class LabelerDataArchiveHTMLEditorKit extends DataArchiveHTMLEditorKit {
+  private static final long serialVersionUID = 1L;
 
   public LabelerDataArchiveHTMLEditorKit(DataArchive arch) {
     super(arch);
@@ -43,6 +44,7 @@ public class LabelerDataArchiveHTMLEditorKit extends DataArchiveHTMLEditorKit {
       super(e);
     }
 
+    @Override
     public float getAlignment(int axis) {
       switch (axis) {
       case View.Y_AXIS:
@@ -59,6 +61,7 @@ public class LabelerDataArchiveHTMLEditorKit extends DataArchiveHTMLEditorKit {
       setLoadsSynchronously(true); //BR// make sure these actually load
     }
 
+    @Override
     public float getAlignment(int axis) {
       switch (axis) {
       case View.Y_AXIS:

--- a/vassal-app/src/main/java/VASSAL/tools/swing/LabelerDataArchiveHTMLEditorKit.java
+++ b/vassal-app/src/main/java/VASSAL/tools/swing/LabelerDataArchiveHTMLEditorKit.java
@@ -23,15 +23,31 @@ public class LabelerDataArchiveHTMLEditorKit extends DataArchiveHTMLEditorKit {
     super(arch);
   }
 
-  float valignImages = 0.5f;
-  float valignText   = 0.5f;
+  float valignImagesDefault = 0.5f;
+  float valignTextDefault   = 0.5f;
 
-  public void setValignImages(float align) {
-    valignImages = align;
+  public void setValignImagesDefault(float align) {
+    valignImagesDefault = align;
   }
 
-  public void setValignText(float align) {
-    valignText = align;
+  public void setValignTextDefault(float align) {
+    valignTextDefault = align;
+  }
+
+  private float getValign(Element e, float def) {
+    final AttributeSet attrs = e.getAttributes();
+    final String v = (String) attrs.getAttribute(HTML.Attribute.VALIGN);
+
+    if ("top".equals(v)) { //NON-NLS
+      return 0f;
+    }
+    else if ("middle".equals(v)) { //NON-NLS
+      return .5f;
+    }
+    else if ("bottom".equals(v)) { //NON-NLS
+      return 1.0f;
+    }
+    return def;
   }
 
   @Override
@@ -40,15 +56,18 @@ public class LabelerDataArchiveHTMLEditorKit extends DataArchiveHTMLEditorKit {
   }
 
   protected class LabelerInlineView extends InlineView {
+    protected float valign;
+
     public LabelerInlineView(Element e) {
       super(e);
+      valign = getValign(e, valignTextDefault);
     }
 
     @Override
     public float getAlignment(int axis) {
       switch (axis) {
       case View.Y_AXIS:
-        return valignText;
+        return valign;
       default:
         return super.getAlignment(axis);
       }
@@ -56,16 +75,19 @@ public class LabelerDataArchiveHTMLEditorKit extends DataArchiveHTMLEditorKit {
   }
 
   private class LabelerDataArchiveImageView extends DataArchiveImageView {
+    protected float valign;
+
     public LabelerDataArchiveImageView(Element e) {
       super(e);
       setLoadsSynchronously(true); //BR// make sure these actually load
+      valign = getValign(e, valignImagesDefault);
     }
 
     @Override
     public float getAlignment(int axis) {
       switch (axis) {
       case View.Y_AXIS:
-        return valignImages;
+        return valign;
       default:
         return super.getAlignment(axis);
       }


### PR DESCRIPTION
If a Text Label trait is wrapped in <html> tags and ALSO contains an <img> tag, then we use JTextPane instead of JLabel to draw its HTML, which allows us to use the DataArchiveHTMLEditorKit previously developed for e.g. the Chat Log