### PR TITLE
12209 - Report correct trait in expression Audit Trail

### DIFF
--- a/vassal-app/src/main/java/VASSAL/tools/FormattedString.java
+++ b/vassal-app/src/main/java/VASSAL/tools/FormattedString.java
@@ -357,7 +357,7 @@ public class FormattedString implements Loopable {
    *
    */
   public int getTextAsInt(PropertySource ps, String description, EditablePiece source) {
-    final AuditTrail audit = AuditTrail.create((Auditable) ps, this, description);
+    final AuditTrail audit = AuditTrail.create((Auditable) source, this, description);
     return getTextAsInt(ps, description, source, (Auditable) ps, audit);
   }
 
@@ -379,7 +379,7 @@ public class FormattedString implements Loopable {
 
   public int getTextAsInt(PropertySource ps, String description, AbstractConfigurable source) {
     int result = 0;
-    final AuditTrail audit = AuditTrail.create((Auditable) ps, this, description);
+    final AuditTrail audit = AuditTrail.create((Auditable) source, this, description);
     final String value = getText(ps, "0", source, audit);
     try {
       result = Integer.parseInt(value);


### PR DESCRIPTION
When reporting an error in the evaluation of a formatted integer field, the Audit report was reporting the outermost trait instead of the trait that was the source of the error.