### PR TITLE
Center of map view during zoom used incorrect coordinate space

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/module/Map.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/Map.java
@@ -3299,7 +3299,7 @@ public class Map extends AbstractToolbarItem implements GameComponent, MouseList
    */
   public void updateCenter() {
     if (!GameModule.getGameModule().isSuppressAutoCenterUpdate()) {
-      preferredCenter = getCenter();
+      preferredCenter = componentToMap(getCenter());
     }
   }
 


### PR DESCRIPTION
preferredCenter should be in map coordinates, not component coordinates