### PR TITLE
GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/module-bug-report.md
+++ b/.github/ISSUE_TEMPLATE/module-bug-report.md
@@ -16,7 +16,7 @@ Reproduce the bug using the latest appropriate Vassal & module combination and e
 A clear and concise description of what the bug is.
 
 **To Reproduce**
-Steps to reproduce the behavior (include a link to the module and other files where required. Small files may be attached; use .zip if necessary):
+Steps to reproduce the behavior (include a link to the module and other files if required. Small files may be attached; use .zip if necessary):
 1. Go to '...'
 2. Click on '....'
 3. Scroll down to '....'

--- a/.github/ISSUE_TEMPLATE/vassal-bug-report.md
+++ b/.github/ISSUE_TEMPLATE/vassal-bug-report.md
@@ -14,7 +14,7 @@ Reproduce the bug using the latest Vassal release and enter its version number a
 A clear and concise description of what the bug is.
 
 **To Reproduce**
-Steps to reproduce the behavior. **Small test modules that explicitly demonstrate a bug help considerably!** (include a link to the module and other files where required. Small files may be attached; use .zip if necessary.):
+Steps to reproduce the behavior. **Small test modules that explicitly demonstrate a bug help considerably!** (include a link to the module and other files if required. Small files may be attached; use .zip if necessary.):
 1. Go to '...'
 2. Click on '....'
 3. Scroll down to '....'

--- a/.github/ISSUE_TEMPLATE/vassal-documentation-issue.md
+++ b/.github/ISSUE_TEMPLATE/vassal-documentation-issue.md
@@ -1,6 +1,6 @@
 ---
 name: Vassal documentation issue
-about: Create a report to help us improve Vassal's documentation.
+about: Create a report to help us improve Vassal documentation.
 title: ''
 labels: documentation
 assignees: ''

--- a/.github/ISSUE_TEMPLATE/vassal-feature-request.md
+++ b/.github/ISSUE_TEMPLATE/vassal-feature-request.md
@@ -1,6 +1,6 @@
 ---
 name: Vassal feature request
-about: Suggest an idea to improve Vassal
+about: Suggest an idea to help improve Vassal
 title: "[Player|Module Manager|Editor|Other delete as appropriate] **summarise here**"
 labels: enhancement
 assignees: ''


### PR DESCRIPTION
Created some templates to help with logging Vassal issues and to support an update to the ["Bug Tracking" website page](https://vassalengine.org/w/index.php?title=Bug_Tracking_Process)