### PR TITLE
12556 Map Shaders on different maps can now have same name

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/module/Map.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/Map.java
@@ -90,6 +90,7 @@ import VASSAL.configure.MandatoryComponent;
 import VASSAL.configure.NamedHotKeyConfigurer;
 import VASSAL.configure.PlayerIdFormattedExpressionConfigurer;
 import VASSAL.configure.SingleChildInstance;
+import VASSAL.configure.UniquelyNamedChildren;
 import VASSAL.configure.VisibilityCondition;
 import VASSAL.counters.BasicPiece;
 import VASSAL.counters.ColoredBorder;
@@ -977,7 +978,8 @@ public class Map extends AbstractToolbarItem implements GameComponent, MouseList
       .append(new SingleChildInstance(this, GlobalProperties.class))
       .append(new SingleChildInstance(this, SelectionHighlighters.class))
       .append(new SingleChildInstance(this, LayeredPieceCollection.class))
-      .append(new SingleChildInstance(this, BoardPicker.class));
+      .append(new SingleChildInstance(this, BoardPicker.class))
+      .append(new UniquelyNamedChildren(this, MapShader.class));
 
     final DragGestureListener dgl = dge -> {
       if (dragGestureListener != null &&

--- a/vassal-app/src/main/java/VASSAL/build/module/map/MapShader.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/MapShader.java
@@ -95,6 +95,10 @@ public class MapShader extends AbstractToolbarItem implements GameComponent, Dra
 
   public static final String ADD_TO_MAP_TOOLBAR = "addToMapToolbar";
 
+  // No longer used but maintained in case class has been referenced in custom code
+  @Deprecated(since = "2023-08-13")
+  protected static final UniqueIdManager idMgr = new UniqueIdManager("MapShader"); //NON-NLS
+
   /** @deprecated use launch from the superclass */
   @Deprecated(since = "2021-04-03", forRemoval = true)
   protected LaunchButton launch;

--- a/vassal-app/src/main/java/VASSAL/build/module/map/MapShader.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/MapShader.java
@@ -95,8 +95,6 @@ public class MapShader extends AbstractToolbarItem implements GameComponent, Dra
 
   public static final String ADD_TO_MAP_TOOLBAR = "addToMapToolbar";
 
-  protected static final UniqueIdManager idMgr = new UniqueIdManager("MapShader"); //NON-NLS
-
   /** @deprecated use launch from the superclass */
   @Deprecated(since = "2021-04-03", forRemoval = true)
   protected LaunchButton launch;
@@ -901,7 +899,6 @@ public class MapShader extends AbstractToolbarItem implements GameComponent, Dra
     GameModule.getGameModule().getToolBar().remove(getLaunchButton());
     GameModule.getGameModule().getGameState().removeGameComponent(this);
     map.removeDrawComponent(this);
-    idMgr.remove(this);
   }
 
   @Override
@@ -929,9 +926,6 @@ public class MapShader extends AbstractToolbarItem implements GameComponent, Dra
 
     GameModule.getGameModule().getGameState().addGameComponent(this);
     map.addDrawComponent(this);
-
-    idMgr.add(this);
-    validator = idMgr;
 
     setAttributeTranslatable(NAME, false);
   }


### PR DESCRIPTION
The UniqueIdManager in MapShader is not need and not used. Replaced with a UniquelyNamedChildren validator on the Map instead.