### PR TITLE
12403 - Extension Editing fixes: Cut & Paste now deletes cut element, Drag & Drop between folders in Extension are saved, stopped UnsupportedOperationException during search

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/module/DoActionButton.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/DoActionButton.java
@@ -759,7 +759,9 @@ public class DoActionButton extends AbstractToolbarItem
    */
   @Override
   public List<String> getFormattedStringList() {
-    return Arrays.asList(reportFormat.getFormat());
+    final List<String> l = new ArrayList<>();
+    l.add(reportFormat.getFormat());
+    return l;
   }
 
   /**

--- a/vassal-app/src/main/java/VASSAL/build/module/map/MassKeyCommand.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/MassKeyCommand.java
@@ -719,7 +719,10 @@ public class MassKeyCommand extends AbstractToolbarItem
    */
   @Override
   public List<String> getFormattedStringList() {
-    return List.of(reportFormat.getFormat());
+    final List<String> l = new ArrayList<>();
+    l.add(reportFormat.getFormat());
+    return l;
+
   }
 
   /**

--- a/vassal-app/src/main/java/VASSAL/configure/ConfigureTree.java
+++ b/vassal-app/src/main/java/VASSAL/configure/ConfigureTree.java
@@ -40,9 +40,7 @@ import VASSAL.build.module.map.DeckGlobalKeyCommand;
 import VASSAL.build.module.map.DrawPile;
 import VASSAL.build.module.map.MassKeyCommand;
 import VASSAL.build.module.map.SetupStack;
-import VASSAL.build.module.map.boardPicker.board.mapgrid.Zone;
 import VASSAL.build.module.properties.ChangePropertyButton;
-import VASSAL.build.module.properties.GlobalProperties;
 import VASSAL.build.module.properties.GlobalProperty;
 import VASSAL.build.module.properties.GlobalTranslatableMessage;
 import VASSAL.build.module.properties.ZoneProperty;
@@ -1313,14 +1311,9 @@ public class ConfigureTree extends JTree implements PropertyChangeListener, Mous
   }
 
   protected boolean insert(Configurable parent, Configurable child, int index) {
-    Configurable theChild = child;
-    // Convert subclasses of GlobalProperty to an actual GlobalProperty before inserting into the GlobalProperties container
-    if (parent.getClass() == GlobalProperties.class && child.getClass() == ZoneProperty.class) {
-      theChild = new GlobalProperty((GlobalProperty) child);
-    }
-    if (parent.getClass() == Zone.class && child.getClass() == GlobalProperty.class) {
-      theChild = new ZoneProperty((GlobalProperty) child);
-    }
+    // Check if the child needs to be converted to a compatible type for this parent
+    final Configurable theChild = convertChild(parent, child);
+
     final DefaultMutableTreeNode childNode = buildTreeNode(theChild);
     final DefaultMutableTreeNode parentNode = getTreeNode(parent);
     final Configurable[] oldContents = parent.getConfigureComponents();

--- a/vassal-app/src/main/java/VASSAL/configure/ConfigureTree.java
+++ b/vassal-app/src/main/java/VASSAL/configure/ConfigureTree.java
@@ -771,7 +771,7 @@ public class ConfigureTree extends JTree implements PropertyChangeListener, Mous
    * we can make them here.
    * @param target Item we just pasted
    */
-  private void postPasteFixups(final Configurable target) {
+  protected void postPasteFixups(final Configurable target) {
     // SetupStacks (and thus DrawPiles) pasted to a new map, but whose owning board setting doesnt exist for this map, are forced to "any"
     if (target instanceof SetupStack) {
       final SetupStack ss = (SetupStack)target;
@@ -2888,7 +2888,9 @@ public class ConfigureTree extends JTree implements PropertyChangeListener, Mous
           }
 
           if (remove(getParent(sourceNode), cutObj)) {
+            postRemoveProcessing(getParent(sourceNode), cutObj);
             insert(target, convertedCutObj, childIndex);
+            postInsertProcessing(target, convertedCutObj);
             postPasteFixups(convertedCutObj);
           }
         }
@@ -2907,12 +2909,14 @@ public class ConfigureTree extends JTree implements PropertyChangeListener, Mous
         if (clone != null) {
           clone.build(copyBase.getBuildElement(Builder.createNewDocument()));
           insert(target, clone, childIndex);
+          postInsertProcessing(target, clone);
           updateGpIds(clone);
         }
       }
 
       return true;
     }
+
 
     @Override
     public String toString() {
@@ -2951,4 +2955,15 @@ public class ConfigureTree extends JTree implements PropertyChangeListener, Mous
       }
     }
   }
+
+  // ExtensionTree to over-ride
+  protected void postInsertProcessing(Configurable parent, Configurable child) {
+    return;
+  }
+
+  // ExtensionTree to over-ride
+  protected void postRemoveProcessing(Configurable parent, Configurable child) {
+    return;
+  }
+
 }

--- a/vassal-app/src/main/java/VASSAL/configure/ConfigureTree.java
+++ b/vassal-app/src/main/java/VASSAL/configure/ConfigureTree.java
@@ -2958,12 +2958,12 @@ public class ConfigureTree extends JTree implements PropertyChangeListener, Mous
 
   // ExtensionTree to over-ride
   protected void postInsertProcessing(Configurable parent, Configurable child) {
-    return;
+
   }
 
   // ExtensionTree to over-ride
   protected void postRemoveProcessing(Configurable parent, Configurable child) {
-    return;
+
   }
 
 }

--- a/vassal-app/src/main/java/VASSAL/configure/ExtensionTree.java
+++ b/vassal-app/src/main/java/VASSAL/configure/ExtensionTree.java
@@ -420,7 +420,6 @@ public class ExtensionTree extends ConfigureTree {
     super.updateEditMenu();
     deleteAction.setEnabled(selected != null && isEditable(selected));
     cutAction.setEnabled(selected != null && isEditable(selected));
-//    cutAction.setEnabled(selected != null && isEditable(selected));
     propertiesAction.setEnabled(selected != null && isEditable(selected) && selected.getConfigurer() != null);
   }
 

--- a/vassal-app/src/main/java/VASSAL/configure/ExtensionTree.java
+++ b/vassal-app/src/main/java/VASSAL/configure/ExtensionTree.java
@@ -252,6 +252,17 @@ public class ExtensionTree extends ConfigureTree {
             final DefaultMutableTreeNode targetNode = getTreeNode(target);
             final Configurable cutTarget = (Configurable) cutData.getUserObject();
             if (remove(getParent(cutData), cutTarget)) {
+              // The cutTarget has been removed from the ConfigureTree, also delete it from the extension if it is the
+              // child of a non-editable Node (i.e. has been added to a module via the extension)
+              if (!isEditable(getParent(cutData))) {
+                for (final ExtensionElement el :
+                  extension.getComponentsOf(ExtensionElement.class)) {
+                  if (el.getExtension() == cutTarget) {
+                    extension.remove(el);
+                    break;
+                  }
+                }
+              }
               if (insert(target, cutTarget, targetNode.getChildCount())) {
                 extension.add(new ExtensionElement(cutTarget, getPath(targetNode)));
               }


### PR DESCRIPTION
Should also be back-ported to 3.6.20

1. Cut and Paste now deletes the cut element when Extension is saved.