### PR TITLE
12197 - OPmotize - faster calls to getMap(), getID(), getParent(), getPosition()

### DIFF
--- a/vassal-app/src/main/java/VASSAL/counters/Decorator.java
+++ b/vassal-app/src/main/java/VASSAL/counters/Decorator.java
@@ -73,6 +73,7 @@ public abstract class Decorator extends AbstractImageFinder implements EditableP
   PropertyExporter, SearchTarget, ImageSearchTarget {
 
   protected GamePiece piece;
+  private GamePiece innermost;
   private Decorator dec;
   private boolean selected = false;
 
@@ -82,6 +83,8 @@ public abstract class Decorator extends AbstractImageFinder implements EditableP
     if (p != null) {
       p.setProperty(Properties.OUTER, this);
     }
+
+    innermost = getInnermost(p);
   }
 
   /** @param m Each GamePiece belongs to a single {@link Map}. Default behavior for a trait is to pass the new map inward toward the BasicPiece. */
@@ -95,7 +98,7 @@ public abstract class Decorator extends AbstractImageFinder implements EditableP
    * eventually reach it. */
   @Override
   public Map getMap() {
-    return piece.getMap();
+    return (innermost != null) ? innermost.getMap() : piece.getMap();
   }
 
   /**
@@ -123,7 +126,7 @@ public abstract class Decorator extends AbstractImageFinder implements EditableP
   /** @return the {@link Stack} to which this piece belongs, if any. Default behavior for a trait is to ask the next member inward. */
   @Override
   public Stack getParent() {
-    return piece.getParent();
+    return (innermost != null) ? innermost.getParent() : piece.getParent();
   }
 
   /**
@@ -313,7 +316,7 @@ public abstract class Decorator extends AbstractImageFinder implements EditableP
    */
   @Override
   public Point getPosition() {
-    return piece.getPosition();
+    return (innermost != null) ? innermost.getPosition() : piece.getPosition();
   }
 
   /**
@@ -499,7 +502,7 @@ public abstract class Decorator extends AbstractImageFinder implements EditableP
    */
   @Override
   public String getId() {
-    return piece.getId();
+    return (innermost != null) ? innermost.getId() : piece.getId();
   }
 
   /**

--- a/vassal-app/src/test/java/VASSAL/counters/DeckTest.java
+++ b/vassal-app/src/test/java/VASSAL/counters/DeckTest.java
@@ -1,14 +1,14 @@
 package VASSAL.counters;
 
+import VASSAL.build.GameModule;
+import VASSAL.build.MockModuleTest;
+import VASSAL.build.module.Map;
+import org.junit.jupiter.api.Test;
+
 import java.awt.Point;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
-
-import VASSAL.build.GameModule;
-import VASSAL.build.module.Map;
-
-import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -16,7 +16,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
-public class DeckTest {
+public class DeckTest extends MockModuleTest {
 
   @Test
   public void defaultConstructorShouldCreateEmptyDeck() {


### PR DESCRIPTION
We never subclass these four in any Decorator and it's difficult to imagine a viable subclassing of any of them existing in the wild. 

This little experiment gives every Decorator direct access to them instead of chaining a a bunch of calls/returns all the way in and out every time. 

Probably relatively mild perf games, but still (also easier to debug things in the debugger when a few more things don't go digging all the way to the core of the earth on every step-in) 

I ran through a whole game of PoG with it and it _seemed_ to work, but  ¯\_(ツ)_/¯