### PR TITLE
12688-Replace with other should not update text of unchangeable labels

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/GpIdChecker.java
+++ b/vassal-app/src/main/java/VASSAL/build/GpIdChecker.java
@@ -288,7 +288,7 @@ public class GpIdChecker {
         // Do not copy the state of Marker traits, we want to see the new value from the new definition
         if (newState != null && !(decoratorNew instanceof Marker)) {
           // Do not copy Labeler (Text Label) label state UNLESS this Text Label has the capacity to be manually updated
-          if (!(decoratorNew instanceof Labeler) || ((((Labeler)decoratorNew).getLabelKey() != null) && !NamedKeyStroke.NULL_KEYSTROKE.equals(((Labeler)decoratorNew).getLabelKey()))) {
+          if (!(decoratorNew instanceof Labeler) || ((Labeler) decoratorNew).canChange()) {
             decoratorNew.mySetState(newState);
           }
         }

--- a/vassal-app/src/main/java/VASSAL/build/GpIdChecker.java
+++ b/vassal-app/src/main/java/VASSAL/build/GpIdChecker.java
@@ -32,7 +32,6 @@ import VASSAL.counters.PieceCloner;
 import VASSAL.counters.PlaceMarker;
 import VASSAL.counters.Properties;
 import VASSAL.i18n.Resources;
-import VASSAL.tools.NamedKeyStroke;
 
 import java.util.ArrayList;
 import java.util.HashMap;

--- a/vassal-app/src/main/java/VASSAL/counters/Labeler.java
+++ b/vassal-app/src/main/java/VASSAL/counters/Labeler.java
@@ -133,6 +133,11 @@ public class Labeler extends Decorator implements TranslatablePiece, Loopable {
     return labelKey;
   }
 
+  /** Can this Label be changed? */
+  public boolean canChange() {
+    return getLabelKey() != null && !NamedKeyStroke.NULL_KEYSTROKE.equals(getLabelKey());
+  }
+
   @Override
   public void mySetType(String type) {
     commands = null;

--- a/vassal-app/src/main/java/VASSAL/counters/Replace.java
+++ b/vassal-app/src/main/java/VASSAL/counters/Replace.java
@@ -24,6 +24,7 @@ import VASSAL.command.RemovePiece;
 import VASSAL.configure.BooleanConfigurer;
 import VASSAL.i18n.PieceI18nData;
 import VASSAL.i18n.Resources;
+import VASSAL.tools.NamedKeyStroke;
 
 import javax.swing.KeyStroke;
 import java.util.ArrayList;
@@ -179,6 +180,13 @@ public class Replace extends PlaceMarker {
             // Match DP's on property name only if Copy by name option is selected
             if (candidate instanceof DynamicProperty && copyDPsByName) {
               if (((DynamicProperty) candidate).getKey().equals(((DynamicProperty) currentMarker).getKey())) {
+                currentMarker.mySetState(candidate.myGetState());
+                candidate = null;
+              }
+            }
+            // Labels are only state matched if they are adjustable. Note this matches the behaviour of the Game Refresher
+            else if (currentMarker instanceof Labeler) {
+              if (((Labeler) currentMarker).canChange()) {
                 currentMarker.mySetState(candidate.myGetState());
                 candidate = null;
               }

--- a/vassal-app/src/main/java/VASSAL/counters/Replace.java
+++ b/vassal-app/src/main/java/VASSAL/counters/Replace.java
@@ -24,7 +24,6 @@ import VASSAL.command.RemovePiece;
 import VASSAL.configure.BooleanConfigurer;
 import VASSAL.i18n.PieceI18nData;
 import VASSAL.i18n.Resources;
-import VASSAL.tools.NamedKeyStroke;
 
 import javax.swing.KeyStroke;
 import java.util.ArrayList;


### PR DESCRIPTION
If `match current state` is specified, then non-changeable Text Labels should be excluded from the state match process.