### PR TITLE
Store correct value in prefs for Module Manager column widths

### DIFF
--- a/vassal-app/src/main/java/VASSAL/launch/ModuleManagerWindow.java
+++ b/vassal-app/src/main/java/VASSAL/launch/ModuleManagerWindow.java
@@ -796,7 +796,7 @@ public class ModuleManagerWindow extends JFrame {
     for (int i = 0; i < model.getColumnCount(); i++) {
       se.append(model.getColumn(i).getWidth());
     }
-    Prefs.getGlobalPrefs().setValue(COLUMN_WIDTHS_KEY, se.toString());
+    Prefs.getGlobalPrefs().setValue(COLUMN_WIDTHS_KEY, se.getValue());
   }
 
   public void updateRequest(File f) {


### PR DESCRIPTION
Call the right function to dump SequenceEncoder value.