### PR TITLE
12401 - Allow Ctrl-V to be entered as a Key Command

### DIFF
--- a/vassal-app/src/main/java/VASSAL/configure/NamedHotKeyConfigurer.java
+++ b/vassal-app/src/main/java/VASSAL/configure/NamedHotKeyConfigurer.java
@@ -201,6 +201,8 @@ public class NamedHotKeyConfigurer extends Configurer implements FocusListener {
       keyStroke.addKeyListener(new KeyStrokeAdapter());
       ((AbstractDocument) keyStroke.getDocument()).setDocumentFilter(new KeyStrokeFilter());
       keyStroke.addFocusListener(this);
+      // Turn off Swing-level paste in the keystroke field
+      keyStroke.setTransferHandler(null);
 
       keyName = getKeyName();
       keyName.setMaximumSize(new Dimension(keyName.getMaximumSize().width, keyName.getPreferredSize().height));


### PR DESCRIPTION
Issue introduced into 3.7 beta. Waiting for Mark to check it works OK on MacOS.