### PR TITLE
Extend by one pixel Boards with locations that round up, to prevent gaps

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/module/Map.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/Map.java
@@ -181,6 +181,7 @@ import java.awt.event.MouseMotionListener;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
 import java.awt.geom.AffineTransform;
+import java.awt.geom.Point2D;
 import java.beans.PropertyChangeListener;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -2376,7 +2377,7 @@ public class Map extends AbstractToolbarItem implements GameComponent, MouseList
     final double os_scale = g2d.getDeviceConfiguration().getDefaultTransform().getScaleX();
     final double dzoom = getZoom() * os_scale;
     for (final Board b : boards) {
-      b.drawRegion(g, getLocation(b, dzoom), visibleRect, dzoom, c);
+      b.drawRegion2D(g, getLocation2D(b, dzoom), visibleRect, dzoom, c);
     }
   }
 
@@ -2729,6 +2730,33 @@ public class Map extends AbstractToolbarItem implements GameComponent, MouseList
       dy += boardHeights[column][y];
     }
     p.translate((int) round(zoom * dx), (int) round(zoom * dy));
+    return p;
+  }
+
+  public Point2D getLocation2D(Board b, double zoom) {
+    final Point2D p;
+    if (zoom == 1.0) {
+      p = b.bounds().getLocation();
+    }
+    else {
+      final Point relPos = b.relativePosition();
+      p = getLocation2D(relPos.x, relPos.y, zoom);
+      p.setLocation(p.getX() + zoom * edgeBuffer.width, p.getY() + zoom * edgeBuffer.height);
+    }
+    return p;
+  }
+
+  protected Point2D getLocation2D(int column, int row, double zoom) {
+    final Point2D p = new Point2D.Double();
+    int dx = 0;
+    for (int x = 0; x < column; ++x) {
+      dx += boardWidths[x][row];
+    }
+    int dy = 0;
+    for (int y = 0; y < row; ++y) {
+      dy += boardHeights[column][y];
+    }
+    p.setLocation(p.getX() + zoom * dx, p.getY() + zoom * dy);
     return p;
   }
 

--- a/vassal-app/src/main/java/VASSAL/build/module/map/boardPicker/Board.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/boardPicker/Board.java
@@ -44,6 +44,7 @@ import VASSAL.tools.imageop.Op;
 import VASSAL.tools.imageop.Repainter;
 import VASSAL.tools.imageop.ScaleOp;
 import VASSAL.tools.imageop.SourceOp;
+import VASSAL.tools.imageop.SVGOp;
 
 import org.jdesktop.animation.timing.Animator;
 import org.jdesktop.animation.timing.TimingTargetAdapter;

--- a/vassal-app/src/main/java/VASSAL/build/module/map/boardPicker/Board.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/boardPicker/Board.java
@@ -38,6 +38,7 @@ import VASSAL.i18n.Resources;
 import VASSAL.tools.ErrorDialog;
 import VASSAL.tools.image.ImageIOException;
 import VASSAL.tools.image.ImageTileSource;
+import VASSAL.tools.imageop.FixedScaleOpBitmapImpl;
 import VASSAL.tools.imageop.ImageOp;
 import VASSAL.tools.imageop.Op;
 import VASSAL.tools.imageop.Repainter;
@@ -59,6 +60,7 @@ import java.awt.Graphics2D;
 import java.awt.Image;
 import java.awt.Point;
 import java.awt.Rectangle;
+import java.awt.geom.Point2D;
 import java.awt.image.BufferedImage;
 import java.io.File;
 import java.util.Arrays;
