### PR TITLE
Update logback configuration to prevent messages to console

### DIFF
--- a/vassal-app/src/main/resources/logback.xml
+++ b/vassal-app/src/main/resources/logback.xml
@@ -26,7 +26,7 @@
   </if>
 
   <conversionRule conversionWord="pid"
-                  converterClass="VASSAL.tools.logging.ProcessIDConverter" />
+                  class="VASSAL.tools.logging.ProcessIDConverter" />
 
   <appender name="FILE" class="ch.qos.logback.core.FileAppender">
     <file>${CONF_DIR}/${LOG_FILE}</file>


### PR DESCRIPTION
logback conversionRule conversionClass is deprecated in favor of class.