### PR TITLE
Draft: Game map progression animation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ VNUM:=3.8.0
 # major-minor part of the version
 V_MAJ_MIN:=$(shell echo "$(VNUM)" | cut -f1,2 -d'.')
 
-MAVEN_VERSION:=$(VNUM)-SNAPSHOT
+MAVEN_VERSION:=$(VNUM)-EISMEER-SNAPSHOT-4
 #MAVEN_VERSION:=$(VNUM)-beta5
 #MAVEN_VERSION:=$(VNUM)
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>org.vassalengine</groupId>
     <artifactId>vassal-parent</artifactId>
-    <version>3.8.0-SNAPSHOT</version>
+    <version>3.8.0-EISMEER-SNAPSHOT-4</version>
     <packaging>pom</packaging>
 
     <name>Vassal Engine</name>

--- a/release-prepare/pom.xml
+++ b/release-prepare/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.vassalengine</groupId>
         <artifactId>vassal-parent</artifactId>
-        <version>3.8.0-SNAPSHOT</version>
+        <version>3.8.0-EISMEER-SNAPSHOT-4</version>
     </parent>
 
     <artifactId>release-prepare</artifactId>

--- a/vassal-app/pom.xml
+++ b/vassal-app/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.vassalengine</groupId>
         <artifactId>vassal-parent</artifactId>
-        <version>3.8.0-SNAPSHOT</version>
+        <version>3.8.0-EISMEER-SNAPSHOT-4</version>
     </parent>
 
     <artifactId>vassal-app</artifactId>

--- a/vassal-app/src/main/java/VASSAL/build/GameModule.java
+++ b/vassal-app/src/main/java/VASSAL/build/GameModule.java
@@ -1595,6 +1595,11 @@ public class GameModule extends AbstractConfigurable
     return s;
   }
 
