### PR TITLE
12119 - Restore vanished Load Comments

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/module/GameState.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/GameState.java
@@ -600,6 +600,8 @@ public class GameState implements CommandEncoder {
     String saveVassalVersion = "?";
     final GameModule g = GameModule.getGameModule();
 
+    loadComments = saveData.getLocalizedDescription();
+
     // Was the Module Data that created the save stored in the save? (Vassal 3.0+)
     if (saveData.getModuleData() != null) {
       saveModuleVersion = saveData.getModuleVersion();


### PR DESCRIPTION
Apparently I accidentally disabled the display of load comments sometime during 3.6 while "cleaning up code" hahaha