### PR TITLE
Revert #12078 - Do not return a default value for ObscuredToOthers

### DIFF
--- a/vassal-app/src/main/java/VASSAL/counters/BasicPiece.java
+++ b/vassal-app/src/main/java/VASSAL/counters/BasicPiece.java
@@ -329,9 +329,6 @@ public class BasicPiece extends AbstractImageFinder implements TranslatablePiece
     else if (Properties.VISIBLE_STATE.equals(key)) {
       return "";
     }
-    else if (Properties.OBSCURED_TO_OTHERS.equals(key)) {
-      return false;
-    }
 
     // Check for a property in the scratch-pad properties
     Object prop = props == null ? null : props.get(key);


### PR DESCRIPTION
Not sure if you want to handle this a a PR, or just revert #12078, but it was in an earlier beta, so might be better to handle it this one.

Original fix has a reasonably high probability of cause module behaviour changes. The fix is fixing something that doesn't really need fixing, so I have added additional documentation to explain the situation (in another PR).