### PR TITLE
12708 - Prevent ArrayIndexOutOfBoundsException if side translation count does not match module

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/module/ChessClockControl.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/ChessClockControl.java
@@ -196,7 +196,7 @@ public class ChessClockControl extends AbstractConfigurable
     final PlayerRoster r = GameModule.getGameModule().getPlayerRoster();
     int added = 0;
     if (r != null) {
-      for (final String s : r.sides) {
+      for (final String s : r.getUntranslatedSideList()) {
         if (!r.isSoloSide(s)) {
           addChild(new ChessClock(s));
           added++;

--- a/vassal-app/src/main/resources/VASSAL/i18n/Editor.properties
+++ b/vassal-app/src/main/resources/VASSAL/i18n/Editor.properties
@@ -2460,6 +2460,7 @@ Editor.ValidationReportDialog.ignore=Ignore, save anyway
 Editor.ValidityChecker.single_warning=No more than one [%1$s] allowed in %2$s [%3$s]
 Editor.ValidityChecker.mandatory_warning=%1$s [%2$s] must contain at least one [%3$s]
 Editor.ValidityChecker.duplicate_warning=More than one [%1$s] with the name '%2$s' has been created in %3$s [%4$s]
+Editor.ValidityChecker.side_warning=Translation [%1$s] has %2$s Sides defined, but [%3$s] has %4$s defined. Sides cannot be translated to %1$s.
 
 # Zone
 Editor.Zone.component_type=Zone

--- a/vassal-app/src/main/resources/VASSAL/i18n/VASSAL.properties
+++ b/vassal-app/src/main/resources/VASSAL/i18n/VASSAL.properties
@@ -1045,6 +1045,7 @@ PlayerRoster.need_non_blank_password=<html><b>You have not yet set your password
 PlayerRoster.please_set_your_password=Please set your password:
 PlayerRoster.failed_pref_write=Failed to write module preferences: %1$s
 PlayerRoster.please_set_non_blank_password=Please set non-blank password
+PlayerRoster.side_translation_error=The module defines %1$s sides, but the current translation defines %2$s. Side names cannot be translated.
 
 #PlayerWindow
 


### PR DESCRIPTION
If the number of sides defined in the current translation does not math the number of sides defined in the module then
1. Report a Validation error when saving module from Editor (and in errorlog when loading module)
2. Do not translate sides in Player mode
3. Add warning message to chat window in Player mode.

Also includes earlier tweaks to side translation.