### PR TITLE
Fix incorrect drag offset on Windows with UI scaling > 100%

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/module/map/PieceMover.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/PieceMover.java
@@ -1626,7 +1626,11 @@ public class PieceMover extends AbstractBuildable
       currentPieceOffsetY =
         (int) (originalPieceOffsetY / dragPieceOffCenterZoom * zoom + 0.5);
 
-      final List<Point> relativePositions = buildBoundingBox(zoom, doOffset);
+      final List<Point> relativePositions = buildBoundingBox(zoom);
+
+      if (doOffset) {
+        calcDrawOffset();
+      }
 
       final int w = boundingBox.width + EXTRA_BORDER * 2;
       final int h = boundingBox.height + EXTRA_BORDER * 2;
@@ -1651,7 +1655,7 @@ public class PieceMover extends AbstractBuildable
     @Deprecated(since = "2023-05-08", forRemoval = true)
     protected void makeDragCursor(double zoom) {}
 
-    private List<Point> buildBoundingBox(double zoom, boolean doOffset) {
+    private List<Point> buildBoundingBox(double zoom) {
       final ArrayList<Point> relativePositions = new ArrayList<>();
       final PieceIterator dragContents = DragBuffer.getBuffer().getIterator();
       final GamePiece firstPiece = dragContents.nextPiece();
@@ -1693,10 +1697,6 @@ public class PieceMover extends AbstractBuildable
       for (Point p: relativePositions) {
         p.x *= zoom;
         p.y *= zoom;
-      }
-
-      if (doOffset) {
-        calcDrawOffset();
       }
 
       return relativePositions;

--- a/vassal-app/src/main/java/VASSAL/build/module/map/PieceMover.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/PieceMover.java
@@ -1621,6 +1621,11 @@ public class PieceMover extends AbstractBuildable
     protected BufferedImage makeDragImageCursorCommon(double zoom, boolean doOffset, Component target) {
       // FIXME: Should be an ImageOp for caching?
 
+      currentPieceOffsetX =
+        (int) (originalPieceOffsetX / dragPieceOffCenterZoom * zoom + 0.5);
+      currentPieceOffsetY =
+        (int) (originalPieceOffsetY / dragPieceOffCenterZoom * zoom + 0.5);
+
       final List<Point> relativePositions = buildBoundingBox(zoom, doOffset);
 
       final int w = boundingBox.width + EXTRA_BORDER * 2;
@@ -1651,11 +1656,6 @@ public class PieceMover extends AbstractBuildable
       final PieceIterator dragContents = DragBuffer.getBuffer().getIterator();
       final GamePiece firstPiece = dragContents.nextPiece();
       GamePiece lastPiece = firstPiece;
-
-      currentPieceOffsetX =
-        (int) (originalPieceOffsetX / dragPieceOffCenterZoom * zoom + 0.5);
-      currentPieceOffsetY =
-        (int) (originalPieceOffsetY / dragPieceOffCenterZoom * zoom + 0.5);
 
       boundingBox = firstPiece.getShape().getBounds();
       boundingBox.width *= zoom;

--- a/vassal-app/src/main/java/VASSAL/build/module/map/PieceMover.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/PieceMover.java
@@ -1894,11 +1894,11 @@ public class PieceMover extends AbstractBuildable
         }
       }
 
+      dragPieceOffCenterZoom *= getDeviceScale(dge);
+
       // dragging from UL results in positive offsets
       originalPieceOffsetX = piecePosition.x - mousePosition.x;
       originalPieceOffsetY = piecePosition.y - mousePosition.y;
-
-      dragPieceOffCenterZoom *= getDeviceScale(dge);
 
       return mousePosition;
     }

--- a/vassal-app/src/main/java/VASSAL/build/module/map/PieceMover.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/PieceMover.java
@@ -1662,9 +1662,6 @@ public class PieceMover extends AbstractBuildable
       boundingBox.height *= zoom;
       boundingBox.x *= zoom;
       boundingBox.y *= zoom;
-      if (doOffset) {
-        calcDrawOffset();
-      }
 
       relativePositions.add(new Point(0, 0));
       int stackCount = 0;
@@ -1695,6 +1692,10 @@ public class PieceMover extends AbstractBuildable
         boundingBox.add(r);
         relativePositions.add(p);
         lastPiece = nextPiece;
+      }
+
+      if (doOffset) {
+        calcDrawOffset();
       }
 
       return relativePositions;

