### PR TITLE
12208 - Remove hide-when-disabled feature for toolbar buttons that was breaking other things

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/AbstractToolbarItem.java
+++ b/vassal-app/src/main/java/VASSAL/build/AbstractToolbarItem.java
@@ -216,8 +216,11 @@ public abstract class AbstractToolbarItem extends AbstractConfigurable implement
   public void checkDisabled() {
     if ((!isShowDisabledOptions() || !canDisable) && (launch != null)) {
       launch.setEnabled(true);
-      launch.setForceInvisible(false);
-      launch.checkVisibility();
+
+      // Disabling hide-when-disabled for now, it seems to be creating problems
+      //launch.setForceInvisible(false);
+      //launch.checkVisibility();
+
       return;
     }
     if ((property == null) && !propertyGate.isEmpty()) {
@@ -234,8 +237,10 @@ public abstract class AbstractToolbarItem extends AbstractConfigurable implement
   public void disableIfTrue(boolean disable) {
     if (launch != null) {
       launch.setEnabled(!isShowDisabledOptions() || !canDisable || !disable);
-      launch.setForceInvisible(disable && canDisable && hideWhenDisabled);
-      launch.checkVisibility();
+
+      // Disabling hide-when-disabled for now, it seems to be creating problems
+      //launch.setForceInvisible(disable && canDisable && hideWhenDisabled);
+      //launch.checkVisibility();
     }
   }
 
@@ -464,11 +469,14 @@ public abstract class AbstractToolbarItem extends AbstractConfigurable implement
 
   @Override
   public VisibilityCondition getAttributeVisibility(String key) {
-    if (List.of(PROPERTY_GATE, HIDE_WHEN_DISABLED).contains(key)) {
+    if (List.of(PROPERTY_GATE).contains(key)) {
       return () -> isShowDisabledOptions() && canDisable;
     }
+    if (HIDE_WHEN_DISABLED.equals(key)) {
+      return () -> false;  // Disabling hide-when-disabled for now, it seems to be creating problems
+    }
     if (DISABLED_ICON.equals(key)) {
-      return () -> isShowDisabledOptions() && canDisable && !hideWhenDisabled;
+      return () -> isShowDisabledOptions() && canDisable; // && !hideWhenDisabled; // removed hide-when-disabled feature for now
     }
     else if (CAN_DISABLE.equals(key)) {
       return this::isShowDisabledOptions;


### PR DESCRIPTION
Fixes #12208

Toolbar buttons are just a total mess (the weird frankenstein thing they do with "menus") -- pulling this out for the moment & probably forever-until-V4

(CHANGELIST - This is just an internal 3.7 patch, removing a feature also added for 3.7, so changes between betas but not from 3.6)