### PR TITLE
12808 - Horizontal scrolling now supports 2-finger-trackpad and mice with additional horizontal wheels

### DIFF
--- a/vassal-app/src/main/java/VASSAL/tools/ScrollPane.java
+++ b/vassal-app/src/main/java/VASSAL/tools/ScrollPane.java
@@ -23,6 +23,8 @@ import VASSAL.tools.swing.SwingUtils;
 import javax.swing.JScrollBar;
 import javax.swing.JScrollPane;
 import java.awt.Component;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
 import java.awt.event.MouseWheelEvent;
 import java.awt.event.MouseWheelListener;
 
@@ -121,6 +123,31 @@ public class ScrollPane extends JScrollPane {
           bar.getValue() +
           e.getUnitsToScroll() *
           bar.getUnitIncrement()
+        );
+      }
+    });
+
+    // adds support for horizontal mouse wheel scrolling.
+    view.addMouseListener(new MouseAdapter() {
+      @Override
+      public void mouseReleased(MouseEvent e) {
+        int scrollDirection = 0;
+        if (e.getButton() == 4) {
+          scrollDirection = -1;
+        }
+        else if (e.getButton() == 5) {
+          scrollDirection = +1;
+        }
+
+      
+        if (!horizontalScrollBar.isVisible()) return;
+
+        GameModule.getGameModule().setSuppressAutoCenterUpdate(false);
+
+        horizontalScrollBar.setValue(
+          horizontalScrollBar.getValue() +
+          scrollDirection *
+          horizontalScrollBar.getUnitIncrement()
         );
       }
     });

--- a/vassal-app/src/main/java/VASSAL/tools/ScrollPane.java
+++ b/vassal-app/src/main/java/VASSAL/tools/ScrollPane.java
@@ -127,30 +127,32 @@ public class ScrollPane extends JScrollPane {
       }
     });
 
-    // adds support for horizontal mouse wheel scrolling.
-    view.addMouseListener(new MouseAdapter() {
-      @Override
-      public void mouseReleased(MouseEvent e) {
-        int scrollDirection = 0;
-        if (e.getButton() == 4) {
-          scrollDirection = -1;
+    if (view != null) {
+      // adds support for horizontal mouse wheel scrolling.
+      view.addMouseListener(new MouseAdapter() {
+        @Override
+        public void mouseReleased(MouseEvent e) {
+          int scrollDirection = 0;
+          if (e.getButton() == 4) {
+            scrollDirection = -1;
+          }
+          else if (e.getButton() == 5) {
+            scrollDirection = +1;
+          }
+
+        
+          if (!horizontalScrollBar.isVisible()) return;
+
+          GameModule.getGameModule().setSuppressAutoCenterUpdate(false);
+
+          horizontalScrollBar.setValue(
+            horizontalScrollBar.getValue() +
+            scrollDirection *
+            horizontalScrollBar.getUnitIncrement()
+          );
         }
-        else if (e.getButton() == 5) {
-          scrollDirection = +1;
-        }
-
-      
-        if (!horizontalScrollBar.isVisible()) return;
-
-        GameModule.getGameModule().setSuppressAutoCenterUpdate(false);
-
-        horizontalScrollBar.setValue(
-          horizontalScrollBar.getValue() +
-          scrollDirection *
-          horizontalScrollBar.getUnitIncrement()
-        );
-      }
-    });
+      });
+    }
 
     verticalScrollBar.addMouseWheelListener(e -> {
       if (e.getScrollAmount() == 0) return;


### PR DESCRIPTION
# 12808 - Horizontal scrolling now supports 2-finger-trackpad and fancy mice w/ additional horizontal wheels
Vassal already supports vertical scrolling of the map via the mouse wheel. This MR adds horizontal scrolling via the mouse wheel as well.

Amongst real mouse wheels, this also enables omnidirectional scrolling via
- two-finger trackpads usage on laptops, and
- middle mouse + [trackpoint](https://de.wikipedia.org/wiki/Trackpoint) movements

Here is a video of the change in action. I think it feels really nice.
[Screencast 2023-10-13 00 15 31.webm](https://github.com/vassalengine/vassal/assets/263263/1f40580a-c17e-44a3-b14e-db1ab5f4c80f)

## Notes
- in general, zooming and scrolling the map feels quite juddery. I wonder if there is anything we can do about that
- Don't ask me why swing exposes horizontal mouse wheel movements as mouse release events :shrug: 
- The change is inspired from a very similar change some time ago in the TripleA game engine:
  - issue: https://github.com/triplea-game/triplea/issues/1443
  - implementation: https://github.com/triplea-game/triplea/pull/1451

Happy for any feedback!