--- a/vassal-app/src/main/java/VASSAL/build/module/map/PieceMover.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/PieceMover.java
@@ -1872,6 +1872,9 @@ public class PieceMover extends AbstractBuildable
         dragPieceOffCenterZoom = map.getZoom();
       }
       else {
+        // NB: In the case where there is no map, piecePosition is already
+        // in the component coordinate system, so we don't convert here.
+
         final Object tempZoom = piece.getProperty(PieceSlot.PIECE_PALETTE_SCALE);
         if (tempZoom != null) {
           final BasicPiece bp = (BasicPiece)Decorator.getInnermost(piece);

--- a/vassal-app/src/main/java/VASSAL/build/module/map/PieceMover.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/PieceMover.java
@@ -1658,40 +1658,41 @@ public class PieceMover extends AbstractBuildable
       GamePiece lastPiece = firstPiece;
 
       boundingBox = firstPiece.getShape().getBounds();
-      boundingBox.width *= zoom;
-      boundingBox.height *= zoom;
-      boundingBox.x *= zoom;
-      boundingBox.y *= zoom;
-
       relativePositions.add(new Point(0, 0));
+
       int stackCount = 0;
       while (dragContents.hasMoreElements()) {
         final GamePiece nextPiece = dragContents.nextPiece();
         final Rectangle r = nextPiece.getShape().getBounds();
-        r.width *= zoom;
-        r.height *= zoom;
-        r.x *= zoom;
-        r.y *= zoom;
 
         final Point p = new Point(
-          (int) Math.round(
-            zoom * (nextPiece.getPosition().x - firstPiece.getPosition().x)),
-          (int) Math.round(
-            zoom * (nextPiece.getPosition().y - firstPiece.getPosition().y)));
+          nextPiece.getPosition().x - firstPiece.getPosition().x,
+          nextPiece.getPosition().y - firstPiece.getPosition().y
+        );
         r.translate(p.x, p.y);
 
         if (nextPiece.getPosition().equals(lastPiece.getPosition())) {
           stackCount++;
           final StackMetrics sm = getStackMetrics(nextPiece);
           r.translate(
-            (int) Math.round(sm.unexSepX * stackCount * zoom),
-            (int) Math.round(-sm.unexSepY * stackCount * zoom)
+            sm.unexSepX * stackCount,
+            -sm.unexSepY * stackCount
           );
         }
 
         boundingBox.add(r);
         relativePositions.add(p);
         lastPiece = nextPiece;
+      }
+
+      boundingBox.width *= zoom;
+      boundingBox.height *= zoom;
+      boundingBox.x *= zoom;
+      boundingBox.y *= zoom;
+
+      for (Point p: relativePositions) {
+        p.x *= zoom;
+        p.y *= zoom;
       }
 
       if (doOffset) {

--- a/vassal-app/src/main/java/VASSAL/build/module/map/PieceMover.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/PieceMover.java
@@ -1876,7 +1876,6 @@ public class PieceMover extends AbstractBuildable
           dragPieceOffCenterZoom = 1.0;
         }
       }
-      dragPieceOffCenterZoom *= getDeviceScale(dge);
 
       // Account for offset of piece within stack. We do this even for
       // un-expanded stacks, since the offset can still be significant if
@@ -1894,6 +1893,8 @@ public class PieceMover extends AbstractBuildable
       // dragging from UL results in positive offsets
       originalPieceOffsetX = piecePosition.x - mousePosition.x;
       originalPieceOffsetY = piecePosition.y - mousePosition.y;
+
+      dragPieceOffCenterZoom *= getDeviceScale(dge);
 
       return mousePosition;
     }

