### PR TITLE
Set the Mac bundle to prefer arm64

### DIFF
--- a/dist/macos/Info.plist
+++ b/dist/macos/Info.plist
@@ -8,7 +8,7 @@ com/DTDs/PropertyList-1.0.dtd">
   <key>CFBundleDisplayName</key>
   <string>VASSAL</string>
   <key>CFBundleIdentifier</key>
-  <string>org.vassalengine.VASSAL</string>
+  <string>org.vassalengine.vassal</string>
   <key>CFBundleVersion</key>
   <string>%NUMVERSION%</string>
   <key>CFBundleShortVersionString</key>
@@ -43,6 +43,10 @@ com/DTDs/PropertyList-1.0.dtd">
     </dict>
   </array>
   <key>LSRequiresNativeExecution</key>
+  <key>LSArchitecturePriority</key>
+  <array>
+    <string>arm64</string>
+  </array>
   <true/>
 </dict>
 </plist>

--- a/dist/macos/Info.plist
+++ b/dist/macos/Info.plist
@@ -47,6 +47,7 @@ com/DTDs/PropertyList-1.0.dtd">
   <key>LSArchitecturePriority</key>
   <array>
     <string>arm64</string>
+    <string>x86_64</string>
   </array>
   <true/>
 </dict>

--- a/dist/macos/Info.plist
+++ b/dist/macos/Info.plist
@@ -43,6 +43,7 @@ com/DTDs/PropertyList-1.0.dtd">
     </dict>
   </array>
   <key>LSRequiresNativeExecution</key>
+  <true/>
   <key>LSArchitecturePriority</key>
   <array>
     <string>arm64</string>


### PR DESCRIPTION
Set LSArchitecturePriority to arm64, and change the bundle id to stop the old architecture preference from being cached.