### PR TITLE
13049 - Compute correct _Degrees property for free rotations

### DIFF
--- a/vassal-app/src/main/java/VASSAL/counters/FreeRotator.java
+++ b/vassal-app/src/main/java/VASSAL/counters/FreeRotator.java
@@ -227,7 +227,7 @@ public class FreeRotator extends Decorator
 
   public void setAngle(double angle) {
     if (isFreeRotation()) {
-      validAngles[angleIndex] = angle;
+      validAngles[angleIndex] = ((angle % 360) - 360) % 360;
     }
     else {
       // We (stupidly) store allowed angles in descending order from 0.
@@ -769,7 +769,7 @@ public class FreeRotator extends Decorator
       return String.valueOf(angleIndex + 1);
     }
     else if ((name + DEGREES).equals(key)) {
-      return String.valueOf((int) (Math.abs(validAngles[angleIndex])));
+      return String.valueOf((int) Math.round(Math.abs(validAngles[angleIndex])) % 360);
     }
     else {
       return super.getProperty(key);
@@ -791,7 +791,12 @@ public class FreeRotator extends Decorator
   private double getRelativeAngle(Point p, Point origin) {
     double myAngle;
     if (p.y == origin.y) {
-      myAngle = p.x < origin.x ? -Math.PI / 2.0 : Math.PI / 2.0;
+      if (p.x == origin.x) {
+        myAngle = 0.0;
+      }
+      else {
+        myAngle = p.x < origin.x ? -Math.PI / 2.0 : Math.PI / 2.0;
+      }
     }
     else {
       myAngle = Math.atan((double)(p.x - origin.x) / (origin.y - p.y));

--- a/vassal-app/src/main/java/VASSAL/counters/FreeRotator.java
+++ b/vassal-app/src/main/java/VASSAL/counters/FreeRotator.java
@@ -226,13 +226,14 @@ public class FreeRotator extends Decorator
   }
 
   public void setAngle(double angle) {
+    // We (stupidly) store allowed angles in descending order from 0.
+    // Normalize the angle to be in (-360, 0] to match that.
+    angle = ((angle % 360) - 360) % 360;
+
     if (isFreeRotation()) {
-      validAngles[angleIndex] = ((angle % 360) - 360) % 360;
+      validAngles[angleIndex] = angle;
     }
     else {
-      // We (stupidly) store allowed angles in descending order from 0.
-      // Normalize the angle to be in (-360, 0] to match that.
-      angle = ((angle % 360) - 360) % 360;
       // ex is the expected index of the angle in angles array
       final double ex = (-angle / 360) * validAngles.length;
       angleIndex = ((int) Math.round(ex)) % validAngles.length;

--- a/vassal-app/src/test/java/VASSAL/counters/FreeRotatorTest.java
+++ b/vassal-app/src/test/java/VASSAL/counters/FreeRotatorTest.java
@@ -235,6 +235,11 @@ public class FreeRotatorTest extends DecoratorTest {
             return input.getArgument(0);
           });
 
+      // Mock a component for the mouse events.
+      final Point origin = new Point(0,0);
+      final Component comp = mock(Component.class);
+      when(comp.getLocationOnScreen()).thenReturn(origin);
+
       // Setup for FreeRotation with initialized command keys.
       fr.mySetType("rotate;1;49,130;Rotate;50,130;Random;FreeRotator;;51,130;Direct;0;true");
       fr.setMap(map);
@@ -242,9 +247,6 @@ public class FreeRotatorTest extends DecoratorTest {
       if (path.length > 0) {
         long when = 1L;
         int index = 0;
-
-        // Dummy component for the mouse events.
-        final Component comp = new Label();
 
         final MouseEvent press = new MouseEvent(comp, MouseEvent.MOUSE_PRESSED, when++, 0,
             path[index].x, path[index].y, 1, false, MouseEvent.BUTTON1);

--- a/vassal-app/src/test/java/VASSAL/counters/FreeRotatorTest.java
+++ b/vassal-app/src/test/java/VASSAL/counters/FreeRotatorTest.java
@@ -17,10 +17,24 @@
 
 package VASSAL.counters;
 
+import VASSAL.build.GameModule;
+import VASSAL.build.module.Map;
 import VASSAL.tools.NamedKeyStroke;
+
+import java.awt.*;
+import java.awt.event.MouseEvent;
 import java.lang.reflect.InvocationTargetException;
 
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import javax.swing.*;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 
 public class FreeRotatorTest extends DecoratorTest {
 
@@ -57,4 +71,380 @@ public class FreeRotatorTest extends DecoratorTest {
     serializeTest("Fixed Rotations", trait); // NON-NLS
 
   }
+  @Test
+  public void clockwiseFacingRotation() {
+    try (MockedStatic<GameModule> staticGm = Mockito.mockStatic(GameModule.class)) {
+      final GameModule gm = mock(GameModule.class);
+      staticGm.when(GameModule::getGameModule).thenReturn(gm);
+
+      final NamedKeyStroke onKey = NamedKeyStroke.of("RotateCmd");
+
+      FreeRotator fr = new FreeRotator();
+      fr.setInner(new FreeRotatorTest.DummyPiece());
+      fr.mySetType("rotate;10");
+      fr.rotateCWKey = onKey;
+      fr.myGetKeyCommands();
+
+      // Repeat key stroke for a full 360 rotation.
+      fr.mySetState("9");
+      for (int i=0;i<10;i++) {
+        fr.myKeyEvent(onKey.getKeyStroke());
+        assertEquals(-36 * i, fr.getAngle());
+      }
+    }
+  }
+
+  @Test
+  public void counterClockwiseFacingRotation() {
+    try (MockedStatic<GameModule> staticGm = Mockito.mockStatic(GameModule.class)) {
+      final GameModule gm = mock(GameModule.class);
+      staticGm.when(GameModule::getGameModule).thenReturn(gm);
+
+      final NamedKeyStroke onKey = NamedKeyStroke.of("RotateCmd");
+
+      FreeRotator fr = new FreeRotator();
+      fr.setInner(new FreeRotatorTest.DummyPiece());
+      fr.mySetType("rotate;10");
+      fr.rotateCCWKey = onKey;
+      fr.myGetKeyCommands();
+
+      fr.mySetState("0");
+      for (int i=0;i<10;i++) {
+        fr.myKeyEvent(onKey.getKeyStroke());
+        assertEquals((36 * (i+1)) -360, fr.getAngle());
+      }
+    }
+  }
+
+  @Test
+  public void rotateDirectFacing() {
+    try (MockedStatic<GameModule> staticGm = Mockito.mockStatic(GameModule.class)) {
+      final GameModule gm = mock(GameModule.class);
+      staticGm.when(GameModule::getGameModule).thenReturn(gm);
+
+      final NamedKeyStroke onKey = NamedKeyStroke.of("RotateCmd");
+
+      FreeRotator fr = new FreeRotator();
+      fr.setInner(new FreeRotatorTest.DummyPiece());
+      // Setup for 10 facings.
+      fr.mySetType("rotate;10");
+      fr.rotateDirectKey = onKey;
+
+      // Max value
+      fr.directExpression.setFormat("10");
+      fr.myKeyEvent(onKey.getKeyStroke());
+      assertEquals("9", fr.myGetState());
+      assertEquals(-36 * 9, fr.getAngle());
+
+      // Out of range greater than max.
+      fr.directExpression.setFormat("11");
+      fr.myKeyEvent(onKey.getKeyStroke());
+      assertEquals("0", fr.myGetState());
+      assertEquals(0, fr.getAngle());
+
+      fr.directExpression.setFormat("12");
+      fr.myKeyEvent(onKey.getKeyStroke());
+      assertEquals("1", fr.myGetState());
+      assertEquals(-36, fr.getAngle());
+
+      // Mid-range value
+      fr.directExpression.setFormat("5");
+      fr.myKeyEvent(onKey.getKeyStroke());
+      assertEquals("4", fr.myGetState());
+      assertEquals(-36 * 4, fr.getAngle());
+
+      // Minimum valid value
+      fr.directExpression.setFormat("1");
+      fr.myKeyEvent(onKey.getKeyStroke());
+      assertEquals("0", fr.myGetState());
+      assertEquals(0, fr.getAngle());
+
+      // Negative and below valid range
+      fr.directExpression.setFormat("-1");
+      fr.myKeyEvent(onKey.getKeyStroke());
+      assertEquals("8", fr.myGetState());
+      assertEquals(-36 * 8, fr.getAngle());
+
+      // Switch to not a directTypeFacing type. The angle should round to the nearest facing.
+      fr.directTypeFacing = false;
+      fr.directExpression.setFormat("181");
+      fr.myKeyEvent(onKey.getKeyStroke());
+      assertEquals("5", fr.myGetState());
+      // Rounds to nearest facing.
+      assertEquals(-180, fr.getAngle());
+    }
+  }
+
+  @Test
+  public void rotateDirectFreeRotation() {
+    try (MockedStatic<GameModule> staticGm = Mockito.mockStatic(GameModule.class)) {
+      final GameModule gm = mock(GameModule.class);
+      staticGm.when(GameModule::getGameModule).thenReturn(gm);
+
+      final NamedKeyStroke onKey = NamedKeyStroke.of("RotateCmd");
+
+      FreeRotator fr = new FreeRotator();
+      fr.setInner(new FreeRotatorTest.DummyPiece());
+      fr.name = "rotateDirectFreeRotation";
+
+      // Setup for FreeRotation
+      fr.mySetType("rotate;1");
+      fr.directTypeFacing = false;
+      fr.rotateDirectKey = onKey;
+
+      // Mid-range value
+      fr.directExpression.setFormat("-9");
+      fr.myKeyEvent(onKey.getKeyStroke());
+      final String degrees = (String)fr.getProperty(fr.name + FreeRotator.DEGREES);
+      assertEquals(-351, fr.getAngle());
+      assertEquals( "351", degrees);
+
+      // Over-range value. Output limited to 0-359 range.
+      fr.directExpression.setFormat("710");
+      fr.myKeyEvent(onKey.getKeyStroke());
+      assertEquals(-350, fr.getAngle());
+      assertEquals("350", fr.getProperty(fr.name+FreeRotator.DEGREES));
+
+      // Negative value
+      fr.directExpression.setFormat("-20");
+      fr.myKeyEvent(onKey.getKeyStroke());
+      assertEquals(-340, fr.getAngle());
+    }
+  }
+
+  /**
+   * Simulate the pressing and dragging of the mouse to test free rotation from mouse input.
+   *
+   * @param fr The FreeRotator object under test.
+   * @param path The path of the mouse drag. The mouse button goes down at the first point.
+   * Mouse button up is at the last point. The mouse can be dragged through an number of
+   * intermediate points.
+   *///
+  private void DragMouseMove(FreeRotator fr, Point[] path) {
+    try (MockedStatic<GameModule> staticGm = Mockito.mockStatic(GameModule.class)) {
+      final GameModule gm = mock(GameModule.class);
+      staticGm.when(GameModule::getGameModule).thenReturn(gm);
+
+      final Map map = mock(Map.class);
+      final JComponent view = mock(JComponent.class);
+      when(map.getView()).thenReturn(view);
+
+      // Return the input parameter, simple one-to-one mapping.
+      when(map.componentToMap(org.mockito.Mockito.any(Point.class))).thenAnswer(
+          input -> {
+            return input.getArgument(0);
+          });
+
+      // Setup for FreeRotation with initialized command keys.
+      fr.mySetType("rotate;1;49,130;Rotate;50,130;Random;FreeRotator;;51,130;Direct;0;true");
+      fr.setMap(map);
+
+      if (path.length > 0) {
+        long when = 1L;
+        int index = 0;
+
+        // Dummy component for the mouse events.
+        final Component comp = new Label();
+
+        final MouseEvent press = new MouseEvent(comp, MouseEvent.MOUSE_PRESSED, when++, 0,
+            path[index].x, path[index].y, 1, false, MouseEvent.BUTTON1);
+        fr.myKeyEvent(fr.setAngleKey.getKeyStroke());
+        fr.mousePressed(press);
+
+        while (index < path.length) {
+          final MouseEvent drag = new MouseEvent(comp, MouseEvent.MOUSE_PRESSED, when++, 0,
+              path[index].x, path[index].y, 1, false, MouseEvent.BUTTON1);
+          fr.mouseDragged(drag);
+          ++index;
+        }
+        index = path.length - 1;
+        final MouseEvent release = new MouseEvent(comp, MouseEvent.MOUSE_RELEASED, when++, 0,
+            path[index].x, path[index].y, 1, false, MouseEvent.BUTTON1);
+        fr.mouseReleased(release);
+      }
+    }
+  }
+
+  // Rotate clockwise from the default orientation.
+    @Test
+  public void rotateClockwiseFreeRotation() {
+    FreeRotator fr = new FreeRotator();
+    fr.setInner(new FreeRotatorTest.DummyPiece());
+
+    // Using the origin as the third point, define a right angle triangle with 45 degree angles.
+    final Point[] path = new Point[] {
+        new Point(0, -10),
+        new Point(5, -5)
+    };
+
+    DragMouseMove(fr, path);
+
+    assertEquals("45", fr.getProperty(fr.name+FreeRotator.DEGREES));
+    assertEquals(-45.0, fr.getAngle());
+  }
+
+  // Rotate counter-clockwise from the default orientation.
+  @Test
+  public void rotateClockwiseDegrees200() {
+    FreeRotator fr = new FreeRotator();
+    fr.setInner(new FreeRotatorTest.DummyPiece());
+
+    // Move the piece off of the origin.
+    final Point center = new Point(50, 80);
+    fr.setPosition(center);
+
+    // Rotation consisting of 90 degree segments
+    final Point[] path = new Point[] {
+        new Point(100, 0),   // Starting on right side of the piece
+        new Point(0, 100),   // 90 degrees
+        new Point(-100, 0),  // 90 degrees
+        new Point(-100, -36) // 20 degrees, tan(20) = 36/100
+    };
+
+    // Offset mouse path by the position of the piece.
+    for (Point p : path) {
+      p.x += center.x;
+      p.y += center.y;
+    }
+    DragMouseMove(fr, path);
+
+    assertEquals("200", fr.getProperty(fr.name+FreeRotator.DEGREES));
+    assertEquals(-200.0, fr.getAngle(), 0.5);
+  }
+
+  // A rotation greater than 360 degrees.
+  @Test
+  public void rotateClockwiseDegrees405() {
+    FreeRotator fr = new FreeRotator();
+    fr.setInner(new FreeRotatorTest.DummyPiece());
+
+    // Rotation consisting of 45 and 90 degree segments
+    final Point[] path = new Point[] {
+        new Point(0, 100),      // Starting from below the piece
+        new Point(-100, 100),   // 45 degrees
+        new Point(-100, -100),  // 90 degrees
+        new Point(-0, -100),    // 45 degrees
+        new Point(100, 0),      // 90 degrees
+        new Point(100, 100),    // 45 degrees
+        new Point(-50, 50)      // 90 degrees, total = 405
+    };
+
+    DragMouseMove(fr, path);
+
+    assertEquals("45", fr.getProperty(fr.name+FreeRotator.DEGREES));
+    assertEquals(-45.0, fr.getAngle(), 0.5);
+  }
+
+  @Test
+  public void rotateCounterClockwiseFreeRotation() {
+    FreeRotator fr = new FreeRotator();
+    fr.setInner(new FreeRotatorTest.DummyPiece());
+
+    // Using the origin as the third point, define a right angle triangle with a 30 degree angle.
+    final Point[] path = new Point[] {
+        new Point(0, -173),
+        new Point(-100, -173)
+    };
+
+    DragMouseMove(fr, path);
+
+    assertEquals("330", fr.getProperty(fr.name+FreeRotator.DEGREES));
+    assertEquals(-330.0, fr.getAngle(), 0.5);
+  }
+
+  @Test
+  public void rotateCounterClockwiseDegrees280() {
+    FreeRotator fr = new FreeRotator();
+    fr.setInner(new FreeRotatorTest.DummyPiece());
+
+    // Rotation consisting of 90 degree segments and a small final angle.
+    final Point[] path = new Point[] {
+        new Point(0, -100),
+        new Point(-100, 0),  // 90 degrees
+        new Point(0, 100),   // 90 degrees
+        new Point(100, 0),   // 90 degrees
+        new Point(100, -17)  // 10 degrees, tan(10) = 17/100
+    };
+
+    DragMouseMove(fr, path);
+
+    assertEquals("80", fr.getProperty(fr.name+FreeRotator.DEGREES));
+    assertEquals(-80.0, fr.getAngle(), 0.5);
+  }
+
+  // The rotateDirect key command.
+  @Test
+  public void rotateDirect() {
+    try (MockedStatic<GameModule> staticGm = Mockito.mockStatic(GameModule.class)) {
+      final GameModule gm = mock(GameModule.class);
+      staticGm.when(GameModule::getGameModule).thenReturn(gm);
+
+      final NamedKeyStroke onKey = NamedKeyStroke.of("RotateCmd");
+
+      FreeRotator fr = new FreeRotator();
+      fr.setInner(new FreeRotatorTest.DummyPiece());
+
+      fr.name = "rotateDirect";
+      fr.mySetType("rotate;36");
+      fr.directTypeFacing = false;
+      fr.rotateDirectKey = onKey;
+
+      // Over-range value
+      fr.directExpression.setFormat("710");
+      fr.myKeyEvent(onKey.getKeyStroke());
+      assertEquals("35", fr.myGetState());
+      assertEquals(-350, fr.getAngle());
+      assertEquals("36", fr.getProperty(fr.name+FreeRotator.FACING));
+    }
+  }
+
+  @Test
+  public void mouseMoveThroughOrigin() {
+    FreeRotator fr = new FreeRotator();
+    fr.setInner(new FreeRotatorTest.DummyPiece());
+
+    final Point[] path = new Point[] {
+        new Point(0, 0),
+        new Point(5, -5)
+    };
+
+    DragMouseMove(fr, path);
+
+    assertEquals("45", fr.getProperty(fr.name+FreeRotator.DEGREES));
+    assertEquals(-45.0, fr.getAngle());
+  }
+
+  // Set the angle in degrees, then read back the internal facing value (i.e. zero based).
+  @Test
+  public void setAngleReadFacing() {
+    FreeRotator fr = new FreeRotator();
+    fr.setInner(new FreeRotatorTest.DummyPiece());
+    fr.mySetType("rotate;90;;;;;;;Name");
+
+    fr.setAngle(4);
+    assertEquals("89", fr.myGetState());
+    assertEquals("90", fr.getProperty(fr.name+FreeRotator.FACING));
+    fr.setAngle(0);
+    assertEquals("0", fr.myGetState());
+    fr.setAngle(3);
+    assertEquals("89", fr.myGetState());
+    fr.setAngle(2);
+    assertEquals("0", fr.myGetState());
+    fr.setAngle(360 + 90);
+    assertEquals("68", fr.myGetState());
+    fr.setAngle(-4);
+    assertEquals("1", fr.myGetState());
+    fr.setAngle(-269);
+    assertEquals("67", fr.myGetState());
+    fr.setAngle(360);
+    assertEquals("0", fr.myGetState());
+  }
+
+  class DummyPiece extends BasicPiece {
+    @Override
+    public Object getPublicProperty(Object key) {
+      return null;
+    }
+  }
+
 }


### PR DESCRIPTION
On counter-clockwise free rotations compute the correct final orientation for the *<rotator_name>_Degrees* property. This fixes a bug where both clockwise and counter-clockwise rotations produce the same degrees despite the final facings being on either side of zero degrees.

When a free rotation passes a full rotation, the *<rotator_name>_Degrees* property keeps increasing potentially well past 360 degrees. This commit limits that property to the range 0 to 359 degrees.

The `getRelativeAngle()` function does not properly handle the case where the mouse position is the same as the counter's origin. This commit checks for that case.

The new unit tests demonstrate these issues and confirm the fixes.

Closes #13049
Closes #13050 