### PR TITLE
13490 - Suppress errors messages from expressions in text Labels during module load, or in Game Palettes.

### DIFF
--- a/vassal-app/src/main/java/VASSAL/counters/CalculatedProperty.java
+++ b/vassal-app/src/main/java/VASSAL/counters/CalculatedProperty.java
@@ -172,31 +172,27 @@ public class CalculatedProperty extends Decorator implements EditablePiece, Loop
   public Object getProperty(Object key) {
     Object result = "";
     if (name.length() > 0 && name.equals(key)) {
-      // Do not attempt to evaluate a Calculated Property if this piece is not on a map
-      if (getMap() == null) {
-        return "";
+
+      // Don't potentially create more infinite loops while already reporting one
+      if (RecursionLimiter.isReportingInfiniteLoop()) {
+        return getExpression();
       }
-      else {
-        // Don't potentially create more infinite loops while already reporting one
-        if (RecursionLimiter.isReportingInfiniteLoop()) {
-          return getExpression();
-        }
 
-        try {
-          RecursionLimiter.startExecution(this);
+      try {
+        RecursionLimiter.startExecution(this);
 
-          result = evaluate();
-        }
-        catch (RecursionLimitException e) {
-          RecursionLimiter.infiniteLoop(e);
-        }
-        finally {
-          RecursionLimiter.endExecution();
-        }
-
-        return result;
+        result = evaluate();
       }
+      catch (RecursionLimitException e) {
+        RecursionLimiter.infiniteLoop(e);
+      }
+      finally {
+        RecursionLimiter.endExecution();
+      }
+
+      return result;
     }
+
     return super.getProperty(key);
   }
 
@@ -215,7 +211,10 @@ public class CalculatedProperty extends Decorator implements EditablePiece, Loop
    * @return value
    */
   protected String evaluate() {
-    return expression.tryEvaluate(getOutermost(this), this, "Editor.CalculatedProperty.expression");
+    // Suppress any generated error messages if the piece is not on a map.
+    return getMap() == null ?
+      expression.quietEvaluate(getOutermost(this), this, "Editor.CalculatedProperty.expression") :
+      expression.tryEvaluate(getOutermost(this), this, "Editor.CalculatedProperty.expression");
   }
 
 

--- a/vassal-app/src/main/java/VASSAL/counters/Labeler.java
+++ b/vassal-app/src/main/java/VASSAL/counters/Labeler.java
@@ -658,13 +658,15 @@ public class Labeler extends Decorator implements TranslatablePiece, Loopable {
   }
 
   public String getLabel() {
-    return labelFormat.getText(getOutermost(this), this, "Editor.TextLabel.label_text");
+    // Suppress all error reporting within the label evaluation if the piece is not on a Map.
+    return labelFormat.getText(getOutermost(this), this, "Editor.TextLabel.label_text", getMap() == null);
   }
 
   public String getLocalizedLabel() {
     final FormattedString f =
       new FormattedString(getTranslation(labelFormat.getFormat()));
-    return f.getLocalizedText(getOutermost(this), this, "Editor.TextLabel.label_text");
+    // Suppress all error reporting within the label evaluation if the piece is not on a Map.
+    return f.getLocalizedText(getOutermost(this), this, "Editor.TextLabel.label_text", getMap() == null);
   }
 
   @Override


### PR DESCRIPTION
Also re-enabled evaluation of Calculated Properties in GamePiece palettes, but suppresses errors reporting,