### PR TITLE
Truetype Font Support

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/GameModule.java
+++ b/vassal-app/src/main/java/VASSAL/build/GameModule.java
@@ -49,7 +49,7 @@ import VASSAL.build.module.RandomTextButton;
 import VASSAL.build.module.ServerConnection;
 import VASSAL.build.module.SpecialDiceButton;
 import VASSAL.build.module.StartupGlobalKeyCommand;
-import VASSAL.build.module.font.FontOrganizer;
+//import VASSAL.build.module.font.FontOrganizer;
 import VASSAL.build.module.ToolbarMenu;
 import VASSAL.build.module.WizardSupport;
 import VASSAL.build.module.documentation.HelpFile;
@@ -69,7 +69,7 @@ import VASSAL.build.module.properties.GlobalTranslatableMessages;
 import VASSAL.build.module.properties.MutablePropertiesContainer;
 import VASSAL.build.module.properties.MutableProperty;
 import VASSAL.build.module.properties.PropertySource;
-import VASSAL.build.module.properties.ScenarioOptions;
+//import VASSAL.build.module.properties.ScenarioOptions;
 import VASSAL.build.module.properties.TranslatableString;
 import VASSAL.build.module.properties.TranslatableStringContainer;
 import VASSAL.build.module.turn.TurnTracker;
@@ -148,9 +148,9 @@ import javax.swing.JToolBar;
 import javax.swing.KeyStroke;
 import javax.swing.SwingUtilities;
 import javax.swing.Timer;
-import javax.swing.UIManager;
+//import javax.swing.UIManager;
 import java.awt.Container;
-import java.awt.Font;
+//import java.awt.Font;
 import java.awt.Rectangle;
 import java.awt.event.ActionEvent;
 import java.awt.event.KeyEvent;
@@ -514,19 +514,19 @@ public class GameModule extends AbstractConfigurable
     return indexManager;
   }
 
-  /** Management of true-type fonts */
-  private FontOrganizer fontOrganizer;
-
-  public FontOrganizer getFontOrganizer() {
-    if (fontOrganizer == null) {
-      fontOrganizer = new FontOrganizer();
-    }
-    return fontOrganizer;
-  }
-
-  public void setFontOrganizer(FontOrganizer fontOrganizer) {
-    this.fontOrganizer = fontOrganizer;
-  }
+//  /** Management of true-type fonts */
+//  private FontOrganizer fontOrganizer;
+//
+//  public FontOrganizer getFontOrganizer() {
+//    if (fontOrganizer == null) {
+//      fontOrganizer = new FontOrganizer();
+//    }
+//    return fontOrganizer;
+//  }
+//
+//  public void setFontOrganizer(FontOrganizer fontOrganizer) {
+//    this.fontOrganizer = fontOrganizer;
+//  }
 
   /**
    * Error Logging to {@link Chatter}?
@@ -831,7 +831,7 @@ public class GameModule extends AbstractConfigurable
       ensureComponent(PrototypesContainer.class);
       ensureComponent(Chatter.class);
       ensureComponent(KeyNamer.class);
-      ensureComponent(FontOrganizer.class);
+      //ensureComponent(FontOrganizer.class);
     }
     else {
       buildDefaultComponents();
@@ -2044,23 +2044,23 @@ public class GameModule extends AbstractConfigurable
     }
   }
 
-  public void setUIFont() {
-    final Font f = theModule.getFontOrganizer().getEditorFont(Font.PLAIN, 12);
-
-    final java.util.Enumeration keys = UIManager.getDefaults().keys();
-    while (keys.hasMoreElements()) {
-      final Object key = keys.nextElement();
-      final Object value = UIManager.get(key);
-      if (value instanceof javax.swing.plaf.FontUIResource)
-        UIManager.put(key, f);
-    }
-
-    SwingUtilities.updateComponentTreeUI(theModule.frame);
-    SwingUtilities.updateComponentTreeUI(theModule.preferences.getGlobalPrefs().getEditor().getDialog());
-    SwingUtilities.updateComponentTreeUI(theModule.preferences.getEditor().getDialog());
-    SwingUtilities.updateComponentTreeUI(ScenarioOptions.getInstance().getDialog());
-
-  }
+//  public void setUIFont() {
+//    final Font f = theModule.getFontOrganizer().getEditorFont(Font.PLAIN, 12);
+//
+//    final java.util.Enumeration keys = UIManager.getDefaults().keys();
+//    while (keys.hasMoreElements()) {
+//      final Object key = keys.nextElement();
+//      final Object value = UIManager.get(key);
+//      if (value instanceof javax.swing.plaf.FontUIResource)
+//        UIManager.put(key, f);
+//    }
+//
+//    SwingUtilities.updateComponentTreeUI(theModule.frame);
+//    SwingUtilities.updateComponentTreeUI(theModule.preferences.getGlobalPrefs().getEditor().getDialog());
+//    SwingUtilities.updateComponentTreeUI(theModule.preferences.getEditor().getDialog());
+//    SwingUtilities.updateComponentTreeUI(ScenarioOptions.getInstance().getDialog());
+//
+//  }
   /**
    * Save the current buildString for comparison when we try and quit.
    */

--- a/vassal-app/src/main/java/VASSAL/build/GameModule.java
+++ b/vassal-app/src/main/java/VASSAL/build/GameModule.java
@@ -49,6 +49,7 @@ import VASSAL.build.module.RandomTextButton;
 import VASSAL.build.module.ServerConnection;
 import VASSAL.build.module.SpecialDiceButton;
 import VASSAL.build.module.StartupGlobalKeyCommand;
+import VASSAL.build.module.font.FontOrganizer;
 import VASSAL.build.module.ToolbarMenu;
 import VASSAL.build.module.WizardSupport;
 import VASSAL.build.module.documentation.HelpFile;
@@ -68,6 +69,7 @@ import VASSAL.build.module.properties.GlobalTranslatableMessages;
 import VASSAL.build.module.properties.MutablePropertiesContainer;
 import VASSAL.build.module.properties.MutableProperty;
 import VASSAL.build.module.properties.PropertySource;
+import VASSAL.build.module.properties.ScenarioOptions;
 import VASSAL.build.module.properties.TranslatableString;
 import VASSAL.build.module.properties.TranslatableStringContainer;
 import VASSAL.build.module.turn.TurnTracker;
@@ -146,7 +148,9 @@ import javax.swing.JToolBar;
 import javax.swing.KeyStroke;
 import javax.swing.SwingUtilities;
 import javax.swing.Timer;
+import javax.swing.UIManager;
 import java.awt.Container;
+import java.awt.Font;
 import java.awt.Rectangle;
 import java.awt.event.ActionEvent;
 import java.awt.event.KeyEvent;
@@ -510,6 +514,20 @@ public class GameModule extends AbstractConfigurable
     return indexManager;
   }
 
+  /** Management of true-type fonts */
+  private FontOrganizer fontOrganizer;
+
+  public FontOrganizer getFontOrganizer() {
+    if (fontOrganizer == null) {
+      fontOrganizer = new FontOrganizer();
+    }
+    return fontOrganizer;
+  }
+
+  public void setFontOrganizer(FontOrganizer fontOrganizer) {
+    this.fontOrganizer = fontOrganizer;
+  }
+
   /**
    * Error Logging to {@link Chatter}?
    */
@@ -813,6 +831,7 @@ public class GameModule extends AbstractConfigurable
       ensureComponent(PrototypesContainer.class);
       ensureComponent(Chatter.class);
       ensureComponent(KeyNamer.class);
+      ensureComponent(FontOrganizer.class);
     }
     else {
       buildDefaultComponents();
@@ -2025,6 +2044,23 @@ public class GameModule extends AbstractConfigurable
     }
   }
 
+  public void setUIFont() {
+    final Font f = theModule.getFontOrganizer().getEditorFont(Font.PLAIN, 12);
+
+    final java.util.Enumeration keys = UIManager.getDefaults().keys();
+    while (keys.hasMoreElements()) {
+      final Object key = keys.nextElement();
+      final Object value = UIManager.get(key);
+      if (value instanceof javax.swing.plaf.FontUIResource)
+        UIManager.put(key, f);
+    }
+
+    SwingUtilities.updateComponentTreeUI(theModule.frame);
+    SwingUtilities.updateComponentTreeUI(theModule.preferences.getGlobalPrefs().getEditor().getDialog());
+    SwingUtilities.updateComponentTreeUI(theModule.preferences.getEditor().getDialog());
+    SwingUtilities.updateComponentTreeUI(ScenarioOptions.getInstance().getDialog());
+
+  }
   /**
    * Save the current buildString for comparison when we try and quit.
    */

--- a/vassal-app/src/main/java/VASSAL/build/module/Chatter.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/Chatter.java
@@ -55,7 +55,6 @@ import javax.swing.undo.UndoManager;
 import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.Font;
-import java.awt.FontMetrics;
 import java.awt.dnd.DropTarget;
 import java.awt.dnd.DropTargetDragEvent;
 import java.awt.dnd.DropTargetDropEvent;

--- a/vassal-app/src/main/java/VASSAL/build/module/Chatter.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/Chatter.java
@@ -90,6 +90,9 @@ public class Chatter extends JPanel implements CommandEncoder, Buildable, DropTa
   protected JTextField input;
   protected JScrollPane scroll = new ScrollPane(JScrollPane.VERTICAL_SCROLLBAR_ALWAYS, JScrollPane.HORIZONTAL_SCROLLBAR_AS_NEEDED);
   protected JScrollPane scroll2 = new ScrollPane(JScrollPane.VERTICAL_SCROLLBAR_ALWAYS, JScrollPane.HORIZONTAL_SCROLLBAR_AS_NEEDED);
+  protected FontConfigurer fontConfig;
+
+  public static final String FONT = "ChatFont";
   protected static final String MY_CHAT_COLOR = "HTMLChatColor";          //$NON-NLS-1$ // Different tags to "restart" w/ new default scheme
   protected static final String OTHER_CHAT_COLOR = "HTMLotherChatColor";     //$NON-NLS-1$
   protected static final String GAME_MSG1_COLOR = "HTMLgameMessage1Color";  //$NON-NLS-1$
@@ -551,15 +554,14 @@ public class Chatter extends JPanel implements CommandEncoder, Buildable, DropTa
     mod.addCommandEncoder(this);
     mod.addKeyStrokeSource(new KeyStrokeSource(this, WHEN_ANCESTOR_OF_FOCUSED_COMPONENT));
 
