### PR TITLE
Spelling correction on Global Options panel

### DIFF
--- a/vassal-app/src/main/resources/VASSAL/i18n/Editor.properties
+++ b/vassal-app/src/main/resources/VASSAL/i18n/Editor.properties
@@ -1124,7 +1124,7 @@ Editor.GlobalOption.inventory_visible_to_all=Inventory can see into Private Wind
 Editor.GlobalOption.send_to_location_movement_trails=Send-to-Location trait generates Movement Trails
 Editor.GlobalOption.leading_zero_integer_strings=Preserve leading zeros in Integers?
 Editor.GlobalOption.purge_blank_property_prompts=Purge blank lines from dynamic/global property prompts?
-Editor.GlobalOption.disable_use_location_indexes=Disable use of location indexs to speed up Global Key Commands?
+Editor.GlobalOption.disable_use_location_indexes=Disable use of location indexes to speed up Global Key Commands?
 
 # Global Properties
 Editor.GlobalProperties.component_type=Global Properties


### PR DESCRIPTION
Correction to spelling of `indexes`.

<img width="471" alt="image" src="https://github.com/vassalengine/vassal/assets/58135975/b4e997d0-8a47-4d07-87ab-0efe1b11c202">
