### PR TITLE
12363 - Initialise Global Option preferences that have no Tab name

### DIFF
--- a/vassal-app/src/main/java/VASSAL/preferences/BasicPreference.java
+++ b/vassal-app/src/main/java/VASSAL/preferences/BasicPreference.java
@@ -144,10 +144,9 @@ public abstract class BasicPreference extends AbstractConfigurable {
     final GameModule g = GameModule.getGameModule();
 
     property.addTo(g);
-
-    if (tabName != null && tabName.length() > 0) {
-      g.getPrefs().addOption(tabName, getPreferenceConfigurer());
-    }
+    // if a tab name is not specified, then pass null as tab name to addOption, which causes the preference to
+    // be created, but not placed on any tab.
+    g.getPrefs().addOption((tabName == null || tabName.isEmpty()) ? null : tabName, getPreferenceConfigurer());
 
   }
 


### PR DESCRIPTION
Currently, Global Option Preferences are ignored and their Global Property is never created if no Tab name is supplied. New behaviour is to create and initialise the Global property, but not include the Configurer on any tab.