### PR TITLE
Avoid requiring Ghostscript when building without the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,7 +107,7 @@ $(TMPDIR) $(JDOCDIR):
 	mkdir -p $@
 
 $(LIBDIR)/Vengine.jar: version-set
-	$(MVN) deploy -DgitVersion=$(VERSION) $(SKIPS)
+	$(MVN) deploy -DgitVersion=$(VERSION) -Dasciidoctor.attributes=optimize $(SKIPS)
 	mv $(LIBDIR)/$(JARNAME).jar $@
 	mv $(LIBDIR)/vassal-agent-$(MAVEN_VERSION).jar $(LIBDIR)/vassal-agent.jar
 

--- a/vassal-doc/src/main/designerguide/designerguide.adoc
+++ b/vassal-doc/src/main/designerguide/designerguide.adoc
@@ -9,7 +9,6 @@
 // :compress: // needs ghostscript
 :front-cover-image: image:_images/image1.jpeg[image,width=784,height=1024]
 :media: screen
-:optimize:
 
 Version {project-version}, {docdate}
 

--- a/vassal-doc/src/main/userguide/userguide.adoc
+++ b/vassal-doc/src/main/userguide/userguide.adoc
@@ -10,7 +10,6 @@
 // :compress: // needs ghostscript
 :front-cover-image: image:image1.png[image,width=816,height=1054]
 :media: screen
-:optimize:
 
 Version {project-version}, {docdate}
 


### PR DESCRIPTION
Set the optimize attribute from outside the asciidoc files. This works around a problem that anyone trying to build on Windows will have with asciidoctor being unable to find Ghostscript.

https://forum.vassalengine.org/t/rghost-issue/11724/12