### PR TITLE
12495 - Mouse-over Stack Viewer 'Show move limited pieces' option no longer dependent on 'Show non-stacking' option.

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/module/map/CounterDetailViewer.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/CounterDetailViewer.java
@@ -2167,9 +2167,6 @@ public class CounterDetailViewer extends AbstractConfigurable implements Drawabl
     else if (EMPTY_HEX_REPORT_FORMAT.equals(name)) {
       return () -> showText && minimumDisplayablePieces == 0;
     }
-    else if (SHOW_MOVE_SELECTED.equals(name) || SHOW_NON_MOVABLE.equals(name)) {
-      return () -> showNoStack;
-    }
     else if (List.of(SHOW_TERRAIN_WIDTH, SHOW_TERRAIN_HEIGHT, SHOW_TERRAIN_ZOOM, SHOW_TERRAIN_SNAPPY).contains(name)) {
       return () -> !NEVER.equals(showTerrainBeneath);
     }


### PR DESCRIPTION
Prior to allowing Does Not Stack pieces to Stack, movement limitations in the Stack Viewer where dependent on the piece already being Non-stacking. When Stacking was added to Does Not Stack, the Stack View configurer was not updated to reflect the fact that the non-movement options should now be selectable independently from the non-stacking option.