### PR TITLE
12327 ! operator will always return false, not error if arg is invalid

### DIFF
--- a/vassal-app/src/main/java/bsh/BSHUnaryExpression.java
+++ b/vassal-app/src/main/java/bsh/BSHUnaryExpression.java
@@ -82,14 +82,19 @@ class BSHUnaryExpression extends SimpleNode implements ParserConstants
 
     private Object unaryOperation( Object op, int kind ) throws UtilEvalError
     {
-        if (op instanceof Boolean || op instanceof Character 
+        // VASSAL - Special handling for ! operator. Don't thow errors
+        // Anything that is not a Boolean should return false, unless it is the string "true"
+        if (kind == ParserConstants.BANG ) {
+          return primitiveWrapperUnaryOperation((op instanceof Boolean ? op : new Boolean("true".equals(op))), kind );
+        }
+
+        if (op instanceof Boolean || op instanceof Character
 			|| op instanceof Number)
             return primitiveWrapperUnaryOperation( op, kind );
 
-        if ( !(op instanceof Primitive) )
+          if ( !(op instanceof Primitive) )
             throw new UtilEvalError( "Unary operation " + tokenImage[kind]
                 + " inappropriate for object" );
-
 		
         return Primitive.unaryOperation((Primitive)op, kind);
     }

--- a/vassal-app/src/main/java/bsh/BSHUnaryExpression.java
+++ b/vassal-app/src/main/java/bsh/BSHUnaryExpression.java
@@ -85,16 +85,14 @@ class BSHUnaryExpression extends SimpleNode implements ParserConstants
         // VASSAL - Special handling for ! operator. Don't thow errors
         // Anything that is not a Boolean should return false, unless it is the string "true"
         if (kind == ParserConstants.BANG ) {
-          return primitiveWrapperUnaryOperation((op instanceof Boolean ? op : new Boolean("true".equals(op))), kind );
+          return primitiveWrapperUnaryOperation((op instanceof Boolean ? op : Boolean.valueOf("true".equals(op))), kind );
         }
 
-        if (op instanceof Boolean || op instanceof Character
-			|| op instanceof Number)
+        if (op instanceof Boolean || op instanceof Character || op instanceof Number)
             return primitiveWrapperUnaryOperation( op, kind );
 
-          if ( !(op instanceof Primitive) )
-            throw new UtilEvalError( "Unary operation " + tokenImage[kind]
-                + " inappropriate for object" );
+        if ( !(op instanceof Primitive) )
+          throw new UtilEvalError( "Unary operation " + tokenImage[kind] + " inappropriate for object" );
 		
         return Primitive.unaryOperation((Primitive)op, kind);
     }


### PR DESCRIPTION
Modified Beanshell parser to treat anything that is not true/false or "true"/"false" as false, instead of throwing a Data Module Error.