### PR TITLE
Execute set later

### DIFF
--- a/dist/VASSAL.sh
+++ b/dist/VASSAL.sh
@@ -4,8 +4,6 @@
 # Execute this file to launch VASSAL on Unix
 #
 
-set -e
-
 # Get java from PATH if not set in environment
 JAVA="${JAVA:-$(which java)}"
 
@@ -14,6 +12,8 @@ if [ ! -x "$JAVA" ]; then
   echo "Error: $JAVA cannot be run. Please ensure that Java is installed." 2>&1
   exit 1
 fi
+
+set -e
 
 # Dereference any possible symbolic link to executable script, then find
 # absolute path where VASSAL is installed 


### PR DESCRIPTION
I moved `set` a little lower in the script so it doesn't exit when checking if Java is installed.

See issue: https://github.com/vassalengine/vassal/issues/12810