### PR TITLE
12826 Fix bug where pieces sometimes teleport from deck back to different map in multiplayer (Ensure map recorded in pieces matches map in parent Stack/Deck)

### DIFF
--- a/vassal-app/src/main/java/VASSAL/counters/BasicPiece.java
+++ b/vassal-app/src/main/java/VASSAL/counters/BasicPiece.java
@@ -665,6 +665,8 @@ public class BasicPiece extends AbstractImageFinder implements TranslatablePiece
   @Override
   public void setParent(Stack s) {
     parent = s;
+    // When adding a piece to a Stack, make sure our map matches the parent
+    if (parent != null) setMap(parent.getMap());
   }
 
   /**
@@ -889,7 +891,7 @@ public class BasicPiece extends AbstractImageFinder implements TranslatablePiece
   @Override
   public String getState() {
     final SequenceEncoder se = new SequenceEncoder(';');
-    final String mapName = map == null ? "null" : map.getIdentifier(); // NON-NLS
+    final String mapName = getMap() == null ? "null" : getMap().getIdentifier(); // NON-NLS
     se.append(mapName);
     final Point p = getPosition();
     se.append(p.x).append(p.y);

--- a/vassal-app/src/main/java/VASSAL/counters/Stack.java
+++ b/vassal-app/src/main/java/VASSAL/counters/Stack.java
@@ -771,6 +771,10 @@ public class Stack extends AbstractImageFinder implements GamePiece, StateMergea
   @Override
   public void setMap(Map map) {
     this.map = map;
+    // And so do all our children
+    for (int i = 0; i < getPieceCount(); i++) {
+      contents[i].setMap(map);
+    }
   }
 
   /**


### PR DESCRIPTION
In the past, BasicPiece.map has not always been kept up to date as a piece moves around. This has mostly not been noticeable, as BasicPiece defers to the parent when reporting it's map, EXCEPT in its own getState() method. This can cause some weird corner cases where a piece teleports back to its old map after a Return to Deck followed by a Dynamic Property Set in a Multi Action button in multiplayer mode when GamePiece Layers are enabled.

This fix does 3 things:
 1. Whenever a piece is added to a Stackk/Deck, it's map is updated to the map of the Stack/Deck 
 2. Whenever a Stack/Deck has its map set, it also sets the map of all its contents
 3. BasicPiece.getState() calls getMap() instead of accessing map directly (in case 1 and 2 aren't a complete fix, this should keep the behaviour consistent).