### PR TITLE
Scenario Options - Allow Observers to Lock option tabs if no Sides taken

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/module/properties/ScenarioPropertiesOptionTab.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/properties/ScenarioPropertiesOptionTab.java
@@ -464,15 +464,19 @@ public class ScenarioPropertiesOptionTab extends AbstractConfigurable implements
       }
 
       // Observers can only lock if no player sides defined
-      final PlayerRoster r = gm.getPlayerRoster();
-      if (r == null) {
+      final PlayerRoster roster = gm.getPlayerRoster();
+      if (roster == null) {
         return true;
       }
 
       // Otherwise, player must have a side to be able to lock
+      // OR is an Observer and no player sides are currently taken
       // Note side=null means no player sides defined, so Ok to lock
       final String side = PlayerRoster.getMySide();
-      return side != null && !PlayerRoster.OBSERVER.equals(side);
+      if (side == null) {
+        return true;
+      }
+      return !PlayerRoster.OBSERVER.equals(side) || (roster.getAvailableSides().size() == roster.getSides().size());
     }
   }
 


### PR DESCRIPTION
Tweak to new beta option to allow Obververs to lock/unlock Scenario Options if no sides have been taken (assuming password matches). Allows Module Designer to manipulate these without having to take a side.