### PR TITLE
Deck Key Commands do not work on subsequent new games

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/module/map/deck/DeckSendKeyCommand.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/deck/DeckSendKeyCommand.java
@@ -315,6 +315,7 @@ public class DeckSendKeyCommand extends AbstractDeckKeyCommand {
   public void deregisterListeners() {
     if (sendListener != null) {
       GameModule.getGameModule().removeKeyStrokeListener(sendListener);
+      sendListener = null;
     }
   }
 

--- a/vassal-app/src/main/java/VASSAL/build/module/map/deck/DeckSortKeyCommand.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/deck/DeckSortKeyCommand.java
@@ -121,6 +121,7 @@ public class DeckSortKeyCommand extends AbstractDeckKeyCommand {
   public void deregisterListeners() {
     if (sortListener != null) {
       GameModule.getGameModule().removeKeyStrokeListener(sortListener);
+      sortListener = null;
     }
   }
 


### PR DESCRIPTION
This fixes deck sorting not working on the next and each subsequent "File->New Game". The deck sort HotKey works the first instance of a game module. After a "File->Close" and then "New Game", the sort HotKey does not work. The workaround prior to this fix: user must completely exit Vassal and restart it.

The sortListener must be null to successfully assign a new HotKey during initialization.