### PR TITLE
12912 Prevent Welcome Wizard loading multiple pre-defined setups concurrently

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/module/WizardSupport.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/WizardSupport.java
@@ -63,6 +63,8 @@ import javax.swing.JRadioButton;
 import javax.swing.SwingUtilities;
 import javax.swing.SwingWorker;
 import javax.swing.UIManager;
+import javax.swing.event.PopupMenuEvent;
+import javax.swing.event.PopupMenuListener;
 import java.awt.AlphaComposite;
 import java.awt.BorderLayout;
 import java.awt.Color;
@@ -481,23 +483,35 @@ public class WizardSupport {
       comboBoxModel.insertElementAt(description, 0);
       final JComboBox<Object> setupSelection = new JComboBox<>(comboBoxModel);
       setupSelection.setSelectedIndex(0);
-      setupSelection.addActionListener(e -> {
-        if (setupSelection.getSelectedItem() instanceof PredefinedSetup) {
-          final PredefinedSetup setup = (PredefinedSetup) setupSelection.getSelectedItem();
-          if (setup.isUseFile() && setup.getFileName() != null) {
-            loadSetup(setup, controller, settings);
+      setupSelection.addPopupMenuListener(new PopupMenuListener() {
+        @Override
+        public void popupMenuWillBecomeVisible(PopupMenuEvent e) {
+        }
+
+        @Override
+        public void popupMenuWillBecomeInvisible(PopupMenuEvent e) {
+          if (setupSelection.getSelectedItem() instanceof PredefinedSetup) {
+            final PredefinedSetup setup = (PredefinedSetup) setupSelection.getSelectedItem();
+            if (setup.isUseFile() && setup.getFileName() != null) {
+              loadSetup(setup, controller, settings);
+            }
+            else {
+              final GameSetupPanels panels = GameSetupPanels.newInstance();
+              settings.put(POST_PLAY_OFFLINE_WIZARD, panels);
+              controller.setProblem(null);
+              controller.setForwardNavigationMode(panels == null ? WizardController.MODE_CAN_FINISH : WizardController.MODE_CAN_CONTINUE);
+            }
           }
           else {
-            final GameSetupPanels panels = GameSetupPanels.newInstance();
-            settings.put(POST_PLAY_OFFLINE_WIZARD, panels);
-            controller.setProblem(null);
-            controller.setForwardNavigationMode(panels == null ? WizardController.MODE_CAN_FINISH : WizardController.MODE_CAN_CONTINUE);
+            controller.setProblem(description);
           }
         }
-        else {
-          controller.setProblem(description);
+
+        @Override
+        public void popupMenuCanceled(PopupMenuEvent e) {
         }
       });
+
       setupSelection.setMaximumSize(new Dimension(setupSelection.getMaximumSize().width, setupSelection.getPreferredSize().height));
       setupSelection.setRenderer(new DefaultListCellRenderer() {
         private static final long serialVersionUID = 1L;

--- a/vassal-app/src/main/java/VASSAL/build/module/WizardSupport.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/WizardSupport.java
@@ -552,10 +552,8 @@ public class WizardSupport {
         return;
       }
 
-      try {
-        final BufferedInputStream bis = new BufferedInputStream(setup.getSavedGameContents());
+      try (InputStream in = setup.getSavedGameContents(); BufferedInputStream bis = new BufferedInputStream(in)) {
         Command setupCommand = GameModule.getGameModule().getGameState().decodeSavedGame(bis);
-        bis.close();
         try {
           if (setupCommand == null) {
             throw new IOException(Resources.getString("WizardSupport.InvalidSavefile")); //$NON-NLS-1$


### PR DESCRIPTION
If you run the wizard and use the arrow to move up and down the pre-defined setup combobox, then each PDS you hit as you arrow is concurrently loaded in a new thread. This creates mayhem on a module with longer save load times. I was able to easily generate an out of memory error and fingers-crossed, this may be the root cause of the Sudden Wizard Death Syndrome.

I have removed the background loading and now load pre-defined setups in the foreground. Wizard users on large modules who use the arrow navigation method on drop-down boxes will notice a performance lag until each PDS loads. Normal people will see no change at all. External games are still loaded via a thread, but this is not as a problem as there can only ever be one.

