### PR TITLE
Refresh code cleanup and minor improvements

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/module/GameRefresher.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/GameRefresher.java
@@ -164,11 +164,11 @@ public final class GameRefresher implements CommandEncoder, GameComponent {
   }
 
   public boolean isTestMode() {
-    return options.contains("TestMode"); //$NON-NLS-1$
+    return options.contains(TEST_MODE); //$NON-NLS-1$
   }
 
   public boolean isDeleteNoMap() {
-    return options.contains("DeleteNoMap"); //$NON-NLS-1$
+    return options.contains(DELETE_NO_MAP); //$NON-NLS-1$
   }
 
   public void start() {
@@ -369,7 +369,7 @@ public final class GameRefresher implements CommandEncoder, GameComponent {
     /*
      * 4/ Refresh properties of decks in the game
      */
-    if (options.contains("RefreshDecks")) { //NON-NLS
+    if (options.contains(REFRESH_DECKS)) { //NON-NLS
       if (isGameActive()) {
         // If somebody feels like packaging all these things into Commands, help yourself...
         log(Resources.getString("GameRefresher.deck_refresh_during_multiplayer"));
@@ -449,7 +449,7 @@ public final class GameRefresher implements CommandEncoder, GameComponent {
           }
         }
 
-        if (options.contains("DeleteOldDecks")) { //NON-NLS
+        if (options.contains(DELETE_OLD_DECKS)) { //NON-NLS
           //log("List of Decks to remove");
           for (final Deck deck : decksToDelete) {
             log(Resources.getString("GameRefresher.deleting_old_deck", deck.getDeckName()));
@@ -508,7 +508,7 @@ public final class GameRefresher implements CommandEncoder, GameComponent {
         }
 
         if (!decksToAdd.isEmpty()) {
-          if (options.contains("AddNewDecks")) { //NON-NLS
+          if (options.contains(ADD_NEW_DECKS)) { //NON-NLS
             for (final DrawPile drawPile : decksToAdd) {
               log(Resources.getString("GameRefresher.adding_new_deck", drawPile.getAttributeValueString(SetupStack.NAME)));
 
@@ -534,8 +534,8 @@ public final class GameRefresher implements CommandEncoder, GameComponent {
 
         log("----------"); //$NON-NLS-1$
         log(Resources.getString("GameRefresher.refreshable_decks", refreshable));
-        log(Resources.getString(options.contains("DeleteOldDecks") ? "GameRefresher.deletable_decks" : "GameRefresher.deletable_decks_2", deletable)); //NON-NLS
-        log(Resources.getString(options.contains("AddNewDecks") ? "GameRefresher.addable_decks" : "GameRefresher.addable_decks_2", addable)); //NON-NLS
+        log(Resources.getString(options.contains(DELETE_OLD_DECKS) ? "GameRefresher.deletable_decks" : "GameRefresher.deletable_decks_2", deletable)); //NON-NLS
+        log(Resources.getString(options.contains(ADD_NEW_DECKS) ? "GameRefresher.addable_decks" : "GameRefresher.addable_decks_2", addable)); //NON-NLS
       }
     }
   }
@@ -727,20 +727,21 @@ public final class GameRefresher implements CommandEncoder, GameComponent {
 
       nameCheck = new JCheckBox(Resources.getString("GameRefresher.use_basic_name"));
       panel.add(nameCheck);
+
       labelerNameCheck = new JCheckBox(Resources.getString("GameRefresher.use_labeler_descr"), true);
       panel.add(labelerNameCheck);
       layerNameCheck = new JCheckBox(Resources.getString("GameRefresher.use_layer_descr"), true);
       panel.add(layerNameCheck);
       rotateNameCheck = new JCheckBox(Resources.getString("GameRefresher.use_rotate_descr"), true);
       panel.add(rotateNameCheck);
-      testModeOn = new JCheckBox(Resources.getString("GameRefresher.test_mode"));
+
+      testModeOn = new JCheckBox(Resources.getString("GameRefresher.test_mode"), false);
       panel.add(testModeOn);
-      deletePieceNoMap = new JCheckBox(Resources.getString("GameRefresher.delete_piece_no_map"));
-      deletePieceNoMap.setSelected(true);
+
+      deletePieceNoMap = new JCheckBox(Resources.getString("GameRefresher.delete_piece_no_map"), true);
       panel.add(deletePieceNoMap);
 
-      refreshDecks = new JCheckBox(Resources.getString("GameRefresher.refresh_decks"));
-      refreshDecks.setSelected(false);
+      refreshDecks = new JCheckBox(Resources.getString("GameRefresher.refresh_decks"), false);
       refreshDecks.addChangeListener(new ChangeListener() {
         @Override
         public void stateChanged(ChangeEvent e) {
@@ -750,12 +751,10 @@ public final class GameRefresher implements CommandEncoder, GameComponent {
       });
       panel.add(refreshDecks);
 
-      deleteOldDecks = new JCheckBox(Resources.getString("GameRefresher.delete_old_decks"));
-      deleteOldDecks.setSelected(false);
+      deleteOldDecks = new JCheckBox("<html><i>&nbsp;" + Resources.getString("GameRefresher.delete_old_decks") + "</i></html>", false);
       panel.add(deleteOldDecks);
 
-      addNewDecks = new JCheckBox(Resources.getString("GameRefresher.add_new_decks"));
-      addNewDecks.setSelected(false);
+      addNewDecks = new JCheckBox("<html><i>&nbsp;" + Resources.getString("GameRefresher.add_new_decks") + "</i></html>", false);
       panel.add(addNewDecks);
 
       if (refresher.isGameActive()) {
@@ -840,7 +839,7 @@ public final class GameRefresher implements CommandEncoder, GameComponent {
       // Send the update to other clients (only done in Player mode)
       g.sendAndLog(command);
 
-      if (options.contains("RefreshDecks") && !refresher.isGameActive()) {
+      if (options.contains(REFRESH_DECKS) && !refresher.isGameActive()) {
         final BasicLogger log = GameModule.getGameModule().getBasicLogger();
         if (log != null) {
           log.blockUndo(1);

--- a/vassal-app/src/main/java/VASSAL/configure/RefreshPredefinedSetupsDialog.java
+++ b/vassal-app/src/main/java/VASSAL/configure/RefreshPredefinedSetupsDialog.java
@@ -107,20 +107,21 @@ public class RefreshPredefinedSetupsDialog extends JDialog {
 
     nameCheck = new JCheckBox(Resources.getString("GameRefresher.use_basic_name"));
     panel.add(nameCheck);
+
     labelerNameCheck = new JCheckBox(Resources.getString("GameRefresher.use_labeler_descr"), true);
     panel.add(labelerNameCheck);
     layerNameCheck = new JCheckBox(Resources.getString("GameRefresher.use_layer_descr"), true);
     panel.add(layerNameCheck);
     rotateNameCheck = new JCheckBox(Resources.getString("GameRefresher.use_rotate_descr"), true);
     panel.add(rotateNameCheck);
-    testModeOn = new JCheckBox(Resources.getString("GameRefresher.test_mode"));
+
+    testModeOn = new JCheckBox(Resources.getString("GameRefresher.test_mode"), false);
     panel.add(testModeOn);
-    deletePieceNoMap = new JCheckBox(Resources.getString("GameRefresher.delete_piece_no_map"));
-    deletePieceNoMap.setSelected(false);
+
+    deletePieceNoMap = new JCheckBox(Resources.getString("GameRefresher.delete_piece_no_map"), true);
     panel.add(deletePieceNoMap);
 
-    refreshDecks = new JCheckBox(Resources.getString("GameRefresher.refresh_decks"));
-    refreshDecks.setSelected(false);
+    refreshDecks = new JCheckBox(Resources.getString("GameRefresher.refresh_decks"), false);
     refreshDecks.addChangeListener(new ChangeListener() {
       @Override
       public void stateChanged(ChangeEvent e) {
@@ -130,12 +131,10 @@ public class RefreshPredefinedSetupsDialog extends JDialog {
     });
     panel.add(refreshDecks);
 
-    deleteOldDecks = new JCheckBox(Resources.getString("GameRefresher.delete_old_decks"));
-    deleteOldDecks.setSelected(false);
+    deleteOldDecks = new JCheckBox("<html><i>&nbsp;" + Resources.getString("GameRefresher.delete_old_decks") + "</i></html>", false);
     panel.add(deleteOldDecks);
 
-    addNewDecks = new JCheckBox(Resources.getString("GameRefresher.add_new_decks"));
-    addNewDecks.setSelected(false);
+    addNewDecks = new JCheckBox("<html><i>&nbsp;" + Resources.getString("GameRefresher.add_new_decks") + "</i></html>", false);
     panel.add(addNewDecks);
 
     panel.add(buttonsBox, "grow"); // NON-NLS
@@ -188,7 +187,7 @@ public class RefreshPredefinedSetupsDialog extends JDialog {
   }
 
   public boolean isTestMode() {
-    return options.contains("TestMode"); //$NON-NLS-1$
+    return options.contains(GameRefresher.TEST_MODE); //$NON-NLS-1$
   }
 
 
@@ -255,8 +254,11 @@ public class RefreshPredefinedSetupsDialog extends JDialog {
         GameModule.getGameModule().setRefreshingSemaphore(false); //BR// Make sure we definitely lower the semaphore
       }
     }
+
+    // Clean up and close the window
     GameModule.getGameModule().getGameState().setup(false); //BR// Clear out whatever data (pieces, listeners, etc) left over from final game loaded.
 
     refreshButton.setEnabled(true);
+    dispose();  // Refresh Counters just does setVisible(false) at this point. dispose() better for memory management ?
   }
 }

--- a/vassal-doc/src/main/readme-referencemanual/ReferenceManual/GameRefresher.adoc
+++ b/vassal-doc/src/main/readme-referencemanual/ReferenceManual/GameRefresher.adoc
@@ -8,7 +8,7 @@
 === Refresh Counters
 When you update the <<GamePiece.adoc#top,Game Pieces>> and <<Prototypes.adoc#top,Prototypes>> in a module, those changes will affect any *future* games started using that module, but the changes will not--by default at least--affect pieces in any ongoing games that you load with the new version of the module. VASSAL saved games include the complete definition of each piece in order to maintain saved game compatibility with older versions of a module: so that replays and saves sent to you by someone with an earlier version of the module will continue to work in the same way they always did with the old version.
 
-But particularly since the <<GameModule.adoc#PredefinedSetup, Predefined Setups>> for module scenarios are stored internally as saved games, it is often important to module designers to be able to update an existing game to use the latest prototypes. That way a module designer can often avoid re-doing complex setups simply because prototypes have been updated and improved.
+Since the <<GameModule.adoc#PredefinedSetup, Predefined Setups>> for module scenarios are stored internally as saved games, it is often important to module designers to be able to update an existing game to use the latest prototypes. That way a module designer can often avoid re-doing complex setups simply because prototypes have been updated and improved.
 
 To use the refresher on the currently loaded game, go to the _Tools_ menu in your main VASSAL window and select _Refresh Counters_. You will be shown a dialog with several choices affecting the manner in which the operation is to be carried out.
 
@@ -16,7 +16,7 @@ Click the _Run_ button when you are ready to perform the refresh. The chat log w
 
 Whenever a piece is created in a VASSAL game, the Id of the definition used to create it is saved in the Piece. This Id identifies a piece in a <<PieceWindow.adoc#top,Game Piece Palette>>, or a Piece Definition in a <<PlaceMarker.adoc#top,Place Marker>> or <<Replace.adoc#top,Replace With Other>> trait.
 
-The Game Refresher works by matching the Id in each piece in the current game to the Id's of all piece definitions in the current module to find the new definition. If a match is found, then the piece is replaced with one created from the new defintion. Then each trait in the new Piece is checked to see if there is an EXACTLY matching trait in the old definition. If an EXACT match is found, then the 'state' of the old trait is copied over (e.g. what is the current layer showing, or current rotation facing).
+The Game Refresher works by matching the Id in each piece in the current game to the Id's of all piece definitions in the current module to find the new definition. If a match is found, then the piece is replaced with one created from the new definition. Then each trait in the new Piece is checked to see if there is an EXACTLY matching trait in the old definition. If an EXACT match is found, then the 'state' of the old trait is copied over (e.g. what is the current layer showing, or current rotation facing).
 
 Problems occur when the definition used to create the piece no longer exists in the module, or if traits are modified slightly so that they no longer EXACTLY match the old piece. There are various options in the Game Refresher dialog that can be used to help match and update these pieces and traits.
 
@@ -25,8 +25,8 @@ image:images/GameRefresher.png[]
 
 [width="100%",cols="50%a",]
 |===
-| *Use counter names to identify unkown counters:*::
-Use this option when the piece defintion used to create a Game Piece no longer exists in the module. +
+| *Use counter names to identify unknown counters:*::
+Use this option when the piece definition used to create a Game Piece no longer exists in the module. +
 +
 This option tells the Refresher to find a Piece Definition with the same Basic Name as the old definition to use for the Refresh. The first such definition found will be used.
 
@@ -61,7 +61,7 @@ Remove Decks from the game that no longer exist in the module. See the <<#DeckRe
 
 *Add decks to game which have been added to the module since this game was created (empty deck will be added):*::
 
-Add Decks to teh game that have been added to the module. See the <<#DeckRefresher,Deck Refresher>> section below for full details.
+Add Decks to the game that have been added to the module. See the <<#DeckRefresher,Deck Refresher>> section below for full details.
 
 
 |===


### PR DESCRIPTION
- Close (dispose) options window at the end of PDS refresh.
- Indent & format deck sub-options, in preparation for further options below deck refresh.
- Make Refresh PDS delete no map pieces the default (consistent with Refresh Counters).
- Rationalise option settings & use the option constants throughout.
- Doc spelling & grammar tweaks.