--- a/vassal-app/src/main/java/VASSAL/build/module/map/PieceMover.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/PieceMover.java
@@ -1860,6 +1860,19 @@ public class PieceMover extends AbstractBuildable
       // PieceWindow has stashed a starting scale for us then use that, else 1.0
       if (map != null) {
         dragPieceOffCenterZoom = map.getZoom();
+
+        // Account for offset of piece within stack. We do this even for
+        // un-expanded stacks, since the offset can still be significant if
+        // the stack is large
+        final Stack parent = piece.getParent();
+        if (parent != null) {
+          final Point offset = parent.getStackMetrics()
+                                     .relativePosition(parent, piece);
+          piecePosition.translate(
+            (int) Math.round(offset.x * dragPieceOffCenterZoom),
+            (int) Math.round(offset.y * dragPieceOffCenterZoom)
+          );
+        }
       }
       else {
         final Object tempZoom = piece.getProperty(PieceSlot.PIECE_PALETTE_SCALE);

--- a/vassal-app/src/main/java/VASSAL/build/module/map/PieceMover.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/PieceMover.java
@@ -1851,7 +1851,8 @@ public class PieceMover extends AbstractBuildable
       // If DragBuffer holds a piece with invalid coordinates (for example, a
       // card drawn from a deck), drag from center of piece
       if (piecePosition.x <= 0 || piecePosition.y <= 0) {
-        piecePosition = mousePosition;
+        piecePosition = map == null ? mousePosition :
+                                      map.componentToMap(mousePosition);
       }
 
       // If coming from a map, we use the map's zoom. Otherwise if our

--- a/vassal-app/src/main/java/VASSAL/build/module/map/PieceMover.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/PieceMover.java
@@ -1666,6 +1666,9 @@ public class PieceMover extends AbstractBuildable
     protected void makeDragCursor(double zoom) {}
 
     private List<Point> buildBoundingBox() {
+      // boundingBox and relativePositions are constructed in map
+      // coordinates in this function
+
       final ArrayList<Point> relativePositions = new ArrayList<>();
       final PieceIterator dragContents = DragBuffer.getBuffer().getIterator();
       final GamePiece firstPiece = dragContents.nextPiece();

--- a/vassal-app/src/main/java/VASSAL/build/module/map/PieceMover.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/PieceMover.java
@@ -1527,6 +1527,7 @@ public class PieceMover extends AbstractBuildable
     protected static final int EXTRA_BORDER = 4;   // pseudo cursor is includes a 4 pixel border
 
     protected Rectangle boundingBox;    // image bounds
+    protected Rectangle boundingBoxComp;    // image bounds
 
     private int originalPieceOffsetX; // How far drag STARTED from GamePiece's center (on original map)
     private int originalPieceOffsetY;
@@ -1609,27 +1610,32 @@ public class PieceMover extends AbstractBuildable
      */
     @Deprecated(since = "2023-05-08", forRemoval = true)
     protected BufferedImage makeDragImageCursorCommon(double zoom, boolean doOffset, Component target, boolean setSize) {
-      return makeDragImageCursorCommon(zoom, doOffset, target);
+      return makeDragImageCursorCommon(zoom, 1.0, doOffset, target);
     }
 
-    /**
-     * Common functionality abstracted from makeDragImage and makeDragCursor
-     *
-     * @param zoom Zoom Level
-     * @param doOffset Drag Offset
-     * @param target Target Component
-     * @return Drag Image
-     */
-    protected BufferedImage makeDragImageCursorCommon(double zoom, boolean doOffset, Component target) {
+    protected BufferedImage makeDragImageCursorCommon(double mapzoom, double os_scale, boolean doOffset, Component target) {
       // FIXME: Should be an ImageOp for caching?
+      final double zoom = mapzoom * os_scale;
 
       currentPieceOffsetX =
-        (int) (originalPieceOffsetX / dragPieceOffCenterZoom * zoom + 0.5);
+        (int) (originalPieceOffsetX / dragPieceOffCenterZoom * mapzoom + 0.5);
       currentPieceOffsetY =
-        (int) (originalPieceOffsetY / dragPieceOffCenterZoom * zoom + 0.5);
+        (int) (originalPieceOffsetY / dragPieceOffCenterZoom * mapzoom + 0.5);
 
       final List<Point> relativePositions = buildBoundingBox();
 
+      // convert boundingBoxComp to component space
+      boundingBoxComp = new Rectangle(boundingBox);
+      boundingBoxComp.width *= mapzoom;
+      boundingBoxComp.height *= mapzoom;
+      boundingBoxComp.x *= mapzoom;
+      boundingBoxComp.y *= mapzoom;
+
+      if (doOffset) {
+        calcDrawOffset();
+      }
+
+      // convert boundingBox, relativePosisions to drawing space
       boundingBox.width *= zoom;
       boundingBox.height *= zoom;
       boundingBox.x *= zoom;
@@ -1638,10 +1644,6 @@ public class PieceMover extends AbstractBuildable
       for (Point p: relativePositions) {
         p.x *= zoom;
         p.y *= zoom;
-      }
-
-      if (doOffset) {
-        calcDrawOffset();
       }
 
       final int w = boundingBox.width + EXTRA_BORDER * 2;
@@ -1660,8 +1662,8 @@ public class PieceMover extends AbstractBuildable
      * @param zoom DragBuffer.getBuffer
      * @return dragImage
      */
-    private BufferedImage makeDragImage(double zoom) {
-      return makeDragImageCursorCommon(zoom, false, null);
+    private BufferedImage makeDragImage(double mapzoom, double os_scale) {
+      return makeDragImageCursorCommon(mapzoom, os_scale, false, null);
     }
 
     @Deprecated(since = "2023-05-08", forRemoval = true)
@@ -1901,8 +1903,6 @@ public class PieceMover extends AbstractBuildable
         }
       }
 
-      dragPieceOffCenterZoom *= getDeviceScale(dge);
-
       // dragging from UL results in positive offsets
       originalPieceOffsetX = piecePosition.x - mousePosition.x;
       originalPieceOffsetY = piecePosition.y - mousePosition.y;
@@ -1915,12 +1915,14 @@ public class PieceMover extends AbstractBuildable
      * @param dge DG event
      */
     protected void beginDragging(DragGestureEvent dge) {
+      final double os_scale = getDeviceScale(dge);
+
       // this call is needed to instantiate the boundingBox object
-      final BufferedImage bImage = makeDragImage(dragPieceOffCenterZoom);
+      final BufferedImage bImage = makeDragImage(dragPieceOffCenterZoom, os_scale);
 
       final Point dragPointOffset = new Point(
-        getOffsetMult() * (boundingBox.x + currentPieceOffsetX - EXTRA_BORDER),
-        getOffsetMult() * (boundingBox.y + currentPieceOffsetY - EXTRA_BORDER)
+        (int) Math.round(getOffsetMult() * ((boundingBoxComp.x + currentPieceOffsetX) * os_scale - EXTRA_BORDER)),
+        (int) Math.round(getOffsetMult() * ((boundingBoxComp.y + currentPieceOffsetY) * os_scale - EXTRA_BORDER))
       );
 
       //BR// Inform PieceMovers of relevant metrics
@@ -2142,12 +2144,18 @@ public class PieceMover extends AbstractBuildable
       drawWin = null;
       dropWin = null;
 
-      makeDragCursor(dragPieceOffCenterZoom);
+      makeDragCursor(dragPieceOffCenterZoom, getDeviceScale(dge));
       setDrawWinToOwnerOf(dragWin);
       SwingUtilities.convertPointToScreen(mousePosition, drawWin);
       moveDragCursor(mousePosition.x, mousePosition.y);
 
       super.dragGestureRecognized(dge);
+    }
+
+    @Override
+    @Deprecated(since = "2023-05-15", forRemoval = true)
+    protected void makeDragCursor(double zoom) {
+      makeDragCursor(zoom, 1.0);
     }
 
     /**
@@ -2158,15 +2166,14 @@ public class PieceMover extends AbstractBuildable
      * @param zoom DragBuffer.getBuffer
      *
      */
-    @Override
-    protected void makeDragCursor(double zoom) {
+    protected void makeDragCursor(double zoom, double os_scale) {
       // create the cursor if necessary
       if (dragCursor == null) {
         dragCursor = new JLabel();
         dragCursor.setVisible(false);
       }
 
-      final BufferedImage img = makeDragImageCursorCommon(zoom, true, dragCursor);
+      final BufferedImage img = makeDragImageCursorCommon(zoom, os_scale, true, dragCursor);
       dragCursor.setSize(img.getWidth(), img.getHeight());
       dragCursor.setIcon(new ImageIcon(img));
       dragCursorZoom = zoom;
@@ -2226,8 +2233,8 @@ public class PieceMover extends AbstractBuildable
         // and the upper-left corner of the cursor
         // accounts for difference between event point (screen coords)
         // and Layered Pane position, boundingBox and off-center drag
-        drawOffset.x = -boundingBox.x - currentPieceOffsetX + EXTRA_BORDER;
-        drawOffset.y = -boundingBox.y - currentPieceOffsetY + EXTRA_BORDER;
+        drawOffset.x = -boundingBoxComp.x - currentPieceOffsetX + EXTRA_BORDER;
+        drawOffset.y = -boundingBoxComp.y - currentPieceOffsetY + EXTRA_BORDER;
         SwingUtilities.convertPointToScreen(drawOffset, drawWin);
       }
     }
@@ -2288,7 +2295,7 @@ public class PieceMover extends AbstractBuildable
         final double newZoom = newDropWin instanceof Map.View
           ? ((Map.View) newDropWin).getMap().getZoom() : 1.0;
         if (Math.abs(newZoom - dragCursorZoom) > 0.01) {
-          makeDragCursor(newZoom);
+          makeDragCursor(newZoom, getDeviceScale(e));
         }
         setDrawWinToOwnerOf(e.getDropTargetContext().getComponent());
         dropWin = newDropWin;

--- a/vassal-app/src/main/java/VASSAL/build/module/map/PieceMover.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/PieceMover.java
@@ -1859,20 +1859,22 @@ public class PieceMover extends AbstractBuildable
       // If coming from a map, we use the map's zoom. Otherwise if our
       // PieceWindow has stashed a starting scale for us then use that, else 1.0
       if (map != null) {
-        dragPieceOffCenterZoom = map.getZoom();
-
         // Account for offset of piece within stack. We do this even for
         // un-expanded stacks, since the offset can still be significant if
         // the stack is large
         final Stack parent = piece.getParent();
         if (parent != null) {
-          final Point offset = parent.getStackMetrics()
-                                     .relativePosition(parent, piece);
+          final Point offset = map.mapToComponent(
+              parent.getStackMetrics().relativePosition(parent, piece)
+          );
+
           piecePosition.translate(
-            (int) Math.round(offset.x * dragPieceOffCenterZoom),
-            (int) Math.round(offset.y * dragPieceOffCenterZoom)
+            (int) Math.round(offset.x),
+            (int) Math.round(offset.y)
           );
         }
+
+        dragPieceOffCenterZoom = map.getZoom();
       }
       else {
         final Object tempZoom = piece.getProperty(PieceSlot.PIECE_PALETTE_SCALE);

--- a/vassal-app/src/main/java/VASSAL/build/module/map/PieceMover.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/PieceMover.java
@@ -1845,9 +1845,11 @@ public class PieceMover extends AbstractBuildable
                       ((Map.View) dge.getComponent()).getMap() : null;
 
       final Point mousePosition = dge.getDragOrigin(); //BR// Bug13137 - now that we're not pre-adulterating dge's event, it already arrives in component coordinates
+
       Point piecePosition = (map == null)
                     ?  piece.getPosition()
                     : map.mapToComponent(piece.getPosition());
+
       // If DragBuffer holds a piece with invalid coordinates (for example, a
       // card drawn from a deck), drag from center of piece
       if (piecePosition.x <= 0 || piecePosition.y <= 0) {
@@ -1875,19 +1877,6 @@ public class PieceMover extends AbstractBuildable
         else {
           dragPieceOffCenterZoom = 1.0;
         }
-      }
-
-      // Account for offset of piece within stack. We do this even for
-      // un-expanded stacks, since the offset can still be significant if
-      // the stack is large
-      if (piece.getParent() != null && map != null) {
-        final Point offset = piece.getParent()
-                                  .getStackMetrics()
-                                  .relativePosition(piece.getParent(), piece);
-        piecePosition.translate(
-          (int) Math.round(offset.x * dragPieceOffCenterZoom),
-          (int) Math.round(offset.y * dragPieceOffCenterZoom)
-        );
       }
 
       // dragging from UL results in positive offsets

--- a/vassal-app/src/main/java/VASSAL/build/module/map/PieceMover.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/PieceMover.java
@@ -1626,7 +1626,17 @@ public class PieceMover extends AbstractBuildable
       currentPieceOffsetY =
         (int) (originalPieceOffsetY / dragPieceOffCenterZoom * zoom + 0.5);
 
-      final List<Point> relativePositions = buildBoundingBox(zoom);
+      final List<Point> relativePositions = buildBoundingBox();
+
+      boundingBox.width *= zoom;
+      boundingBox.height *= zoom;
+      boundingBox.x *= zoom;
+      boundingBox.y *= zoom;
+
+      for (Point p: relativePositions) {
+        p.x *= zoom;
+        p.y *= zoom;
+      }
 
       if (doOffset) {
         calcDrawOffset();
@@ -1655,7 +1665,7 @@ public class PieceMover extends AbstractBuildable
     @Deprecated(since = "2023-05-08", forRemoval = true)
     protected void makeDragCursor(double zoom) {}
 
-    private List<Point> buildBoundingBox(double zoom) {
+    private List<Point> buildBoundingBox() {
       final ArrayList<Point> relativePositions = new ArrayList<>();
       final PieceIterator dragContents = DragBuffer.getBuffer().getIterator();
       final GamePiece firstPiece = dragContents.nextPiece();
@@ -1687,16 +1697,6 @@ public class PieceMover extends AbstractBuildable
         boundingBox.add(r);
         relativePositions.add(p);
         lastPiece = nextPiece;
-      }
-
-      boundingBox.width *= zoom;
-      boundingBox.height *= zoom;
-      boundingBox.x *= zoom;
-      boundingBox.y *= zoom;
-
-      for (Point p: relativePositions) {
-        p.x *= zoom;
-        p.y *= zoom;
       }
 
       return relativePositions;

--- a/vassal-app/src/main/java/VASSAL/build/module/map/PieceMover.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/PieceMover.java
@@ -1560,6 +1560,8 @@ public class PieceMover extends AbstractBuildable
      */
     protected abstract double getDeviceScale(DragGestureEvent dge);
 
+    protected abstract double getDeviceScale(DropTargetDragEvent e);
+
     /**
      * @param e DropTargetEvent
      * @return associated DropTargetListener
@@ -2080,6 +2082,16 @@ public class PieceMover extends AbstractBuildable
       g2d.dispose();
       return os_scale;
     }
+
+    @Override
+    protected double getDeviceScale(DropTargetDragEvent e) {
+      // Get the OS scaling; note that this handler is _probably_ running only
+      // on Windows.
+      final Graphics2D g2d = (Graphics2D) e.getDropTargetContext().getComponent().getGraphics();
+      final double os_scale = g2d.getDeviceConfiguration().getDefaultTransform().getScaleX();
+      g2d.dispose();
+      return os_scale;
+    }
   }
 
   /**
@@ -2096,6 +2108,11 @@ public class PieceMover extends AbstractBuildable
     protected double getDeviceScale(DragGestureEvent dge) {
       // Retina Macs account for the device scaling for the drag icon,
       // so we don't have to.
+      return 1.0;
+    }
+
+    @Override
+    protected double getDeviceScale(DropTargetDragEvent e) {
       return 1.0;
     }
   }
@@ -2237,6 +2254,11 @@ public class PieceMover extends AbstractBuildable
 
     @Override
     protected double getDeviceScale(DragGestureEvent dge) {
+      return 1.0;
+    }
+
+    @Override
+    protected double getDeviceScale(DropTargetDragEvent e) {
       return 1.0;
     }
 

--- a/vassal-app/src/main/java/VASSAL/build/module/map/PieceMover.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/PieceMover.java
@@ -1696,6 +1696,7 @@ public class PieceMover extends AbstractBuildable
         relativePositions.add(p);
         lastPiece = nextPiece;
       }
+
       return relativePositions;
     }
 

--- a/vassal-app/src/main/java/VASSAL/build/module/map/PieceMover.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/PieceMover.java
@@ -1846,9 +1846,7 @@ public class PieceMover extends AbstractBuildable
 
       final Point mousePosition = dge.getDragOrigin(); //BR// Bug13137 - now that we're not pre-adulterating dge's event, it already arrives in component coordinates
 
-      Point piecePosition = (map == null)
-                    ?  piece.getPosition()
-                    : map.mapToComponent(piece.getPosition());
+      Point piecePosition = piece.getPosition();
 
       // If DragBuffer holds a piece with invalid coordinates (for example, a
       // card drawn from a deck), drag from center of piece
@@ -1864,15 +1862,12 @@ public class PieceMover extends AbstractBuildable
         // the stack is large
         final Stack parent = piece.getParent();
         if (parent != null) {
-          final Point offset = map.mapToComponent(
-              parent.getStackMetrics().relativePosition(parent, piece)
-          );
-
-          piecePosition.translate(
-            (int) Math.round(offset.x),
-            (int) Math.round(offset.y)
-          );
+          final Point offset = parent.getStackMetrics()
+                                     .relativePosition(parent, piece);
+          piecePosition.translate(offset.x, offset.y);
         }
+
+        piecePosition = map.mapToComponent(piecePosition);
 
         dragPieceOffCenterZoom = map.getZoom();
       }


### PR DESCRIPTION
piecePosition is in component coordinates, not drawing coordinates, so its scale factor should not have the UI scale factor applied to it.