### PR TITLE
Fix poor performance of Piece Definer; remove spurious blank line from Mass Piece Loader

### DIFF
--- a/vassal-app/src/main/java/VASSAL/counters/MassPieceLoader.java
+++ b/vassal-app/src/main/java/VASSAL/counters/MassPieceLoader.java
@@ -823,6 +823,11 @@ public class MassPieceLoader {
       refresh();
     }
 
+    @Override
+    public boolean isPrototype() {
+      return true;
+    }
+
   }
 
   /**

--- a/vassal-app/src/main/java/VASSAL/counters/PieceDefiner.java
+++ b/vassal-app/src/main/java/VASSAL/counters/PieceDefiner.java
@@ -106,7 +106,7 @@ public class PieceDefiner extends JPanel {
   // A reduced inset size for the icon buttons gives a better look
   private static final Insets buttonInsets = new Insets(1, 2, 1, 2);
 
-  // Some empty space around the rendered Piece Image so it doesn't look to crammed
+  // Some empty space around the rendered Piece Image, so it doesn't look too crammed
   private static final int PIECE_IMAGE_INSET = 10;
 
   protected static DefaultListModel<GamePiece> availableModel;
@@ -168,7 +168,7 @@ public class PieceDefiner extends JPanel {
   }
 
   public boolean isPrototype() {
-    return prototypeName.isEmpty();
+    return !prototypeName.isEmpty();
   }
 
   public PieceDefiner(String id, GpIdSupport s) {
@@ -264,7 +264,7 @@ public class PieceDefiner extends JPanel {
   }
 
   /**
-   * Add an additional definition to the list of available traits.
+   * Add another definition to the list of available traits.
    * Add to the bottom of the classic list
    * Regenerate the Alpha list
    * reset the model depending on the sort setting
@@ -487,7 +487,7 @@ public class PieceDefiner extends JPanel {
     splitPane = new JSplitPane(JSplitPane.HORIZONTAL_SPLIT, true, slotPanel, controls);
     splitPane.addPropertyChangeListener(JSplitPane.DIVIDER_LOCATION_PROPERTY, e -> splitChanged());
 
-    // Set a MouseListener on the Divider so we can distinguish manual drags from auto-resizes
+    // Set a MouseListener on the Divider, so we can distinguish manual drags from auto-resizes
     final SplitPaneUI spui = splitPane.getUI();
     if (spui instanceof BasicSplitPaneUI) {
       ((BasicSplitPaneUI) spui).getDivider().addMouseListener(new MouseAdapter() {
@@ -1303,23 +1303,32 @@ public class PieceDefiner extends JPanel {
       super.getListCellRendererComponent(list, "", index, selected, hasFocus);
 
       // For Pieces, bump index to 1
-      final int lineno = definer.isPrototype() ? index + 1 : index;
+      final int lineno = definer.isPrototype() ? index : index + 1;
 
-      if (value instanceof EditablePiece) {
+      // Prototype will be zero for first item and will be skipped (not a real trait)
+      if (lineno > 0) {
+        if (value instanceof EditablePiece) {     // Safety first
 
-        if (value instanceof Decorator && ((Decorator) value).myGetType().startsWith(Comment.ID)) {
-          setText(cellText(lineno, "<b>/* " + ConfigureTree.noHTML(((EditablePiece) value).getDescription() + " */")));
+          final String s = ((EditablePiece) value).getDescription();
+
+          if (lineno == 1 && s.isEmpty()) {
+            // Patch the first line of Mass Piece Loader Template
+            setText(cellText(lineno, "Basic Piece"));
+          }
+          else {
+            if (value instanceof Comment) {
+              setText(cellText(lineno, "<b>/* " + ConfigureTree.noHTML((s) + " */")));
+            }
+            else {
+              setText(cellText(lineno, ConfigureTree.noHTML(s)));
+            }
+          }
         }
