### PR TITLE
13336 - Correct issue when auto-attach and allow attachement to self features both enabled

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/module/AttachmentManager.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/AttachmentManager.java
@@ -63,7 +63,7 @@ public class AttachmentManager {
    * A piece has been added to the game.
    * 1. If it has as Auto-attach, attach all other Attachments with same name to it.
    * 2. Tell all other Auto-attach traits with same name to attach to it.
-   *
+   * <p>
    * Create the self attachment if required
    * @param piece Piece moved or added
    */
@@ -75,16 +75,15 @@ public class AttachmentManager {
 
       // Find all Attachment traits (not pieces) that use that attachment name and loop through them
       final Set<Attachment> currentAttachments = attachments.computeIfAbsent(attachName, k -> new HashSet<>());
-      for (final Attachment targetAttachment : currentAttachments) {
 
-        if (targetAttachment.equals(attach)) {
-          if (attach.isAllowSelfAttach()) {
-            // Self attach
-            attach.autoAttach(targetAttachment);
-          }
-        }
-        else {
-          // Auto-attach the traits to each other. The traits will do nothing if they are not auto-attach, and will prevent double attachs.
+      if (attach.isAllowSelfAttach()) {
+        // Self attach
+        attach.autoAttach(attach);
+      }
+
+      for (final Attachment targetAttachment : currentAttachments) {
+        // Auto-attach the traits to each other. The traits will do nothing if they are not auto-attach, and will prevent double attaches.
+        if (!targetAttachment.equals(attach)) {
           attach.autoAttach(targetAttachment);
           targetAttachment.autoAttach(attach);
         }

--- a/vassal-app/src/main/java/VASSAL/counters/Attachment.java
+++ b/vassal-app/src/main/java/VASSAL/counters/Attachment.java
@@ -241,9 +241,9 @@ public class Attachment extends Decorator implements TranslatablePiece, Recursio
       myClearAllCommand  = new KeyCommand(clearAllCommandName, clearAllKey, getOutermost(this), this);
       myClearMatchingCommand = new KeyCommand(clearMatchingCommandName, clearMatchingKey, getOutermost(this), this);
 
-      final boolean doAttach = (attachCommandName.length() > 0) && attachKey != null && !attachKey.isNull();
-      final boolean doClearAll = (clearAllCommandName.length() > 0) && clearAllKey != null && !clearAllKey.isNull();
-      final boolean doClearMatching = (clearMatchingCommandName.length() > 0) && clearMatchingKey != null && !clearMatchingKey.isNull();
+      final boolean doAttach = (!attachCommandName.isEmpty()) && attachKey != null && !attachKey.isNull();
+      final boolean doClearAll = (!clearAllCommandName.isEmpty()) && clearAllKey != null && !clearAllKey.isNull();
+      final boolean doClearMatching = (!clearMatchingCommandName.isEmpty()) && clearMatchingKey != null && !clearMatchingKey.isNull();
 
       if (doAttach) {
         if (doClearAll) {
@@ -426,7 +426,7 @@ public class Attachment extends Decorator implements TranslatablePiece, Recursio
 
   /**
    * Auto-attach to a piece
-   * 1. We must be in auto-attah mode
+   * 1. We must be in auto-attach mode
    * 2. Must not already be attached to the piece.
    * NOTE: Auto-attach is handled locally by each client, no Commands are generated
    * @param attach Attachment trait within the target piece
@@ -441,7 +441,7 @@ public class Attachment extends Decorator implements TranslatablePiece, Recursio
   }
 
   /**
-   * @param p a particular gamepiece
+   * @param p a particular game piece
    * @return true if the given piece is on our list of targets
    */
   public boolean hasTarget(GamePiece p) {
@@ -569,7 +569,7 @@ public class Attachment extends Decorator implements TranslatablePiece, Recursio
       d += " " + Resources.getString("Editor.Attachment.auto");
     }
 
-    if (desc.length() > 0) {
+    if (!desc.isEmpty()) {
       d += " - " + desc;
     }
 


### PR DESCRIPTION
Fixes #13289 
When "auto-attach" and "allow attachment to self"
are both enabled and a new piece is dragged onto
an existing stack, the new piece fails to
attach to self.