### PR TITLE
12765 - Cancelling Return To Deck no longer causes crash

### DIFF
--- a/vassal-app/src/main/java/VASSAL/counters/ReturnToDeck.java
+++ b/vassal-app/src/main/java/VASSAL/counters/ReturnToDeck.java
@@ -151,8 +151,8 @@ public class ReturnToDeck extends Decorator implements TranslatablePiece {
 
       if (deckSelect) {
         pile = promptForDrawPile();
-        if (pile != null) {
-          return null;  // No Deck selected
+        if (pile == null) {
+          return null;  // No Deck selected, just do nothing
         }
       }
       else {

--- a/vassal-app/src/main/java/VASSAL/counters/ReturnToDeck.java
+++ b/vassal-app/src/main/java/VASSAL/counters/ReturnToDeck.java
@@ -151,6 +151,9 @@ public class ReturnToDeck extends Decorator implements TranslatablePiece {
 
       if (deckSelect) {
         pile = promptForDrawPile();
+        if (pile != null) {
+          return null;  // No Deck selected
+        }
       }
       else {
         final AuditTrail audit = AuditTrail.create(this, deckExpression, Resources.getString("Editor.ReturnToDeck.deck_name"));


### PR DESCRIPTION
When 'Prompt for Deck' option on a return to Deck trait is selected, then a list of available Decks is provided. You click one, then click the OK or Cancel button.

If you click OK or Cancel without selecting a Deck, you get a NPE.