### PR TITLE
13360 - Coerce Regular Expression operator arguments to be strings

### DIFF
--- a/vassal-app/src/main/java/bsh/Primitive.java
+++ b/vassal-app/src/main/java/bsh/Primitive.java
@@ -241,6 +241,11 @@ public final class Primitive implements ParserConstants, java.io.Serializable
     static Object binaryOperationImpl( Object lhs, Object rhs, int kind )
         throws UtilEvalError
 	{
+        /*
+         * VASSAL - Coerce Regular Expression Match/Not Match arguments to be Strings
+         */
+        if(kind == MATCH || kind == NMATCH)
+            return stringBinaryOperation(lhs.toString(), rhs.toString(), kind);
         if(lhs instanceof Boolean)
             return booleanBinaryOperation((Boolean)lhs, (Boolean)rhs, kind);
         else if(lhs instanceof Integer)


### PR DESCRIPTION
Prevents Bad Data in Module errors if Regex happens to look like an Integer.