### PR TITLE
4446 - Dynamic button labels (can use expressions and $...$ in certain toolbar buttons) 

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/AbstractToolbarItem.java
+++ b/vassal-app/src/main/java/VASSAL/build/AbstractToolbarItem.java
@@ -119,6 +119,7 @@ public abstract class AbstractToolbarItem extends AbstractConfigurable implement
    */
   protected LaunchButton makeLaunchButton(String tooltip, String button_text, String iconFile, ActionListener action) {
     launch = new LaunchButton(button_text, tooltipKey, buttonTextKey, hotKeyKey, iconKey, action, true);
+    //launch = new LaunchButton(button_text, tooltipKey, buttonTextKey, hotKeyKey, iconKey, action);
     if (!tooltip.isEmpty()) {
       setAttribute(tooltipKey, tooltip);
     }
@@ -318,7 +319,7 @@ public abstract class AbstractToolbarItem extends AbstractConfigurable implement
     if (!nameKey.isEmpty()) {
       return new Class<?>[]{
         String.class,
-        String.class,
+        FormattedStringConfig.class,
         String.class,
         IconConfig.class,
         NamedKeyStroke.class,
@@ -329,7 +330,7 @@ public abstract class AbstractToolbarItem extends AbstractConfigurable implement
     }
     else {
       return new Class<?>[]{
-        String.class,
+        FormattedStringConfig.class,
         String.class,
         IconConfig.class,
         NamedKeyStroke.class,

--- a/vassal-app/src/main/java/VASSAL/build/AbstractToolbarItem.java
+++ b/vassal-app/src/main/java/VASSAL/build/AbstractToolbarItem.java
@@ -26,8 +26,10 @@ import VASSAL.configure.Configurer;
 import VASSAL.configure.ConfigurerFactory;
 import VASSAL.configure.IconConfigurer;
 import VASSAL.configure.NamedHotKeyConfigurer;
+import VASSAL.configure.PlayerIdFormattedExpressionConfigurer;
 import VASSAL.configure.VisibilityCondition;
 import VASSAL.i18n.Resources;
+import VASSAL.i18n.TranslatableConfigurerFactory;
 import VASSAL.tools.LaunchButton;
 import VASSAL.tools.NamedKeyStroke;
 import VASSAL.tools.ToolBarComponent;
@@ -116,7 +118,7 @@ public abstract class AbstractToolbarItem extends AbstractConfigurable implement
    * @return launch button
    */
   protected LaunchButton makeLaunchButton(String tooltip, String button_text, String iconFile, ActionListener action) {
-    launch = new LaunchButton(button_text, tooltipKey, buttonTextKey, hotKeyKey, iconKey, action);
+    launch = new LaunchButton(button_text, tooltipKey, buttonTextKey, hotKeyKey, iconKey, action, true);
     if (!tooltip.isEmpty()) {
       setAttribute(tooltipKey, tooltip);
     }
@@ -335,6 +337,14 @@ public abstract class AbstractToolbarItem extends AbstractConfigurable implement
         String.class,
         IconConfig.class,
       };
+    }
+  }
+
+
+  public static class FormattedStringConfig implements TranslatableConfigurerFactory {
+    @Override
+    public Configurer getConfigurer(AutoConfigurable c, String key, String name) {
+      return new PlayerIdFormattedExpressionConfigurer(key, name, new String[]{});
     }
   }
 

--- a/vassal-app/src/main/java/VASSAL/build/GameModule.java
+++ b/vassal-app/src/main/java/VASSAL/build/GameModule.java
@@ -2312,6 +2312,8 @@ public class GameModule extends AbstractConfigurable
     buttonLabelUpdateScheduled = true;
 
     SwingUtilities.invokeLater(() -> {
+        buttonLabelUpdateScheduled = false;
+
         updateToolbarButtons();
 
         for (final Map map : Map.getMapList()) {

--- a/vassal-app/src/main/java/VASSAL/build/GameModule.java
+++ b/vassal-app/src/main/java/VASSAL/build/GameModule.java
@@ -142,6 +142,7 @@ import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import javax.swing.JToolBar;
 import javax.swing.KeyStroke;
+import javax.swing.SwingUtilities;
 import javax.swing.Timer;
 import java.awt.Container;
 import java.awt.Rectangle;
@@ -279,6 +280,7 @@ public class GameModule extends AbstractConfigurable
 
   private boolean matSupport = false; // If no Mats exist in the module, we don't need to spend any time doing mat-related calculations during moves/selects
   private boolean trueMovedSupport = false; // If not ignore-small-moves traits exist in the module, we don't need to spend any time doing related calculations
+  private boolean mutableButtonLabelSupport = false; // If no mutable buttons, we don't need to spend time checking for updates of them;
 
   private boolean suppressSounds = false; // Semaphore if currently suppressing sounds (eg during Global Key Command processing)
 
@@ -316,11 +318,27 @@ public class GameModule extends AbstractConfigurable
   }
 
   /**
-   * @param fancyMoveSupport true if a ignore-small-moves trait exists in the module
+   * @param trueMoveSupport true if a ignore-small-moves trait exists in the module
    */
   public void setTrueMovedSupport(boolean trueMovedSupport) {
     this.trueMovedSupport = trueMovedSupport;
   }
+
+
+  /**
+   * @param support true if any toolbar buttons use $...$ or { } expressions
+   */
+  public void setMutableButtonSupport(boolean support) {
+    mutableButtonLabelSupport = support;
+  }
+
+  /**
+   * @return True if there are toolbar buttons using $...$ or {   } expressions in the module
+   */
+  public boolean isMutableButtonLabelSupport() {
+    return mutableButtonLabelSupport;
+  }
+
 
 
   /**
@@ -2281,6 +2299,28 @@ public class GameModule extends AbstractConfigurable
     final TranslatableString s = transContainer.getTranslatableString(String.valueOf(key));
     return s == null ? null : s.getPropertyValue();
   }
+
+
+  private boolean buttonLabelUpdateScheduled = false;
+
+  /**
+   * A property has changed somewhere, so we need to redraw all the toolbar buttons that use properties
+   */
+  public void updateMutableButtonLabels() {
+    if (!isMutableButtonLabelSupport() || buttonLabelUpdateScheduled) return;
+
+    buttonLabelUpdateScheduled = true;
+
+    SwingUtilities.invokeLater(() -> {
+        updateToolbarButtons();
+
+        for (final Map map : Map.getMapList()) {
+          map.updateToolbarButtons();
+        }
+      }
+    );
+  }
+
 
   /**
    * Gets the value of a mutable (changeable) "Global Property". Module level Global Properties serve as the

--- a/vassal-app/src/main/java/VASSAL/build/module/properties/MutableProperty.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/properties/MutableProperty.java
@@ -17,13 +17,14 @@
  */
 package VASSAL.build.module.properties;
 
+import VASSAL.build.GameModule;
+import VASSAL.command.Command;
+
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.beans.PropertyChangeSupport;
 import java.util.ArrayList;
 import java.util.List;
-
-import VASSAL.command.Command;
 
 /**
  * A container for a String property that can be updated
@@ -146,6 +147,7 @@ public interface MutableProperty {
       final Command c = getChangeCommand(value, newValue);
       value = newValue;
       propSupport.firePropertyChange(propertyName, oldValue, newValue);
+      GameModule.getGameModule().updateMutableButtonLabels();
       return c;
     }
   }

--- a/vassal-app/src/main/java/VASSAL/tools/LaunchButton.java
+++ b/vassal-app/src/main/java/VASSAL/tools/LaunchButton.java
@@ -75,13 +75,13 @@ public class LaunchButton extends JButton implements Auditable {
     tooltipAtt = tooltipAttribute;
   }
 
+
   public LaunchButton(String text, String textAttribute, String hotkeyAttribute, String iconAttribute, final ActionListener al, boolean allowExpression) {
     super(text);
 
     this.allowExpression = allowExpression;
     if (allowExpression) {
       setFormat(text);
-      updateText();
     }
 
     alwaysAcceptKeystroke = false;
@@ -109,7 +109,9 @@ public class LaunchButton extends JButton implements Auditable {
 
   private void setFormat(String text) {
     formatted.setFormat(text);
-    usesExpression = formatted.getFormat().contains("$") || formatted.getFormat().contains("{");
+    usesExpression = true;
+    updateText();
+    usesExpression = text.contains("$") || text.contains("{");
     if (usesExpression) {
       GameModule.getGameModule().setMutableButtonSupport(true); // We're gonna need a bigger updater...
     }
@@ -192,7 +194,6 @@ public class LaunchButton extends JButton implements Auditable {
 
         if (allowExpression) {
           setFormat((String)value);
-          updateText();
         }
         else {
           setText((String) value);

--- a/vassal-app/src/main/java/VASSAL/tools/LaunchButton.java
+++ b/vassal-app/src/main/java/VASSAL/tools/LaunchButton.java
@@ -25,6 +25,7 @@ import VASSAL.configure.NamedHotKeyConfigurer;
 import VASSAL.configure.StringConfigurer;
 import VASSAL.i18n.Localization;
 import VASSAL.i18n.Resources;
+import VASSAL.script.expression.Auditable;
 
 import javax.swing.Icon;
 import javax.swing.JButton;
@@ -36,7 +37,7 @@ import java.awt.event.ActionListener;
  * Handles configuration of a hotkey shortcut, maintains appropriate
  * tooltip text, etc.
  */
-public class LaunchButton extends JButton {
+public class LaunchButton extends JButton implements Auditable {
   private static final long serialVersionUID = 1L;
   public static final String UNTRANSLATED_TEXT = "unTranslatedText"; //$NON-NLS-1$
   protected String tooltipAtt;
@@ -49,6 +50,9 @@ public class LaunchButton extends JButton {
   protected Configurer nameConfig, keyConfig;
   protected boolean alwaysAcceptKeystroke;
   protected boolean forceVisible = false;
+  protected boolean allowExpression;
+  protected boolean usesExpression = false;
+  protected FormattedString formatted = new FormattedString("");
 
   public LaunchButton(String text, String textAttribute,
                       String hotkeyAttribute, ActionListener al) {
@@ -63,7 +67,23 @@ public class LaunchButton extends JButton {
   }
 
   public LaunchButton(String text, String textAttribute, String hotkeyAttribute, String iconAttribute, final ActionListener al) {
+    this(text, textAttribute, hotkeyAttribute, iconAttribute, al, false);
+  }
+
+  public LaunchButton(String text, String tooltipAttribute, String textAttribute, String hotkeyAttribute, String iconAttribute, final ActionListener al, boolean allowExpression) {
+    this(text, textAttribute, hotkeyAttribute, iconAttribute, al, allowExpression);
+    tooltipAtt = tooltipAttribute;
+  }
+
+  public LaunchButton(String text, String textAttribute, String hotkeyAttribute, String iconAttribute, final ActionListener al, boolean allowExpression) {
     super(text);
+
+    this.allowExpression = allowExpression;
+    if (allowExpression) {
+      setFormat(text);
+      updateText();
+    }
+
     alwaysAcceptKeystroke = false;
     nameAtt = textAttribute;
     keyAtt = hotkeyAttribute;
@@ -81,6 +101,24 @@ public class LaunchButton extends JButton {
     }
     setFocusable(false);
     checkVisibility();
+  }
+
+  public boolean isUsesExpression() {
+    return usesExpression;
+  }
+
+  private void setFormat(String text) {
+    formatted.setFormat(text);
+    usesExpression = formatted.getFormat().contains("$") || formatted.getFormat().contains("{");
+    if (usesExpression) {
+      GameModule.getGameModule().setMutableButtonSupport(true); // We're gonna need a bigger updater...
+    }
+  }
+
+  public void updateText() {
+    if (usesExpression) {
+      setText(formatted.getText(GameModule.getGameModule(), this, "Editor.DrawPile.count_express"));
+    }
   }
 
   /**
@@ -151,7 +189,14 @@ public class LaunchButton extends JButton {
         if (Localization.getInstance().isTranslationInProgress()) {
           putClientProperty(UNTRANSLATED_TEXT, getText());
         }
-        setText((String) value);
+
+        if (allowExpression) {
+          setFormat((String)value);
+          updateText();
+        }
+        else {
+          setText((String) value);
+        }
         checkVisibility();
       }
       else if (key.equals(keyAtt)) {
@@ -213,4 +258,18 @@ public class LaunchButton extends JButton {
   protected void checkVisibility() {
     setVisible(isNonBlank() || forceVisible);
   }
+
+  @Override
+  public String getComponentTypeName() {
+    return "Launch Button";
+  };
+
+  /**
+   * Return the name of the trait or Component an Auditable is
+   * @return Component name
+   */
+  @Override
+  public String getComponentName() {
+    return "Launch Button";
+  };
 }

--- a/vassal-app/src/main/java/VASSAL/tools/ToolBarComponent.java
+++ b/vassal-app/src/main/java/VASSAL/tools/ToolBarComponent.java
@@ -1,6 +1,7 @@
 package VASSAL.tools;
 
 import javax.swing.JToolBar;
+import java.awt.Component;
 
 /**
  * Indicates a component with a toolbar
@@ -10,4 +11,20 @@ import javax.swing.JToolBar;
 @FunctionalInterface
 public interface ToolBarComponent {
   JToolBar getToolBar();
+
+  /**
+   * Update the text labels in the toolbar's component buttons (for mutable button label support)
+   */
+  default void updateToolbarButtons() {
+    final JToolBar toolbar = getToolBar();
+    if (toolbar == null) return;
+
+    final int tools = toolbar.getComponentCount();
+    for (int t = 0; t < tools; t++) {
+      final Component tool = toolbar.getComponentAtIndex(t);
+      if (tool instanceof LaunchButton) {
+        ((LaunchButton)tool).updateText();
+      }
+    }
+  }
 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/3742246/226475066-fe149883-1e54-46e2-bd4f-2f0c385ba107.png)

Fixes #4446

Supports expressions in the button text field of anything that's an "AbstractToolbarItem", so lots of the main candidates e.g. Action Buttons and GKC buttons.