+  public FileChooser getDirectoryChooser() {
+    return FileChooser.createFileChooser(getPlayerWindow(),
+        getGameState().getSavedGameDirectoryPreference(), FileChooser.DIRECTORIES_ONLY);
+  }
+
   /**
    * @return a common FileChooser so that recent file locations
    * can be remembered

--- a/vassal-app/src/main/java/VASSAL/build/module/GameState.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/GameState.java
@@ -927,14 +927,17 @@ public class GameState implements CommandEncoder {
   private int i = 0;
 
   // Only make screenshots for the following map ID
-  private String RELEVANT_MAP_ID = "Map0";
+  private static final String RELEVANT_MAP_ID = "Map0";
 
   /**
    * Loads a series of game files in a folder and makes a screenshot at the end of each. 
    * Those screenshots can then be made into an animation at the end
    * 
+   * (optional) Cut playarea from complete map pictures (when only part of the map is used)
+   mogrify -format 'png' -crop 2173x1005+3543+938 +repage *-Map0.png
+   mogrify -format 'png' +repage *-Map0.png
    * (optional) Add filename watermark to top right of the image:
-   mogrify -format 'png' -font Liberation-Sans -fill white -undercolor '#00000080' -pointsize 26 -gravity NorthEast -annotate +10+10 %t *-Map0-*.png
+   mogrify -format 'png' -font Liberation-Sans -fill white -undercolor '#00000080' -pointsize 26 -gravity NorthEast -annotate +10+10 %t *-Map0.png
    * make images into a webm video
    ffmpeg -f image2 -framerate 1 -pattern_type glob -i "*-Map0-*.png" output.webm
    * 
@@ -964,15 +967,18 @@ public class GameState implements CommandEncoder {
       for (final File logFile : logFiles) {
         System.out.println("Processing logfile " + logFile.getName());
 
+        // TODO: can we somehow skip non-movement commands?
         loadFastForward(false, () -> loadGame(logFile, true, true), () -> {
           i = i + 1;
           for (final VASSAL.build.module.Map map : VASSAL.build.module.Map.getMapList()) {
             if (!map.mapID.equals(RELEVANT_MAP_ID)) {
               continue;
             }
+
             final String path = Paths.get(
               fc.getSelectedFile().getAbsolutePath(), 
-              logFile.getName() + "-" + i + "-" + map.mapID + ".png"
+              // make i zero padded!
+              logFile.getName() + "-" + String.format("%03d", i) + "-" + map.mapID + ".png"
             ).toString();
             System.out.println("Saving image to " + path);
             final File mapPictureFile = new File(path);

--- a/vassal-app/src/main/java/VASSAL/build/module/GameState.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/GameState.java
@@ -982,7 +982,7 @@ public class GameState implements CommandEncoder {
             // TODO Auto-generated catch block
             e.printStackTrace();
           }
-        }, 2000, TimeUnit.MILLISECONDS);
+        }, 3000, TimeUnit.MILLISECONDS);
         loadGame(saveFile, false, true);
         System.out.println("file loaded");
         for (final VASSAL.build.module.Map map : VASSAL.build.module.Map.getMapList()) {

--- a/vassal-app/src/main/java/VASSAL/build/module/GameState.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/GameState.java
@@ -924,10 +924,18 @@ public class GameState implements CommandEncoder {
    * Those screenshots can then be made into an animation at the end
    */
   private void createGameAnimation() {
-    loadFastForward(false);
-    System.out.println("Now screenshot");
-    final VASSAL.build.module.Map map = this.getAllPieces().iterator().next().getMap();
-    new ImageSaver(map).writeMapAsImage();
+    final Boolean oldStartNewLogfileSetting = (Boolean) GameModule.getGameModule().getPrefs().getValue(BasicLogger.PROMPT_NEW_LOG_END);
+    GameModule.getGameModule().getPrefs().setValue(BasicLogger.PROMPT_NEW_LOG_END, Boolean.FALSE);
+    try {
+      loadFastForward(false);
+      System.out.println("Now screenshot");
+      final VASSAL.build.module.Map map = this.getAllPieces().iterator().next().getMap();
+      new ImageSaver(map).writeMapAsImage();
+    }
+    finally {
+      GameModule.getGameModule().getPrefs().setValue(BasicLogger.PROMPT_NEW_LOG_END, oldStartNewLogfileSetting);
+    }
+
   }
 
   /**

--- a/vassal-app/src/main/java/VASSAL/build/module/GameState.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/GameState.java
@@ -928,9 +928,9 @@ public class GameState implements CommandEncoder {
    * Those screenshots can then be made into an animation at the end
    * 
    * (optional) Add filename watermark to top right of the image:
-   mogrify -format 'png' -font Liberation-Sans -fill white -undercolor '#00000080' -pointsize 26 -gravity NorthEast -annotate +10+10 %t *.png
+   mogrify -format 'png' -font Liberation-Sans -fill white -undercolor '#00000080' -pointsize 26 -gravity NorthEast -annotate +10+10 %t *-Map0.png
    * make images into a webm video
-   ffmpeg -f image2 -framerate 1 -pattern_type glob -i "*.png" output.webm
+   ffmpeg -f image2 -framerate 1 -pattern_type glob -i "*-Map0.png" output.webm
    * 
    * Video creation with watermark in one step didn't get it to run yet)
    ffmpeg \
@@ -945,7 +945,6 @@ public class GameState implements CommandEncoder {
     final Boolean oldStartNewLogfileSetting = (Boolean) GameModule.getGameModule().getPrefs().getValue(BasicLogger.PROMPT_NEW_LOG_END);
     GameModule.getGameModule().getPrefs().setValue(BasicLogger.PROMPT_NEW_LOG_END, Boolean.FALSE);
     try {
-      // TODO: how to get rid of "want to overwrite this folder" message? We're not overwriting content!
       final FileChooser fc = GameModule.getGameModule().getDirectoryChooser();
       if (fc.showOpenDialog(GameModule.getGameModule().getPlayerWindow()) != FileChooser.APPROVE_OPTION) return;
       System.out.println(fc.getCurrentDirectory().getAbsolutePath());
@@ -960,12 +959,15 @@ public class GameState implements CommandEncoder {
         System.out.println("Processing logfile " + logFile.getName());
         loadFastForward(false, () -> loadGame(logFile, true, true));
 
-        final String path = Paths.get(fc.getSelectedFile().getAbsolutePath(), logFile.getName() + ".png").toString();
-
-        System.out.println("Saving image to " + path);
-        final File mapPictureFile = new File(path);
-        final VASSAL.build.module.Map map = this.getAllPieces().iterator().next().getMap();
-        new ImageSaver(map).writeMapAsImage(mapPictureFile);
+        for (final VASSAL.build.module.Map map : VASSAL.build.module.Map.getMapList()) {
+          final String path = Paths.get(
+            fc.getSelectedFile().getAbsolutePath(), 
+            logFile.getName() + "-" + map.mapID + ".png"
+          ).toString();
+          System.out.println("Saving image to " + path);
+          final File mapPictureFile = new File(path);
+          new ImageSaver(map).writeMapAsImage(mapPictureFile);
+        }        
       }
       
     }

--- a/vassal-app/src/main/java/VASSAL/build/module/GameState.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/GameState.java
@@ -972,14 +972,14 @@ public class GameState implements CommandEncoder {
         System.out.println("Processing savefile " + saveFile.getName());
 
         pool.schedule(() -> {
-          System.out.println("waited a two seconds");
+          System.out.println("waited three seconds");
           try {
             Robot rob = new Robot();
             rob.keyPress(KeyEvent.VK_ENTER);
             rob.keyRelease(KeyEvent.VK_ENTER);
             System.out.println("enter pressed");
-          } catch (AWTException e) {
-            // TODO Auto-generated catch block
+          }
+          catch (AWTException e) {
             e.printStackTrace();
           }
         }, 3000, TimeUnit.MILLISECONDS);

--- a/vassal-app/src/main/java/VASSAL/build/module/GameState.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/GameState.java
@@ -70,7 +70,10 @@ import javax.swing.JFrame;
 import javax.swing.JOptionPane;
 import javax.swing.SwingUtilities;
 import javax.swing.SwingWorker;
+
+import java.awt.AWTException;
 import java.awt.Cursor;
+import java.awt.Robot;
 import java.awt.datatransfer.DataFlavor;
 import java.awt.datatransfer.Transferable;
 import java.awt.datatransfer.UnsupportedFlavorException;
@@ -78,6 +81,7 @@ import java.awt.dnd.DnDConstants;
 import java.awt.dnd.DropTargetDropEvent;
 import java.awt.dnd.InvalidDnDOperationException;
 import java.awt.event.ActionEvent;
+import java.awt.event.KeyEvent;
 import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
 import java.io.File;
@@ -102,6 +106,9 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.zip.ZipEntry;
@@ -940,8 +947,11 @@ public class GameState implements CommandEncoder {
   // Only make screenshots for the following map ID
   private static final String RELEVANT_MAP_ID = "Map0";
 
+  private static final ScheduledExecutorService pool = Executors.newScheduledThreadPool(1);
   /**
    * Loads a set of VSAV files in a folder and makes a screenshot of the initial state of each. 
+   * @throws AWTException 
+   * @throws InterruptedException 
    */
   private void createVSAVScreenshots() {
     final FileChooser fc = GameModule.getGameModule().getDirectoryChooser();
@@ -961,7 +971,20 @@ public class GameState implements CommandEncoder {
       for (final File saveFile : saveFiles) {
         System.out.println("Processing savefile " + saveFile.getName());
 
+        pool.schedule(() -> {
+          System.out.println("waited a two seconds");
+          try {
+            Robot rob = new Robot();
+            rob.keyPress(KeyEvent.VK_ENTER);
+            rob.keyRelease(KeyEvent.VK_ENTER);
+            System.out.println("enter pressed");
+          } catch (AWTException e) {
+            // TODO Auto-generated catch block
+            e.printStackTrace();
+          }
+        }, 2000, TimeUnit.MILLISECONDS);
         loadGame(saveFile, false, true);
+        System.out.println("file loaded");
         for (final VASSAL.build.module.Map map : VASSAL.build.module.Map.getMapList()) {
           if (!map.mapID.equals(RELEVANT_MAP_ID)) {
             continue;

--- a/vassal-app/src/main/java/VASSAL/build/module/GameState.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/GameState.java
@@ -975,7 +975,7 @@ public class GameState implements CommandEncoder {
         pool.schedule(() -> {
           System.out.println("waited three seconds");
           try {
-            Robot rob = new Robot();
+            final Robot rob = new Robot();
             rob.keyPress(KeyEvent.VK_ENTER);
             rob.keyRelease(KeyEvent.VK_ENTER);
             System.out.println("enter pressed");

--- a/vassal-app/src/main/java/VASSAL/build/module/GameState.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/GameState.java
@@ -947,7 +947,7 @@ public class GameState implements CommandEncoder {
     try {
       // TODO: how to get rid of "want to overwrite this folder" message? We're not overwriting content!
       final FileChooser fc = GameModule.getGameModule().getDirectoryChooser();
-      if (fc.showSaveDialog(GameModule.getGameModule().getPlayerWindow()) != FileChooser.APPROVE_OPTION) return;
+      if (fc.showOpenDialog(GameModule.getGameModule().getPlayerWindow()) != FileChooser.APPROVE_OPTION) return;
       System.out.println(fc.getCurrentDirectory().getAbsolutePath());
       System.out.println(fc.getSelectedFile().getAbsolutePath());
 

--- a/vassal-app/src/main/java/VASSAL/build/module/GameState.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/GameState.java
@@ -69,6 +69,7 @@ import javax.swing.JOptionPane;
 import javax.swing.SwingUtilities;
 import javax.swing.SwingWorker;
 import java.awt.Cursor;
+import java.awt.Frame;
 import java.awt.datatransfer.DataFlavor;
 import java.awt.datatransfer.Transferable;
 import java.awt.datatransfer.UnsupportedFlavorException;
@@ -928,9 +929,20 @@ public class GameState implements CommandEncoder {
     GameModule.getGameModule().getPrefs().setValue(BasicLogger.PROMPT_NEW_LOG_END, Boolean.FALSE);
     try {
       loadFastForward(false);
-      System.out.println("Now screenshot");
+
       final VASSAL.build.module.Map map = this.getAllPieces().iterator().next().getMap();
-      new ImageSaver(map).writeMapAsImage();
+      final FileChooser fc = GameModule.getGameModule().getDirectoryChooser();
+      final Frame frame = (Frame) SwingUtilities.getAncestorOfClass(Frame.class, map.getView());
+      if (fc.showSaveDialog(frame) != FileChooser.APPROVE_OPTION) return;
+      System.out.println(fc.getCurrentDirectory().getAbsolutePath());
+      System.out.println(fc.getSelectedFile().getAbsolutePath());
+      
+      final String path = fc.getSelectedFile().getAbsolutePath() + 
+        GameModule.getGameModule().getLocalizedGameName() + 
+        "/Map1.png";
+      System.out.println(path);
+      final File mapPictureFile = new File(path);
+      new ImageSaver(map).writeMapAsImage(mapPictureFile);
     }
     finally {
       GameModule.getGameModule().getPrefs().setValue(BasicLogger.PROMPT_NEW_LOG_END, oldStartNewLogfileSetting);

--- a/vassal-app/src/main/java/VASSAL/build/module/GameState.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/GameState.java
@@ -20,6 +20,7 @@ import VASSAL.Info;
 import VASSAL.build.AbstractBuildable;
 import VASSAL.build.Buildable;
 import VASSAL.build.GameModule;
+import VASSAL.build.module.Chatter.DisplayText;
 import VASSAL.build.module.map.ImageSaver;
 import VASSAL.build.module.metadata.AbstractMetaData;
 import VASSAL.build.module.metadata.MetaDataFactory;
@@ -1099,6 +1100,11 @@ public class GameState implements CommandEncoder {
         final Command c = bl.logInput.get(bl.nextInput++);
         c.execute();
         g.sendAndLog(c);
+        // System.out.println("Command type: " + c.getClass().getName());
+        if (c instanceof DisplayText || c instanceof NullCommand) {
+          System.out.println("Skipping non-screenshot-worthy command " + c.getClass().getName());
+          continue;
+        }
         afterEachReplay.run();
       }
       bl.stepAction.setEnabled(false);

--- a/vassal-app/src/main/java/VASSAL/build/module/GameState.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/GameState.java
@@ -20,6 +20,7 @@ import VASSAL.Info;
 import VASSAL.build.AbstractBuildable;
 import VASSAL.build.Buildable;
 import VASSAL.build.GameModule;
+import VASSAL.build.module.map.ImageSaver;
 import VASSAL.build.module.metadata.AbstractMetaData;
 import VASSAL.build.module.metadata.MetaDataFactory;
 import VASSAL.build.module.metadata.SaveMetaData;
@@ -234,6 +235,15 @@ public class GameState implements CommandEncoder {
       }
     };
 
+    final Action createMapAnimationOfGame = new AbstractAction("Load series of files and create map animation") {
+
+      @Override
+      public void actionPerformed(ActionEvent e) {
+        createGameAnimation();
+      }
+
+    };
+
     saveGame = new AbstractAction(Resources.getString("GameState.save_game")) {
       private static final long serialVersionUID = 1L;
 
@@ -304,6 +314,7 @@ public class GameState implements CommandEncoder {
     mm.addAction("GameState.close_game", closeGame);
     mm.addAction("GameState.load_and_fast_forward", loadAndFastForward);
     mm.addAction("GameState.load_and_append", loadAndAppend);
+    mm.addAction("GameState.create_game_animation", createMapAnimationOfGame);
 
     saveGame.setEnabled(gameStarting);
     saveGameAs.setEnabled(gameStarting);
@@ -906,6 +917,17 @@ public class GameState implements CommandEncoder {
     final int max = 24;
     final int end = rgs.size();
     recentGamesConf.setValue(rgs.subList(Math.max(0, end - max), end).toArray(new String[0]));
+  }
+
+  /**
+   * Loads a series of game files in a folder and makes a screenshot at the end of each. 
+   * Those screenshots can then be made into an animation at the end
+   */
+  private void createGameAnimation() {
+    loadFastForward(false);
+    System.out.println("Now screenshot");
+    final VASSAL.build.module.Map map = this.getAllPieces().iterator().next().getMap();
+    new ImageSaver(map).writeMapAsImage();
   }
 
   /**

--- a/vassal-app/src/main/java/VASSAL/build/module/GameState.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/GameState.java
@@ -939,7 +939,7 @@ public class GameState implements CommandEncoder {
    * (optional) Add filename watermark to top right of the image:
    mogrify -format 'png' -font Liberation-Sans -fill white -undercolor '#00000080' -pointsize 26 -gravity NorthEast -annotate +10+10 %t *-Map0.png
    * make images into a webm video
-   ffmpeg -f image2 -framerate 1 -pattern_type glob -i "*-Map0-*.png" output.webm
+   ffmpeg -f image2 -framerate 1 -pattern_type glob -i "*-Map0.png" output.webm
    * 
    * Video creation with watermark in one step didn't get it to run yet)
    ffmpeg \

--- a/vassal-app/src/main/java/VASSAL/build/module/GameState.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/GameState.java
@@ -931,6 +931,7 @@ public class GameState implements CommandEncoder {
     final Boolean oldStartNewLogfileSetting = (Boolean) GameModule.getGameModule().getPrefs().getValue(BasicLogger.PROMPT_NEW_LOG_END);
     GameModule.getGameModule().getPrefs().setValue(BasicLogger.PROMPT_NEW_LOG_END, Boolean.FALSE);
     try {
+      // TODO: how to get rid of "want to overwrite this folder" message? We're not overwriting content!
       final FileChooser fc = GameModule.getGameModule().getDirectoryChooser();
       if (fc.showSaveDialog(GameModule.getGameModule().getPlayerWindow()) != FileChooser.APPROVE_OPTION) return;
       System.out.println(fc.getCurrentDirectory().getAbsolutePath());
@@ -943,7 +944,7 @@ public class GameState implements CommandEncoder {
       
       for (final File logFile : logFiles) {
         System.out.println("Processing logfile " + logFile.getName());
-        loadFastForward(false, () -> loadGame(logFile, false, true));
+        loadFastForward(false, () -> loadGame(logFile, true, true));
 
         final String path = Paths.get(fc.getSelectedFile().getAbsolutePath(), logFile.getName() + ".png").toString();
 

--- a/vassal-app/src/main/java/VASSAL/build/module/GameState.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/GameState.java
@@ -1012,8 +1012,10 @@ public class GameState implements CommandEncoder {
    * Loads a series of game files in a folder and makes a screenshot for each move in each file. 
    * Those screenshots can then be made into an animation at the end
    * 
+   * Make sure to set the zoom level (in vassal) to your desired setting before starting the screen shot generation
+   * 
    * (optional) Cut playarea from complete map pictures (when only part of the map is used)
-   mogrify -format 'png' -crop 2173x1005+3543+938 +repage *-Map0.png
+   mogrify -format 'png' -crop 5587x3698+5846+3734 +repage -verbose *-Map0.png
    mogrify -format 'png' +repage *-Map0.png
    * (optional) Add filename watermark to top right of the image:
    mogrify -format 'png' -font Liberation-Sans -fill white -undercolor '#00000080' -pointsize 26 -gravity NorthEast -annotate +10+10 %t *-Map0.png

--- a/vassal-app/src/main/java/VASSAL/build/module/GameState.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/GameState.java
@@ -926,6 +926,20 @@ public class GameState implements CommandEncoder {
   /**
    * Loads a series of game files in a folder and makes a screenshot at the end of each. 
    * Those screenshots can then be made into an animation at the end
+   * 
+   * (optional) Add filename watermark to top right of the image:
+   mogrify -format 'png' -font Liberation-Sans -fill white -undercolor '#00000080' -pointsize 26 -gravity NorthEast -annotate +10+10 %t *.png
+   * make images into a webm video
+   ffmpeg -f image2 -framerate 1 -pattern_type glob -i "*.png" output.webm
+   * 
+   * Video creation with watermark in one step didn't get it to run yet)
+   ffmpeg \
+    -f image2 \
+    -pattern_type glob \
+    -export_path_metadata 1 \
+    -i '*.png' \
+    -vf "drawtext=text='%{metadata\:lavf.image2dec.source_basename\:NA}'" \
+    -y ./output.webm
    */
   private void createGameAnimation() {
     final Boolean oldStartNewLogfileSetting = (Boolean) GameModule.getGameModule().getPrefs().getValue(BasicLogger.PROMPT_NEW_LOG_END);

--- a/vassal-app/src/main/java/VASSAL/build/module/GameState.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/GameState.java
@@ -926,6 +926,9 @@ public class GameState implements CommandEncoder {
   // TODO: hacky workaround
   private int i = 0;
 
+  // Only make screenshots for the following map ID
+  private String RELEVANT_MAP_ID = "Map0";
+
   /**
    * Loads a series of game files in a folder and makes a screenshot at the end of each. 
    * Those screenshots can then be made into an animation at the end
@@ -964,9 +967,12 @@ public class GameState implements CommandEncoder {
         loadFastForward(false, () -> loadGame(logFile, true, true), () -> {
           i = i + 1;
           for (final VASSAL.build.module.Map map : VASSAL.build.module.Map.getMapList()) {
+            if (!map.mapID.equals(RELEVANT_MAP_ID)) {
+              continue;
+            }
             final String path = Paths.get(
               fc.getSelectedFile().getAbsolutePath(), 
-              logFile.getName() + "-" + map.mapID + "-" + i + ".png"
+              logFile.getName() + "-" + i + "-" + map.mapID + ".png"
             ).toString();
             System.out.println("Saving image to " + path);
             final File mapPictureFile = new File(path);

--- a/vassal-app/src/main/java/VASSAL/build/module/map/ImageSaver.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/ImageSaver.java
@@ -128,9 +128,6 @@ public class ImageSaver extends AbstractToolbarItem {
     }
   }
 
-  /**
-   * Write a PNG-encoded snapshot of the map.
-   */
   public void writeMapAsImage() {
     // prompt user for image filename
     final FileChooser fc = GameModule.getGameModule().getFileChooser();
@@ -145,7 +142,15 @@ public class ImageSaver extends AbstractToolbarItem {
 
     if (fc.showSaveDialog(frame) != FileChooser.APPROVE_OPTION) return;
 
-    final File file = fc.getSelectedFile();
+    writeMapAsImage(fc.getSelectedFile());
+  }
+
+  /**
+   * Write a PNG-encoded snapshot of the map.
+   */
+  public void writeMapAsImage(File file) {
+    final Frame frame =
+      (Frame) SwingUtilities.getAncestorOfClass(Frame.class, map.getView());
 
     dialog = new ProgressDialog(frame, Resources.getString("Editor.ImageSaver.saving_map_image_title"),
                                        Resources.getString("Editor.ImageSaver.saving_map_image_text"));

--- a/vassal-app/src/main/java/VASSAL/launch/PlayerWindow.java
+++ b/vassal-app/src/main/java/VASSAL/launch/PlayerWindow.java
@@ -150,6 +150,8 @@ public class PlayerWindow extends JFrame {
     toolsMenu.add(mm.addKey("GameState.load_and_fast_forward"));
     toolsMenu.add(mm.addKey("GameState.load_and_append"));
 
+    toolsMenu.add(mm.addKey("GameState.create_game_animation"));
+
     toolsMenu.addSeparator();
     
     final CheckBoxMenuItemProxy debugCheckbox = new CheckBoxMenuItemProxy(new AbstractAction(

--- a/vassal-app/src/main/java/VASSAL/launch/PlayerWindow.java
+++ b/vassal-app/src/main/java/VASSAL/launch/PlayerWindow.java
@@ -151,6 +151,7 @@ public class PlayerWindow extends JFrame {
     toolsMenu.add(mm.addKey("GameState.load_and_append"));
 
     toolsMenu.add(mm.addKey("GameState.create_game_animation"));
+    toolsMenu.add(mm.addKey("GameState.create_save_screenshots"));
 
     toolsMenu.addSeparator();
     

--- a/vassal-app/src/main/java/VASSAL/tools/filechooser/SaveFileFilter.java
+++ b/vassal-app/src/main/java/VASSAL/tools/filechooser/SaveFileFilter.java
@@ -1,0 +1,34 @@
+/*
+ *
+ * Copyright (c) 2008 by Joel Uckelman
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License (LGPL) as published by the Free Software Foundation.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public
+ * License along with this library; if not, copies are available
+ * at http://www.opensource.org.
+ */
+package VASSAL.tools.filechooser;
+
+import VASSAL.i18n.Resources;
+
+/**
+ * A {@link FileFilter} for VASSAL saves.
+ *
+ * @author Joel Uckelman
+ * @since 3.1.0
+ */
+public class SaveFileFilter extends ExtensionFileFilter {
+  public static final String[] types = { ".vsav" }; //NON-NLS
+
+  public SaveFileFilter() {
+    super(Resources.getString("Editor.FileFilter.vassal_log"), types);
+  }
+}

--- a/vassal-deprecation/pom.xml
+++ b/vassal-deprecation/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.vassalengine</groupId>
         <artifactId>vassal-parent</artifactId>
-        <version>3.8.0-SNAPSHOT</version>
+        <version>3.8.0-EISMEER-SNAPSHOT-4</version>
     </parent>
 
     <artifactId>vassal-deprecation</artifactId>

--- a/vassal-doc/pom.xml
+++ b/vassal-doc/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.vassalengine</groupId>
         <artifactId>vassal-parent</artifactId>
-        <version>3.8.0-SNAPSHOT</version>
+        <version>3.8.0-EISMEER-SNAPSHOT-4</version>
     </parent>
 
     <artifactId>vassal-doc</artifactId>


### PR DESCRIPTION
The general idea is to create a video of the map progression throughout a game. Ideally, we see the progress of the pieces over the course of a game, for example a shifting frontline.

## Current approach
The current approach is rather primitive and only semi-automated.
The MR adds another menu entry "Load series of files and create map animation" to the "tools" menu. If you click it, you need to select a folder containing all the vlog files of your game.

Then we'll automatically loop over those vlog files, iterate through every command in the logfile and take a map screenshot each time. At the very end of the process, the selected folder will contain a series of map screenshot, a screenshot for every command in every logfile.

After that, I'm (optionally) cropping the screenshots to the map section I'm interested in (for limited scenarios)
```
mogrify -format 'png' -crop 2173x1005+3543+938 +repage *-Map0.png
```
Note, I need to do that since Vassal's `SnapshotTask` currently takes x,y coordinates, but ignores them.


After that, I'm (optionally) watermarking the map screenshots with the name of the save game via
```
mogrify -format 'png' -font Liberation-Sans -fill white -undercolor '#00000080' -pointsize 26 -gravity NorthEast -annotate +10+10 %t *-Map0.png
```

As a last step, I'm combining all map screenshots into a video via
```
ffmpeg -f image2 -framerate 30 -pattern_type glob -i "*-Map0.png" output-30fps.webm
```

## Know shortcomings

- not fully integrated into the vassal java application (should/can it?)
- lots of temporary image files. The first two turns of my current small scenario game of Last Blitzkrieg resulted in 2042 screenshots and over 60GB of image data. The PNG screenshots are huge. Note that the final encoded video is only 13 MB.
- Currently I'm creating a screenshot for _every_ command, even when it was just a text message. I should filter that somehow to only screenshot the actual piece movements

## Questions

- Can we somehow easier get a video stream than doing expensive map screenshots?
- Can the ffmpeg part also be done in plain java?
- External dependencies and everything aside, would this kind of functionality be interesting to include in the vassal application?