### PR TITLE
12127 - Toolbar buttons disableable by a property (e.g. GKC, ActionButton, etc) can be set to hide when disabled

### DIFF
--- a/vassal-app/src/main/java/VASSAL/tools/LaunchButton.java
+++ b/vassal-app/src/main/java/VASSAL/tools/LaunchButton.java
@@ -50,6 +50,7 @@ public class LaunchButton extends JButton implements Auditable {
   protected Configurer nameConfig, keyConfig;
   protected boolean alwaysAcceptKeystroke;
   protected boolean forceVisible = false;
+  protected boolean forceInvisible = false;
   protected boolean allowExpression;
   protected boolean usesExpression = false;
   protected FormattedString formatted = new FormattedString("");
@@ -144,6 +145,14 @@ public class LaunchButton extends JButton implements Auditable {
 
   public void setForceVisible(boolean fv) {
     forceVisible = fv;
+  }
+
+  public boolean isForceInvisible() {
+    return forceInvisible;
+  }
+
+  public void setForceInvisible(boolean fiv) {
+    forceInvisible = fiv;
   }
 
   @Override
@@ -256,8 +265,8 @@ public class LaunchButton extends JButton implements Auditable {
     return (getText() != null && getText().length() > 0) || getIcon() != null;
   }
 
-  protected void checkVisibility() {
-    setVisible(isNonBlank() || forceVisible);
+  public void checkVisibility() {
+    setVisible((isNonBlank() || forceVisible) && !forceInvisible);
   }
 
   @Override

--- a/vassal-app/src/main/resources/VASSAL/i18n/Editor.properties
+++ b/vassal-app/src/main/resources/VASSAL/i18n/Editor.properties
@@ -139,6 +139,7 @@ Editor.AbstractLaunchAction.unnamed_module=Unnamed Module
 Editor.AbstractToolbarItem.can_disable=Toolbar button can be disabled by a property
 Editor.AbstractToolbarItem.property_gate=Global Property to disable this button when "true"
 Editor.AbstractToolbarItem.disabled_icon=Button Icon when disabled
+Editor.AbstractToolbarItem.hide_when_disabled=Hide button when disabled
 
 # Action Button
 Editor.ActionButton.trait_description=Action Button


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/3742246/226715058-27309d2d-cb1c-4c0b-8d39-30085fd66608.png)
