### PR TITLE
BorderOutline trait accepts two fields

### DIFF
--- a/vassal-app/src/main/java/VASSAL/counters/BorderOutline.java
+++ b/vassal-app/src/main/java/VASSAL/counters/BorderOutline.java
@@ -178,36 +178,36 @@ public class BorderOutline extends Decorator implements TranslatablePiece {
     return true;
   }
 
+  protected boolean checkProperties() {
+    final boolean p1 = checkProperty(propertyName);
+    if (propertyName.isEmpty()) return true;
+
+    if (propertyName2.isEmpty()) {
+      return p1;
+    }
+    else {
+      final boolean p2 = checkProperty(propertyName2);
+      final LogicalCompareMode mode = LogicalCompareMode.whichSymbol(compareMode);
+      switch (mode) {
+      case OR:
+        return p1 || p2;
+      case XOR:
+        return (p1 || p2) && !(p1 && p2);
+      case NOR:
+        return !p1 && !p2;
+      default:
+        return p1 && p2;
+      }
+    }
+  }
+
   @Override
   public void draw(Graphics g, int x, int y, Component obs, double zoom) {
     piece.draw(g, x, y, obs, zoom);
 
-    final boolean p1 = checkProperty(propertyName);
-    if (!propertyName.isEmpty()) {
-      if (propertyName2.isEmpty()) {
-        if (!p1) return;
-      }
-      else {
-        final boolean p2 = checkProperty(propertyName2);
-        final LogicalCompareMode mode = LogicalCompareMode.whichSymbol(compareMode);
-        switch (mode) {
-        case OR:
-          if (!p1 && !p2) return;
-          break;
-        case XOR:
-          if ((p1 && p2) || (!p1 && !p2)) return;
-          break;
-        case NOR:
-          if (p1 || p2) return;
-          break;
-        default:
-          if (!(p1 && p2)) return;
-          break;
-        }
-      }
+    if (checkProperties()) {
+      border.draw(this, g, x, y, obs, zoom);
     }
-
-    border.draw(this, g, x, y, obs, zoom);
   }
 
   @Override
@@ -249,6 +249,23 @@ public class BorderOutline extends Decorator implements TranslatablePiece {
     if (! Objects.equals(compareMode, c.compareMode)) return false;
     return Objects.equals(thickness, c.thickness);
   }
+
+  @Override
+  public Object getProperty(Object key) {
+    if (key.equals(Properties.VISIBLE_STATE)) {
+      return String.valueOf(super.getProperty(key)) + checkProperties();
+    }
+    return super.getProperty(key);
+  }
+
+  @Override
+  public Object getLocalizedProperty(Object key) {
+    if (key.equals(Properties.VISIBLE_STATE)) {
+      return getProperty(key);
+    }
+    return super.getLocalizedProperty(key);
+  }
+
 
   private static class Ed implements PieceEditor {
     private final StringConfigurer propertyInput;

--- a/vassal-app/src/main/java/VASSAL/counters/BorderOutline.java
+++ b/vassal-app/src/main/java/VASSAL/counters/BorderOutline.java
@@ -22,6 +22,7 @@ import VASSAL.command.Command;
 import VASSAL.configure.ColorConfigurer;
 import VASSAL.configure.IntConfigurer;
 import VASSAL.configure.StringConfigurer;
+import VASSAL.configure.TranslatingStringEnumConfigurer;
 import VASSAL.i18n.Resources;
 import VASSAL.i18n.TranslatablePiece;
 import VASSAL.tools.SequenceEncoder;
@@ -31,6 +32,7 @@ import java.awt.Component;
 import java.awt.Graphics;
 import java.awt.Rectangle;
 import java.awt.Shape;
+import java.util.Arrays;
 import java.util.Objects;
 
 /**
@@ -40,6 +42,7 @@ public class BorderOutline extends Decorator implements TranslatablePiece {
   public static final String ID = "border;"; // NON-NLS
 
   private String propertyName;
+  private String compareMode;
   private String propertyName2;
   private String description;
   private int thickness = 2;
@@ -56,6 +59,48 @@ public class BorderOutline extends Decorator implements TranslatablePiece {
     setInner(p);
   }
 
+  /**
+   * Comparison Modes for property match
+   */
+  public enum LogicalCompareMode {
+    AND("AND"), //NON-NLS
+    OR("OR"),   //NON-NLS
+    XOR("XOR"), //NON-NLS
+    NOR("NOR"); //NON-NLS
+
+
+    private static final String[] KEYS = new String[] { "Editor.AND", "Editor.OR", "Editor.XOR", "Editor.NOR" };
+
+    String symbol;
+
+    LogicalCompareMode(String symbol) {
+      this.symbol = symbol;
+    }
+
+    public String getSymbol() {
+      return symbol;
+    }
+
+    public static BorderOutline.LogicalCompareMode whichSymbol(String symbol) {
+      for (final BorderOutline.LogicalCompareMode mode : BorderOutline.LogicalCompareMode.values()) {
+        if (mode.getSymbol().equals(symbol)) {
+          return mode;
+        }
+      }
+      return AND;
+    }
+
+    public static String[] getSymbols() {
+      return Arrays.stream(values())
+        .map(BorderOutline.LogicalCompareMode::getSymbol)
+        .toArray(String[]::new);
+    }
+
+    public static String[] getKeys() {
+      return KEYS;
+    }
+  }
+
   @Override
   public void mySetType(String type) {
     final SequenceEncoder.Decoder st = new SequenceEncoder.Decoder(type, ';');
@@ -65,6 +110,7 @@ public class BorderOutline extends Decorator implements TranslatablePiece {
     thickness    = st.nextInt(2);
     color        = st.nextColor(Color.RED);
     propertyName2 = st.nextToken("");
+    compareMode   = st.nextToken(LogicalCompareMode.AND.toString()); //NON-NLS
 
     border.setColor(color);
     border.setThickness(thickness);
@@ -82,7 +128,7 @@ public class BorderOutline extends Decorator implements TranslatablePiece {
   @Override
   public String myGetType() {
     final SequenceEncoder se = new SequenceEncoder(';');
-    se.append(propertyName).append(description).append(thickness).append(color).append(propertyName2);
+    se.append(propertyName).append(description).append(thickness).append(color).append(propertyName2).append(compareMode);
     return ID + se.getValue();
   }
 
@@ -117,37 +163,58 @@ public class BorderOutline extends Decorator implements TranslatablePiece {
     if ((name != null) && !name.isEmpty()) {
       final Object propValue = Decorator.getOutermost(this).getProperty(name);
       if (propValue == null) {
-        return true;
+        return false;
       }
       else if (propValue instanceof String) {
         final String string = (String)propValue;
         if ("".equals(string) || "false".equals(string) || "0".equals(string)) { //NON-NLS
-          return true;
+          return false;
         }
       }
       else if (propValue instanceof Boolean) {
-        if (!((Boolean)propValue)) return true;
+        if (!((Boolean)propValue)) return false;
       }
       else if (propValue instanceof Integer) {
-        if (((Integer)propValue) == 0) return true;
+        if (((Integer)propValue) == 0) return false;
       }
     }
-    return false;
+    return true;
   }
 
   @Override
   public void draw(Graphics g, int x, int y, Component obs, double zoom) {
     piece.draw(g, x, y, obs, zoom);
 
-    if (checkProperty(propertyName)) return;
-    if (checkProperty(propertyName2)) return;
+    final boolean p1 = checkProperty(propertyName);
+
+    if (propertyName2.isEmpty()) {
+      if (!p1) return;
+    }
+    else {
+      final boolean p2 = checkProperty(propertyName2);
+      final LogicalCompareMode mode = LogicalCompareMode.whichSymbol(compareMode);
+      switch (mode) {
+      case OR:
+        if (!p1 && !p2) return;
+        break;
+      case XOR:
+        if ((p1 && p2) || (!p1 && !p2)) return;
+        break;
+      case NOR:
+        if (p1 || p2) return;
+        break;
+      default:
+        if (!(p1 && p2)) return;
+        break;
+      }
+    }
 
     border.draw(this, g, x, y, obs, zoom);
   }
 
   @Override
   public String getDescription() {
-    return buildDescription("Editor.BorderOutline.trait_description", propertyName + (((propertyName2 != null) && !propertyName2.isEmpty()) ? " / " + propertyName2 : ""), description);
+    return buildDescription("Editor.BorderOutline.trait_description", propertyName + (((propertyName2 != null) && !propertyName2.isEmpty()) ? " " + compareMode + " " + propertyName2 : ""), description);
   }
 
   @Override
@@ -181,11 +248,13 @@ public class BorderOutline extends Decorator implements TranslatablePiece {
     if (! Objects.equals(color, c.color)) return false;
     if (! Objects.equals(propertyName, c.propertyName)) return false;
     if (! Objects.equals(propertyName2, c.propertyName2)) return false;
+    if (! Objects.equals(compareMode, c.compareMode)) return false;
     return Objects.equals(thickness, c.thickness);
   }
 
   private static class Ed implements PieceEditor {
     private final StringConfigurer propertyInput;
+    private final LogicalCompareConfigurer compareInput;
     private final StringConfigurer propertyInput2;
     private final StringConfigurer descInput;
     private final IntConfigurer thicknessConfig;
@@ -202,6 +271,10 @@ public class BorderOutline extends Decorator implements TranslatablePiece {
 
       propertyInput = new StringConfigurer(p.propertyName);
       box.add("Editor.BorderOutline.property_name", propertyInput);
+
+      compareInput = new LogicalCompareConfigurer();
+      compareInput.setValue(p.compareMode);
+      box.add("Editor.BorderOutline.compare_mode", compareInput);
 
       propertyInput2 = new StringConfigurer(p.propertyName2);
       box.add("Editor.BorderOutline.property_name_2", propertyInput2);
@@ -221,13 +294,22 @@ public class BorderOutline extends Decorator implements TranslatablePiece {
     @Override
     public String getType() {
       final SequenceEncoder se = new SequenceEncoder(';');
-      se.append(propertyInput.getValueString()).append(descInput.getValueString()).append(thicknessConfig.getValueString()).append(colorConfig.getValueString()).append(propertyInput2.getValueString());
+      se.append(propertyInput.getValueString()).append(descInput.getValueString()).append(thicknessConfig.getValueString()).append(colorConfig.getValueString()).append(propertyInput2.getValueString()).append(compareInput.getValueString());
       return ID + se.getValue();
     }
 
     @Override
     public String getState() {
       return "false"; // NON-NLS
+    }
+  }
+
+  /**
+   * Happy little Configurer class for the Compare Modes
+   */
+  private static class LogicalCompareConfigurer extends TranslatingStringEnumConfigurer {
+    LogicalCompareConfigurer() {
+      super(null, null, LogicalCompareMode.getSymbols(), LogicalCompareMode.getKeys());
     }
   }
 }

--- a/vassal-app/src/main/java/VASSAL/counters/BorderOutline.java
+++ b/vassal-app/src/main/java/VASSAL/counters/BorderOutline.java
@@ -69,7 +69,7 @@ public class BorderOutline extends Decorator implements TranslatablePiece {
     NOR("NOR"); //NON-NLS
 
 
-    private static final String[] KEYS = new String[] { "Editor.AND", "Editor.OR", "Editor.XOR", "Editor.NOR" };
+    private static final String[] KEYS = { "Editor.AND", "Editor.OR", "Editor.XOR", "Editor.NOR" };
 
     String symbol;
 

--- a/vassal-app/src/main/java/VASSAL/counters/BorderOutline.java
+++ b/vassal-app/src/main/java/VASSAL/counters/BorderOutline.java
@@ -70,7 +70,7 @@ public class BorderOutline extends Decorator implements TranslatablePiece {
 
     private static final String[] KEYS = { "Editor.AND", "Editor.OR", "Editor.XOR", "Editor.NOR" };
 
-    String symbol;
+    private final String symbol;
 
     LogicalCompareMode(String symbol) {
       this.symbol = symbol;

--- a/vassal-app/src/main/java/VASSAL/counters/BorderOutline.java
+++ b/vassal-app/src/main/java/VASSAL/counters/BorderOutline.java
@@ -61,10 +61,10 @@ public class BorderOutline extends Decorator implements TranslatablePiece {
     final SequenceEncoder.Decoder st = new SequenceEncoder.Decoder(type, ';');
     st.nextToken();
     propertyName = st.nextToken("");
-    propertyName2 = st.nextToken("");
     description  = st.nextToken("");
     thickness    = st.nextInt(2);
     color        = st.nextColor(Color.RED);
+    propertyName2 = st.nextToken("");
 
     border.setColor(color);
     border.setThickness(thickness);
@@ -147,7 +147,7 @@ public class BorderOutline extends Decorator implements TranslatablePiece {
 
   @Override
   public String getDescription() {
-    return buildDescription("Editor.BorderOutline.trait_description", propertyName + (((propertyName2 != null) && !propertyName2.isEmpty()) ? " / " + propertyName2 : 0), description);
+    return buildDescription("Editor.BorderOutline.trait_description", propertyName + (((propertyName2 != null) && !propertyName2.isEmpty()) ? " / " + propertyName2 : ""), description);
   }
 
   @Override

--- a/vassal-app/src/main/java/VASSAL/counters/BorderOutline.java
+++ b/vassal-app/src/main/java/VASSAL/counters/BorderOutline.java
@@ -166,15 +166,13 @@ public class BorderOutline extends Decorator implements TranslatablePiece {
       }
       else if (propValue instanceof String) {
         final String string = (String)propValue;
-        if ("".equals(string) || "false".equals(string) || "0".equals(string)) { //NON-NLS
-          return false;
-        }
+        return !"".equals(string) && !"false".equals(string) && !"0".equals(string); //NON-NLS
       }
       else if (propValue instanceof Boolean) {
-        if (!((Boolean)propValue)) return false;
+        return (Boolean) propValue;
       }
       else if (propValue instanceof Integer) {
-        if (((Integer)propValue) == 0) return false;
+        return ((Integer) propValue) != 0;
       }
     }
     return true;

--- a/vassal-app/src/main/java/VASSAL/counters/BorderOutline.java
+++ b/vassal-app/src/main/java/VASSAL/counters/BorderOutline.java
@@ -187,25 +187,27 @@ public class BorderOutline extends Decorator implements TranslatablePiece {
 
     final boolean p1 = checkProperty(propertyName);
 
-    if (propertyName2.isEmpty()) {
-      if (!p1) return;
-    }
-    else {
-      final boolean p2 = checkProperty(propertyName2);
-      final LogicalCompareMode mode = LogicalCompareMode.whichSymbol(compareMode);
-      switch (mode) {
-      case OR:
-        if (!p1 && !p2) return;
-        break;
-      case XOR:
-        if ((p1 && p2) || (!p1 && !p2)) return;
-        break;
-      case NOR:
-        if (p1 || p2) return;
-        break;
-      default:
-        if (!(p1 && p2)) return;
-        break;
+    if (!propertyName.isEmpty()) {
+      if (propertyName2.isEmpty()) {
+        if (!p1) return;
+      }
+      else {
+        final boolean p2 = checkProperty(propertyName2);
+        final LogicalCompareMode mode = LogicalCompareMode.whichSymbol(compareMode);
+        switch (mode) {
+        case OR:
+          if (!p1 && !p2) return;
+          break;
+        case XOR:
+          if ((p1 && p2) || (!p1 && !p2)) return;
+          break;
+        case NOR:
+          if (p1 || p2) return;
+          break;
+        default:
+          if (!(p1 && p2)) return;
+          break;
+        }
       }
     }
 

--- a/vassal-app/src/main/java/VASSAL/counters/BorderOutline.java
+++ b/vassal-app/src/main/java/VASSAL/counters/BorderOutline.java
@@ -68,7 +68,6 @@ public class BorderOutline extends Decorator implements TranslatablePiece {
     XOR("XOR"), //NON-NLS
     NOR("NOR"); //NON-NLS
 
-
     private static final String[] KEYS = { "Editor.AND", "Editor.OR", "Editor.XOR", "Editor.NOR" };
 
     String symbol;
@@ -186,7 +185,6 @@ public class BorderOutline extends Decorator implements TranslatablePiece {
     piece.draw(g, x, y, obs, zoom);
 
     final boolean p1 = checkProperty(propertyName);
-
     if (!propertyName.isEmpty()) {
       if (propertyName2.isEmpty()) {
         if (!p1) return;

--- a/vassal-app/src/main/resources/VASSAL/i18n/Editor.properties
+++ b/vassal-app/src/main/resources/VASSAL/i18n/Editor.properties
@@ -111,7 +111,11 @@ Editor.top_right=Top right
 Editor.bottom_left=Bottom left
 Editor.bottom_right=Bottom right
 Editor.import_module=Import module
-Editor.convert_setupstack_or_deck=[%1$s] %2$s has "Belongs to Board" field set to a board (%3$s) that does not exist on the map to which it has just been pasted. Belongs to Board set to [any] instead. 
+Editor.AND=AND
+Editor.OR=OR
+Editor.XOR=XOR
+Editor.NOR=NOR
+Editor.convert_setupstack_or_deck=[%1$s] %2$s has "Belongs to Board" field set to a board (%3$s) that does not exist on the map to which it has just been pasted. Belongs to Board set to [any] instead.
 
 # Serif Font
 Editor.Font.serif=Serif
@@ -322,6 +326,7 @@ Editor.BoardPicker.out_of_sequence=The [%1$s] component must be defined in %2$s 
 # Border Outline
 Editor.BorderOutline.trait_description=Border Outline
 Editor.BorderOutline.property_name=Property Name (optional)
+Editor.BorderOutline.compare_mode=Comparison
 Editor.BorderOutline.property_name_2=Second Property Name (optional)
 Editor.BorderOutline.color=Color
 Editor.BorderOutline.thickness=Thickness

--- a/vassal-app/src/main/resources/VASSAL/i18n/Editor.properties
+++ b/vassal-app/src/main/resources/VASSAL/i18n/Editor.properties
@@ -321,7 +321,8 @@ Editor.BoardPicker.out_of_sequence=The [%1$s] component must be defined in %2$s 
 
 # Border Outline
 Editor.BorderOutline.trait_description=Border Outline
-Editor.BorderOutline.property_name=Property Name (or none for "always show")
+Editor.BorderOutline.property_name=Property Name (optional)
+Editor.BorderOutline.property_name_2=Second Property Name (optional)
 Editor.BorderOutline.color=Color
 Editor.BorderOutline.thickness=Thickness
 

--- a/vassal-doc/src/main/readme-referencemanual/ReferenceManual/BorderOutline.adoc
+++ b/vassal-doc/src/main/readme-referencemanual/ReferenceManual/BorderOutline.adoc
@@ -15,7 +15,9 @@ Pieces which have the _Border Outline_ trait will automatically display a colore
 |
 *Description:*:: A short description of this trait for your own reference.
 
-*Property Name (or none for "always show"):*:: If blank, the border will always be shown. Otherwise the value of the named property will be checked, and the outline will be shown if the property value is anything other than 0, false, or an empty string.
+*Property Name (or none for true):*:: A property which, if specified, must have a value other than 0, false, or the empty string for the border outline to be shown.
+
+*Second Property Name (or none for true):*:: A second property which, if specified, must have a value other than 0, false, or the empty string in order for the outline to be shown. If both property names are left blank, the border outline will always be shown. If both property names are specified, then _both_ properties must be non-0, non-false, non-empty. If a single property name is specified (in either field), then only that property must be non-0, non-false, non-empty.
 
 *Color:*:: The color of the border outline.
 

--- a/vassal-doc/src/main/readme-referencemanual/ReferenceManual/BorderOutline.adoc
+++ b/vassal-doc/src/main/readme-referencemanual/ReferenceManual/BorderOutline.adoc
@@ -15,9 +15,11 @@ Pieces which have the _Border Outline_ trait will automatically display a colore
 |
 *Description:*:: A short description of this trait for your own reference.
 
-*Property Name (or none for true):*:: A property which, if specified, must have a value other than 0, false, or the empty string for the border outline to be shown.
+*Property Name (optional):*:: A property which, if specified, is checked to make sure it has a value other than 0, false, or an empty string. If no property is specified, the border outline is always displayed. If this property is the only one specified, then the border outline is displayed when this property's value is anything _except_ 0, false, or an empty string.
 
-*Second Property Name (or none for true):*:: A second property which, if specified, must have a value other than 0, false, or the empty string in order for the outline to be shown. If both property names are left blank, the border outline will always be shown. If both property names are specified, then _both_ properties must be non-0, non-false, non-empty. If a single property name is specified (in either field), then only that property must be non-0, non-false, non-empty.
+*Comparison:*:: If two property names are specified, then this field determines the comparison done. The default _AND_ means to display the border outline if *both* properties have values other than 0, false, and empty string. If the comparison is _OR_ then the outline is displayed if *either* property is non-0, non-false,  non-blank. _XOR_ means *either but not both*, and _NOR_ means *neither*.
+
+*Second Property Name (optional):*:: A second property which, if specified, is checked whether it has a value other than 0, false, or an empty string. If a second property is specified, the _Comparison_ field above determine how the properties are used.
 
 *Color:*:: The color of the border outline.
 


### PR DESCRIPTION
This is an improvement to a feature that didn't exist until 3.7.0-beta1. 