### PR TITLE
12549 Simplify Trait edit window title

### DIFF
--- a/vassal-app/src/main/java/VASSAL/counters/PieceDefiner.java
+++ b/vassal-app/src/main/java/VASSAL/counters/PieceDefiner.java
@@ -1169,12 +1169,12 @@ public class PieceDefiner extends JPanel {
     PieceEditor ed;
 
     private Ed(Frame owner, final EditablePiece p) {
-      super(owner, Resources.getString("Editor.PieceDefiner.properties", p.getDescription()), true);
+      super(owner, Resources.getString("Editor.PieceDefiner.properties", p.getBaseDescription()), true);
       initialize(p);
     }
 
     private Ed(Dialog owner, final EditablePiece p) {
-      super(owner, Resources.getString("Editor.PieceDefiner.properties", p.getDescription()), true);
+      super(owner, Resources.getString("Editor.PieceDefiner.properties", p.getBaseDescription()), true);
       initialize(p);
     }
 


### PR DESCRIPTION
Change Window title of trait editor window from getDescription() to getBaseDescription(). Full description is not needed when editing traits and looks untidy. Plus it seems window titles do not natively support HTML, so the Comment trait was display raw html in the title.