### PR TITLE
13393 - Prevent slowdown when editing multiple Prototypes in sequence.

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/module/PrototypesContainer.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/PrototypesContainer.java
@@ -106,7 +106,6 @@ public class PrototypesContainer extends AbstractConfigurable {
     def.addPropertyChangeListener(evt -> {
       if (NAME_PROPERTY.equals(evt.getPropertyName())) {
         // When a prototype is renamed we need to rebuild the prototype map, so that if there was a duplicate of the same name it will re-establish its presence
-        definitions.clear();
         rebuildPrototypeMap();
       }
     });

--- a/vassal-app/src/main/java/VASSAL/build/module/PrototypesContainer.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/PrototypesContainer.java
@@ -95,18 +95,11 @@ public class PrototypesContainer extends AbstractConfigurable {
     return Resources.getString("Editor.PrototypesContainer.component_type"); //$NON-NLS-1$
   }
 
-
-  private void rebuildPrototypeMap(AbstractBuildable target) {
-    for (final Buildable b : target.getBuildables()) {
-      if (b instanceof PrototypeDefinition) {
-        addDefinition((PrototypeDefinition)b);
-      }
-      else if (b instanceof AbstractBuildable) {
-        rebuildPrototypeMap((AbstractBuildable)b);
-      }
-    }
+  // Rebuild prototype cross-reference
+  private void rebuildPrototypeMap() {
+    definitions.clear();
+    GameModule.getGameModule().getAllDescendantComponentsOf(PrototypeDefinition.class).forEach((def) -> definitions.put(def.getConfigureName(), def));
   }
-
 
   public void addDefinition(PrototypeDefinition def) {
     definitions.put(def.getConfigureName(), def);
@@ -114,7 +107,7 @@ public class PrototypesContainer extends AbstractConfigurable {
       if (NAME_PROPERTY.equals(evt.getPropertyName())) {
         // When a prototype is renamed we need to rebuild the prototype map, so that if there was a duplicate of the same name it will re-establish its presence
         definitions.clear();
-        rebuildPrototypeMap(GameModule.getGameModule());
+        rebuildPrototypeMap();
       }
     });
   }


### PR DESCRIPTION
Turned out the number of Property Change Listeners attached to Prototype Definitions (each firing of a rebuild of the prototype cross-refererence) increased geometrically with the number of prototype definitions that are edited and have their name changed, finally melting down around the 15th edit.

Re-factored the cross-reference rebuild code to not create additional property change listeners.