### PR TITLE
Fix Inaccurate Hex Grid location reports

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/module/Map.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/Map.java
@@ -1276,7 +1276,7 @@ public class Map extends AbstractToolbarItem implements GameComponent, MouseList
    * @see Board#snapTo
    * @see VASSAL.build.module.map.boardPicker.board.MapGrid#snapTo
    */
-  public Point snapTo(Point p, boolean force) {
+  public Point snapTo(Point p, boolean force, boolean onlyCenter) {
     Point snap = new Point(p);
 
     final Board b = findBoard(p);
@@ -1284,7 +1284,7 @@ public class Map extends AbstractToolbarItem implements GameComponent, MouseList
 
     final Rectangle r = b.bounds();
     snap.translate(-r.x, -r.y);
-    snap = b.snapTo(snap, force);
+    snap = b.snapTo(snap, force, onlyCenter);
     snap.translate(r.x, r.y);
 
     //CC bugfix13409
@@ -1293,7 +1293,7 @@ public class Map extends AbstractToolbarItem implements GameComponent, MouseList
     if (bSnappedTo != null && !b.equals(bSnappedTo)) {
       final Rectangle rSnappedTo = bSnappedTo.bounds();
       snap.translate(-rSnappedTo.x, -rSnappedTo.y);
-      snap = bSnappedTo.snapTo(snap, force);
+      snap = bSnappedTo.snapTo(snap, force, onlyCenter);
       snap.translate(rSnappedTo.x, rSnappedTo.y);
     }
     // RFE 882378
@@ -1319,9 +1319,12 @@ public class Map extends AbstractToolbarItem implements GameComponent, MouseList
     return snap;
   }
 
+  public Point snapTo(Point p, boolean force) {
+    return snapTo(p, force, true);
+  }
 
   public Point snapTo(Point p) {
-    return snapTo(p, false);
+    return snapTo(p, false, false);
   }
 
 

--- a/vassal-app/src/main/java/VASSAL/build/module/map/CounterDetailViewer.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/CounterDetailViewer.java
@@ -447,7 +447,7 @@ public class CounterDetailViewer extends AbstractConfigurable implements Drawabl
       if (!boards.isEmpty()) {
         // get map reference point
         final Point ptMap = pieces.isEmpty() ?
-          map.snapTo(map.componentToMap(currentMousePosition.getPoint()), showTerrainSnappy) :
+          map.snapTo(map.componentToMap(currentMousePosition.getPoint()), showTerrainSnappy, false) :
           pieces.get(0).getPosition();
 
         // get the rectangle of the map to draw
@@ -769,7 +769,7 @@ public class CounterDetailViewer extends AbstractConfigurable implements Drawabl
 
   String getTerrainBeneathText() {
     final Point mapPt = map.componentToMap(currentMousePosition.getPoint());
-    final Point snapPt = map.snapTo(mapPt, showTerrainSnappy);
+    final Point snapPt = map.snapTo(mapPt, showTerrainSnappy, false);
     final String locationName = map.localizedLocationName(snapPt);
     showTerrainText.setProperty(BasicPiece.LOCATION_NAME, locationName.equals(Resources.getString("Map.offboard")) ? "" : locationName);
     showTerrainText.setProperty(BasicPiece.CURRENT_MAP, map.getLocalizedMapName());
@@ -793,7 +793,9 @@ public class CounterDetailViewer extends AbstractConfigurable implements Drawabl
 
   String getEmptyText() {
     final Point mapPt = map.componentToMap(currentMousePosition.getPoint());
-    final Point snapPt = map.snapTo(mapPt);
+    // When snapping, only snap to the center point, not edges or corners,
+    // to ensure that the right text is retrieved.
+    final Point snapPt = map.snapTo(mapPt, false, true);
     final String locationName = map.localizedLocationName(snapPt);
     emptyHexReportFormat.setProperty(BasicPiece.LOCATION_NAME, locationName.equals(Resources.getString("Map.offboard")) ? "" : locationName);
     emptyHexReportFormat.setProperty(BasicPiece.CURRENT_MAP, map.getLocalizedMapName());

--- a/vassal-app/src/main/java/VASSAL/build/module/map/boardPicker/Board.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/boardPicker/Board.java
@@ -608,12 +608,25 @@ public class Board extends AbstractConfigurable implements GridContainer {
     return grid == null ? null : grid.localizedLocationName(localCoordinates(p));
   }
 
-  public Point snapTo(Point p, boolean force) {
-    return grid == null ? p : globalCoordinates(grid.snapTo(localCoordinates(p), force));
+  /**
+   * @see MapGrid#snapTo(Point p, boolean force, boolean onlyCenter)
+   */
+  public Point snapTo(Point p, boolean force, boolean onlyCenter) {
+    return grid == null ? p : globalCoordinates(grid.snapTo(localCoordinates(p), force, onlyCenter));
   }
 
+  /**
+   * @see MapGrid#snapTo(Point p, boolean force, boolean onlyCenter)
+   */
+  public Point snapTo(Point p, boolean force) {
+    return snapTo(p, force, false);
+  }
+
+  /**
+   * @see Board#snapTo(Point p, boolean force, boolean onlyCenter)
+   */
   public Point snapTo(Point p) {
-    return snapTo(p, false);
+    return snapTo(p, false, false);
   }
 
     /**

--- a/vassal-app/src/main/java/VASSAL/build/module/map/boardPicker/board/HexGrid.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/boardPicker/board/HexGrid.java
@@ -452,11 +452,15 @@ public class HexGrid extends AbstractConfigurable
   }
 
   @Override
-  public Point snapTo(Point p, boolean force) {
+  public Point snapTo(Point p, boolean force, boolean centerOnly) {
+
     if (!snapTo && !force) {
       return p;
     }
     final Point center = snapToHex(p);
+    if (centerOnly) {
+      return center;
+    }
 
     if (edgesLegal && cornersLegal) {
       final Point edge = snapToHexSide(p);
@@ -483,8 +487,13 @@ public class HexGrid extends AbstractConfigurable
   }
 
   @Override
+  public Point snapTo(Point p, boolean force) {
+    return snapTo(p, force, false);
+  }
+
+  @Override
   public Point snapTo(Point p) {
-    return snapTo(p, false);
+    return snapTo(p, false, false);
   }
 
   // FIXME: snapToHexVertex() does not always return the correct X co-ordinate

--- a/vassal-app/src/main/java/VASSAL/build/module/map/boardPicker/board/HexGrid.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/boardPicker/board/HexGrid.java
@@ -44,6 +44,7 @@ import java.awt.geom.AffineTransform;
 import java.awt.geom.Area;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.List;
 
 import static java.lang.Math.abs;
 import static java.lang.Math.ceil;
@@ -565,10 +566,14 @@ public class HexGrid extends AbstractConfigurable
     return p;
   }
 
-  public void rotate(Point p) {
+  private static void rotatePoint(Point p) {
     final int swap = p.x;
     p.x = p.y;
     p.y = swap;
+  }
+
+  public void rotate(Point p) {
+    HexGrid.rotatePoint(p);
   }
 
   public void rotateIfSideways(Point p) {
@@ -619,11 +624,17 @@ public class HexGrid extends AbstractConfigurable
 
   /**
    * Return the Shape of a single hex
-   * @param centerX X co-ord of hex centre
-   * @param centerY Y co-ord of hex centre
+   * @param centerX X co-ord of hex centre .
+   * @param centerY Y co-ord of hex centre .
+   * @param reversed ?
+   * @param sideways See HexGrid.sideways .
+   * @param dx Grid cell width, see HexGrid.dx .
+   * @param dy Grid cell height, see HexGrid.dy .
    * @return Hex Shape
    */
-  protected Area getSingleHexShape(int centerX, int centerY, boolean reversed) {
+  private static Area getSingleHexShape(
+          int centerX, int centerY, boolean reversed, boolean sideways, double dx, double dy) {
+
     final Polygon poly = new Polygon();
 
     final float x = (sideways ? centerY : centerX);
@@ -642,8 +653,8 @@ public class HexGrid extends AbstractConfigurable
     final float x6;
     final float y6;
 
-    final float deltaX = (float) (this.dx);
-    final float deltaY = (float) (this.dy);
+    final float deltaX = (float) dx;
+    final float deltaY = (float) dy;
 
     final float r = 2.F * deltaX / 3.F;
 
@@ -679,12 +690,12 @@ public class HexGrid extends AbstractConfigurable
     p6.setLocation(round(x6), round(y6) + 1);
 
     if (sideways) {
-      rotate(p1);
-      rotate(p2);
-      rotate(p3);
-      rotate(p4);
-      rotate(p5);
-      rotate(p6);
+      rotatePoint(p1);
+      rotatePoint(p2);
+      rotatePoint(p3);
+      rotatePoint(p4);
+      rotatePoint(p5);
+      rotatePoint(p6);
     }
 
     poly.addPoint(p1.x, p1.y);
@@ -696,6 +707,14 @@ public class HexGrid extends AbstractConfigurable
     poly.addPoint(p1.x, p1.y);
 
     return new Area(poly);
+  }
+
+  /**
+   * @see HexGrid#getSingleHexShape(int, int, boolean, boolean, double, double)
+   */
+  protected Area getSingleHexShape(int centerX, int centerY, boolean reversed) {
+
+    return getSingleHexShape(centerX, centerY, reversed, sideways, dx, dy);
   }
 
   // Calculate the Raw Column number (independent of any grid numbering).
@@ -756,19 +775,85 @@ public class HexGrid extends AbstractConfigurable
     return hexPoint(x, y).y;
   }
 
+  private Point hexPointCenterFromRawIndex(int nx, int ny) {
+
+    final int xLoc = ((int) (dx * nx + origin.x));
+    final int yLoc = nx % 2 == 0
+        ? (int) (dy * ny + origin.y)
+        : (int) (dy * ny + (int) (dy / 2) + origin.y);
+
+    return new Point(xLoc, yLoc);
+  }
+
+  private static final List<Point> hexPointRawIndexOffsets1 = List.of(
+          new Point(-1, -1),
+          new Point(-1, 0),
+          new Point(1, -1),
+          new Point(1, 0)
+  );
+
+  private static final List<Point> hexPointRawIndexOffsets2 = List.of(
+          new Point(-1, 0),
+          new Point(-1, 1),
+          new Point(1, 0),
+          new Point(1, 1)
+  );
+
+  // Assumes that the point has already been rotated by callers if sideways.
   private Point hexPoint(int x, int y) {
 
+    ////////////////////////////////////////////////////////////////////////////
+    // First find a candidate hex cell by treating hex cells as rectangles.   //
+    ////////////////////////////////////////////////////////////////////////////
+
     final int nx = (int) floor((x - origin.x + dx / 2) / dx);
+    final int ny = nx % 2 == 0
+        ? (int) floor((y - origin.y + dy / 2) / dy)
+        : (int) floor((y - origin.y) / dy);
 
-    int xLoc = ((int) (dx * nx + origin.x));
+    final Point firstCenter = hexPointCenterFromRawIndex(nx, ny);
+    // Start off with using the first candidate hex.
+    int xLoc = firstCenter.x;
+    int yLoc = firstCenter.y;
 
-    int yLoc;
-    if (nx % 2 == 0)
-      yLoc = ((int)
-              (dy * (int) floor((y - origin.y + dy / 2) / dy) + origin.y));
-    else
-      yLoc = ((int)
-              (dy * (int) floor((y - origin.y) / dy) + (int) (dy / 2) + origin.y));
+    ////////////////////////////////////////////////////////////////////////////
+    // Then check and find the precise hex cell by first checking the         //
+    // first candidate hex, and then checking the neighboring hexes.          //
+    ////////////////////////////////////////////////////////////////////////////
+
+    // Always pass 'false' for 'sideways', since the input point has already been rotated by callers of 'hexPoint'.
+    final Area firstHex = HexGrid.getSingleHexShape(xLoc, yLoc, false, false, dx, dy);
+
+    // In case the first candidate hex apparently does not contain the
+    // point (apart possibly from floating-point rounding issues).
+    if (!firstHex.contains(x, y)) {
+
+      // Try each of the other 4 potential hexes. If the point is contained there, use the center
+      // of that hex. If the point is found nowhere (possibly floating-point issue), just
+      // use the first candidate hex - presumably the point lies on the edge or corner of
+      // the originally found hex.
+
+      final var hexPointRawIndexOffsets = nx % 2 == 0
+              ? hexPointRawIndexOffsets1
+              : hexPointRawIndexOffsets2;
+
+      for (final var offset : hexPointRawIndexOffsets) {
+
+        final Point c = hexPointCenterFromRawIndex(nx + offset.x, ny + offset.y);
+        final Area candidateHex = HexGrid.getSingleHexShape(c.x, c.y, false, false, dx, dy);
+
+        if (candidateHex.contains(x, y)) {
+
+          xLoc = c.x;
+          yLoc = c.y;
+          break;
+        }
+      }
+    }
+
+    ////////////////////////////////////////////////////////////////////////////
+    // Then handle `snapeScale`.                                              //
+    ////////////////////////////////////////////////////////////////////////////
 
     if (snapScale > 0) {
       {
@@ -788,6 +873,10 @@ public class HexGrid extends AbstractConfigurable
         yLoc += delta;
       }
     }
+
+    ////////////////////////////////////////////////////////////////////////////
+    // Return result.                                                         //
+    ////////////////////////////////////////////////////////////////////////////
 
     return new Point(xLoc, yLoc);
   }

--- a/vassal-app/src/main/java/VASSAL/build/module/map/boardPicker/board/HexGrid.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/boardPicker/board/HexGrid.java
@@ -520,7 +520,7 @@ public class HexGrid extends AbstractConfigurable
   public Point snapToHex(Point p) {
     p = new Point(p);
     rotateIfSideways(p);
-    p.setLocation(hexX(p.x, p.y), hexY(p.x, p.y));
+    p.setLocation(hexPoint(p.x, p.y));
     rotateIfSideways(p);
     return p;
   }
@@ -534,11 +534,10 @@ public class HexGrid extends AbstractConfigurable
     int x = sideX(p.x, p.y);
     int y = sideY(p.x, p.y);
     if (snapScale > 0) {
-      final int hexX = hexX(p.x, p.y);
-      final int hexY = hexY(p.x, p.y);
-      if (abs(p.x - hexX) + abs(p.y - hexY) <= abs(p.x - x) + abs(p.y - y)) {
-        x = hexX;
-        y = hexY;
+      final Point hexPoint = hexPoint(p.x, p.y);
+      if (abs(p.x - hexPoint.x) + abs(p.y - hexPoint.y) <= abs(p.x - x) + abs(p.y - y)) {
+        x = hexPoint.x;
+        y = hexPoint.y;
       }
     }
     p.setLocation(x, y);
@@ -555,11 +554,10 @@ public class HexGrid extends AbstractConfigurable
     int x = vertexX(p.x, p.y);
     int y = vertexY(p.x, p.y);
     if (snapScale > 0) {
-      final int hexX = hexX(p.x, p.y);
-      final int hexY = hexY(p.x, p.y);
-      if (abs(p.x - hexX) + abs(p.y - hexY) <= abs(p.x - x) + abs(p.y - y)) {
-        x = hexX;
-        y = hexY;
+      final Point hexPoint = hexPoint(p.x, p.y);
+      if (abs(p.x - hexPoint.x) + abs(p.y - hexPoint.y) <= abs(p.x - x) + abs(p.y - y)) {
+        x = hexPoint.x;
+        y = hexPoint.y;
       }
     }
     p.setLocation(x, y);
@@ -748,37 +746,50 @@ public class HexGrid extends AbstractConfigurable
     return h1.distance(h2);
   }
 
+  @Deprecated(since = "2023-06-03", forRemoval = true)
   protected int hexX(int x, int y) {
-    int loc = ((int) (dx * (int) floor((x - origin.x + dx / 2) / dx) + origin.x));
-    if (snapScale > 0) {
-      int delta = x - loc;
-      delta = (int)round(delta / (0.5 * dx / snapScale));
-      delta = max(delta, 1 - snapScale);
-      delta = min(delta, snapScale - 1);
-      delta = (int)round(delta * 0.5 * dx / snapScale);
-      loc += delta;
-    }
-    return loc;
+    return hexPoint(x, y).x;
   }
 
+  @Deprecated(since = "2023-06-03", forRemoval = true)
   protected int hexY(int x, int y) {
+    return hexPoint(x, y).y;
+  }
+
+  private Point hexPoint(int x, int y) {
+
     final int nx = (int) floor((x - origin.x + dx / 2) / dx);
-    int loc;
+
+    int xLoc = ((int) (dx * nx + origin.x));
+
+    int yLoc;
     if (nx % 2 == 0)
-      loc = ((int)
-          (dy * (int) floor((y - origin.y + dy / 2) / dy) + origin.y));
+      yLoc = ((int)
+              (dy * (int) floor((y - origin.y + dy / 2) / dy) + origin.y));
     else
-      loc = ((int)
-          (dy * (int) floor((y - origin.y) / dy) + (int) (dy / 2) + origin.y));
+      yLoc = ((int)
+              (dy * (int) floor((y - origin.y) / dy) + (int) (dy / 2) + origin.y));
+
     if (snapScale > 0) {
-      int delta = y - loc;
-      delta = (int)round(delta / (0.5 * dy / snapScale));
-      delta = max(delta, 1 - snapScale);
-      delta = min(delta, snapScale - 1);
-      delta = (int)round(delta * 0.5 * dy / snapScale);
-      loc += delta;
+      {
+        int delta = x - xLoc;
+        delta = (int)round(delta / (0.5 * dx / snapScale));
+        delta = max(delta, 1 - snapScale);
+        delta = min(delta, snapScale - 1);
+        delta = (int)round(delta * 0.5 * dx / snapScale);
+        xLoc += delta;
+      }
+      {
+        int delta = y - yLoc;
+        delta = (int)round(delta / (0.5 * dy / snapScale));
+        delta = max(delta, 1 - snapScale);
+        delta = min(delta, snapScale - 1);
+        delta = (int)round(delta * 0.5 * dy / snapScale);
+        yLoc += delta;
+      }
     }
-    return loc;
+
+    return new Point(xLoc, yLoc);
   }
 
   protected int sideX(int x, int y) {

--- a/vassal-app/src/main/java/VASSAL/build/module/map/boardPicker/board/MapGrid.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/boardPicker/board/MapGrid.java
@@ -29,12 +29,24 @@ import java.awt.Rectangle;
  */
 public interface MapGrid {
   /**
-   * @return the nearest grid location to the given point
+   * @see MapGrid#snapTo(Point p, boolean force, boolean onlyCenter)
    */
   Point snapTo(Point p);
 
-  default Point snapTo(Point p, boolean force) {
+  /**
+   * @param onlyCenter If true, snaps only to the center, never to the edge or corner.
+   * @return The nearest grid location to the given point. This can for instance snap
+   * to center, edge or corner, depending on settings and arguments.
+   */
+  default Point snapTo(Point p, boolean force, boolean onlyCenter) {
     return snapTo(p);
+  }
+
+  /**
+   * @see MapGrid#snapTo(Point p, boolean force, boolean onlyCenter)
+   */
+  default Point snapTo(Point p, boolean force) {
+    return snapTo(p, force, false);
   }
 
   /**

--- a/vassal-app/src/main/java/VASSAL/build/module/map/boardPicker/board/RegionGrid.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/boardPicker/board/RegionGrid.java
@@ -339,7 +339,7 @@ public class RegionGrid extends AbstractConfigurable implements MapGrid, Configu
   // Locate nearest point
   //
   @Override
-  public Point snapTo(Point p, boolean force) {
+  public Point snapTo(Point p, boolean force, boolean onlyCenter) {
 
     //
     // Need at least one point to snap to and snapping needs to be pn.
@@ -352,8 +352,13 @@ public class RegionGrid extends AbstractConfigurable implements MapGrid, Configu
   }
 
   @Override
+  public Point snapTo(Point p, boolean force) {
+    return snapTo(p, force, false);
+  }
+
+  @Override
   public Point snapTo(Point p) {
-    return snapTo(p, false);
+    return snapTo(p, false, false);
   }
 
   @Override

--- a/vassal-app/src/main/java/VASSAL/build/module/map/boardPicker/board/SquareGrid.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/boardPicker/board/SquareGrid.java
@@ -416,7 +416,8 @@ public class SquareGrid extends AbstractConfigurable implements GeometricGrid, G
   }
 
   @Override
-  public Point snapTo(Point p, boolean force) {
+  public Point snapTo(Point p, boolean force, boolean onlyCenter) {
+
     if (!snapTo && !force) {
       return p;
     }
@@ -434,7 +435,7 @@ public class SquareGrid extends AbstractConfigurable implements GeometricGrid, G
     Point snap = null;
 
     if (!cornersLegal || !edgesLegal) {
-      if (cornersLegal) {
+      if (cornersLegal && !onlyCenter) {
         if (ny % 2 == 0) {  // on a cell center
           nx = 2 * (int) round(offsetX / dx);
         }
@@ -442,7 +443,7 @@ public class SquareGrid extends AbstractConfigurable implements GeometricGrid, G
           nx = 1 + 2 * (int) round(offsetX / dx - 0.5);
         }
       }
-      else if (edgesLegal) {
+      else if (edgesLegal && !onlyCenter) {
         if (ny % 2 == 0) {
           if (nx % 2 == 0) { // Cell center
             nx = 2 * (int) round(offsetX / dx);
@@ -479,8 +480,13 @@ public class SquareGrid extends AbstractConfigurable implements GeometricGrid, G
   }
 
   @Override
+  public Point snapTo(Point p, boolean force) {
+    return snapTo(p, force, false);
+  }
+
+  @Override
   public Point snapTo(Point p) {
-    return snapTo(p, false);
+    return snapTo(p, false, false);
   }
 
   @Override

--- a/vassal-app/src/main/java/VASSAL/build/module/map/boardPicker/board/ZonedGrid.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/boardPicker/board/ZonedGrid.java
@@ -336,21 +336,26 @@ public class ZonedGrid extends AbstractConfigurable implements GeometricGrid, Gr
   }
 
   @Override
-  public Point snapTo(Point p, boolean force) {
+  public Point snapTo(Point p, boolean force, boolean centerOnly) {
     Point snap = null;
     final Zone z = findZone(p);
     if (z != null) {
-      snap = z.snapTo(p, force);
+      snap = z.snapTo(p, force, centerOnly);
     }
     if (snap == null) {
-      snap = background != null ? background.snapTo(p, force) : p;
+      snap = background != null ? background.snapTo(p, force, centerOnly) : p;
     }
     return snap;
   }
 
   @Override
+  public Point snapTo(Point p, boolean force) {
+    return snapTo(p, force, false);
+  }
+
+  @Override
   public Point snapTo(Point p) {
-    return snapTo(p, false);
+    return snapTo(p, false, false);
   }
 
   @Override

--- a/vassal-app/src/main/java/VASSAL/build/module/map/boardPicker/board/mapgrid/Zone.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/boardPicker/board/mapgrid/Zone.java
@@ -412,18 +412,28 @@ public class Zone extends AbstractConfigurable implements GridContainer, Mutable
   }
 
   /**
-   * Snap to the grid in this zone,
+   * @see MapGrid#snapTo
    */
-  public Point snapTo(Point p, boolean force) {
+  public Point snapTo(Point p, boolean force, boolean centerOnly) {
     Point snap = p;
     if (getGrid() != null) {
-      snap = getGrid().snapTo(p, force);
+      snap = getGrid().snapTo(p, force, centerOnly);
     }
     return snap;
   }
 
+  /**
+   * @see MapGrid#snapTo
+   */
+  public Point snapTo(Point p, boolean force) {
+    return snapTo(p, force, false);
+  }
+
+  /**
+   * @see MapGrid#snapTo
+   */
   public Point snapTo(Point p) {
-    return snapTo(p, false);
+    return snapTo(p, false, false);
   }
 
   @Override


### PR DESCRIPTION
I am not familiar with the Vassal codebase, so this might not be a good approach to fixing the issue, or it may have bugs in it. I have only tested the specific case with `HexGrid`, not the other types of grids, or other situations than the one described in #12070 .

In particular:
- Are the changes in `RegionGrid` correct?
- Are the changes in `SquareGrid` correct?