### PR TITLE
12324 - Fixed ClassCastException caused by reordering columns in Delayed Notes table

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/module/noteswindow/SecretNotesController.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/noteswindow/SecretNotesController.java
@@ -427,9 +427,8 @@ public class SecretNotesController implements GameComponent, CommandEncoder, Add
       if (selectedRow < 0) {
         return;
       }
-      final String selectedName = (String) table.getValueAt(selectedRow, COL_NAME);
-      SecretNote note = getNoteForName(selectedName);
 
+      SecretNote note = notes.get(table.convertRowIndexToModel(selectedRow));
       if (note.getOwner().equals(GameModule.getActiveUserId())) {
         note = new SecretNote(note.getName(), note.getOwner(), note.getText(), false, note.getDate(), note.getHandle());
         if (note != null) {
@@ -521,9 +520,8 @@ public class SecretNotesController implements GameComponent, CommandEncoder, Add
       if (selectedRow < 0) {
         return;
       }
-      final String selectedName = (String) table.getValueAt(selectedRow, COL_NAME);
-      final SecretNote note = getNoteForName(selectedName);
 
+      final SecretNote note = notes.get(table.convertRowIndexToModel(selectedRow));
       if (note != null) {
         if (note.getOwner().equals(GameModule.getActiveUserId())) {
           text.setText(note.getText());


### PR DESCRIPTION
 Convert selected delayed notes table row to model, and get note object that way. JTable.getValueAt() indexes the columns as displayed, which is not the same order as in the table model if the colums have been reordered by the user.