### PR TITLE
12644 - Prevent NPE when Editing Deck count expressions

### DIFF
--- a/vassal-app/pom.xml
+++ b/vassal-app/pom.xml
@@ -18,6 +18,7 @@
         <main.basedir>${project.basedir}${file.separator}..</main.basedir>
         <project.reporting.outputEncoding>${project.build.sourceEncoding}</project.reporting.outputEncoding>
         <version.batik>1.17</version.batik>
+        <clirr.nofork.comparison.version>3.6.19</clirr.nofork.comparison.version>
     </properties>
 
     <dependencyManagement>
@@ -401,6 +402,7 @@
                 <artifactId>clirr-maven-plugin</artifactId>
                 <configuration>
                     <ignoredDifferencesFile>src/test/resources/clirr-ignored-differences.xml</ignoredDifferencesFile>
+                    <comparisonVersion>${clirr.nofork.comparison.version}</comparisonVersion>
                 </configuration>
                 <executions>
                     <execution>

--- a/vassal-app/src/main/java/VASSAL/counters/Deck.java
+++ b/vassal-app/src/main/java/VASSAL/counters/Deck.java
@@ -865,8 +865,7 @@ public class Deck extends Stack implements PlayerRoster.SideChangeListener {
     for (int index = 0; index < countExpressionsString.length; index++) {
       final CountExpression n = new CountExpression(countExpressionsString[index]);
       if (n.getName() != null) {
-        c[index] = n;
-        goodExpressionCount++;
+        c[goodExpressionCount++] = n;
       }
     }
 


### PR DESCRIPTION
This also resolves the clirr nofork issues in master which are due to comparison to the previous beta instead of 3.6.19.

This fix should also be applied to 3.6.20