### PR TITLE
Labels have incorrect bounds when using italics

### DIFF
--- a/vassal-app/src/main/java/VASSAL/counters/Labeler.java
+++ b/vassal-app/src/main/java/VASSAL/counters/Labeler.java
@@ -66,8 +66,10 @@ import java.awt.Point;
 import java.awt.Rectangle;
 import java.awt.RenderingHints;
 import java.awt.Shape;
+import java.awt.font.TextLayout;
 import java.awt.geom.AffineTransform;
 import java.awt.geom.Area;
+import java.awt.geom.Rectangle2D;
 import java.awt.image.BufferedImage;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -547,12 +549,19 @@ public class Labeler extends Decorator implements TranslatablePiece, Loopable {
       return im;
     }
 
+    // Use TextLayout instead of getFontMetrics because of the italics problem.
     protected Dimension buildDimensions() {
       final Graphics2D g = ImageUtils.NULL_IMAGE.createGraphics();
-      final FontMetrics fm = g.getFontMetrics(font);
-      final Dimension s = new Dimension(fm.stringWidth(txt), fm.getHeight());
+      final TextLayout layout = new TextLayout(txt, font, g.getFontRenderContext());
+      final Rectangle2D lBounds = new Rectangle2D.Float(
+        0f,
+        -layout.getAscent() - layout.getLeading(),
+        layout.getAdvance(),
+        layout.getAscent() + layout.getDescent() + 2f * layout.getLeading()
+      );
+      final Rectangle2D bounds = lBounds.createUnion(layout.getBounds());
       g.dispose();
-      return s;
+      return bounds.getBounds().getSize();
     }
 
     @Override


### PR DESCRIPTION
Currently a label font using italics can run off the edge of its bounding box, as you can see with the "0" here:

<img width="118" alt="Screenshot 2023-11-26 at 9 20 29 PM" src="https://github.com/vassalengine/vassal/assets/78529/905256da-0992-4b83-bbf9-7cb4f0dbe7dc">

This is actually a quirk of italics, as the `getFontMetrics` function does logical vs visual calculations. Old but relevant conversation at https://bugs.openjdk.org/browse/JDK-4262130, from which I borrowed for the solution.

Original conversation starts at https://discord.com/channels/740127632586178572/911199889059360798/1178520800928735272 for those interested.