### PR TITLE
Add BorderOutline's property names to the searchable target list

### DIFF
--- a/vassal-app/src/main/java/VASSAL/counters/BorderOutline.java
+++ b/vassal-app/src/main/java/VASSAL/counters/BorderOutline.java
@@ -336,6 +336,6 @@ public class BorderOutline extends Decorator implements TranslatablePiece {
    */
   @Override
   public List<String> getPropertyList() {
-    return Arrays.asList(propertyName, propertyName2);
+    return List.of(propertyName, propertyName2);
   }
 }

--- a/vassal-app/src/main/java/VASSAL/counters/BorderOutline.java
+++ b/vassal-app/src/main/java/VASSAL/counters/BorderOutline.java
@@ -25,6 +25,7 @@ import VASSAL.configure.StringConfigurer;
 import VASSAL.configure.TranslatingStringEnumConfigurer;
 import VASSAL.i18n.Resources;
 import VASSAL.i18n.TranslatablePiece;
+import VASSAL.search.SearchTarget;
 import VASSAL.tools.SequenceEncoder;
 
 import java.awt.Color;
@@ -33,6 +34,7 @@ import java.awt.Graphics;
 import java.awt.Rectangle;
 import java.awt.Shape;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Objects;
 
 /**
@@ -326,5 +328,14 @@ public class BorderOutline extends Decorator implements TranslatablePiece {
     LogicalCompareConfigurer() {
       super(null, null, LogicalCompareMode.getSymbols(), LogicalCompareMode.getKeys());
     }
+  }
+
+  /**
+   * {@link SearchTarget}
+   * @return a list of any Property Names referenced in the Decorator, if any (for search)
+   */
+  @Override
+  public List<String> getPropertyList() {
+    return Arrays.asList(propertyName, propertyName2);
   }
 }


### PR DESCRIPTION
(Minor fix/improvement to new 3.7 feature -- it wasn't adding the property names to the searchable list)