-        else if (lineno > 0) {
-          // Prototype? Skip first (dummy) item
-          setText(cellText(lineno, ConfigureTree.noHTML(((EditablePiece) value).getDescription())));
+        else {
+          // Safety net for non-EditablePiece (probably redundant) - item will use last element of class name
+          final String s = value.getClass().getName();
+          setText(cellText(lineno, s.substring(s.lastIndexOf('.') + 1)));
         }
-
-      }
-      else {
-        // Redundant ?
-        final String s = value.getClass().getName();
-        setText(cellText(lineno, s.substring(s.lastIndexOf('.') + 1)));
       }
       return this;
     }

--- a/vassal-app/src/main/java/VASSAL/counters/PieceDefiner.java
+++ b/vassal-app/src/main/java/VASSAL/counters/PieceDefiner.java
@@ -1305,24 +1305,19 @@ public class PieceDefiner extends JPanel {
       // For Pieces, bump index to 1
       final int lineno = definer.isPrototype() ? index : index + 1;
 
-      // Prototype will be zero for first item and will be skipped (not a real trait)
+      // Prototype or MPL Template will be zero for first item and will be skipped (not a real trait)
       if (lineno > 0) {
         if (value instanceof EditablePiece) {     // Safety first
 
-          final String s = ((EditablePiece) value).getDescription();
+          final String s = ConfigureTree.noHTML(((EditablePiece) value).getDescription());
 
-          if (lineno == 1 && s.isEmpty()) {
-            // Patch the first line of Mass Piece Loader Template
-            setText(cellText(lineno, "Basic Piece"));
+          if (value instanceof Comment) {
+            setText(cellText(lineno, "<b>/* " + s + " */"));
           }
           else {
-            if (value instanceof Comment) {
-              setText(cellText(lineno, "<b>/* " + ConfigureTree.noHTML((s) + " */")));
-            }
-            else {
-              setText(cellText(lineno, ConfigureTree.noHTML(s)));
-            }
+            setText(cellText(lineno, s));
           }
+
         }
         else {
           // Safety net for non-EditablePiece (probably redundant) - item will use last element of class name

--- a/vassal-app/src/main/java/VASSAL/counters/PieceDefiner.java
+++ b/vassal-app/src/main/java/VASSAL/counters/PieceDefiner.java
@@ -1285,10 +1285,10 @@ public class PieceDefiner extends JPanel {
     }
 
     // This can be used from cellTextHTML() to format the line numbers - stopped using at Vassal v3.7.5 as performance was poor for very large trait lists
-    private static String getLineNumber(int lineNumber) {
-      // prep line number for output
-      return "<span style=color:#A0A0A0>" + lineNumber + ".</span>";
-    }
+//    private static String getLineNumber(int lineNumber) {
+//      // prep line number for output
+//      return "<span style=color:#A0A0A0>" + lineNumber + ".</span>";
+//    }
 
     private static String cellTextHTML(int lineno, String s) {
       return "<html>" + lineno + ". " + s + "</html>";

--- a/vassal-app/src/main/java/VASSAL/counters/PieceDefiner.java
+++ b/vassal-app/src/main/java/VASSAL/counters/PieceDefiner.java
@@ -1284,49 +1284,40 @@ public class PieceDefiner extends JPanel {
       this.definer = definer;
     }
 
-    // This can be used from cellTextHTML() to format the line numbers - stopped using at Vassal v3.7.5 as performance was poor for very large trait lists
-//    private static String getLineNumber(int lineNumber) {
-//      // prep line number for output
-//      return "<span style=color:#A0A0A0>" + lineNumber + ".</span>";
-//    }
-
-    private static String cellTextHTML(int lineno, String s) {
-      return "<html>" + lineno + ". " + s + "</html>";
+    private static String getLineNumber(int lineNumber) {
+      // prep line number for output
+      return "<span style=color:#A0A0A0>" + lineNumber + ".</span>";
     }
 
     private static String cellText(int lineno, String s) {
-      return lineno + ". " + s;
+      return "<html>" + getLineNumber(lineno) + " " + s + "</html>";
     }
 
     @Override
     public Component getListCellRendererComponent(
-      JList list, Object value, int index, boolean selected, boolean hasFocus) {
+            JList list, Object value, int index, boolean selected, boolean hasFocus) {
 
       // DO NOT pass value to super.getListCellRendererComponent()
       // It is incredibly inefficient for GamePieces and is not needed
       // since we overwrite the label text anyway.
       super.getListCellRendererComponent(list, "", index, selected, hasFocus);
 
-      final int lineOffset = definer.isPrototype() ? 1 : 0;
-      final int lineno = index + lineOffset;
+      // For Pieces, bump index to 1
+      final int lineno = definer.isPrototype() ? index + 1 : index;
 
       if (value instanceof EditablePiece) {
-        final EditablePiece editableValue = (EditablePiece) value;
 
-        // Prototype? Skip first (dummy) item to avoid outputting a blank line
-        if (lineOffset == 1 || index > 0) {
-          // For Pieces, bump index to 1
-          // Special formatting for Comments
-          if ((editableValue.getType().startsWith(Comment.ID))) {
-            setText(cellTextHTML(lineno, "<b>/* " + ConfigureTree.noHTML((editableValue.getDescription())) + " */</b>"));
-          }
-          else {
-            setText(cellText(lineno, editableValue.getDescription())); // removed ConfigureTree.noHTML() wrap for performance
-          }
+        if (value instanceof Decorator && ((Decorator) value).myGetType().startsWith(Comment.ID)) {
+          setText(cellText(lineno, "<b>/* " + ConfigureTree.noHTML(((EditablePiece) value).getDescription() + " */")));
         }
+        else if (lineno > 0) {
+          // Prototype? Skip first (dummy) item
+          setText(cellText(lineno, ConfigureTree.noHTML(((EditablePiece) value).getDescription())));
+        }
+
       }
       else {
-        // FIXME: When does this get used ? Assumed that prototype might have to be skipped here also.
+        // Redundant ?
         final String s = value.getClass().getName();
         setText(cellText(lineno, s.substring(s.lastIndexOf('.') + 1)));
       }

--- a/vassal-app/src/main/java/VASSAL/counters/PieceDefiner.java
+++ b/vassal-app/src/main/java/VASSAL/counters/PieceDefiner.java
@@ -1284,13 +1284,18 @@ public class PieceDefiner extends JPanel {
       this.definer = definer;
     }
 
+    // This can be used from cellTextHTML() to format the line numbers - stopped using at Vassal v3.7.5 as performance was poor for very large trait lists
     private static String getLineNumber(int lineNumber) {
       // prep line number for output
       return "<span style=color:#A0A0A0>" + lineNumber + ".</span>";
     }
 
+    private static String cellTextHTML(int lineno, String s) {
+      return "<html>" + lineno + ". " + s + "</html>";
+    }
+
     private static String cellText(int lineno, String s) {
-      return "<html>" + getLineNumber(lineno) + " " + s + "</html>";
+      return lineno + ". " + s;
     }
 
     @Override
@@ -1313,10 +1318,10 @@ public class PieceDefiner extends JPanel {
           // For Pieces, bump index to 1
           // Special formatting for Comments
           if ((editableValue.getType().startsWith(Comment.ID))) {
-            setText(cellText(lineno, "<b>/* " + ConfigureTree.noHTML((editableValue.getDescription())) + " */</b>"));
+            setText(cellTextHTML(lineno, "<b>/* " + ConfigureTree.noHTML((editableValue.getDescription())) + " */</b>"));
           }
           else {
-            setText(cellText(lineno, ConfigureTree.noHTML(editableValue.getDescription())));
+            setText(cellText(lineno, editableValue.getDescription())); // removed ConfigureTree.noHTML() wrap for performance
           }
         }
       }


### PR DESCRIPTION
(Updated) PR now reverts MPL to pre-v3.7.5 behaviour - no Basic Piece line, blank or otherwise.

This PR can supersede, or be merged back into, PR #12997.
