### PR TITLE
12155 - Change-property buttons don't generate completely empty chat lines.

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/module/properties/ChangePropertyButton.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/properties/ChangePropertyButton.java
@@ -91,10 +91,15 @@ public class ChangePropertyButton extends AbstractToolbarItem implements Propert
         report.setProperty(OLD_VALUE_FORMAT, oldValue);
         report.setProperty(NEW_VALUE_FORMAT, property.getPropertyValue());
         report.setProperty(DESCRIPTION_FORMAT, property.getDescription());
-        final Chatter.DisplayText chatCommand =
-          new Chatter.DisplayText(GameModule.getGameModule().getChatter(), "* " + report.getLocalizedText(this, "Editor.report_format"));
-        chatCommand.execute();
-        c.append(chatCommand);
+
+        final String reportText = report.getLocalizedText(this, "Editor.report_format");
+
+        if (!reportText.isEmpty()) {
+          final Chatter.DisplayText chatCommand =
+            new Chatter.DisplayText(GameModule.getGameModule().getChatter(), "* " + reportText);
+          chatCommand.execute();
+          c.append(chatCommand);
+        }
       }
       GameModule.getGameModule().sendAndLog(c);
     }


### PR DESCRIPTION
Fixes #12155 

In this case it makes no sense to spurt out a blank line anyway. If somebody (inconceivably) depends on it, they can output a space and it will show the empty line.