### PR TITLE
12444 - Implement real Unique Piece Id property UniqueID that does not change during refresh. 

### DIFF
--- a/vassal-app/src/main/java/VASSAL/counters/BasicPiece.java
+++ b/vassal-app/src/main/java/VASSAL/counters/BasicPiece.java
@@ -946,7 +946,14 @@ public class BasicPiece extends AbstractImageFinder implements TranslatablePiece
     // Persistent Property values will always be String (for now).
     // Create the HashMap as lazily as possible, no point in creating it for pieces that never move
     if (persistentProps != null) {
+      // Maintain the value of UNIQUE_ID, as it will have been defaulted for legacy units when they are first
+      // created, prior to getting their state set (which does not specify a value for UNIQUE_ID).
+      // Post UniqueID units will just overwrite this default from the new state being set
+      final Object uniqueId = persistentProps.get(UNIQUE_ID);
       persistentProps.clear();
+      if (uniqueId != null) {
+        persistentProps.put(UNIQUE_ID, uniqueId);
+      }
     }
     final int propCount = st.nextInt(0);
     for (int i = 0; i < propCount; i++) {

--- a/vassal-app/src/main/java/VASSAL/counters/BasicPiece.java
+++ b/vassal-app/src/main/java/VASSAL/counters/BasicPiece.java
@@ -110,6 +110,8 @@ public class BasicPiece extends AbstractImageFinder implements TranslatablePiece
   public static final String PIECE_UID = "PieceUID"; // NON-NLS
   public static final String STACK_POS = "StackPos";
   public static final String STACK_SIZE = "StackSize";
+  public static final String UNIQUE_ID = "UniqueID";
+
 
   @Deprecated(since = "2022-08-08", forRemoval = true)
   public static Font POPUP_MENU_FONT = new Font(Font.DIALOG, Font.PLAIN, 11);
@@ -309,6 +311,9 @@ public class BasicPiece extends AbstractImageFinder implements TranslatablePiece
     }
     else if (PIECE_UID.equals(key)) {
       return getId();
+    }
+    else if (UNIQUE_ID.equals(key)) {
+      return (String) persistentProps.get(BasicPiece.UNIQUE_ID);
     }
     else if (STACK_POS.equals(key)) {
       final Stack parent = getParent();
@@ -987,6 +992,19 @@ public class BasicPiece extends AbstractImageFinder implements TranslatablePiece
   @Override
   public void setId(String id) {
     this.id = id;
+
+    // Piece's and hence Piece Id's are replaced during Refresh. Save the first Piece Id allocated in the
+    // persistent properties so it will be copied to the refreshed piece.
+    if (persistentProps == null) {
+      persistentProps = new HashMap<>();
+      persistentProps.put(UNIQUE_ID, id);
+    }
+    else {
+      if (persistentProps.get(UNIQUE_ID) == null) {
+        persistentProps.put(UNIQUE_ID, id);
+      }
+    }
+
   }
 
   /**
@@ -1231,6 +1249,7 @@ public class BasicPiece extends AbstractImageFinder implements TranslatablePiece
     l.add(Properties.SELECTED);
     l.add(STACK_POS);
     l.add(STACK_SIZE);
+    l.add(UNIQUE_ID);
     return l;
   }
 

--- a/vassal-app/src/main/java/VASSAL/counters/Clone.java
+++ b/vassal-app/src/main/java/VASSAL/counters/Clone.java
@@ -36,6 +36,7 @@ import java.awt.Component;
 import java.awt.Graphics;
 import java.awt.Rectangle;
 import java.awt.Shape;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
@@ -45,6 +46,8 @@ import java.util.Objects;
  */
 public class Clone extends Decorator implements TranslatablePiece {
   public static final String ID = "clone;"; // NON-NLS
+  public static final String CLONE_ID = "CloneID";
+
   protected KeyCommand[] command;
   protected String commandName;
   protected NamedKeyStroke key;
@@ -112,9 +115,23 @@ public class Clone extends Decorator implements TranslatablePiece {
       newPiece.setState(outer.getState());
       c = new AddPiece(newPiece);
 
-      // Set the UniqueID
+      // Set the UniqueID and CloneID
       if (newPiece instanceof PersistentPropertyContainer) {
+
+        // Set the UniqueId in the target piece to its current PieceUID
         c = c.append(((PersistentPropertyContainer) newPiece).setPersistentProperty(BasicPiece.UNIQUE_ID, newPiece.getProperty(BasicPiece.PIECE_UID)));
+
+        // Find the CloneID for this piece
+        String cloneId = (String) getProperty(CLONE_ID);
+        if (cloneId == null || cloneId.isEmpty()) {
+          // Never been cloned and not a clone, set a new CloneID
+          cloneId = (String) getProperty(BasicPiece.UNIQUE_ID);
+          c = c.append(((PersistentPropertyContainer) this).setPersistentProperty(CLONE_ID, cloneId));
+        }
+
+        // Set the CloneID into the target piece
+        c = c.append(((PersistentPropertyContainer) newPiece).setPersistentProperty(CLONE_ID, cloneId));
+
       }
 
       if (getMap() != null) {
@@ -200,6 +217,13 @@ public class Clone extends Decorator implements TranslatablePiece {
   @Override
   public PieceI18nData getI18nData() {
     return getI18nData(commandName, Resources.getString("Editor.Clone.clone_command_description"));
+  }
+
+  @Override
+  public List<String> getPropertyNames() {
+    final ArrayList<String> l = new ArrayList<>();
+    l.add(CLONE_ID);
+    return l;
   }
 
   @Override

--- a/vassal-app/src/main/java/VASSAL/counters/Clone.java
+++ b/vassal-app/src/main/java/VASSAL/counters/Clone.java
@@ -27,6 +27,7 @@ import VASSAL.configure.StringConfigurer;
 import VASSAL.i18n.PieceI18nData;
 import VASSAL.i18n.Resources;
 import VASSAL.i18n.TranslatablePiece;
+import VASSAL.property.PersistentPropertyContainer;
 import VASSAL.tools.NamedKeyStroke;
 import VASSAL.tools.SequenceEncoder;
 
@@ -110,6 +111,12 @@ public class Clone extends Decorator implements TranslatablePiece {
       GameModule.getGameModule().getGameState().addPiece(newPiece);
       newPiece.setState(outer.getState());
       c = new AddPiece(newPiece);
+
+      // Set the UniqueID
+      if (newPiece instanceof PersistentPropertyContainer) {
+        c = c.append(((PersistentPropertyContainer) newPiece).setPersistentProperty(BasicPiece.UNIQUE_ID, newPiece.getProperty(BasicPiece.PIECE_UID)));
+      }
+
       if (getMap() != null) {
         c.append(getMap().placeOrMerge(newPiece, outer.getPosition()));
         KeyBuffer.getBuffer().remove(outer);

--- a/vassal-app/src/main/java/VASSAL/counters/Decorator.java
+++ b/vassal-app/src/main/java/VASSAL/counters/Decorator.java
@@ -278,7 +278,7 @@ public abstract class Decorator extends AbstractImageFinder implements EditableP
   @Override
   public Command setPersistentProperty(Object key, Object val) {
     // Not all GamePieces have persistent properties (though piece almost certainly will).
-    if (innermost != null && innermost instanceof PersistentPropertyContainer) {
+    if (innermost instanceof PersistentPropertyContainer) {
       return ((PersistentPropertyContainer) innermost).setPersistentProperty(key, val);
     }
     else if (piece instanceof PersistentPropertyContainer) {

--- a/vassal-app/src/main/java/VASSAL/counters/Decorator.java
+++ b/vassal-app/src/main/java/VASSAL/counters/Decorator.java
@@ -278,7 +278,10 @@ public abstract class Decorator extends AbstractImageFinder implements EditableP
   @Override
   public Command setPersistentProperty(Object key, Object val) {
     // Not all GamePieces have persistent properties (though piece almost certainly will).
-    if (piece instanceof PersistentPropertyContainer) {
+    if (innermost != null && innermost instanceof PersistentPropertyContainer) {
+      return ((PersistentPropertyContainer) innermost).setPersistentProperty(key, val);
+    }
+    else if (piece instanceof PersistentPropertyContainer) {
       return ((PersistentPropertyContainer) piece).setPersistentProperty(key, val);
     }
     return null;
@@ -290,8 +293,8 @@ public abstract class Decorator extends AbstractImageFinder implements EditableP
    */
   @Override
   public Object getPersistentProperty(Object key) {
-    // Standard getProperty also returns persistent properties
-    return piece.getProperty(key);
+    // Standard getProperty also returns persistent properties.
+    return innermost == null ? piece.getProperty(key) : innermost.getProperty(key);
   }
 
   /** @return next piece "outward" (away from BasicPiece) in the trait list. This method is required

--- a/vassal-app/src/main/java/VASSAL/counters/PlaceMarker.java
+++ b/vassal-app/src/main/java/VASSAL/counters/PlaceMarker.java
@@ -90,7 +90,7 @@ import static VASSAL.counters.MatCargo.CURRENT_MAT_OFFSET_Y;
  */
 public class PlaceMarker extends Decorator implements TranslatablePiece, RecursionLimiter.Loopable {
   public static final String ID = "placemark;"; // NON-NLS
-  public static final String PARENT_ID = "parentID";
+  public static final String PARENT_ID = "ParentID";
 
   protected KeyCommand command;
   protected NamedKeyStroke key;

--- a/vassal-app/src/main/java/VASSAL/counters/PlaceMarker.java
+++ b/vassal-app/src/main/java/VASSAL/counters/PlaceMarker.java
@@ -71,6 +71,7 @@ import java.awt.event.ActionEvent;
 import java.awt.event.KeyEvent;
 import java.awt.geom.AffineTransform;
 import java.awt.geom.Point2D;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
@@ -89,6 +90,8 @@ import static VASSAL.counters.MatCargo.CURRENT_MAT_OFFSET_Y;
  */
 public class PlaceMarker extends Decorator implements TranslatablePiece, RecursionLimiter.Loopable {
   public static final String ID = "placemark;"; // NON-NLS
+  public static final String PARENT_ID = "parentID";
+
   protected KeyCommand command;
   protected NamedKeyStroke key;
   protected String markerSpec;
@@ -179,13 +182,19 @@ public class PlaceMarker extends Decorator implements TranslatablePiece, Recursi
   }
 
   protected Command placeMarker() {
+    return placeMarker(false);
+  }
+
+  protected Command placeMarker(boolean clearParentId) {
     final Map m = getMap();
     if (m == null) return null;
 
     final GamePiece marker = createMarker();
     if (marker == null) return null;
 
+
     Command c;
+
     final GamePiece outer = getOutermost(this);
     Point p = getPosition();
 
@@ -277,6 +286,11 @@ public class PlaceMarker extends Decorator implements TranslatablePiece, Recursi
     }
     else {
       c = m.placeAt(marker, p);
+    }
+
+    // Set Our ParentID into the markers parent UniqueID. May have been called by Replace, in which case we do not set a parent Id as the parent will be deleted
+    if (!clearParentId) {
+      c = c.append(((PersistentPropertyContainer) marker).setPersistentProperty(PARENT_ID, getProperty(BasicPiece.UNIQUE_ID)));
     }
 
     // Mat support
@@ -435,6 +449,13 @@ public class PlaceMarker extends Decorator implements TranslatablePiece, Recursi
   @Override
   public Shape getShape() {
     return piece.getShape();
+  }
+
+  @Override
+  public List<String> getPropertyNames() {
+    final ArrayList<String> l = new ArrayList<>();
+    l.add(PARENT_ID);
+    return l;
   }
 
   static boolean updateSemaphore = false;

--- a/vassal-app/src/main/java/VASSAL/counters/Replace.java
+++ b/vassal-app/src/main/java/VASSAL/counters/Replace.java
@@ -26,6 +26,8 @@ import VASSAL.i18n.PieceI18nData;
 import VASSAL.i18n.Resources;
 
 import javax.swing.KeyStroke;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * GamePiece trait that replaces a GamePiece with another one
@@ -52,7 +54,7 @@ public class Replace extends PlaceMarker {
 
   protected Command replacePiece() {
     Command c;
-    c = placeMarker();
+    c = placeMarker(true);
     if (c == null) {
       reportDataError(this, Resources.getString("Error.bad_replace"));
     }
@@ -207,6 +209,11 @@ public class Replace extends PlaceMarker {
         currentMarker = null;
       }
     }
+  }
+
+  @Override
+  public List<String> getPropertyNames() {
+    return new ArrayList<>();
   }
 
   @Override

--- a/vassal-app/src/main/java/VASSAL/script/ExpressionInterpreter.java
+++ b/vassal-app/src/main/java/VASSAL/script/ExpressionInterpreter.java
@@ -310,12 +310,19 @@ public class ExpressionInterpreter extends AbstractInterpreter implements Loopab
             setVar(var, Integer.parseInt(value));
           }
           catch (NumberFormatException ex1) {
-
+            // A very large integer (e.g. a PieceUID) will fail to convert to an Integer.
+            // Don't let it convert to a Float, store it as a String instead
             try {
-              setVar(var, Float.parseFloat(value));
-            }
-            catch (NumberFormatException ex2) {
+              NumberUtils.createBigInteger(value); // Will fail if non-integer
               setVar(var, value);
+            }
+            catch (NumberFormatException ex3) {
+              try {
+                setVar(var, Float.parseFloat(value));
+              }
+              catch (NumberFormatException ex2) {
+                setVar(var, value);
+              }
             }
           }
         }

--- a/vassal-doc/src/main/readme-referencemanual/ReferenceManual/BasicPiece.adoc
+++ b/vassal-doc/src/main/readme-referencemanual/ReferenceManual/BasicPiece.adoc
@@ -59,7 +59,8 @@ If the piece is in a <<ZonedGrid.adoc#top,Zone>> in a Multi-Zone Grid, then whet
 * _Selected_ contains _true_ when the piece has been selected with the mouse
 * _PieceId_ contains a string that uniquely defines the source of the piece.
 All pieces sourced from the same <<PieceWindow.adoc#top,Game Piece Palette>> slot will have the same PieceId string.
-* _PieceUID_ contains a string that uniquely defines a piece. No two pieces will ever have the same PieceUID string.
+* _PieceUID_ contains a string that uniquely defines a piece. No two pieces will ever have the same PieceUID string. PieceUID's are re-allocated when a game is refreshed and so cannot be guaranteed to link pieces long-term and should only be used for short-term comparisons.
+* _UniqueID_ contains a string that uniquely defines a piece. No two pieces will ever have the same UniqueID string. UniqueID's *ARE* maintained across a Game Refresh and can be used for long-term comparisons between pieces.
 * _DrawingMouseover_ contains _true_ when a <<MouseOver.adoc#top, Mouseover Stack Viewer>> is currently being drawn, and contains _false_ otherwise.
 * _DrawingMouseoverIndex_ contains 2 when a <<MouseOver.adoc#top, Mouseover Stack Viewer>> is currently being drawn, and contains 1 otherwise. This can be used, e.g., in the _Follows Expression_ field of a <<Layer.adoc#top, Layer trait>> to draw a different image for the Mouseover than is normally used when drawing the piece on the map.
 

--- a/vassal-doc/src/main/readme-referencemanual/ReferenceManual/Clone.adoc
+++ b/vassal-doc/src/main/readme-referencemanual/ReferenceManual/Clone.adoc
@@ -11,6 +11,16 @@ The Clone trait provides the capability for a piece to be duplicated by players 
 
 When this trait's Key Command or menu item is activated, an exact copy of the piece is placed in the game at the same location.
 
+The piece that initiates the first Clone, and all subsequent pieces Cloned from Clones, have a unique value (the value of the <<Properties.adoc#uniqueId,UniqueID>> property from initially Cloning piece) stored into the property *CloneID* that uniquely identifies that set of clones.
+
+This allows any of the Clones to use the <<GlobalKeyCommand.adoc#top, Global Key Command>> trait or the <<SetPieceProperty.adoc#top,Set Piece Property>> trait to communicate with the other Clones by including the following in the _Additional matching expression_: +
+
+`{CloneID=="$CloneID$"}` +
+
+If you need to know which of the Clones was the initial piece that was cloned, it will have a value for the *CloneID* property that is equal to its own *UniqueID* property.
+
+NOTE: If you pull a new version of a piece that has been Cloned from a Piece Palette, it will NOT have a value for *CloneID* and if you then Clone it, the value of *CloneID* for it and the clone will be different to any earlier Clonings of the earlier version of the piece.
+
 [width="100%",cols="50%a,50%a",]
 |===
 |

--- a/vassal-doc/src/main/readme-referencemanual/ReferenceManual/Concepts.adoc
+++ b/vassal-doc/src/main/readme-referencemanual/ReferenceManual/Concepts.adoc
@@ -252,9 +252,9 @@ Vassal provides the following properties available on Game Pieces to assist with
 |  *Property* | *Description* +
 
 | PieceId | The *PieceId* property uniquely defines the definition that created this piece. All pieces created from the same definition (Piece Definition in a <<PieceWindow.adoc#top,Game Piece Palette>>, <<SetupStack.adoc#top,At-Start Stack>> or <<Deck.adoc#top,Deck>>, or a Piece Definition in a <<Marker.adoc#top,Place Marker>> or <<Replace.adoc#top,Replace>> trait) will have the same PieceId value.
-| PieceUID | The *PieceUID* property uniquely defines a piece. Each piece in a particular game is guaranteed to have a unique PieceUID and this is carried forward in Save games *UNTIL* the next time the game is manually refreshed by the <<GameRefresher.adoc#top, Game Refresher>>, when a new *PieceUID* will be allocated. It will nearly always be better to use the *UniqueId* property rather than *PieceUID*.
-| UniqueId | The *UniqueId* property uniquely defines a piece. Each piece in a particular game is guaranteed to have a unique UniqueId and this is carried forward in Save games *AND* is maintained when a Game is refreshed via the <<GameRefresher.adoc#top, Game Refresher>>. The *UniqueId* of a piece takes and keeps the value of the *PieceUID* that is first assigned to the piece.
-| ParentId | The *ParentId* only exists in pieces that have been created with the <<Replace.adoc#top,Replace>> trait and contains the *UniqueId* of the Game Piece that created piece.
+| PieceUID | The *PieceUID* property uniquely defines a piece. Each piece in a particular game is guaranteed to have a unique PieceUID and this is carried forward in Save games *UNTIL* the next time the game is manually refreshed by the <<GameRefresher.adoc#top, Game Refresher>>, when a new *PieceUID* will be allocated. It will nearly always be better to use the *UniqueID* property rather than *PieceUID*.
+| UniqueID | The *UniqueID* property uniquely defines a piece. Each piece in a particular game is guaranteed to have a unique UniqueID and this is carried forward in Save games *AND* is maintained when a Game is refreshed via the <<GameRefresher.adoc#top, Game Refresher>>. The *UniqueID* of a piece takes and keeps the value of the *PieceUID* that is first assigned to the piece.
+| ParentID | The *ParentID* only exists in pieces that have been created with the <<Replace.adoc#top,Replace>> trait and contains the *UniqueID* of the Game Piece that created piece.
 |===
 
 [#expressions]

--- a/vassal-doc/src/main/readme-referencemanual/ReferenceManual/Concepts.adoc
+++ b/vassal-doc/src/main/readme-referencemanual/ReferenceManual/Concepts.adoc
@@ -254,7 +254,11 @@ Vassal provides the following properties available on Game Pieces to assist with
 | PieceId | The *PieceId* property uniquely defines the definition that created this piece. All pieces created from the same definition (Piece Definition in a <<PieceWindow.adoc#top,Game Piece Palette>>, <<SetupStack.adoc#top,At-Start Stack>> or <<Deck.adoc#top,Deck>>, or a Piece Definition in a <<Marker.adoc#top,Place Marker>> or <<Replace.adoc#top,Replace>> trait) will have the same PieceId value.
 | PieceUID | The *PieceUID* property uniquely defines a piece. Each piece in a particular game is guaranteed to have a unique PieceUID and this is carried forward in Save games *UNTIL* the next time the game is manually refreshed by the <<GameRefresher.adoc#top, Game Refresher>>, when a new *PieceUID* will be allocated. It will nearly always be better to use the *UniqueID* property rather than *PieceUID*.
 | UniqueID | The *UniqueID* property uniquely defines a piece. Each piece in a particular game is guaranteed to have a unique UniqueID and this is carried forward in Save games *AND* is maintained when a Game is refreshed via the <<GameRefresher.adoc#top, Game Refresher>>. The *UniqueID* of a piece takes and keeps the value of the *PieceUID* that is first assigned to the piece.
-| ParentID | The *ParentID* only exists in pieces that have been created with the <<Replace.adoc#top,Replace>> trait and contains the *UniqueID* of the Game Piece that created piece.
+| ParentID | The *ParentID* property only exists in pieces that have been created with the <<Replace.adoc#top,Replace>> trait and contains the *UniqueID* of the Game Piece that created piece.
+| CloneID | The *CloneID* only exists in pieces that have been duplicated with the <<Clone.adoc#top,Clone>> trait and contains the *UniqueID* of the Game Piece that initial piece that performed the first Clone (which also has *CloneID* set). +
+
+If a new version of a Cloned piece is pulled from a Piece Paletter and Cloned, it and the new clones will have a different *CloneID* from any earlier clones.
+
 |===
 
 [#expressions]

--- a/vassal-doc/src/main/readme-referencemanual/ReferenceManual/Concepts.adoc
+++ b/vassal-doc/src/main/readme-referencemanual/ReferenceManual/Concepts.adoc
@@ -24,6 +24,7 @@ A brief overwiew of some of the main concepts you need to know to get started cr
 ** <<#globalProperties, Global Properties>> +
 ** <<#pieceProperties, Piece Properties>> +
 ** <<#propertyVisibility,Property Visibility>> +
+** <<#Unique, Uniquely Identifying Pieces>> +
 * <<#expressions,Expressions>> +
 ** <<#oldStyle,Old-Style Expressions>> +
 ** <<#beanshell,BeanShell Expressions>> +
@@ -201,7 +202,7 @@ Global Properties can have their value changed by +
 === Piece Properties
 Piece Properties are user defined properties that exist within a specific Piece and can have their value changed by user actions during play.
 
-* A <<Marker.adoc#top,Marker>> defines a read-only Property that can't be changed.
+* A <<PropertyMarker.adoc#top,Marker>> defines a read-only Property that can't be changed.
 
 * A <<DynamicProperty.adoc#top,Dynamic Property>> defines a Property that can have its value updated.
 
@@ -237,7 +238,24 @@ Pieces can only 'see' the Zone level properties in their current Zone, the Map l
 
 These visibility rules can be over-ridden using the <<ExpressionProperty.adoc#top,GetProperty>> <<#beanshell,BeanShell>> functions.
 
+[#Unique]
+==== Uniquely Identifying Pieces
+In more advanced modules, there is a need to be able to identify particular pieces to perform automated operations on them.
 
+Module designers can classify groups of pieces using <<PropertyMarker.adoc#top,Markers>>, applied via <<UsePrototype.adoc#top,Prototypes>>. Pieces can also be identified by their <<Properties.adoc#BasicName,BasicName>> property, but this will not be unique if multiple pieces have been created from the same definition.
+
+Vassal provides the following properties available on Game Pieces to assist with identifying pieces in advanced modules:
+
+[width="100%"]
+[cols="20%a,80%a"]
+|===
+|  *Property* | *Description* +
+
+| PieceId | The *PieceId* property uniquely defines the definition that created this piece. All pieces created from the same definition (Piece Definition in a <<PieceWindow.adoc#top,Game Piece Palette>>, <<SetupStack.adoc#top,At-Start Stack>> or <<Deck.adoc#top,Deck>>, or a Piece Definition in a <<Marker.adoc#top,Place Marker>> or <<Replace.adoc#top,Replace>> trait) will have the same PieceId value.
+| PieceUID | The *PieceUID* property uniquely defines a piece. Each piece in a particular game is guaranteed to have a unique PieceUID and this is carried forward in Save games *UNTIL* the next time the game is manually refreshed by the <<GameRefresher.adoc#top, Game Refresher>>, when a new *PieceUID* will be allocated. It will nearly always be better to use the *UniqueId* property rather than *PieceUID*.
+| UniqueId | The *UniqueId* property uniquely defines a piece. Each piece in a particular game is guaranteed to have a unique UniqueId and this is carried forward in Save games *AND* is maintained when a Game is refreshed via the <<GameRefresher.adoc#top, Game Refresher>>. The *UniqueId* of a piece takes and keeps the value of the *PieceUID* that is first assigned to the piece.
+| ParentId | The *ParentId* only exists in pieces that have been created with the <<Replace.adoc#top,Replace>> trait and contains the *UniqueId* of the Game Piece that created piece.
+|===
 
 [#expressions]
 == Expressions

--- a/vassal-doc/src/main/readme-referencemanual/ReferenceManual/GamePiece.adoc
+++ b/vassal-doc/src/main/readme-referencemanual/ReferenceManual/GamePiece.adoc
@@ -5,6 +5,15 @@
 
 '''''
 
+* <<#GamePiece,Game Piece>> +
+* <<#TraitOrder,Trait Ordering and YOU>> +
+** <<#DrawOrder,Draw Order and Traits>> +
+** <<#OtherTraits,Traits That Control Other Traits>> +
+** <<#TraitOrderKeyCommands,Key Commands and Traits>> +
+* <<#Advanced,Advanced Trait Ordering>> +
+* <<#Traits,List of Piece Traits>> +
+
+[#GamePiece]
 === Game Piece
 
 A Game Piece, sometimes simply referred to as a piece, is any counter, marker, or card used in a game.
@@ -43,6 +52,7 @@ Perhaps the trait you expected to be hidden by the Mask trait you just added isn
 
 Well it turns out that the interactions between different traits within the same piece are substantially affected by the _order_ those traits appear in the Game Piece's trait list! This section will walk you through the relationships between traits, provide you with some basic "rules of thumb" for ordering your traits, and then end with a comprehensive trait ordering guide that should be a regular touchstone even when you've become a VASSAL master!
 
+[#DrawOrder]
 ==== Draw Order and Traits
 
 [cols=",",]
@@ -58,6 +68,7 @@ For example if the _Text Label_ trait were moved up to the position directly und
 |image:images/GamePieceDrawOrder.png[] +
 |===
 
+[#OtherTraits]
 ==== Traits That Control Other Traits
 
 [cols=",",]
@@ -96,6 +107,7 @@ This happens starting at the bottom of the list and proceeding up toward the <<B
 |image:images/GamePieceOrder.png[] +
 |===
 
+[#Advanced]
 === Advanced Trait Ordering
 
 [cols="a,a",]

--- a/vassal-doc/src/main/readme-referencemanual/ReferenceManual/Marker.adoc
+++ b/vassal-doc/src/main/readme-referencemanual/ReferenceManual/Marker.adoc
@@ -11,8 +11,8 @@ A Game Piece with this trait will have a menu command that places a different pi
 You can select any existing piece for the marker or define a new one from scratch.
 A new piece will be placed each time this trait is activated.
 
-The new piece placed by this trait will have the <<Properties.adoc#parentId,ParentId>> property set to the value of the <<Properties.adoc#uniqueId,UniqueId>> property from the piece that placed it. This allows the placed marker to use the <<GlobalKeyCommand.adoc#top, Global Key Command>> trait or the <<SetPieceProperty.adoc#top,Set Piece Property>> trait to communicate with the parent piece by including the following in the _Additional matching expression_:
-`{UniqueId=="$ParentId$"}` +
+The new piece placed by this trait will have the <<Properties.adoc#parentId,ParentID>> property set to the value of the <<Properties.adoc#uniqueId,UniqueID>> property from the piece that placed it. This allows the placed marker to use the <<GlobalKeyCommand.adoc#top, Global Key Command>> trait or the <<SetPieceProperty.adoc#top,Set Piece Property>> trait to communicate with the parent piece by including the following in the _Additional matching expression_:
+`{UniqueID=="$ParentID$"}` +
 
 
 

--- a/vassal-doc/src/main/readme-referencemanual/ReferenceManual/Marker.adoc
+++ b/vassal-doc/src/main/readme-referencemanual/ReferenceManual/Marker.adoc
@@ -11,7 +11,8 @@ A Game Piece with this trait will have a menu command that places a different pi
 You can select any existing piece for the marker or define a new one from scratch.
 A new piece will be placed each time this trait is activated.
 
-The new piece placed by this trait will have the <<Properties.adoc#parentId,ParentID>> property set to the value of the <<Properties.adoc#uniqueId,UniqueID>> property from the piece that placed it. This allows the placed marker to use the <<GlobalKeyCommand.adoc#top, Global Key Command>> trait or the <<SetPieceProperty.adoc#top,Set Piece Property>> trait to communicate with the parent piece by including the following in the _Additional matching expression_:
+The new piece placed by this trait will have the <<Properties.adoc#parentId,ParentID>> property set to the value of the <<Properties.adoc#uniqueId,UniqueID>> property from the piece that placed it. This allows the placed marker to use the <<GlobalKeyCommand.adoc#top, Global Key Command>> trait or the <<SetPieceProperty.adoc#top,Set Piece Property>> trait to communicate with the parent piece by including the following in the _Additional matching expression_: +
+
 `{UniqueID=="$ParentID$"}` +
 
 

--- a/vassal-doc/src/main/readme-referencemanual/ReferenceManual/Marker.adoc
+++ b/vassal-doc/src/main/readme-referencemanual/ReferenceManual/Marker.adoc
@@ -11,6 +11,11 @@ A Game Piece with this trait will have a menu command that places a different pi
 You can select any existing piece for the marker or define a new one from scratch.
 A new piece will be placed each time this trait is activated.
 
+The new piece placed by this trait will have the <<Properties.adoc#parentId,ParentId>> property set to the value of the <<Properties.adoc#uniqueId,UniqueId>> property from the piece that placed it. This allows the placed marker to use the <<GlobalKeyCommand.adoc#top, Global Key Command>> trait or the <<SetPieceProperty.adoc#top,Set Piece Property>> trait to communicate with the parent piece by including the following in the _Additional matching expression_:
+`{UniqueId=="$ParentId$"}` +
+
+
+
 NOTE:  This trait should not be confused with the <<PropertyMarker.adoc#top,Marker>> trait which allows a piece to be assigned a <<Properties.adoc#top,Property>> with a static constant value.
 
 *EXAMPLE:*  If a game uses a fortification counter to indicate fortified status of an army counter, this trait could be given to the army counter to place a fortification marker on the army with the right-click context menu or a keyboard shortcut, as an alternative to dragging the fortification counter from the Game Piece Palette.

--- a/vassal-doc/src/main/readme-referencemanual/ReferenceManual/Properties.adoc
+++ b/vassal-doc/src/main/readme-referencemanual/ReferenceManual/Properties.adoc
@@ -45,18 +45,24 @@ in cases like these as this will generate an error if the property does not have
 
 * The <<BasicPiece.adoc#top,Basic Piece>> defines properties related to a piece's name, location, side, and whether it's selected.
 
+* The <<DynamicProperty.adoc#top,Dynamic Property>> trait allows you to define your own changeable properties.
+
+* The <<Hideable.adoc#top,Invisible>> trait sets a property when the piece is invisible.
+
 * The <<Layer.adoc#Properties,Layer>> trait defines properties related to the state of that Layer.
+
+* The <<PropertyMarker.adoc#top,Marker>> trait allows you to define your own static properties.
+
+* The <<MarkMoved.adoc#top,Mark When Moved>> trait sets a property when a piece has moved.
+
+* The <<Mask.adoc#Properties,Mask>> trait sets a property when the piece is masked.
+
+* The <<PropertySheet.adoc#top,Property Sheet>> trait exposes a set of user-editable properties.
+
 * The <<Rotate.adoc#top,Rotate>> trait defines properties related to the current facing of the piece.
 
 * The <<Label.adoc#top,Text Label>> trait returns the value of the label as a property.
-* The <<PropertyMarker.adoc#top,Marker>> trait allows you to define your own static properties.
-* The <<DynamicProperty.adoc#top,Dynamic Property>> trait allows you to define your own changeable properties.
 
-* The <<MarkMoved.adoc#top,Mark When Moved>> trait sets a property when a piece has moved.
-* The <<Mask.adoc#Properties,Mask>> trait sets a property when the piece is masked.
-* The <<Hideable.adoc#top,Invisible>> trait sets a property when the piece is invisible.
-
-* The <<PropertySheet.adoc#top,Property Sheet>> trait exposes a set of user-editable properties.
 
 *Properties defined by other components*
 
@@ -74,7 +80,9 @@ in cases like these as this will generate an error if the property does not have
 |*Property* |*Trait* |*Description*
 
 |*AttachCount* |<<Attachment.adoc#top,Attachment>> |Returns the current Attachment count of the last defined _Attachment_ trait.
-|*BasicName* |<<BasicPiece.adoc#top,Basic Piece>> or <<BasicName.adoc#top,Basic Name>>|The basic name of the piece.
+|*BasicName* |
+[#BasicName]
+<<BasicPiece.adoc#top,Basic Piece>> or <<BasicName.adoc#top,Basic Name>>|The basic name of the piece.
 |*BoardOfCommand* |<<MultiLocationCommand.adoc#top,Multi-Location Command>> |Contains the Board Name of the last selected _Multi-Location_ Command.
 |*cannotMove* |<<NonStacking.adoc#top,Does not stack>> |"true" if this piece cannot move at all (note spelling).
 |*ClickedX* |<<BasicPiece#top,Basic Piece>>|Map X-coordinate where player last right-clicked on piece to bring up context menu (or 0 if never).
@@ -138,14 +146,20 @@ CurrentMatProp9* |<<Cargo#top,Cargo>>|If the piece is Cargo loaded on a Mat, the
 |*OldX* |<<BasicPiece#top,Basic Piece>>|X coordinate prior to most recent movement.
 |*OldY* |<<BasicPiece#top,Basic Piece>>|Y coordinate prior to most recent movement.
 |*OldZone* |<<BasicPiece#top,Basic Piece>>|Zone name prior to most recent movement.
+|*ParentId* |<<Marker#top,Place Marker>>|
+[#parentId]
+The <<#uniqueId,UniqueId>> of the piece that placed this piece using the Place Marker trait. Can be used to communicate back to the parent piece.
 |*PieceId* |<<BasicPiece#top,Basic Piece>>|A string that uniquely identifies the source of a piece (e.g. A Game Piece Palette entry, an At-Start Stack or Definition, or a Place Marker or Replace definition). All pieces created from the same source will have the same PieceId.
 |*PieceName* |<<BasicPiece#top,Basic Piece>>|Full piece name including both Basic Name and all additional strings provided by traits.
-|*PieceUID* |<<BasicPiece#top,Basic Piece>>|A string that uniquely identifies an individual piece. No two pieces will ever have the same PieceUID.
+|*PieceUID* |<<BasicPiece#top,Basic Piece>>|A string that uniquely identifies an individual piece. No two pieces will ever have the same PieceUID. A new PieceUID is allocated when a game is <<GameRefresher.adoc#top,Refreshed>>. See <<#uniqueId,UniqueId>> for a Uniquely identifying property that is guaranteed to never change.
 |*Restricted* |<<RestrictedAccess.adoc#top,Restricted Access>> |"true" if there are restrictions as to who can access this piece.
 |*RestrictedMovement* |<<RestrictedAccess.adoc#top,Restricted Access>> |"true" if non-owning players are resticted from moving the current piece.
 |*Selected* |<<BasicPiece#top,Basic Piece>>|"true" if the piece is currently selected.
 |*StackPos* |<<BasicPiece#top,Basic Piece>>|The position of the piece in its current Stack. Returns 1 if not stacked.
 |*StackSize* |<<BasicPiece#top,Basic Piece>>|Number of pieces in the Stack this piece is stacked in. Returns 1 if not stacked.
+|*UniqueId* |<<BasicPiece#top,Basic Piece>>|
+[#uniqueId]
+A string that uniquely identifies an individual piece and is guaranteed to never change, even if a game is refreshed.
 |*ZoneOfCommand* |<<MultiLocationCommand.adoc#top,Multi-Location Command>> |Contains the Zone Name of the last selected _Multi-Location_ Command.
 
 |===

--- a/vassal-doc/src/main/readme-referencemanual/ReferenceManual/Properties.adoc
+++ b/vassal-doc/src/main/readme-referencemanual/ReferenceManual/Properties.adoc
@@ -146,18 +146,18 @@ CurrentMatProp9* |<<Cargo#top,Cargo>>|If the piece is Cargo loaded on a Mat, the
 |*OldX* |<<BasicPiece#top,Basic Piece>>|X coordinate prior to most recent movement.
 |*OldY* |<<BasicPiece#top,Basic Piece>>|Y coordinate prior to most recent movement.
 |*OldZone* |<<BasicPiece#top,Basic Piece>>|Zone name prior to most recent movement.
-|*ParentId* |<<Marker#top,Place Marker>>|
+|*ParentID* |<<Marker#top,Place Marker>>|
 [#parentId]
-The <<#uniqueId,UniqueId>> of the piece that placed this piece using the Place Marker trait. Can be used to communicate back to the parent piece.
+The <<#uniqueId,UniqueID>> of the piece that placed this piece using the Place Marker trait. Can be used to communicate back to the parent piece.
 |*PieceId* |<<BasicPiece#top,Basic Piece>>|A string that uniquely identifies the source of a piece (e.g. A Game Piece Palette entry, an At-Start Stack or Definition, or a Place Marker or Replace definition). All pieces created from the same source will have the same PieceId.
 |*PieceName* |<<BasicPiece#top,Basic Piece>>|Full piece name including both Basic Name and all additional strings provided by traits.
-|*PieceUID* |<<BasicPiece#top,Basic Piece>>|A string that uniquely identifies an individual piece. No two pieces will ever have the same PieceUID. A new PieceUID is allocated when a game is <<GameRefresher.adoc#top,Refreshed>>. See <<#uniqueId,UniqueId>> for a Uniquely identifying property that is guaranteed to never change.
+|*PieceUID* |<<BasicPiece#top,Basic Piece>>|A string that uniquely identifies an individual piece. No two pieces will ever have the same PieceUID. A new PieceUID is allocated when a game is <<GameRefresher.adoc#top,Refreshed>>. See <<#uniqueId,UniqueID>> for a Uniquely identifying property that is guaranteed to never change.
 |*Restricted* |<<RestrictedAccess.adoc#top,Restricted Access>> |"true" if there are restrictions as to who can access this piece.
 |*RestrictedMovement* |<<RestrictedAccess.adoc#top,Restricted Access>> |"true" if non-owning players are resticted from moving the current piece.
 |*Selected* |<<BasicPiece#top,Basic Piece>>|"true" if the piece is currently selected.
 |*StackPos* |<<BasicPiece#top,Basic Piece>>|The position of the piece in its current Stack. Returns 1 if not stacked.
 |*StackSize* |<<BasicPiece#top,Basic Piece>>|Number of pieces in the Stack this piece is stacked in. Returns 1 if not stacked.
-|*UniqueId* |<<BasicPiece#top,Basic Piece>>|
+|*UniqueID* |<<BasicPiece#top,Basic Piece>>|
 [#uniqueId]
 A string that uniquely identifies an individual piece and is guaranteed to never change, even if a game is refreshed.
 |*ZoneOfCommand* |<<MultiLocationCommand.adoc#top,Multi-Location Command>> |Contains the Zone Name of the last selected _Multi-Location_ Command.

--- a/vassal-doc/src/main/readme-referencemanual/ReferenceManual/Properties.adoc
+++ b/vassal-doc/src/main/readme-referencemanual/ReferenceManual/Properties.adoc
@@ -45,6 +45,8 @@ in cases like these as this will generate an error if the property does not have
 
 * The <<BasicPiece.adoc#top,Basic Piece>> defines properties related to a piece's name, location, side, and whether it's selected.
 
+* The <<Clone.adoc#top,Clone>> trait sets a property in all pieces Cloned from the same piece that links them together.
+
 * The <<DynamicProperty.adoc#top,Dynamic Property>> trait allows you to define your own changeable properties.
 
 * The <<Hideable.adoc#top,Invisible>> trait sets a property when the piece is invisible.
@@ -56,6 +58,8 @@ in cases like these as this will generate an error if the property does not have
 * The <<MarkMoved.adoc#top,Mark When Moved>> trait sets a property when a piece has moved.
 
 * The <<Mask.adoc#Properties,Mask>> trait sets a property when the piece is masked.
+
+* The <<Marker.adoc#Properties,Place Marker>> trait sets a property in the created marker piece that links back to the piece that created it.
 
 * The <<PropertySheet.adoc#top,Property Sheet>> trait exposes a set of user-editable properties.
 
@@ -87,6 +91,7 @@ in cases like these as this will generate an error if the property does not have
 |*cannotMove* |<<NonStacking.adoc#top,Does not stack>> |"true" if this piece cannot move at all (note spelling).
 |*ClickedX* |<<BasicPiece#top,Basic Piece>>|Map X-coordinate where player last right-clicked on piece to bring up context menu (or 0 if never).
 |*ClickedY* |<<BasicPiece#top,Basic Piece>>|Map Y-coordinate where player last right-clicked on piece to bring up context menu (or 0 if never).
+|*CloneId* |<<Clone#top,Clone>>|All pieces Cloned from the same piece (including the original piece) will have the same unique value for CloneId.
 |*CurrentBoard* |<<BasicPiece#top,Basic Piece>>|Current Board name or "" if not on a map.
 |*CurrentMap* |<<BasicPiece#top,Basic Piece>>|Current Map name or "" if not on a map.
 |*CurrentMat* |<<Cargo#top,Cargo>>|If the piece is Cargo loaded on a Mat, then the name of the Mat, otherwise ""


### PR DESCRIPTION
Add ParentId property to placed markers.
Update all related documentation

My apologies for this extra one, but it is big issue for more advanced module designers and makes using place markers far, far easier without needing reams of traits to process communication back to the parent piece.