### PR TITLE
12215 - New MarkMoved commands shouldn't default to being displayed if no key commands entered

### DIFF
--- a/vassal-app/src/main/java/VASSAL/counters/Decorator.java
+++ b/vassal-app/src/main/java/VASSAL/counters/Decorator.java
@@ -438,6 +438,27 @@ public abstract class Decorator extends AbstractImageFinder implements EditableP
   protected abstract KeyCommand[] myGetKeyCommands();
 
   /**
+   * @param menuText menu text
+   * @param keystroke keystroke or named keystroke
+   * @return true if a context menu item should be displayed for the text/keystroke combination
+   */
+  protected boolean isMenuCommand(String menuText, NamedKeyStroke keystroke) {
+    if ((menuText == null) || menuText.isEmpty()) return false;
+    return (keystroke != null) && !keystroke.isNull();
+  }
+
+  /**
+   * If text/keystroke pair is valid, add it to the provided list
+   * @param list
+   * @param menuText
+   * @param keyStroke
+   */
+  protected void addMenuCommand(List<KeyCommand> list, String menuText, NamedKeyStroke keyStroke) {
+    if (!isMenuCommand(menuText, keyStroke)) return;
+    list.add(new KeyCommand(menuText, keyStroke, Decorator.getOutermost(this), (TranslatablePiece)this));
+  }
+
+  /**
    * @return The set of key commands that will populate the piece's right-click menu.
    * The key commands are accessible through the {@link Properties#KEY_COMMANDS} property.
    * The commands for a Trait/{@link Decorator} are a composite of {@link #myGetKeyCommands} and the

--- a/vassal-app/src/main/java/VASSAL/counters/MovementMarkable.java
+++ b/vassal-app/src/main/java/VASSAL/counters/MovementMarkable.java
@@ -72,6 +72,7 @@ public class MovementMarkable extends Decorator implements TranslatablePiece {
   private boolean hasMoved = false;
   private String description;
   private boolean ignoreSameLocation = false;
+  private KeyCommand[] commands = null;
 
   public MovementMarkable() {
     this(ID + "moved.gif;0;0", null); // NON-NLS
@@ -115,6 +116,8 @@ public class MovementMarkable extends Decorator implements TranslatablePiece {
     catch (NoSuchElementException e) {
       keyFalse = NamedKeyStroke.NULL_KEYSTROKE;
     }
+
+    commands = null;
   }
 
   @Override
@@ -140,13 +143,20 @@ public class MovementMarkable extends Decorator implements TranslatablePiece {
 
   @Override
   protected KeyCommand[] myGetKeyCommands() {
-    return command.isEmpty() || key == null || key.isNull() ?
-      KeyCommand.NONE :
-      new KeyCommand[] {
-        new KeyCommand(command, key, Decorator.getOutermost(this), this),
-        new KeyCommand(commandTrue, keyTrue, Decorator.getOutermost(this), this),
-        new KeyCommand(commandFalse, keyFalse, Decorator.getOutermost(this), this)
-      };
+    if (commands == null) {
+      final List<KeyCommand> list = new ArrayList<>();
+      addMenuCommand(list, command, key);
+      addMenuCommand(list, commandTrue, keyTrue);
+      addMenuCommand(list, commandFalse, keyFalse);
+
+      if (list.isEmpty()) {
+        commands = KeyCommand.NONE;
+      }
+      else {
+        commands = list.toArray(new KeyCommand[0]);
+      }
+    }
+    return commands;
   }
 
   @Override


### PR DESCRIPTION
(CHANGES note -- this is a between-betas patch to 3.7.0, so new in the next beta or release but nothing "new" from 3.6 to 3.7, if that makes a difference in changelist)