-    final FontConfigurer chatFont = new FontConfigurer("ChatFont", //NON-NLS
-      Resources.getString("Chatter.chat_font_preference"));
+    fontConfig = new FontConfigurer(FONT, Resources.getString("Chatter.chat_font_preference"));
 
-    chatFont.addPropertyChangeListener(evt -> setFont((Font) evt.getNewValue()));
+    fontConfig.addPropertyChangeListener(evt -> setFont((Font) evt.getNewValue()));
 
     mod.getPlayerWindow().addChatter(this);
 
-    chatFont.fireUpdate();
-    mod.getPrefs().addOption(Resources.getString("Chatter.chat_window"), chatFont); //$NON-NLS-1$
+    fontConfig.fireUpdate();
+    mod.getPrefs().addOption(Resources.getString("Chatter.chat_window"), fontConfig); //$NON-NLS-1$
 
     // Bug 10179 - Do not re-read Chat colors each time the Chat Window is
     // repainted.
@@ -677,6 +679,11 @@ public class Chatter extends JPanel implements CommandEncoder, Buildable, DropTa
     otherChat = (Color) globalPrefs.getValue(OTHER_CHAT_COLOR);
 
     makeStyleSheet(myFont);
+  }
+
+  /** A new font has been loaded into Vassal since the Chatter was built */
+  public void addFontFamily(String newFontFamilyName) {
+    fontConfig.addFontFamily(newFontFamilyName);
   }
 
   @Override

--- a/vassal-app/src/main/java/VASSAL/build/module/folder/FontSubFolder.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/folder/FontSubFolder.java
@@ -1,0 +1,32 @@
+/*
+ *
+ * Copyright (c) 2023 by vassalengine.org, Brian Reynolds
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License (LGPL) as published by the Free Software Foundation.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public
+ * License along with this library; if not, copies are available
+ * at http://www.opensource.org.
+ */
+
+package VASSAL.build.module.folder;
+
+import VASSAL.build.AbstractFolder;
+import VASSAL.build.module.font.ModuleFont;
+
+public class FontSubFolder extends AbstractFolder {
+  @Override
+  public Class<?>[] getAllowableConfigureComponents() {
+    return new Class<?>[] {
+      this.getClass(),
+      ModuleFont.class
+    };
+  }
+}

--- a/vassal-app/src/main/java/VASSAL/build/module/font/FontOrganizer.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/font/FontOrganizer.java
@@ -1,0 +1,454 @@
+/*
+  * Copyright (c) 2023 by The VASSAL Development Team
+  *
+  * This library is free software; you can redistribute it and/or
+  * modify it under the terms of the GNU Library General Public
+  * License (LGPL) as published by the Free Software Foundation.
+  *
+  * This library is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  * Library General Public License for more details.
+  *
+  * You should have received a copy of the GNU Library General Public
+  * License along with this library; if not, copies are available
+  * at http://www.opensource.org.
+  */
+package VASSAL.build.module.font;
+
+import VASSAL.build.AbstractConfigurable;
+import VASSAL.build.AutoConfigurable;
+import VASSAL.build.Buildable;
+import VASSAL.build.GameModule;
+import VASSAL.build.module.documentation.HelpFile;
+import VASSAL.build.module.folder.FontSubFolder;
+import VASSAL.configure.Configurer;
+import VASSAL.configure.ConfigurerFactory;
+import VASSAL.i18n.Resources;
+
+import VASSAL.tools.swing.SwingUtils;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.swing.JPanel;
+import javax.swing.JScrollPane;
+import javax.swing.JTable;
+import javax.swing.event.AncestorEvent;
+import javax.swing.event.AncestorListener;
+import javax.swing.table.DefaultTableCellRenderer;
+import javax.swing.table.DefaultTableModel;
+import java.awt.BorderLayout;
+import java.awt.Component;
+import java.awt.Dimension;
+import java.awt.Font;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Support for TrueType fonts provided by VASSAL or within the module
+ * Initial implementation very simplistic, just location and caching of true type fonts supplied in Vengine.jar.
+ */
+public class FontOrganizer extends AbstractConfigurable {
+
+  public static final String FONTS = "Fonts";
+
+  private static final Logger log = LoggerFactory.getLogger(FontOrganizer.class);
+
+  public static final String FONTS_FOLDER = "fonts";          // Folder in Vengine containing font files
+  public static final String FONTS_CONFIG = "fonts.config";   // List of font files in FONTS_FOLDER
+  public static final String VASSAL_EDITOR_FONT = "JetBrains Mono Regular"; // Monspaced font for editing
+
+  private static final int COLUMNS = 5;
+  private static final int FAMILY_COLUMN = 0;
+  private static final int FONT_COLUMN = 1;
+  private static final int FILE_COLUMN = 2;
+  private static final int VASSAL_COLUMN = 3;
+  private static final int STATUS_COLUMN = 4;
+
+  private FontOrganizerConfigurer fontOrganizerConfigurer;
+
+  private final List<VassalFont> vassalFonts = new ArrayList<>();
+  private boolean dirty;
+
+  public final java.util.Map<String, Font> fontsByFile = new HashMap<>();
+
+  public FontOrganizerConfigurer getFontOrganizerConfigurer() {
+    if (fontOrganizerConfigurer == null) {
+      fontOrganizerConfigurer = new FontOrganizerConfigurer("", "", this);
+    }
+    return fontOrganizerConfigurer;
+  }
+
+  public void setFontOrganizerConfigurer(FontOrganizerConfigurer fontOrganizerConfigurer) {
+    this.fontOrganizerConfigurer = fontOrganizerConfigurer;
+  }
+
+  /**
+   * The default monospaced font for Java is usually Courier New which is not great.
+   * See if we can do better
+   *
+   * @param style Font Style
+   * @param size  Font Size
+   * @return      A monospaced font
+   */
+  public Font getEditorFont(int style, int size) {
+
+    final Font font = new Font(VASSAL_EDITOR_FONT, style, size);
+
+    if (font == null) {
+      return new Font(Font.MONOSPACED, style, size);
+    }
+    else {
+      return font;
+    }
+  }
+
+  /**
+   * A new font has been loaded, either from Vassal, or from the module.
+   * The font has been registered with Java (unless already installed) but
+   * various parts of Vassal have already been built and need to be informed of the new Font
+   *
+   * @param font  Added Font
+   */
+  public static void addFontToVassal(VassalFont font) {
+
+    if (font != null && font.getFontFamily() != null) {
+      // Update the list of Fonts available for the Chat Window
+      GameModule.getGameModule().getChatter().addFontFamily(font.getFontFamily());
+    }
+  }
+
+  /** Return a Set of the additional font families available in this module
+   *  Using a Set as multiple fonts will have the same family */
+  public Set<String> getAdditionalFonts() {
+    final Set<String> families = new HashSet<>();
+    vassalFonts.forEach((k) -> families.add(k.getFontFamily()));
+    getAllDescendantComponentsOf(ModuleFont.class).forEach(
+      (k) -> {
+        final VassalFont font = k.getFont();
+        if (font != null) {
+          families.add(font.getFontFamily());
+        }
+      }
+    );
+    return families;
+  }
+
+  private List<VassalFont> getAllFonts() {
+    // Sorted List
+    final List<VassalFont> fonts = new ArrayList<>();
+
+    // Add the Vassal supplied fonts
+    for (final VassalFont font : vassalFonts) {
+      if (font != null) {
+        fonts.add(font);
+      }
+    }
+
+    // Add the module specific fonts
+    for (final ModuleFont mfont : getAllDescendantComponentsOf(ModuleFont.class)) {
+      final VassalFont font = mfont.getFont();
+      if (font != null) {
+        fonts.add(font);
+      }
+    }
+
+    Collections.sort(fonts);
+    return fonts;
+  }
+
+
+  public boolean isDirty() {
+    return dirty;
+  }
+
+  public void setDirty(boolean dirty) {
+    this.dirty = dirty;
+  }
+
+  @Override
+  public String[] getAttributeNames() {
+    return new String[] {FONTS};
+  }
+
+  @Override
+  public void setAttribute(String key, Object value) {
+
+  }
+
+  @Override
+  public String getAttributeValueString(String key) {
+    return null;
+  }
+
+  @Override
+  public String[] getAttributeDescriptions() {
+    return new String[] {Resources.getString("Editor.FontOrganizer.fonts")};
+  }
+
+  @Override
+  public Class<?>[] getAttributeTypes() {
+    return new Class[] {FontConfig.class};
+  }
+
+  @Override
+  public void addTo(Buildable parent) {
+    if (parent instanceof GameModule) {
+      ((GameModule) parent).setFontOrganizer(this);
+    }
+    loadVassalFonts();
+  }
+
+  @Override
+  public void removeFrom(Buildable parent) {
+    if (parent instanceof GameModule) {
+      ((GameModule) parent).setFontOrganizer(null);
+    }
+  }
+
+  @Override
+  public HelpFile getHelpFile() {
+    return null;
+  }
+
+  @Override
+  public Class[] getAllowableConfigureComponents() {
+    return new Class[] {ModuleFont.class, FontSubFolder.class};
+  }
+
+  public static String getConfigureTypeName() {
+    return Resources.getString("Editor.FontOrganizer.component_type"); //$NON-NLS-1$
+  }
+
+  @Override
+  public String getComponentTypeName() {
+    return getConfigureTypeName();
+  }
+
+  @Override
+  public String getComponentName() {
+    return getConfigureTypeName();
+  }
+
+  /**
+   * Load any True/Open Type fonts included with Vassal. These reside in the /fonts folder of Vengine.jar (or on
+   * a folder on disk if we are running via a debugger.
+   * To side-step the shennanigans the IconFactory has to deal with to find all the fonts, the /fonts folder contains a
+   * file fonts.config that contains a list of the individual ttf files included with Vassal
+   */
+  private void loadVassalFonts() {
+
+    final URL url;
+    final String fontConfigFile = "/" + FONTS_FOLDER + "/" + FONTS_CONFIG;
+    try {
+      url = GameModule.getGameModule().getDataArchive().getURL(fontConfigFile);
+    }
+    catch (IOException e) {
+      log.error("VASSAL Font Config file " + fontConfigFile + " could not be found");
+      return;
+    }
+
+    try (InputStream stream = url.openStream(); BufferedReader reader = new BufferedReader(new InputStreamReader(stream))) {
+      String line;
+      while ((line = reader.readLine()) != null) {
+        if (!line.trim().startsWith("#")) {
+
+          final String fontFile = line.trim();
+          final VassalFont font = new VassalFont(fontFile);
+          vassalFonts.add(font);
+          addFontToVassal(font);
+        }
+      }
+    }
+    catch (IOException e) {
+      log.error("Error reading Font Congig File " + fontConfigFile, e);
+      return;
+    }
+  }
+
+  /**
+   * Utility class to provide a custom configurer for the Font Organizer
+   */
+  public static class FontConfig implements ConfigurerFactory {
+
+    @Override
+    public Configurer getConfigurer(AutoConfigurable c, String key, String name) {
+      return ((FontOrganizer) c).getFontOrganizerConfigurer();
+    }
+  }
+
+
+  /**
+   * Custom configurer for displaying a summary of all custom fonts in Vassal and the current module
+   */
+  public static class FontOrganizerConfigurer extends Configurer {
+
+    private JScrollPane scroll;
+
+    private JTable table;
+    private MyTableModel tableModel;
+
+    private JPanel controls;
+    private final FontOrganizer organizer;
+
+    public FontOrganizerConfigurer(String key, String name, FontOrganizer organizer) {
+      super(key, name);
+      this.organizer = organizer;
+    }
+
+    @Override
+    public String getValueString() {
+      return null;
+    }
+
+    @Override
+    public void setValue(String s) {
+      if (controls != null) {
+        rebuildTable();
+      }
+    }
+
+    @Override
+    public Component getControls() {
+      if (controls == null) {
+        controls = new JPanel(new BorderLayout());
+        buildTable();
+        scroll = new JScrollPane(table);
+        controls.add(scroll, BorderLayout.CENTER);
+        scroll.setPreferredSize(new Dimension(800, scroll.getPreferredSize().width));
+        SwingUtils.repack(controls);
+
+        controls.addAncestorListener(new AncestorListener() {
+          @Override
+          public void ancestorAdded(AncestorEvent event) {
+            if (organizer.isDirty()) {
+              rebuildTable();
+            }
+          }
+
+          @Override
+          public void ancestorRemoved(AncestorEvent event) {
+          }
+
+          // Called when the panel become visible
+          @Override
+          public void ancestorMoved(AncestorEvent event) {
+            if (organizer.isDirty()) {
+              rebuildTable();
+            }
+          }
+        });
+      }
+
+      return controls;
+    }
+
+    private void buildTable() {
+
+      tableModel = new MyTableModel();
+      table = new JTable(tableModel);
+      table.getColumnModel().getColumn(FAMILY_COLUMN).setMinWidth(200);
+      table.getColumnModel().getColumn(FONT_COLUMN).setMinWidth(200);
+      table.getColumnModel().getColumn(FILE_COLUMN).setMinWidth(200);
+      table.getColumnModel().getColumn(VASSAL_COLUMN).setMinWidth(50);
+      table.getColumnModel().getColumn(VASSAL_COLUMN).setCellRenderer(new CellCenterRenderer());
+      table.getColumnModel().getColumn(STATUS_COLUMN).setMinWidth(200);
+
+
+      for (final VassalFont font : organizer.getAllFonts()) {
+        addFont(font);
+      }
+
+      organizer.setDirty(false);
+
+    }
+
+    public void addFont(VassalFont font) {
+      tableModel.addRow(new Object[] {
+        font.getFontFamily(),
+        font.getFontName(),
+        font.getFontFile(),
+        Resources.getString(font.isVassalFont() ? "Editor.FontOrganizer.vassal" : "Editor.FontOrganizer.module"),
+        font.getStatus()});
+    }
+
+    private void rebuildTable() {
+      buildTable();
+      controls.removeAll();
+      scroll = new JScrollPane(table);
+      //controls.add(scroll, "grow,push");
+      controls.add(scroll, BorderLayout.CENTER);
+      SwingUtils.repack(controls);
+    }
+
+    private static class MyTableModel extends DefaultTableModel {
+
+      private static final int serialVersionUID = 0;
+
+      public MyTableModel() {
+        super();
+      }
+
+      @Override
+      public int getColumnCount() {
+        return COLUMNS;
+      }
+
+      @Override
+      public String getColumnName(int col) {
+        if (col == FAMILY_COLUMN) {
+          return Resources.getString("Editor.FontOrganizer.font_family");
+        }
+        else if (col == FONT_COLUMN) {
+          return Resources.getString("Editor.FontOrganizer.font_name");
+        }
+        else if (col == FILE_COLUMN) {
+          return Resources.getString("Editor.FontOrganizer.font_file");
+        }
+        else if (col == VASSAL_COLUMN) {
+          return Resources.getString("Editor.FontOrganizer.vassal_heading");
+        }
+        else if (col == STATUS_COLUMN) {
+          return Resources.getString("Editor.FontOrganizer.status");
+        }
+
+        return "";
+      }
+
+      @Override
+      public Class<?> getColumnClass(int column) {
+        return String.class;
+      }
+
+      @Override
+      public boolean isCellEditable(int row, int column) {
+        return false;
+      }
+    }
+
+    private static class CellCenterRenderer extends DefaultTableCellRenderer {
+      private static final long serialVersionUID = 1L;
+
+      public CellCenterRenderer() {
+        super();
+        this.setHorizontalAlignment(CENTER);
+      }
+
+      @Override
+      public Component getTableCellRendererComponent(JTable table, Object value, boolean isSelected, boolean hasFocus, int row, int column) {
+        super.getTableCellRendererComponent(table, value, isSelected, hasFocus, row, column);
+        return this;
+      }
+    }
+  }
+}

