### PR TITLE
Suppress piece palette boolean bad data errors

### DIFF
--- a/vassal-app/src/main/java/VASSAL/configure/PropertyExpression.java
+++ b/vassal-app/src/main/java/VASSAL/configure/PropertyExpression.java
@@ -1,7 +1,6 @@
 package VASSAL.configure;
 
 import VASSAL.build.BadDataReport;
-import VASSAL.build.module.Map;
 import VASSAL.build.module.properties.PropertySource;
 import VASSAL.counters.EditablePiece;
 import VASSAL.counters.GamePiece;

--- a/vassal-app/src/main/java/VASSAL/configure/PropertyExpression.java
+++ b/vassal-app/src/main/java/VASSAL/configure/PropertyExpression.java
@@ -2,6 +2,7 @@ package VASSAL.configure;
 
 import VASSAL.build.BadDataReport;
 import VASSAL.build.module.properties.PropertySource;
+import VASSAL.counters.EditablePiece;
 import VASSAL.counters.GamePiece;
 import VASSAL.counters.PieceFilter;
 import VASSAL.i18n.Resources;
@@ -15,7 +16,7 @@ import VASSAL.tools.ErrorDialog;
 
 /*
  * Class encapsulating a Property Match Expression
- * A PropertyExpression is it's own PieceFilter.
+ * A PropertyExpression is its own PieceFilter.
  */
 public class PropertyExpression implements PieceFilter {
 
@@ -120,7 +121,9 @@ public class PropertyExpression implements PieceFilter {
       result = expression.evaluate(ps, owner, audit);
     }
     catch (ExpressionException e) {
-      ErrorDialog.dataWarning(new BadDataReport(Resources.getString("Error.expression_error"),
+      // suppress error report if this is an editable piece on the Piece Palette (where boolean calcs are not supported)
+      if (!(owner instanceof EditablePiece) || ((EditablePiece) owner).getMap() != null)
+        ErrorDialog.dataWarning(new BadDataReport(Resources.getString("Error.expression_error"),
         "Expression=" + getExpression() + ", Error=" + e.getError(), e)); //NON-NLS
     }
     return "true".equals(result); //NON-NLS


### PR DESCRIPTION
This PR suppresses the most common bad data errors that are generated by pieces on a palette. The issue arises when a boolean expression such as {x && y} contains properties that are neither true or false. This can happen for spurious reasons in that some properties aren't correctly initialised until instantiated onto a map ... e.g. `<layer>_Active`.

The PR checks whether the source of the error ("owner") is an Editable Piece and if so, the bad data report is not issued unless that piece is on a map (map name != null).