### PR TITLE
Added VassalGameFileName property

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/GameModule.java
+++ b/vassal-app/src/main/java/VASSAL/build/GameModule.java
@@ -218,10 +218,8 @@ public class GameModule extends AbstractConfigurable
   public static final String MODULE_OTHER2_PROPERTY = "ModuleOther2"; //NON-NLS
   public static final String MODULE_VASSAL_VERSION_CREATED_PROPERTY = "VassalVersionCreated"; //NON-NLS
   public static final String MODULE_VASSAL_VERSION_RUNNING_PROPERTY = "VassalVersionRunning"; //NON-NLS
-
   public static final String MODULE_CURRENT_LOCALE = "CurrentLanguage"; //NON-NLS
   public static final String MODULE_CURRENT_LOCALE_NAME = "CurrentLanguageName"; //NON-NLS
-
   public static final String DRAWING_MOUSEOVER_PROPERTY = "DrawingMouseover"; //NON-NLS
   public static final String DRAWING_MOUSEOVER_INDEX_PROPERTY = "DrawingMouseoverIndex"; //NON-NLS
 
@@ -230,6 +228,7 @@ public class GameModule extends AbstractConfigurable
   private static final char COMMAND_SEPARATOR = KeyEvent.VK_ESCAPE;
 
   public static final String RECENT_GAMES = "RecentGames"; //NON-NLS
+  private static final String GAME_FILE_PROPERTY = "VassalGameFileName"; //NON-NLS
 
   private final List<MenuItemProxy> openRecentItems = new ArrayList<>();
 
@@ -408,7 +407,7 @@ public class GameModule extends AbstractConfigurable
    * Our finder of the resources, for translation of images.
    */
   private final ResourcePathFinder resourceFinder;
-  
+
   /**
    * The user preferences
    */
@@ -1737,6 +1736,7 @@ public class GameModule extends AbstractConfigurable
    */
   public void setGameFileMode(GameFileMode mode) {
     gameFileMode = Objects.requireNonNull(mode);
+    if (mode == GameFileMode.NEW_GAME) gameFile = "";
     updateTitleBar();
   }
 
@@ -2277,6 +2277,9 @@ public class GameModule extends AbstractConfigurable
     else if (GameModule.MODULE_CURRENT_LOCALE_NAME.equals(key)) {
       return Resources.getLocale().getDisplayName();
     }
+    else if (GAME_FILE_PROPERTY.equals(key)) {
+      return gameFile;
+    }
     else if (DRAWING_MOUSEOVER_PROPERTY.equals(key)) {
       return CounterDetailViewer.isDrawingMouseOver();
     }
@@ -2318,6 +2321,7 @@ public class GameModule extends AbstractConfigurable
     l.add(MODULE_CURRENT_LOCALE_NAME);
     l.add(MODULE_VASSAL_VERSION_CREATED_PROPERTY);
     l.add(MODULE_VASSAL_VERSION_RUNNING_PROPERTY);
+    l.add(GAME_FILE_PROPERTY);
 
     return l;
   }

--- a/vassal-app/src/main/java/VASSAL/build/module/WizardSupport.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/WizardSupport.java
@@ -191,6 +191,7 @@ public class WizardSupport {
       if (Boolean.TRUE.equals(showWizard) && g.shutDown()) {
         System.exit(0);
       }
+      g.setGameFileMode(GameModule.GameFileMode.NEW_GAME); // reset gameFile and title
       g.getPlayerWindow().setVisible(true);
     }
   }
@@ -519,6 +520,7 @@ public class WizardSupport {
     }
 
     protected void loadSetup(PredefinedSetup setup, final WizardController controller, final Map settings) {
+      final GameModule g = GameModule.getGameModule();
       try {
         new SavedGameLoader(controller, settings, new BufferedInputStream(setup.getSavedGameContents()), POST_PLAY_OFFLINE_WIZARD, true).start();
       }
@@ -526,6 +528,8 @@ public class WizardSupport {
       catch (IOException e1) {
         controller.setProblem(Resources.getString("WizardSupport.UnableToLoad"));
       }
+      // Predefined Scenarios are files too...
+      g.setGameFile(setup.getFileName(), GameModule.GameFileMode.LOADED_GAME);
     }
   }
 
@@ -712,6 +716,7 @@ public class WizardSupport {
                   @Override
                   public void run() {
                     final GameModule g = GameModule.getGameModule();
+                    // FIXME: The following default save/load attempt does not work (on MacOS at least the default is left "unknown"; please confirm for other platforms before fixing).
                     g.getFileChooser().setSelectedFile(f); //BR// When loading a saved game from Wizard, put it appropriately into the "default" for the next save/load/etc.
                     g.setGameFile(f.getName(), GameModule.GameFileMode.LOADED_GAME); //BR// ... aaaand put it in the app window description.
                     super.run();
@@ -836,9 +841,11 @@ public class WizardSupport {
 
     @Override
     public boolean cancel(Map settings) {
-      GameModule.getGameModule().setGameFileMode(GameModule.GameFileMode.NEW_GAME);
-      GameModule.getGameModule().getGameState().setup(false);
-      GameModule.getGameModule().getGameState().freshenStartupGlobalKeyCommands(GameModule.getGameModule());
+      final GameModule g = GameModule.getGameModule();
+      g.setGameFileMode(GameModule.GameFileMode.NEW_GAME);
+      g.getGameState().setup(false);
+      g.getGameState().freshenStartupGlobalKeyCommands(GameModule.getGameModule());
+
       return true;
     }
 

--- a/vassal-doc/src/main/readme-referencemanual/ReferenceManual/Properties.adoc
+++ b/vassal-doc/src/main/readme-referencemanual/ReferenceManual/Properties.adoc
@@ -210,7 +210,8 @@ A string that uniquely identifies an individual piece and is guaranteed to never
 |*PlayerName* |<<GameModule.adoc#top,Game Module>>| Module| The Player Name of the current player
 |*PlayerSide* |<<GameModule.adoc#top,Game Module>>| Module| The Side taken by the current player if Sides have been defined in the module
 |*VassalVersionCreated* |<<GameModule.adoc#top,Game Module>>| Module| The version number of Vassal that was used to create the current module.
-|*VassalVersionRuning* |<<GameModule.adoc#top,Game Module>>| Module| The version number of Vassal that is currently running.
+|*VassalVersionRunning* |<<GameModule.adoc#top,Game Module>>| Module| The version number of Vassal that is currently running.
+|*VassalGameFileName* |<<GameModule.adoc#top,Game Module>>| Module| The last game file opened by the current player.
 |===
 
 ===== Property names provided by VASSAL Components that can be accessed by traits, but are dependent on the module


### PR DESCRIPTION
Creates a property VassalGameFileName (akin to existing read-only properties such as ModuleVersion).
It is set to the file name of the most recent VSAV/VLOG.

Also fixes two issues with managing window title names from the Wizard which would have impeded the PR.