### PR TITLE
Add autosave functionality to BasicLogger

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/module/BasicLogger.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/BasicLogger.java
@@ -130,8 +130,8 @@ public class BasicLogger implements Logger, Buildable, GameComponent, CommandEnc
       File autosaveFile = new File(outputFile.getParent(), "autosave_" + outputFile.getName());  //$NON-NLS-1$
       try {
         write(autosaveFile);
-      } catch (IOException e)
-      {
+      }
+      catch (IOException e) {
         GameModule.getGameModule().warn("Failed to autosave log file: " + e.getMessage());
       }
     }

--- a/vassal-app/src/main/java/VASSAL/build/module/BasicLogger.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/BasicLogger.java
@@ -127,7 +127,7 @@ public class BasicLogger implements Logger, Buildable, GameComponent, CommandEnc
 
   private void autosave() {
     if (isLogging() && !isReplaying()) {
-      File autosaveFile = new File(outputFile.getParent(), "autosave_" + outputFile.getName());  //$NON-NLS-1$
+      final File autosaveFile = new File(outputFile.getParent(), "autosave_" + outputFile.getName());  //$NON-NLS-1$
       try {
         write(autosaveFile);
       }

--- a/vassal-app/src/main/java/VASSAL/build/module/BasicLogger.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/BasicLogger.java
@@ -130,7 +130,8 @@ public class BasicLogger implements Logger, Buildable, GameComponent, CommandEnc
       File autosaveFile = new File(outputFile.getParent(), "autosave_" + outputFile.getName());  //$NON-NLS-1$
       try {
         write(autosaveFile);
-      } catch (IOException e) {
+      } catch (IOException e)
+      {
         GameModule.getGameModule().warn("Failed to autosave log file: " + e.getMessage());
       }
     }

--- a/vassal-app/src/main/resources/VASSAL/i18n/VASSAL.properties
+++ b/vassal-app/src/main/resources/VASSAL/i18n/VASSAL.properties
@@ -359,6 +359,7 @@ BasicLogger.replay_commencing=New Session Beginning
 BasicLogger.replay_completed=End of Logfile
 BasicLogger.dont_prompt_again=Don't prompt again
 BasicLogger.logging_begun=Logging begun
+BasicLogger.logging_autosaving=Autosaving logfile
 BasicLogger.logfile_written=Logfile written.
 BasicLogger.undo_icon=Undo button icon
 BasicLogger.unsaved_log=Unsaved log


### PR DESCRIPTION
This pull request introduces an autosave feature to the `BasicLogger` class in the Vassal application. The most important changes include the addition of a scheduled executor service to handle periodic autosaving, the implementation of the autosave logic, and modifications to the `write` method to support writing to a specified file. We simply append the word autosave_ to the current file we are logging to and then save to that file every 5 minutes.


### Autosave Feature Implementation:

* Added `ScheduledExecutorService` to `BasicLogger` for scheduling periodic tasks. [[1]](diffhunk://#diff-767dfe244177a3b3bd7c0b28f6ded74c404f88c40087dc6dcadef5668554af5dR65-R67) [[2]](diffhunk://#diff-767dfe244177a3b3bd7c0b28f6ded74c404f88c40087dc6dcadef5668554af5dR111)
* Implemented `startAutosave` method to schedule the `autosave` method at fixed intervals.
* Added `autosave` method to handle the logic of saving the log file periodically.

### Modifications to Writing Logic:

* Modified `write` method to support writing to a specified file, used by the autosave feature.

### Localization:

* Added a new localization string for autosave log message in `VASSAL.properties`.