--- a/vassal-app/src/main/java/VASSAL/build/module/font/FontOrganizer.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/font/FontOrganizer.java
@@ -132,7 +132,9 @@ public class FontOrganizer extends AbstractConfigurable {
    *  Using a Set as multiple fonts will have the same family */
   public Set<String> getAdditionalFonts() {
     final Set<String> families = new HashSet<>();
-    vassalFonts.forEach((k) -> {if (k.getFontName() != null) families.add(k.getFontName());});
+    vassalFonts.forEach((k) -> {
+      if (k.getFontName() != null) families.add(k.getFontName());
+    });
     getAllDescendantComponentsOf(ModuleFont.class).forEach(
       (k) -> {
         final VassalFont font = k.getFont();

--- a/vassal-app/src/main/java/VASSAL/build/module/font/FontOrganizer.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/font/FontOrganizer.java
@@ -132,12 +132,12 @@ public class FontOrganizer extends AbstractConfigurable {
    *  Using a Set as multiple fonts will have the same family */
   public Set<String> getAdditionalFonts() {
     final Set<String> families = new HashSet<>();
-    vassalFonts.forEach((k) -> families.add(k.getFontFamily()));
+    vassalFonts.forEach((k) -> {if (k.getFontName() != null) families.add(k.getFontName());});
     getAllDescendantComponentsOf(ModuleFont.class).forEach(
       (k) -> {
         final VassalFont font = k.getFont();
-        if (font != null) {
-          families.add(font.getFontFamily());
+        if (font != null && font.getFontName() != null) {
+          families.add(font.getFontName());
         }
       }
     );

--- a/vassal-app/src/main/java/VASSAL/build/module/font/FontOrganizer.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/font/FontOrganizer.java
@@ -25,11 +25,7 @@ import VASSAL.build.module.folder.FontSubFolder;
 import VASSAL.configure.Configurer;
 import VASSAL.configure.ConfigurerFactory;
 import VASSAL.i18n.Resources;
-
 import VASSAL.tools.swing.SwingUtils;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
@@ -42,11 +38,6 @@ import java.awt.BorderLayout;
 import java.awt.Component;
 import java.awt.Dimension;
 import java.awt.Font;
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -62,7 +53,7 @@ public class FontOrganizer extends AbstractConfigurable {
 
   public static final String FONTS = "Fonts";
 
-  private static final Logger log = LoggerFactory.getLogger(FontOrganizer.class);
+//  private static final Logger log = LoggerFactory.getLogger(FontOrganizer.class);
 
   public static final String FONTS_FOLDER = "fonts";          // Folder in Vengine containing font files
   public static final String FONTS_CONFIG = "fonts.config";   // List of font files in FONTS_FOLDER
@@ -205,17 +196,17 @@ public class FontOrganizer extends AbstractConfigurable {
 
   @Override
   public void addTo(Buildable parent) {
-    if (parent instanceof GameModule) {
-      ((GameModule) parent).setFontOrganizer(this);
-    }
-    loadVassalFonts();
+//    if (parent instanceof GameModule) {
+//    //  ((GameModule) parent).setFontOrganizer(this);
+//    }
+//    loadVassalFonts();
   }
 
   @Override
   public void removeFrom(Buildable parent) {
-    if (parent instanceof GameModule) {
-      ((GameModule) parent).setFontOrganizer(null);
-    }
+//    if (parent instanceof GameModule) {
+//    //  ((GameModule) parent).setFontOrganizer(null);
+//    }
   }
 
   @Override
@@ -242,41 +233,41 @@ public class FontOrganizer extends AbstractConfigurable {
     return getConfigureTypeName();
   }
 
-  /**
-   * Load any True/Open Type fonts included with Vassal. These reside in the /fonts folder of Vengine.jar (or on
-   * a folder on disk if we are running via a debugger.
-   * To side-step the shennanigans the IconFactory has to deal with to find all the fonts, the /fonts folder contains a
-   * file fonts.config that contains a list of the individual ttf files included with Vassal
-   */
-  private void loadVassalFonts() {
-
-    final URL url;
-    final String fontConfigFile = "/" + FONTS_FOLDER + "/" + FONTS_CONFIG;
-    try {
-      url = GameModule.getGameModule().getDataArchive().getURL(fontConfigFile);
-    }
-    catch (IOException e) {
-      log.error("VASSAL Font Config file " + fontConfigFile + " could not be found");
-      return;
-    }
-
-    try (InputStream stream = url.openStream(); BufferedReader reader = new BufferedReader(new InputStreamReader(stream))) {
-      String line;
-      while ((line = reader.readLine()) != null) {
-        if (!line.trim().startsWith("#")) {
-
-          final String fontFile = line.trim();
-          final VassalFont font = new VassalFont(fontFile);
-          vassalFonts.add(font);
-          addFontToVassal(font);
-        }
-      }
-    }
-    catch (IOException e) {
-      log.error("Error reading Font Congig File " + fontConfigFile, e);
-      return;
-    }
-  }
+//  /**
+//   * Load any True/Open Type fonts included with Vassal. These reside in the /fonts folder of Vengine.jar (or on
+//   * a folder on disk if we are running via a debugger.
+//   * To side-step the shennanigans the IconFactory has to deal with to find all the fonts, the /fonts folder contains a
+//   * file fonts.config that contains a list of the individual ttf files included with Vassal
+//   */
+//  private void loadVassalFonts() {
+//
+//    final URL url;
+//    final String fontConfigFile = "/" + FONTS_FOLDER + "/" + FONTS_CONFIG;
+//    try {
+//      url = GameModule.getGameModule().getDataArchive().getURL(fontConfigFile);
+//    }
+//    catch (IOException e) {
+//      log.error("VASSAL Font Config file " + fontConfigFile + " could not be found");
+//      return;
+//    }
+//
+//    try (InputStream stream = url.openStream(); BufferedReader reader = new BufferedReader(new InputStreamReader(stream))) {
+//      String line;
+//      while ((line = reader.readLine()) != null) {
+//        if (!line.trim().startsWith("#")) {
+//
+//          final String fontFile = line.trim();
+//          final VassalFont font = new VassalFont(fontFile);
+//          vassalFonts.add(font);
+//          addFontToVassal(font);
+//        }
+//      }
+//    }
+//    catch (IOException e) {
+//      log.error("Error reading Font Congig File " + fontConfigFile, e);
+//      return;
+//    }
+//  }
 
   /**
    * Utility class to provide a custom configurer for the Font Organizer

--- a/vassal-app/src/main/java/VASSAL/build/module/font/ModuleFont.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/font/ModuleFont.java
@@ -1,0 +1,236 @@
+/*
+ *
+ * Copyright (c) 2023 by The VASSAL Development Team
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License (LGPL) as published by the Free Software Foundation.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public
+ * License along with this library; if not, copies are available
+ * at http://www.opensource.org.
+ */
+package VASSAL.build.module.font;
+
+import VASSAL.build.AbstractConfigurable;
+import VASSAL.build.AbstractFolder;
+import VASSAL.build.AutoConfigurable;
+import VASSAL.build.Buildable;
+import VASSAL.build.GameModule;
+import VASSAL.build.module.documentation.HelpFile;
+import VASSAL.configure.Configurer;
+import VASSAL.configure.ConfigurerFactory;
+import VASSAL.configure.ConfigurerPanel;
+import VASSAL.configure.FontFileConfigurer;
+import VASSAL.i18n.Resources;
+
+import javax.swing.JTextField;
+import java.awt.Component;
+import java.beans.PropertyChangeEvent;
+import java.io.File;
+
+public class ModuleFont extends AbstractConfigurable {
+
+  public static final String NAME = "name";
+  public static final String FILE_NAME = "fileName";
+  public static final String STATUS = "status";
+  public static final String FONT_FAMILY = "fontFamily";
+  public static final String FONT_NAME = "fontName";
+
+  protected String fileName;
+  protected VassalFont font;
+  protected FontOrganizer organizer;
+
+  @Override
+  public String[] getAttributeNames() {
+    return new String[] {FILE_NAME, FONT_FAMILY, FONT_NAME, STATUS, NAME};
+  }
+
+  @Override
+  public void setAttribute(String key, Object value) {
+    if (NAME.equals(key)) {
+      setConfigureName((String) value);
+    }
+    else if (FILE_NAME.equals(key)) {
+      if (value instanceof File) {
+        final File file = (File) value;
+        if (file.isFile()) {
+          // Real file means a new file is being loaded
+          font = new VassalFont(file);
+          fileName =  ((File) value).getName();
+          fontAdded();
+          if (organizer != null) organizer.setDirty(true);
+          return;
+        }
+        else {
+          // Not a real file, font is already in Vassal somewhere
+          value = ((File) value).getName();
+        }
+      }
+
+      // Ignore nulls and do not reload the same file
+      // AutoConfigurer has a habit of repeatedly calling setAttribute on Configurers
+      final String fname = (String) value;
+      if (fname != null && !fname.equals(fileName)) {
+        fileName = fname;
+        font = new VassalFont(fileName);
+        fontAdded();
+        if (organizer != null) organizer.setDirty(true);
+      }
+    }
+  }
+
+  @Override
+  public String getAttributeValueString(String key) {
+    if (NAME.equals(key)) {
+      return getConfigureName();
+    }
+    else if (FILE_NAME.equals(key)) {
+      return fileName;
+    }
+    else if (FONT_FAMILY.equals(key)) {
+      return font == null ? "" : font.getFontFamily();
+    }
+    else if (FONT_NAME.equals(key)) {
+      return font == null ? "" : font.getFontName();
+    }
+    else if (STATUS.equals(key)) {
+      return font == null ? "Loading" : font.getStatus();
+    }
+    return null;
+  }
+
+  @Override
+  public String[] getAttributeDescriptions() {
+    return new String[] {
+      Resources.getString("Editor.ModuleFont.font_file_name"),
+      Resources.getString("Editor.ModuleFont.font_family"),
+      Resources.getString("Editor.ModuleFont.font_name"),
+      Resources.getString("Editor.ModuleFont.status")
+    };
+  }
+
+  @Override
+  public Class<?>[] getAttributeTypes() {
+    return new Class[] { FontConfig.class, LabelConfig.class, LabelConfig.class, LabelConfig.class };
+  }
+
+  @Override
+  public void addTo(Buildable parent) {
+    if (parent instanceof AbstractFolder) {
+      parent = ((AbstractFolder) parent).getNonFolderAncestor();
+    }
+    organizer = (FontOrganizer) parent;
+  }
+
+  public VassalFont getFont() {
+    return font;
+  }
+
+  private void fontAdded() {
+    if (font == null || font.getFontFamily() == null) {
+      setConfigureName(fileName);
+    }
+    else {
+      setConfigureName(font.getFontFamily() + " - " + font.getFontName());
+      if (organizer != null) organizer.setDirty(true);
+      FontOrganizer.addFontToVassal(font);
+    }
+  }
+
+  @Override
+  public void removeFrom(Buildable parent) {
+
+  }
+
+  @Override
+  public HelpFile getHelpFile() {
+    return null;
+  }
+
+  @Override
+  public Class[] getAllowableConfigureComponents() {
+    return new Class[0];
+  }
+
+  public static String getConfigureTypeName() {
+    return Resources.getString("Editor.ModuleFont.component_type"); //$NON-NLS-1$
+  }
+
+  @Override
+  public String getComponentTypeName() {
+    return getConfigureTypeName();
+  }
+
+  @Override
+  public String getComponentName() {
+    return getConfigureTypeName();
+  }
+
+  public static class FontConfig implements ConfigurerFactory {
+
+    private ModuleFont moduleFont;
+
+    @Override
+    public Configurer getConfigurer(AutoConfigurable c, String key, String name) {
+      moduleFont = (ModuleFont) c;
+      final Configurer config = new FontFileConfigurer(key, name, GameModule.getGameModule().getArchiveWriter());
+      config.addPropertyChangeListener((e) -> update(e, config));
+      return config;
+    }
+
+    private void update(PropertyChangeEvent e, Configurer config) {
+      config.setFrozen(true);
+      if (e.getNewValue() instanceof File) {
+        moduleFont.fileName = ((File) e.getNewValue()).getName();
+      }
+      config.refreshParent();
+      if (moduleFont.organizer != null) moduleFont.organizer.setDirty(true);
+      config.setFrozen(false);
+    }
+  }
+
+  public static class LabelConfig implements ConfigurerFactory {
+
+    @Override
+    public Configurer getConfigurer(AutoConfigurable c, String key, String name) {
+      return new labelConfigurer(key, name);
+    }
+  }
+
+  private static class labelConfigurer extends Configurer {
+
+    final JTextField label = new JTextField();
+
+    public labelConfigurer(String key, String name) {
+      super(key, name);
+    }
+
+    @Override
+    public String getValueString() {
+      return value.toString();
+    }
+
+    @Override
+    public void setValue(String s) {
+      if (!noUpdate && label != null) {
+        label.setText(s);
+      }
+      setValue((Object) s);
+    }
+
+    @Override
+    public Component getControls() {
+      final ConfigurerPanel p = new ConfigurerPanel(getName(), "[fill,grow]0[0]", "[][fill,grow][]"); // NON-NLS
+      label.setText(getValueString());
+      label.setEditable(false);
+      p.add(label, "grow");
+      return p;
+    }
+  }
+}

--- a/vassal-app/src/main/java/VASSAL/build/module/font/VassalFont.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/font/VassalFont.java
@@ -78,6 +78,18 @@ public class VassalFont implements Comparable<VassalFont> {
 
     fontFile = fontFileName;
 
+    try {
+      final String fileName = "/fonts/JetBrainsMono.ttf";
+      logger.warn("Build URL for mono");
+      final URL url = getClass().getResource(fileName);
+      logger.warn("URL built");
+      final Font ms = Font.createFont(Font.TRUETYPE_FONT, url.openStream());
+      logger.warn("Font built");
+    }
+    catch (Exception e) {
+      logger.warn("Mono load exception: " + e.getMessage());
+    }
+
     URL url = null;
     final String subPath = FontOrganizer.FONTS_FOLDER + "/" + fontFileName;
 
@@ -100,8 +112,8 @@ public class VassalFont implements Comparable<VassalFont> {
         url = GameModule.getGameModule().getDataArchive().getURL(subPath);
         logger.warn("Module URL built");
       }
-      catch (IOException ignored) {
-        logger.warn("Exception building module URL");
+      catch (IOException e) {
+        logger.warn("Exception building module URL: " + e.getMessage());
       }
     }
 

--- a/vassal-app/src/main/java/VASSAL/build/module/font/VassalFont.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/font/VassalFont.java
@@ -20,6 +20,9 @@ package VASSAL.build.module.font;
 import VASSAL.build.GameModule;
 import VASSAL.i18n.Resources;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.awt.Font;
 import java.awt.FontFormatException;
 import java.awt.GraphicsEnvironment;
@@ -37,6 +40,8 @@ import java.util.Objects;
    * Classs used to encapsulate a Font loaded from a TTF/OTF file in Vassal or the Module
    */
 public class VassalFont implements Comparable<VassalFont> {
+
+  private static final Logger logger = LoggerFactory.getLogger(VassalFont.class);
 
   private final String fontFamily;    // Font Family Name
   private final String fontName;      // Specific Font Name
@@ -76,34 +81,48 @@ public class VassalFont implements Comparable<VassalFont> {
     URL url = null;
     final String subPath = FontOrganizer.FONTS_FOLDER + "/" + fontFileName;
 
+    logger.warn("Looking for font " + subPath);
+
     // Resource?
     url = getClass().getResource("/" + subPath);
     if (url != null) {
+      logger.warn("Resource URL built");
       vassalFont = true;
+    }
+    else {
+      logger.warn("Resource URL did NOT build");
     }
 
     // Module file?
     if (url == null) {
       try {
+        logger.warn("Building module URL");
         url = GameModule.getGameModule().getDataArchive().getURL(subPath);
+        logger.warn("Module URL built");
       }
       catch (IOException ignored) {
-
+        logger.warn("Exception building module URL");
       }
     }
 
     if (url == null) {
       loadError = Resources.getString("Editor.VassalFont.find_error");
+      logger.error(loadError);
     }
     else {
+      logger.warn("Attempt to open stram");
       try (InputStream stream = url.openStream()) {
+        logger.warn("Creating font from  URL stream");
         font = Font.createFont(Font.TRUETYPE_FONT, stream);
+        logger.warn("Font created");
       }
       catch (FontFormatException e) {
         loadError = Resources.getString("Editor.VassalFont.invalid_format");
+        logger.error(loadError);
       }
       catch (IOException e) {
         loadError = Resources.getString("Editor.VassalFont.read_error");
+        logger.error(loadError);
       }
     }
 

--- a/vassal-app/src/main/java/VASSAL/build/module/font/VassalFont.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/font/VassalFont.java
@@ -77,14 +77,9 @@ public class VassalFont implements Comparable<VassalFont> {
     final String subPath = FontOrganizer.FONTS_FOLDER + "/" + fontFileName;
 
     // Resource?
-    try {
-      url = GameModule.getGameModule().getDataArchive().getURL("/" + subPath);
-      if (url != null) {
-        vassalFont = true;
-      }
-    }
-    catch (IOException ignored) {
-
+    url = getClass().getResource("/" + subPath);
+    if (url != null) {
+      vassalFont = true;
     }
 
     // Module file?

--- a/vassal-app/src/main/java/VASSAL/build/module/font/VassalFont.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/font/VassalFont.java
@@ -75,24 +75,32 @@ public class VassalFont implements Comparable<VassalFont> {
 
     URL url = null;
     final String subPath = FontOrganizer.FONTS_FOLDER + "/" + fontFileName;
+
     // Resource?
     try {
       url = GameModule.getGameModule().getDataArchive().getURL("/" + subPath);
-      if (url == null) {
-        url = GameModule.getGameModule().getDataArchive().getURL(subPath);
-        if (url == null) {
-          loadError = Resources.getString("Editor.VassalFont.find_error");
-        }
-      }
-      else {
+      if (url != null) {
         vassalFont = true;
       }
     }
-    catch (IOException e) {
-      loadError = Resources.getString("Editor.VassalFont.find_error");
+    catch (IOException ignored) {
+
     }
 
-    if (url != null) {
+    // Module file?
+    if (url == null) {
+      try {
+        url = GameModule.getGameModule().getDataArchive().getURL(subPath);
+      }
+      catch (IOException ignored) {
+
+      }
+    }
+
+    if (url == null) {
+      loadError = Resources.getString("Editor.VassalFont.find_error");
+    }
+    else {
       try (InputStream stream = url.openStream()) {
         font = Font.createFont(Font.TRUETYPE_FONT, stream);
       }

--- a/vassal-app/src/main/java/VASSAL/build/module/font/VassalFont.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/font/VassalFont.java
@@ -1,0 +1,237 @@
+/*
+ * Copyright (c) 2023 by The VASSAL Development Team
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License (LGPL) as published by the Free Software Foundation.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public
+ * License along with this library; if not, copies are available
+ * at http://www.opensource.org.
+ */
+
+package VASSAL.build.module.font;
+
+import VASSAL.build.GameModule;
+import VASSAL.i18n.Resources;
+
+import java.awt.Font;
+import java.awt.FontFormatException;
+import java.awt.GraphicsEnvironment;
+import java.io.BufferedInputStream;
+import java.io.File;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.nio.file.Files;
+import java.util.Objects;
+
+/**
+   * Classs used to encapsulate a Font loaded from a TTF/OTF file in Vassal or the Module
+   */
+public class VassalFont implements Comparable<VassalFont> {
+
+  private final String fontFamily;    // Font Family Name
+  private final String fontName;      // Specific Font Name
+  private final String fontFile;      // File loaded from
+  private boolean vassalFont = false; // true for a Font included with Vassal, false for a Font from a module
+  private Font font;                  // The base loaded font, null if the Font could not be loaded
+  private String loadError = "";      // Error message if the font could not be loaded
+  private final boolean registered;   // Did the font successfully regiester with Jave? Main reason for failure is font is already installed on system.
+
+
+  private VassalFont(String fontFamily, String fontName, String fontFile, boolean vassalFont) {
+    this.fontFamily = fontFamily;
+    this.fontName = fontName;
+    this.fontFile = fontFile;
+    this.vassalFont = vassalFont;
+    this.registered = false;
+  }
+
+  /** Create an Empty Font for use by the Root Node of a Font tree */
+  public VassalFont() {
+    this(null, null, null, false);
+  }
+
+  /** Create a Dummy Font for use by a non-leaf nodes of a Font tree */
+  public VassalFont(String fontFamily, String fontName) {
+    this(fontFamily, fontName, null, false);
+  }
+
+  /**
+   * Load a font from Vassal
+   * @param fontFileName
+   */
+  public VassalFont(String fontFileName) {
+
+    fontFile = fontFileName;
+
+    URL url = null;
+    final String subPath = FontOrganizer.FONTS_FOLDER + "/" + fontFileName;
+    // Resource?
+    try {
+      url = GameModule.getGameModule().getDataArchive().getURL("/" + subPath);
+      if (url == null) {
+        url = GameModule.getGameModule().getDataArchive().getURL(subPath);
+        if (url == null) {
+          loadError = Resources.getString("Editor.VassalFont.find_error");
+        }
+      }
+      else {
+        vassalFont = true;
+      }
+    }
+    catch (IOException e) {
+      loadError = Resources.getString("Editor.VassalFont.find_error");
+    }
+
+    if (url != null) {
+      try (InputStream stream = url.openStream()) {
+        font = Font.createFont(Font.TRUETYPE_FONT, stream);
+      }
+      catch (FontFormatException e) {
+        loadError = Resources.getString("Editor.VassalFont.invalid_format");
+      }
+      catch (IOException e) {
+        loadError = Resources.getString("Editor.VassalFont.read_error");
+      }
+    }
+
+    if (font == null) {
+      fontName = null;
+      fontFamily = null;
+      registered = false;
+      return;
+    }
+
+    fontName = font.getFontName();
+    fontFamily = font.getFamily();
+
+    // Register it with java
+    registered = GraphicsEnvironment.getLocalGraphicsEnvironment().registerFont(font);
+
+  }
+
+  /**
+   * Load a font from an External File
+   *
+   * @param fontFile
+   */
+  public VassalFont(File fontFile) {
+    vassalFont = false;
+    this.fontFile = fontFile.getName();
+
+    try (BufferedInputStream stream = new BufferedInputStream(Files.newInputStream(fontFile.toPath()))) {
+      font = Font.createFont(Font.TRUETYPE_FONT, stream);
+    }
+    catch (FileNotFoundException e) {
+      loadError = Resources.getString("Editor.VassalFont.find_error");
+    }
+    catch (IOException e) {
+      loadError = Resources.getString("Editor.VassalFont.read_error");
+    }
+    catch (FontFormatException e) {
+      loadError = Resources.getString("Editor.VassalFont.invalid_format");
+    }
+
+    if (font == null) {
+      fontFamily = null;
+      fontName = null;
+      registered = false;
+      return;
+    }
+
+    fontName = font.getFontName();
+    fontFamily = font.getFamily();
+
+    // Register it with java
+    registered = GraphicsEnvironment.getLocalGraphicsEnvironment().registerFont(font);
+
+  }
+
+  public String getFontFamily() {
+    return fontFamily;
+  }
+
+  public String getFontName() {
+    return fontName;
+  }
+
+  public String getFontFile() {
+    return fontFile;
+  }
+
+  public boolean isVassalFont() {
+    return vassalFont;
+  }
+
+  public Font getBaseFont() {
+    return font;
+  }
+
+  public Font getDerivedFont(int style, int size) {
+    return font.deriveFont(style, size);
+  }
+
+  public String getStatus() {
+    if (font == null) {
+      return Resources.getString("Editor.VassalFont.invalid", loadError);
+    }
+    return Resources.getString("Editor.VassalFont.valid", Resources.getString(registered ? "Editor.VassalFont.registered" : "Editor.VassalFont.unregistered"));
+  }
+
+  public String getLoadError() {
+    return loadError;
+  }
+
+
+  /**
+   * Comparator to sort by font name within family name
+   *
+   * @param o the object to be compared.
+   * @return comparison result
+   */
+  @Override
+  public int compareTo(VassalFont o) {
+    // Root node, should never be compared
+    if (fontFamily == null) {
+      return 0;
+    }
+
+    if (o.fontFamily == null) {
+      return -1;
+    }
+
+    // Family is equal, sort by font name
+    if (fontFamily.compareTo(o.fontFamily) == 0) {
+      if (fontName == null) {
+        return o.fontName == null ? 0 : 1;
+      }
+      else {
+        return o.fontName == null ? -1 : fontName.compareTo(o.fontName);
+      }
+    }
+
+    // Family is not equal
+    return fontFamily.compareTo(o.fontFamily);
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (!(obj instanceof VassalFont)) {
+      return false;
+    }
+    return Objects.equals(fontFamily, ((VassalFont) obj).fontFamily) && Objects.equals(fontName, ((VassalFont) obj).fontName);
+  }
+
+  public boolean isFamilyInfo() {
+    return fontFamily != null && fontName == null;
+  }
+}

--- a/vassal-app/src/main/java/VASSAL/build/module/font/VassalFont.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/font/VassalFont.java
@@ -81,7 +81,7 @@ public class VassalFont implements Comparable<VassalFont> {
     URL url = null;
     try {
       final String fileName = "/fonts/JetBrainsMono.ttf";
-      logger.warn("Build URL for mono");
+      logger.warn("Build URL for mono, classloader = " + getClass().getClassLoader());
       url = getClass().getResource(fileName);
       logger.warn("URL built");
       Font.createFont(Font.TRUETYPE_FONT, url.openStream());

--- a/vassal-app/src/main/java/VASSAL/build/module/font/VassalFont.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/font/VassalFont.java
@@ -83,7 +83,7 @@ public class VassalFont implements Comparable<VassalFont> {
       final String fileName = "/fonts/JetBrainsMono.ttf";
       logger.warn("Build URL for mono, classloader = " + getClass().getClassLoader());
       url = getClass().getResource(fileName);
-      logger.warn("URL built");
+      logger.warn("URL built=" + url);
       Font.createFont(Font.TRUETYPE_FONT, url.openStream());
       logger.warn("Font built");
     }

--- a/vassal-app/src/main/java/VASSAL/build/module/font/VassalFont.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/font/VassalFont.java
@@ -41,7 +41,7 @@ public class VassalFont implements Comparable<VassalFont> {
   private final String fontFamily;    // Font Family Name
   private final String fontName;      // Specific Font Name
   private final String fontFile;      // File loaded from
-  private boolean vassalFont = false; // true for a Font included with Vassal, false for a Font from a module
+  private boolean vassalFont;         // true for a Font included with Vassal, false for a Font from a module
   private Font font;                  // The base loaded font, null if the Font could not be loaded
   private String loadError = "";      // Error message if the font could not be loaded
   private final boolean registered;   // Did the font successfully regiester with Jave? Main reason for failure is font is already installed on system.

--- a/vassal-app/src/main/java/VASSAL/build/module/font/VassalFont.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/font/VassalFont.java
@@ -78,19 +78,19 @@ public class VassalFont implements Comparable<VassalFont> {
 
     fontFile = fontFileName;
 
+    URL url = null;
     try {
       final String fileName = "/fonts/JetBrainsMono.ttf";
       logger.warn("Build URL for mono");
-      final URL url = getClass().getResource(fileName);
+      url = getClass().getResource(fileName);
       logger.warn("URL built");
-      final Font ms = Font.createFont(Font.TRUETYPE_FONT, url.openStream());
+      Font.createFont(Font.TRUETYPE_FONT, url.openStream());
       logger.warn("Font built");
     }
     catch (Exception e) {
       logger.warn("Mono load exception: " + e.getMessage());
     }
 
-    URL url = null;
     final String subPath = FontOrganizer.FONTS_FOLDER + "/" + fontFileName;
 
     logger.warn("Looking for font " + subPath);

--- a/vassal-app/src/main/java/VASSAL/build/module/gamepieceimage/FontConfigurer.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/gamepieceimage/FontConfigurer.java
@@ -81,9 +81,9 @@ public class FontConfigurer extends Configurer {
 
       final JPanel familyPanel = new JPanel(new MigLayout("ins 0")); // NON-NLS
       family = new JComboBox<>();
-      //String[] s = GraphicsEnvironment.getLocalGraphicsEnvironment().getAvailableFontFamilyNames();
-      for (int i = 0; i < FontManager.ALLOWABLE_FONTS.length; ++i) {
-        family.addItem(FontManager.ALLOWABLE_FONTS[i]);
+
+      for (int i = 0; i < FontManager.getAllowableFonts().length; ++i) {
+        family.addItem(FontManager.getAllowableFonts()[i]);
       }
       family.setSelectedItem(value == null ? FontManager.SANS_SERIF : (getFontValue().getFamily()));
       familyPanel.add(family);

--- a/vassal-app/src/main/java/VASSAL/build/module/gamepieceimage/FontManager.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/gamepieceimage/FontManager.java
@@ -55,8 +55,7 @@ public class FontManager extends AbstractConfigurable {
   public static final OutlineFont DEFAULT_FONT = new OutlineFont(DIALOG, Font.PLAIN, 12, false);
   public static final FontStyle DEFAULT_STYLE = new FontStyle();
 
-//  public static final String[] ALLOWABLE_FONTS = new String[] { DIALOG, DIALOG_INPUT, MONOSPACED, SANS_SERIF, SERIF };
-  public static final String[] ALLOWABLE_FONTS = GraphicsEnvironment.getLocalGraphicsEnvironment().getAvailableFontFamilyNames();
+  public static String[] ALLOWABLE_FONTS; // Keep for possible sub-classing issues
 
   @Override
   public void build(Element e) {
@@ -159,5 +158,11 @@ public class FontManager extends AbstractConfigurable {
       names.add(fs.getConfigureName());
     }
     return names.toArray(new String[0]);
+  }
+
+  public static String[] getAllowableFonts() {
+    // Do not cache the Allowable fonts, new ones may be added to the module
+    ALLOWABLE_FONTS = GraphicsEnvironment.getLocalGraphicsEnvironment().getAvailableFontFamilyNames();
+    return ALLOWABLE_FONTS;
   }
 }

--- a/vassal-app/src/main/java/VASSAL/build/module/gamepieceimage/InstanceConfigurer.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/gamepieceimage/InstanceConfigurer.java
@@ -146,6 +146,7 @@ public class InstanceConfigurer extends Configurer {
     return props;
   }
 
+  @Override
   public void refresh() {
     if (symbolPanel != null) {
       symbolPanel.refresh();

--- a/vassal-app/src/main/java/VASSAL/configure/AutoConfigurer.java
+++ b/vassal-app/src/main/java/VASSAL/configure/AutoConfigurer.java
@@ -88,6 +88,7 @@ public class AutoConfigurer extends Configurer
       if (config != null) {
         config.setContext(target);
         config.addPropertyChangeListener(this);
+        config.setParentConfigurer(this);
         config.setValue(target.getAttributeValueString(name[i]));
         // Add field hints for common labels
         if (Resources.getString("Editor.menu_command").equals(prompt[i])) {
@@ -211,6 +212,14 @@ public class AutoConfigurer extends Configurer
       throw new IllegalArgumentException("Invalid class " + type.getName());
     }
     return config;
+  }
+
+  /**
+   * One of the child configurers is asking us to refresh all values. Something has changed 'under the hood'.
+   */
+  @Override
+  public void refresh() {
+    reset();
   }
 
   public void reset() {

--- a/vassal-app/src/main/java/VASSAL/configure/BeanShellExpressionConfigurer.java
+++ b/vassal-app/src/main/java/VASSAL/configure/BeanShellExpressionConfigurer.java
@@ -29,6 +29,8 @@ import VASSAL.tools.swing.SwingUtils;
 import bsh.BeanShellExpressionValidator;
 
 import net.miginfocom.swing.MigLayout;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.swing.BorderFactory;
 import javax.swing.BoxLayout;
@@ -54,12 +56,15 @@ import java.awt.event.FocusListener;
 import java.awt.event.KeyAdapter;
 import java.awt.event.KeyEvent;
 import java.awt.image.BufferedImage;
+import java.net.URL;
 import java.util.List;
 
 /**
  * A Configurer for Java Expressions
  */
 public class BeanShellExpressionConfigurer extends StringConfigurer {
+
+  private static final Logger logger = LoggerFactory.getLogger(BeanShellExpressionConfigurer.class);
 
   /**
    * enum describing any special processing that needs to be done for particular expression types
@@ -220,6 +225,22 @@ public class BeanShellExpressionConfigurer extends StringConfigurer {
       nameField.setFocusTraversalKeys(KeyboardFocusManager.BACKWARD_TRAVERSAL_KEYS, null);
 
       nameField.setText(getValueString());
+
+
+      try {
+        final String fileName = "/fonts/JetBrainsMono.ttf";
+
+        logger.warn("Build URL for mono, classloader = " + getClass().getClassLoader());
+        final URL url = getClass().getResource(fileName);
+        logger.warn("URL built");
+        final Font ms = Font.createFont(Font.TRUETYPE_FONT, url.openStream());
+        logger.warn("Font built");
+        nameField.setFont(ms.deriveFont(Font.PLAIN, 14));
+      }
+      catch (Exception e) {
+        logger.warn("Mono load exception: " + e.getMessage());
+      }
+
       panel.add(nameField, "grow"); //NON-NLS
       nameField.addKeyListener(new KeyAdapter() {
         @Override

--- a/vassal-app/src/main/java/VASSAL/configure/BeanShellExpressionConfigurer.java
+++ b/vassal-app/src/main/java/VASSAL/configure/BeanShellExpressionConfigurer.java
@@ -17,7 +17,6 @@
  */
 package VASSAL.configure;
 
-import VASSAL.build.GameModule;
 import VASSAL.counters.EditablePiece;
 import VASSAL.counters.GamePiece;
 import VASSAL.i18n.Resources;
@@ -207,7 +206,6 @@ public class BeanShellExpressionConfigurer extends StringConfigurer {
   @Override
   public Component getControls() {
     if (p == null) {
-      // expressionPanel = new JPanel(new MigLayout("fillx,ins 0", "[][grow][][]")); //NON-NLS
       expressionPanel = new ConfigurerPanel(getName(), "[grow,fill]", "[][grow,fill]", "[grow, fill]"); // NON-NLS
       ((MigLayout) expressionPanel.getLayout()).setLayoutConstraints("ins 0,fill");
 
@@ -216,7 +214,7 @@ public class BeanShellExpressionConfigurer extends StringConfigurer {
       validator = new Validator();
       nameField = new JTextArea(1, 100);
 
-      nameField.setFont(GameModule.getGameModule().getFontOrganizer().getEditorFont(Font.PLAIN, 14));
+      nameField.setFont(getEditorFont(Font.PLAIN, 14));
       nameField.setLineWrap(true);
       nameField.setWrapStyleWord(true);
       nameField.setBorder(BorderFactory.createLineBorder(Color.gray));
@@ -225,22 +223,6 @@ public class BeanShellExpressionConfigurer extends StringConfigurer {
       nameField.setFocusTraversalKeys(KeyboardFocusManager.BACKWARD_TRAVERSAL_KEYS, null);
 
       nameField.setText(getValueString());
-
-
-      try {
-        final String fileName = "/fonts/JetBrainsMono.ttf";
-
-        logger.warn("Build URL for mono, classloader = " + getClass().getClassLoader());
-        final URL url = getClass().getResource(fileName);
-        logger.warn("URL built");
-        final Font ms = Font.createFont(Font.TRUETYPE_FONT, url.openStream());
-        logger.warn("Font built");
-        nameField.setFont(ms.deriveFont(Font.PLAIN, 14));
-      }
-      catch (Exception e) {
-        logger.warn("Mono load exception: " + e.getMessage());
-      }
-
       panel.add(nameField, "grow"); //NON-NLS
       nameField.addKeyListener(new KeyAdapter() {
         @Override
@@ -343,6 +325,19 @@ public class BeanShellExpressionConfigurer extends StringConfigurer {
     if (builder != null) {
       builder.update();
     }
+  }
+
+  protected Font getEditorFont(int style, int size) {
+    try {
+      final String fileName = "/fonts/JetBrainsMono.ttf";
+      final URL url = getClass().getResource(fileName);
+      logger.warn("URL=" + url);
+      final Font ms = Font.createFont(Font.TRUETYPE_FONT, url.openStream());
+      return ms.deriveFont(style, size);
+    }
+    catch (Exception ignored) {
+    }
+    return new Font("monospaced", style, size);
   }
 
   protected void doPopup() {

--- a/vassal-app/src/main/java/VASSAL/configure/BeanShellExpressionConfigurer.java
+++ b/vassal-app/src/main/java/VASSAL/configure/BeanShellExpressionConfigurer.java
@@ -214,7 +214,7 @@ public class BeanShellExpressionConfigurer extends StringConfigurer {
       validator = new Validator();
       nameField = new JTextArea(1, 100);
 
-      nameField.setFont(getEditorFont(Font.PLAIN, 14));
+     // nameField.setFont(getEditorFont(Font.PLAIN, 14));
       nameField.setLineWrap(true);
       nameField.setWrapStyleWord(true);
       nameField.setBorder(BorderFactory.createLineBorder(Color.gray));

--- a/vassal-app/src/main/java/VASSAL/configure/BeanShellExpressionConfigurer.java
+++ b/vassal-app/src/main/java/VASSAL/configure/BeanShellExpressionConfigurer.java
@@ -17,6 +17,7 @@
  */
 package VASSAL.configure;
 
+import VASSAL.build.GameModule;
 import VASSAL.counters.EditablePiece;
 import VASSAL.counters.GamePiece;
 import VASSAL.i18n.Resources;
@@ -210,7 +211,7 @@ public class BeanShellExpressionConfigurer extends StringConfigurer {
       validator = new Validator();
       nameField = new JTextArea(1, 100);
 
-      nameField.setFont(new Font("Monospaced", Font.PLAIN, 14));
+      nameField.setFont(GameModule.getGameModule().getFontOrganizer().getEditorFont(Font.PLAIN, 14));
       nameField.setLineWrap(true);
       nameField.setWrapStyleWord(true);
       nameField.setBorder(BorderFactory.createLineBorder(Color.gray));

--- a/vassal-app/src/main/java/VASSAL/configure/Configurer.java
+++ b/vassal-app/src/main/java/VASSAL/configure/Configurer.java
@@ -83,6 +83,8 @@ public abstract class Configurer {
   protected ContextLevel contextLevel;
   protected AbstractBuildable context;
 
+  protected Configurer parentConfigurer;
+
   public Configurer(String key, String name) {
     this(key, name, null);
   }
@@ -380,5 +382,23 @@ public abstract class Configurer {
 
   public void setContextLevel(ContextLevel contextLevel) {
     this.contextLevel = contextLevel;
+  }
+
+  public Configurer getParentConfigurer() {
+    return parentConfigurer;
+  }
+
+  public void setParentConfigurer(Configurer parentConfigurer) {
+    this.parentConfigurer = parentConfigurer;
+  }
+
+  public void refreshParent() {
+    if (parentConfigurer != null) {
+      parentConfigurer.refresh();
+    }
+  }
+
+  public void refresh() {
+
   }
 }

--- a/vassal-app/src/main/java/VASSAL/configure/FontConfigurer.java
+++ b/vassal-app/src/main/java/VASSAL/configure/FontConfigurer.java
@@ -38,13 +38,14 @@ public class FontConfigurer extends Configurer {
   private JComboBox<Integer> size;
   private JComboBox<String> family;
   private final int[] sizes;
+  private String preferredFontName;
 
   public FontConfigurer(String key, String name) {
     this(key, name, new Font(Font.SANS_SERIF, Font.PLAIN, 12));
   }
 
   public FontConfigurer(String key, String name, Font val) {
-    this(key, name, val, new int[]{9, 10, 11, 12, 15, 18});
+    this(key, name, val, new int[]{9, 10, 11, 12, 13, 14, 15, 16, 18, 20});
   }
 
   public FontConfigurer(String key, String name, Font val, int[] sizes) {
@@ -59,7 +60,10 @@ public class FontConfigurer extends Configurer {
 
   @Override
   public void setValue(String s) {
-    setValue(decode(s));
+    final Font f = decode(s);
+    // Save the preferred font name in case it is a Vassal font that hasn't been loaded yet.
+    preferredFontName = f.getName();
+    setValue(f);
   }
 
   @Override
@@ -94,6 +98,40 @@ public class FontConfigurer extends Configurer {
       family.addItemListener(l);
     }
     return p;
+  }
+
+  /**
+   * A new font has been loaded into Vassal. The supplied family may or may not exist in our
+   * drop-down. Check it doesn't already exist and add it in the correct place
+   * @param newFamily
+   */
+  public void addFontFamily(String newFamily) {
+    int pos = 0;
+    for (int i = 0; i < family.getItemCount(); i++) {
+      final String item = family.getItemAt(i);
+      if (item.equals(newFamily)) {
+        return;
+      }
+      if (item.compareTo(newFamily) <= 0) {
+        pos = i;
+      }
+      else {
+        break;
+      }
+    }
+    // Add the new family name to the drop-down
+    family.insertItemAt(newFamily, pos + 1);
+
+    // If this font is the one initally preferred, but was unavailable, create a proper version and set as the value
+    // and select oin the drop-down.
+    if (newFamily.equals(preferredFontName)) {
+      setValue(new Font(
+        (String) preferredFontName,
+        Font.PLAIN,
+        (Integer) size.getSelectedItem()
+      ));
+      family.setSelectedItem(preferredFontName);
+    }
   }
 
   public static Font decode(String s) {

--- a/vassal-app/src/main/java/VASSAL/configure/FontFileConfigurer.java
+++ b/vassal-app/src/main/java/VASSAL/configure/FontFileConfigurer.java
@@ -1,0 +1,57 @@
+/*
+ *
+ * Copyright (c) 2006-2023 by Joel Uckelman, The VASSAL Development Team
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License (LGPL) as published by the Free Software Foundation.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public
+ * License along with this library; if not, copies are available
+ * at http://www.opensource.org.
+ */
+
+package VASSAL.configure;
+
+import VASSAL.build.GameModule;
+import VASSAL.tools.ArchiveWriter;
+import VASSAL.tools.filechooser.FileChooser;
+import VASSAL.tools.filechooser.FontFileFilter;
+import VASSAL.tools.swing.SwingUtils;
+
+public class FontFileConfigurer extends FileConfigurer {
+  protected static DirectoryConfigurer fontDirPref;
+
+  public FontFileConfigurer(String key, String name, ArchiveWriter archive) {
+    super(key, name);
+    this.archive = archive;
+    setEditable(false);
+  }
+
+  @Override
+  protected FileChooser initFileChooser() {
+    if (fontDirPref == null) {
+      fontDirPref = new DirectoryConfigurer("fonts", null); //NON-NLS
+      GameModule.getGameModule().getPrefs().addOption(null, fontDirPref);
+    }
+    final FileChooser fc = FileChooser.createFileChooser(GameModule.getGameModule().getPlayerWindow(), fontDirPref);
+    fc.setFileFilter(new FontFileFilter());
+    return fc;
+  }
+
+  @Override
+  protected void addToArchive(java.io.File f) {
+    archive.addFont(f.getPath(), f.getName());
+  }
+
+  @Override
+  public void setValue(Object o) {
+    super.setValue(o);
+    SwingUtils.repack(p);
+  }
+}

--- a/vassal-app/src/main/java/VASSAL/counters/Labeler.java
+++ b/vassal-app/src/main/java/VASSAL/counters/Labeler.java
@@ -886,10 +886,10 @@ public class Labeler extends Decorator implements TranslatablePiece, Loopable {
       final List<String> fontNames = new ArrayList<>();
       final List<String> fontDescriptions = new ArrayList<>();
 
-      GameModule.getGameModule().getFontOrganizer().getAdditionalFonts().forEach(
-        (k) -> {
-          if (k != null) fontNames.add(k);
-        });
+//      GameModule.getGameModule().getFontOrganizer().getAdditionalFonts().forEach(
+//        (k) -> {
+//          if (k != null) fontNames.add(k);
+//        });
       fontNames.addAll(List.of(Font.SERIF, Font.SANS_SERIF, Font.MONOSPACED, Font.DIALOG, Font.DIALOG_INPUT));
       Collections.sort(fontNames);
       fontNames.forEach(

--- a/vassal-app/src/main/java/VASSAL/counters/Labeler.java
+++ b/vassal-app/src/main/java/VASSAL/counters/Labeler.java
@@ -888,7 +888,7 @@ public class Labeler extends Decorator implements TranslatablePiece, Loopable {
 
       GameModule.getGameModule().getFontOrganizer().getAdditionalFonts().forEach(
         (k) -> {
-          fontNames.add(k);
+          if (k != null) fontNames.add(k);
         });
       fontNames.addAll(List.of(Font.SERIF, Font.SANS_SERIF, Font.MONOSPACED, Font.DIALOG, Font.DIALOG_INPUT));
       Collections.sort(fontNames);

--- a/vassal-app/src/main/java/VASSAL/counters/Labeler.java
+++ b/vassal-app/src/main/java/VASSAL/counters/Labeler.java
@@ -883,15 +883,45 @@ public class Labeler extends Decorator implements TranslatablePiece, Loopable {
       labelKeyInput = new NamedHotKeyConfigurer(l.labelKey);
       controls.add("Editor.keyboard_command", labelKeyInput);
 
-      fontFamily = new TranslatingStringEnumConfigurer(
-        new String[]{Font.SERIF, Font.SANS_SERIF, Font.MONOSPACED, Font.DIALOG, Font.DIALOG_INPUT},
-        new String[] {
-          "Editor.Font.serif",
-          "Editor.Font.sans_serif",
-          "Editor.Font.monospaced",
-          "Editor.Font.dialog",
-          "Editor.Font.dialog_input"},
-          l.font.getFamily());
+      final List<String> fontNames = new ArrayList<>();
+      final List<String> fontDescriptions = new ArrayList<>();
+
+      GameModule.getGameModule().getFontOrganizer().getAdditionalFonts().forEach(
+        (k) -> {
+          fontNames.add(k);
+        });
+      fontNames.addAll(List.of(Font.SERIF, Font.SANS_SERIF, Font.MONOSPACED, Font.DIALOG, Font.DIALOG_INPUT));
+      Collections.sort(fontNames);
+      fontNames.forEach(
+        (k) -> {
+          if (Font.SERIF.equals(k)) {
+            fontDescriptions.add(Resources.getString("Editor.Font.serif"));
+          }
+          else if (Font.SANS_SERIF.equals(k)) {
+            fontDescriptions.add(Resources.getString("Editor.Font.sans_serif"));
+          }
+          else if (Font.MONOSPACED.equals(k)) {
+            fontDescriptions.add(Resources.getString("Editor.Font.monospaced"));
+          }
+          else if (Font.DIALOG.equals(k)) {
+            fontDescriptions.add(Resources.getString("Editor.Font.dialog"));
+          }
+          else if (Font.DIALOG_INPUT.equals(k)) {
+            fontDescriptions.add(Resources.getString("Editor.Font.dialog_input"));
+          }
+          else {
+            // No translation for Vassal supplied fonts
+            fontDescriptions.add(k);
+          }
+        }
+      );
+
+      fontFamily = new TranslatingStringEnumConfigurer(null, null,
+        fontNames,
+        fontDescriptions,
+        l.font.getFamily(),
+        true
+      );
 
       JPanel p = new JPanel(new MigLayout("ins 0", "[]unrel[]rel[]unrel[]rel[]unrel[]rel[]")); // NON-NLS
       p.add(fontFamily.getControls());

--- a/vassal-app/src/main/java/VASSAL/tools/ArchiveWriter.java
+++ b/vassal-app/src/main/java/VASSAL/tools/ArchiveWriter.java
@@ -174,6 +174,10 @@ public class ArchiveWriter extends DataArchive {
     addFile(path, soundDir + fileName);
   }
 
+  public void addFont(String path, String fileName) {
+    addFile(path, fontDir + fileName);
+  }
+
   public void removeImage(String name) {
     removeFile(imageDir + name);
     localImages = null;

--- a/vassal-app/src/main/java/VASSAL/tools/DataArchive.java
+++ b/vassal-app/src/main/java/VASSAL/tools/DataArchive.java
@@ -65,6 +65,9 @@ public class DataArchive extends SecureClassLoader implements Closeable {
   public static final String SOUND_DIR = "sounds/"; //NON-NLS
   protected String soundDir = SOUND_DIR;
 
+  public static final String FONT_DIR = "fonts/"; //NON-NLS
+  protected String fontDir = FONT_DIR;
+
   public static final String ICON_DIR = "icons/"; //NON-NLS
 
   protected DataArchive() {

--- a/vassal-app/src/main/java/VASSAL/tools/filechooser/FontFileFilter.java
+++ b/vassal-app/src/main/java/VASSAL/tools/filechooser/FontFileFilter.java
@@ -1,0 +1,36 @@
+/*
+ *
+ * Copyright (c) 2006-2023 by Joel Uckelman, The VASSAL Development Team
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License (LGPL) as published by the Free Software Foundation.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public
+ * License along with this library; if not, copies are available
+ * at http://www.opensource.org.
+ */
+package VASSAL.tools.filechooser;
+
+import VASSAL.i18n.Resources;
+
+/**
+ * A FileFilter for OTF and TTF files. Used by file choosers to
+ * filter out files which aren't font files.
+ *
+ * @author Joel Uckelman
+ */
+public class FontFileFilter extends ExtensionFileFilter {
+  public static final String[] types = {
+    ".otf", ".ttf"  //NON-NLS
+  };
+
+  public FontFileFilter() {
+    super(Resources.getString("Editor.FileFilter.font"), types);
+  }
+}

--- a/vassal-app/src/main/resources/VASSAL/i18n/Editor.properties
+++ b/vassal-app/src/main/resources/VASSAL/i18n/Editor.properties
@@ -879,6 +879,7 @@ Editor.FileChooser.exists=File exists
 
 # File Filter
 Editor.FileFilter.audio=Audio files
+Editor.FileFilter.font=Font files
 Editor.FileFilter.bmp=Windows bitmap files
 Editor.FileFilter.directories=Directories
 Editor.FileFilter.image=Image files
@@ -929,6 +930,30 @@ Editor.Footprint.selected_transparency=Selected unit trail transparency (0-100)
 Editor.Footprint.unselected_transparency=Unselected unit trail transparency (0-100)
 Editor.Footprint.display_trail_points_off_map=Display trail points off-map (pixels)
 Editor.Footprint.display_trails_off_map=Display trails off-map (pixels)
+
+# Font Related
+Editor.FontOrganizer.component_type=Fonts
+Editor.FontOrganizer.font_family=Font Family
+Editor.FontOrganizer.font_name=Font Name
+Editor.FontOrganizer.font_file=File
+Editor.FontOrganizer.vassal_heading=Source
+Editor.FontOrganizer.status=Status
+Editor.FontOrganizer.fonts=Fonts
+Editor.FontOrganizer.vassal=Vassal
+Editor.FontOrganizer.module=Module
+Editor.ModuleFont.component_type=Module Font
+Editor.ModuleFont.font_file_name=Font file name
+Editor.ModuleFont.font_family=Font Family
+Editor.ModuleFont.font_name=Font Name
+Editor.ModuleFont.status=Status
+Editor.VassalFont.invalid_format=Font file invalid
+Editor.VassalFont.find_error=Font file could not be located
+Editor.VassalFont.read_error=Font file could not be read
+Editor.VassalFont.valid=Valid, %1$s
+Editor.VassalFont.invalid=Invalid, %1$s
+Editor.VassalFont.registered=Registered
+Editor.VassalFont.unregistered=Registration failed
+
 
 # FontStyle
 Editor.FontStyle.component_type=Font Style

--- a/vassal-app/src/main/resources/fonts/fonts.config
+++ b/vassal-app/src/main/resources/fonts/fonts.config
@@ -1,0 +1,3 @@
+# A list of Font files present as Vassal resources. Simplifies Font discovery by FontOrganizer
+# NOTE: If JetBrainsMono is removed, then FontOrganizer.VASSAL_EDITOR_FONT must be changed to a new supplied font
+JetBrainsMono.ttf

--- a/vassal-app/src/test/java/VASSAL/counters/DecoratorTest.java
+++ b/vassal-app/src/test/java/VASSAL/counters/DecoratorTest.java
@@ -27,10 +27,13 @@ import static org.mockito.Mockito.when;
 import VASSAL.build.GameModule;
 import VASSAL.build.GpIdSupport;
 import VASSAL.build.module.BasicCommandEncoder;
+import VASSAL.build.module.font.FontOrganizer;
 import VASSAL.tools.DataArchive;
 import VASSAL.tools.icon.IconFactory;
 import VASSAL.tools.imageop.ImageOp;
 import VASSAL.tools.imageop.Op;
+
+import java.awt.Font;
 import java.awt.image.BufferedImage;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
@@ -78,10 +81,16 @@ public class DecoratorTest {
           // Mock some GpID Support
           final GpIdSupport gpid = mock(GpIdSupport.class);
 
+          // Font Organizer
+          final FontOrganizer fo = mock(FontOrganizer.class);
+          when(fo.getEditorFont(any(Integer.class), any(Integer.class))).thenReturn(new Font("monospaced", Font.PLAIN, 10));
+
           // Mock GameModule to return various resources
           final GameModule gm = mock(GameModule.class);
           when(gm.getDataArchive()).thenReturn(da);
           when(gm.getGpIdSupport()).thenReturn(gpid);
+          when(gm.getFontOrganizer()).thenReturn(fo);
+
 
           staticGm.when(GameModule::getGameModule).thenReturn(gm);
 

--- a/vassal-app/src/test/java/VASSAL/counters/DecoratorTest.java
+++ b/vassal-app/src/test/java/VASSAL/counters/DecoratorTest.java
@@ -89,7 +89,7 @@ public class DecoratorTest {
           final GameModule gm = mock(GameModule.class);
           when(gm.getDataArchive()).thenReturn(da);
           when(gm.getGpIdSupport()).thenReturn(gpid);
-          when(gm.getFontOrganizer()).thenReturn(fo);
+          //when(gm.getFontOrganizer()).thenReturn(fo);
 
 
           staticGm.when(GameModule::getGameModule).thenReturn(gm);

--- a/vassal-app/src/test/resources/clirr-ignored-differences.xml
+++ b/vassal-app/src/test/resources/clirr-ignored-differences.xml
@@ -110,6 +110,36 @@
         <justification>Class added in beta, then removed</justification>
     </difference>
 
+    <difference>
+        <className>VASSAL/build/module/properties/RemoteEnumeratedPropertyPrompt</className>
+        <differenceType>7004</differenceType>
+        <method>java.lang.String getNewValue(VASSAL.counters.DynamicProperty, VASSAL.script.expression.Auditable)</method>
+        <justification>Only introduced in beta4</justification>
+    </difference>
+    <difference>
+        <className>VASSAL/build/module/properties/RemoteIncrementProperty</className>
+        <differenceType>7004</differenceType>
+        <method>java.lang.String getNewValue(VASSAL.counters.DynamicProperty, VASSAL.script.expression.Auditable)</method>
+        <justification>Only introduced in beta4</justification>
+    </difference>
+    <difference>
+        <className>VASSAL/build/module/properties/RemotePropertyChanger</className>
+        <differenceType>7004</differenceType>
+        <method>java.lang.String getNewValue(VASSAL.counters.DynamicProperty, VASSAL.script.expression.Auditable)</method>
+        <justification>Only introduced in beta4</justification>
+    </difference>
+    <difference>
+        <className>VASSAL/build/module/properties/RemotePropertyPrompt</className>
+        <differenceType>7004</differenceType>
+        <method>java.lang.String getNewValue(VASSAL.counters.DynamicProperty, VASSAL.script.expression.Auditable)</method>
+        <justification>Only introduced in beta4</justification>
+    </difference>
+    <difference>
+        <className>VASSAL/build/module/properties/RemotePropertySetter</className>
+        <differenceType>7004</differenceType>
+        <method>java.lang.String getNewValue(VASSAL.counters.DynamicProperty, VASSAL.script.expression.Auditable)</method>
+        <justification>Only introduced in beta4</justification>
+    </difference>
     <!-- 3.6.14 -->
 
     <difference>


### PR DESCRIPTION
 - Includes a high quality monospaced font JetBrains Mono for use in the expanded Calculated Property window
 - Allows Designers to add TrueType/OpenType Fonts to a module (New top level Fonts component)
 - All new fonts (Vassal supplied and designer supplied) can be used in the following contexts:
   o Text Label selected font
   o Game Piece Image font
   o Chat Window font
   o Any Swing renderered HTML
 - Fonts added to a module will be used on all target machines the module is run on UNLESS the user already has that font installed on their system, in which case the installed font will be used.