@@ -338,11 +340,25 @@ public class Board extends AbstractConfigurable implements GridContainer {
                          Rectangle visibleRect,
                          double zoom,
                          final Component obs) {
+    drawRegion2D(g, location, visibleRect, zoom, obs);
+  }
+
+  public void drawRegion2D(final Graphics g,
+                           final Point2D location,
+                           Rectangle visibleRect,
+                           double zoom,
+                           final Component obs) {
+
+    final int lx = (int) Math.floor(location.getX());
+    final int ly = (int) Math.floor(location.getY());
+
     zoom *= magnification;
-    final Rectangle bounds =
-      new Rectangle(location.x, location.y,
-                    Math.round(boundaries.width * (float) zoom),
-                    Math.round(boundaries.height * (float) zoom));
+    final Rectangle bounds = new Rectangle(
+      lx,
+      ly,
+      (int) Math.floor(location.getX() + boundaries.width * zoom) - lx,
+      (int) Math.floor(location.getY() + boundaries.height * zoom) - ly
+    );
 
     if (!visibleRect.intersects(bounds)) {
       return;
@@ -360,7 +376,12 @@ public class Board extends AbstractConfigurable implements GridContainer {
       }
       else {
         if (scaledImageOp == null || scaledImageOp.getScale() != zoom) {
-          scaledImageOp = Op.scale(boardImageOp, zoom);
+          if (boardImageOp instanceof SVGOp) {
+            scaledImageOp = Op.scale(boardImageOp, zoom);
+          }
+          else {
+            scaledImageOp = new FixedScaleOpBitmapImpl(boardImageOp, zoom, bounds.width, bounds.height);
+          }
         }
         op = reversed ? Op.rotate(scaledImageOp, 180) : scaledImageOp;
       }
@@ -373,8 +394,8 @@ public class Board extends AbstractConfigurable implements GridContainer {
       op = new GridOp(op, grid, zoom, reversed, g2d.getRenderingHints());
     }
 
-    final Rectangle r = new Rectangle(visibleRect.x - location.x,
-                                      visibleRect.y - location.y,
+    final Rectangle r = new Rectangle(visibleRect.x - lx,
+                                      visibleRect.y - ly,
                                       visibleRect.width,
                                       visibleRect.height);
     final int ow = op.getTileWidth();
@@ -383,12 +404,12 @@ public class Board extends AbstractConfigurable implements GridContainer {
     final Point[] tiles = op.getTileIndices(r);
     for (final Point tile : tiles) {
       // find tile position
-      final int tx = location.x + tile.x * ow;
-      final int ty = location.y + tile.y * oh;
+      final int tx = lx + tile.x * ow;
+      final int ty = ly + tile.y * oh;
 
       // find actual tile size
-      final int tw = Math.min(ow, location.x + bounds.width - tx);
-      final int th = Math.min(oh, location.y + bounds.height - ty);
+      final int tw = Math.min(ow, lx + bounds.width - tx);
+      final int th = Math.min(oh, ly + bounds.height - ty);
 
       // find position in component
       final int cx = (int)(tx / os_scale);

--- a/vassal-app/src/main/java/VASSAL/tools/imageop/FixedScaleOpBitmapImpl.java
+++ b/vassal-app/src/main/java/VASSAL/tools/imageop/FixedScaleOpBitmapImpl.java
@@ -1,0 +1,254 @@
+/*
+ * Copyright (c) 2007-2023 by Joel Uckelman
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License (LGPL) as published by the Free Software Foundation.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public
+ * License along with this library; if not, copies are available
+ * at http://www.opensource.org.
+ */
+
+package VASSAL.tools.imageop;
+
+import java.awt.Dimension;
+import java.awt.Rectangle;
+import java.awt.RenderingHints;
+import java.awt.image.BufferedImage;
+import java.awt.image.WritableRaster;
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+
+import VASSAL.tools.image.GeneralFilter;
+import VASSAL.tools.image.ImageUtils;
+
+/**
+ * An {@link ImageOp} which scales its source.
+ *
+ * @since 3.1.0
+ * @author Joel Uckelman
+ */
+public class FixedScaleOpBitmapImpl extends AbstractTiledOpImpl
+                                    implements ScaleOp {
+  protected final ImageOp sop;
+  protected final RenderingHints hints;
+  protected final double scale;
+  protected final int hash;
+
+  // FIXME: We try to always use the same hints object because hints is
+  // used in our equals() and RenderingHints.equals() is ridiculously slow
+  // if a full comparison is made. This way hints == defaultHints, usually,
+  // and so a quick equality comparison succeeds.
+  protected static final RenderingHints defaultHints =
+    ImageUtils.getDefaultHints();
+
+  /**
+   * Constructs an <code>ImageOp</code> which will scale
+   * the image produced by its source <code>ImageOp</code>.
+   *
+   * @param sop the source operation
+   * @param scale the scale factor
+   */
+  public FixedScaleOpBitmapImpl(ImageOp sop, double scale, int width, int height) {
+    this(sop, scale, width, height, defaultHints);
+  }
+
+  /**
+   * Constructs an <code>ImageOp</code> which will scale
+   * the image produced by its source <code>ImageOp</code>.
+   *
+   * @param sop the source operation
+   * @param scale the scale factor
+   * @param hints rendering hints
+   */
+  public FixedScaleOpBitmapImpl(ImageOp sop, double scale, int width, int height, RenderingHints hints) {
+    if (sop == null)
+      throw new IllegalArgumentException("Attempt to scale null image");
+    if (scale <= 0)
+      throw new IllegalArgumentException("Cannot scale image at " + scale);
+    if (width <= 0)
+      throw new IllegalArgumentException("Cannot scale image to width " + width);
+    if (height <= 0)
+      throw new IllegalArgumentException("Cannot scale image to height " + height);
+
+    this.sop = sop;
+    this.scale = scale;
+    size = new Dimension(width, height);
+    this.hints = hints;
+
+    hash = new HashCodeBuilder().append(sop)
+                                .append(scale)
+                                .append(size)
+                                .append(hints)
+                                .toHashCode();
+  }
+
+  @Override
+  protected void fixSize() { }
+
+  @Override
+  public List<VASSAL.tools.opcache.Op<?>> getSources() {
+    return Collections.<VASSAL.tools.opcache.Op<?>>singletonList(sop);
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * @throws Exception passed up from the source <code>ImageOp</code>.
+   */
+  @Override
+  public BufferedImage eval() throws Exception {
+    return ImageUtils.transform(sop.getImage(null), size.width, size.height, hints);
+  }
+
+  @Override
+  protected ImageOp createTileOp(int tileX, int tileY) {
+    return new TileOp(this, tileX, tileY);
+  }
+
+  private static class TileOp extends AbstractTileOpImpl {
+    private final ImageOp sop;
+    private final Rectangle dr;
+    private final int dx0, dy0, dw, dh;
+    @SuppressWarnings("unused")
+    private final RenderingHints hints;
+    private final int hash;
+
+    private static final GeneralFilter.Filter downFilter =
+      new GeneralFilter.Lanczos3Filter();
+    private static final GeneralFilter.Filter upFilter =
+      new GeneralFilter.MitchellFilter();
+
+    public TileOp(FixedScaleOpBitmapImpl rop, int tileX, int tileY) {
+      if (rop == null) throw new IllegalArgumentException();
+
+      if (tileX < 0 || tileX >= rop.getNumXTiles() ||
+          tileY < 0 || tileY >= rop.getNumYTiles())
+        throw new IndexOutOfBoundsException();
+
+      sop = rop.sop;
+      hints = rop.getHints();
+
+      dr = new Rectangle(rop.getSize());
+
+      dx0 = tileX * rop.getTileWidth();
+      dy0 = tileY * rop.getTileHeight();
+      dw = Math.min(rop.getTileWidth(), dr.width - dx0);
+      dh = Math.min(rop.getTileHeight(), dr.height - dy0);
+
+      size = new Dimension(dw, dh);
+
+      hash = new HashCodeBuilder().append(sop)
+                                  .append(dx0)
+                                  .append(dy0)
+                                  .append(dw)
+                                  .append(dh)
+                                  .append(dr)
+                                  .toHashCode();
+    }
+
+    @Override
+    public List<VASSAL.tools.opcache.Op<?>> getSources() {
+      return Collections.<VASSAL.tools.opcache.Op<?>>singletonList(sop);
+    }
+
+    @Override
+    public BufferedImage eval() throws Exception {
+      if (dw < 1 || dh < 1) return ImageUtils.NULL_IMAGE;
+
+      // ensure that src is a type which GeneralFilter can handle
+      final BufferedImage src = ImageUtils.coerceToIntType(sop.getImage(null));
+
+      final WritableRaster dstR = src.getColorModel()
+                                     .createCompatibleWritableRaster(dw, dh)
+                                     .createWritableTranslatedChild(dx0, dy0);
+      // zoom! zoom!
+      GeneralFilter.zoom(dstR, dr, src, dr.width < src.getWidth() ? downFilter : upFilter);
+
+      return ImageUtils.toCompatibleImage(new BufferedImage(
+        src.getColorModel(),
+        dstR.createWritableTranslatedChild(0, 0),
+        src.isAlphaPremultiplied(),
+        null
+      ));
+    }
+
+    @Override
+    protected void fixSize() { }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) return true;
+      if (o == null || o.getClass() != this.getClass()) return false;
+
+      final TileOp op = (TileOp) o;
+      return dx0 == op.dx0 &&
+        dy0 == op.dy0 &&
+        dw == op.dw &&
+        dh == op.dh &&
+        dr.equals(op.dr) &&
+        sop.equals(op.sop);
+    }
+
+    @Override
+    public int hashCode() {
+      return hash;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public String toString() {
+      return getClass().getName() +
+        "[sop=" + sop + //NON-NLS
+        ",dx0=" + dx0 + ",dy0=" + dy0 + ",dw=" + dw + ",dy=" + dh + "]"; //NON-NLS
+    }
+  }
+
+  @Override
+  public RenderingHints getHints() {
+    return hints;
+  }
+
+  /**
+   * Returns the scale factor.
+   *
+   * @return the scale factor, in the range <code>(0,Double.MAX_VALUE]</code>.
+   */
+  @Override
+  public double getScale() {
+    return scale;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || o.getClass() != this.getClass()) return false;
+
+    final FixedScaleOpBitmapImpl op = (FixedScaleOpBitmapImpl) o;
+    return size.equals(op.size) &&
+           sop.equals(op.sop) &&
+           hints.equals(op.hints);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public int hashCode() {
+    return hash;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public String toString() {
+    return getClass().getName() +
+      "[sop=" + sop + ",size=" + size + ",hints=" + hints + "]"; //NON-NLS
+  }
+}


### PR DESCRIPTION
Extend Boards by a pixel to account for location rounding.