### PR TITLE
12237 - Fix edge case Mat Refresh bugs

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/module/GameRefresher.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/GameRefresher.java
@@ -38,6 +38,7 @@ import VASSAL.counters.Deck;
 import VASSAL.counters.Decorator;
 import VASSAL.counters.GamePiece;
 import VASSAL.counters.Mat;
+import VASSAL.counters.MatCargo;
 import VASSAL.counters.MatHolder;
 import VASSAL.counters.Properties;
 import VASSAL.counters.Stack;
@@ -817,7 +818,16 @@ public final class GameRefresher implements CommandEncoder, GameComponent {
       // And add the cargo back onto the mat
       for (final Refresher r : loadedCargo) {
         for (final GamePiece refreshedCargo : r.getRefreshedPieces()) {
-          command = command.append(((Mat) Decorator.getDecorator(newMatPiece, Mat.class)).makeAddCargoCommand(refreshedCargo));
+          final Mat mat = (Mat) Decorator.getDecorator(Decorator.getOutermost(newMatPiece), Mat.class);
+
+          // New piece for "mat" could have conceivably had Mat trait deleted
+          if (mat == null) continue;
+
+          // New piece for "cargo" could have conceivably had Cargo trait deleted
+          if (Decorator.getDecorator(Decorator.getOutermost(refreshedCargo), MatCargo.class) == null) continue;
+
+          // So both freshened versions are still existentially capable: attach the cargo to the mat
+          command = command.append(mat.makeAddCargoCommand(refreshedCargo));
         }
       }
     }


### PR DESCRIPTION
Brent noticed this edge case last night ... right after we released 3.6.16 hohoho

Basically things like ... when you refresh a piece it might turn out the new version _doesn't have a Mat trait any more_ and stuff like that.