### PR TITLE
13405 - At-Start Stack positioning tool now expands prototypes before displaying piece

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/module/map/SetupStack.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/SetupStack.java
@@ -811,7 +811,7 @@ public class SetupStack extends AbstractConfigurable implements GameComponent, U
       myStack = stack;
       mySlot = stack.getTopPiece();
       if (mySlot != null) {
-        myPiece = mySlot.getPiece();
+        myPiece = PieceCloner.getInstance().clonePiece(mySlot.getPiece());
       }
 
       myStack.updatePosition();


### PR DESCRIPTION
Piece can be invisible if it has variable visibility calculated inside a prototype