### PR TITLE
13022 - Prevent room non-owners starting new games

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/GameModule.java
+++ b/vassal-app/src/main/java/VASSAL/build/GameModule.java
@@ -845,7 +845,10 @@ public class GameModule extends AbstractConfigurable
 
         @Override
         public void actionPerformed(ActionEvent e) {
-          getGameState().loadGame(new File(rg), false);
+          final GameState gs = getGameState();
+          if (gs.isNewGameAllowed()) {
+            gs.loadGame(new File(rg), false);
+          }
         }
       });
 

--- a/vassal-app/src/main/java/VASSAL/build/module/PredefinedSetup.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/PredefinedSetup.java
@@ -208,6 +208,8 @@ public class PredefinedSetup extends AbstractConfigurable implements GameCompone
 
   public void launch() {
     final GameModule g = GameModule.getGameModule();
+    if (!g.getGameState().isNewGameAllowed()) return;
+
     if (useFile && fileName != null) {
       try {
         g.getGameState().loadGameInBackground(fileName, getSavedGameContents(), true);

--- a/vassal-app/src/main/java/VASSAL/chat/node/NodeClient.java
+++ b/vassal-app/src/main/java/VASSAL/chat/node/NodeClient.java
@@ -52,8 +52,8 @@ import VASSAL.command.CommandEncoder;
 import VASSAL.i18n.Resources;
 import VASSAL.tools.PropertiesEncoder;
 import VASSAL.tools.SequenceEncoder;
-
 import VASSAL.tools.version.VersionUtils;
+
 import java.beans.PropertyChangeListener;
 import java.beans.PropertyChangeSupport;
 import java.io.IOException;
@@ -263,6 +263,26 @@ public class NodeClient implements LockableChatServerConnection,
       send(Protocol.encodeStatsCommand(new PropertiesEncoder(me.toProperties())
           .getStringValue()));
     }
+  }
+
+  /** Return true if
+   *  1. The current room is the default room
+   *  OR
+   *  2. The current player is the Owner of the current room
+   *
+   * @return true if this player owns the current room
+   */
+  public boolean isOwner() {
+    final Room room = getRoom();
+    if (!isDefaultRoom(room)) {
+      if (room instanceof NodeRoom) {
+        final String owner = ((NodeRoom) room).getOwner();
+        if (owner == null || !owner.equals(getUserInfo().getId())) {
+          return false;
+        }
+      }
+    }
+    return true;
   }
 
   @Override

--- a/vassal-app/src/main/resources/VASSAL/i18n/VASSAL.properties
+++ b/vassal-app/src/main/resources/VASSAL/i18n/VASSAL.properties
@@ -782,6 +782,9 @@ GameState.fast_forward=!<b>Log fast-forwarded to final position.
 GameState.fast_forward_new_log=!<b>Log fast-forwarded to final position. The new log being written will begin from the <i>present</i> position.
 GameState.simple_save_append=?<b>Game loaded but included no logging information. New logfile will start from this point.
 GameState.open_recent=Open Recent...
+GameState.new_game_not_allowed_title=New Game Not Allowed
+GameState.new_game_not_allowed_heading=New Game Not Allowed
+GameState.new_game_not_allowed_warning=You may not start a new game, or load a continuation unless you are the owner of the this room. Use the Synchronize option to re-join the game in progress. 
 
 # GlobalOptions
 GlobalOptions.use_combined=Use combined application window (requires restart)


### PR DESCRIPTION
This solution pops up a dialog if a non-owner tries to start a new game in an online room and does not start the game.  Not ideal, but manipulating the enabled status of all the different menu options involved is too difficult. 