### PR TITLE
Bug in Makefile when pulling from branch with "/" in name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,8 @@ MAVEN_VERSION:=$(VNUM)-SNAPSHOT
 
 JARNAME:=vassal-app-$(MAVEN_VERSION)
 
-GITBRANCH:=$(shell git rev-parse --abbrev-ref HEAD)
+#Slashes are substituted so as not to create subdirectories
+GITBRANCH := $(subst /,_,$(shell git rev-parse --abbrev-ref HEAD))
 GITCOMMIT:=$(shell git rev-parse --short HEAD)
 
 ifeq ($(shell git describe --tags), $(MAVEN_VERSION))


### PR DESCRIPTION
The makeFile currently does not handle having merges from branches with "/" in them such as a branch named features/cool_feature.  If the slashes are not removed from those branch names, subdirectories get created that then break the code. For example at line 191-192:

$(TMPDIR)/VASSAL-$(VERSION)-other.zip: $(TMPDIR)/other-$(VERSION)-build/VASSAL-$(VERSION)
	pushd $(TMPDIR)/other-$(VERSION)-build ; zip -9rv ../../$@ VASSAL-$(VERSION) ; popd

Breaks becuase the "../../" part assumes no subdirectories are created by $(VERSION). The code also breaks at 209-210.

I'm surprised this bug hasnt been detected sooner. I recently had to rename I branch I was creating a PR from because of this issue.

Here is part of the log showing the errors caused by keeping slashes in branch name:

  ```
mkdir -p tmp/linux-3.8.0-SNAPSHOT-ea5e6a6-feature/log_autosave-build/VASSAL-3.8.0-SNAPSHOT-ea5e6a6-feature/log_autosave
  cp -a release-prepare/target/doc tmp/linux-3.8.0-SNAPSHOT-ea5e6a6-feature/log_autosave-build/VASSAL-3.8.0-SNAPSHOT-ea5e6a6-feature/log_autosave/doc
  cp -a CHANGES LICENSE README.md tmp/linux-3.8.0-SNAPSHOT-ea5e6a6-feature/log_autosave-build/VASSAL-3.8.0-SNAPSHOT-ea5e6a6-feature/log_autosave
  cp -a release-prepare/target/lib tmp/linux-3.8.0-SNAPSHOT-ea5e6a6-feature/log_autosave-build/VASSAL-3.8.0-SNAPSHOT-ea5e6a6-feature/log_autosave/lib
  cp dist/VASSAL.sh tmp/linux-3.8.0-SNAPSHOT-ea5e6a6-feature/log_autosave-build/VASSAL-3.8.0-SNAPSHOT-ea5e6a6-feature/log_autosave
  cp vassal-app/src/main/resources/icons/scalable/VASSAL.svg tmp/linux-3.8.0-SNAPSHOT-ea5e6a6-feature/log_autosave-build/VASSAL-3.8.0-SNAPSHOT-ea5e6a6-feature/log_autosave
  find tmp/linux-3.8.0-SNAPSHOT-ea5e6a6-feature/log_autosave-build/VASSAL-3.8.0-SNAPSHOT-ea5e6a6-feature/log_autosave -type f -exec chmod 644 \{\} \+
  find tmp/linux-3.8.0-SNAPSHOT-ea5e6a6-feature/log_autosave-build/VASSAL-3.8.0-SNAPSHOT-ea5e6a6-feature/log_autosave -type d -exec chmod 755 \{\} \+
  chmod 755 tmp/linux-3.8.0-SNAPSHOT-ea5e6a6-feature/log_autosave-build/VASSAL-3.8.0-SNAPSHOT-ea5e6a6-feature/log_autosave/VASSAL.sh
  tar cjvf tmp/VASSAL-3.8.0-SNAPSHOT-ea5e6a6-feature/log_autosave-linux.tar.bz2 -C tmp/linux-3.8.0-SNAPSHOT-ea5e6a6-feature/log_autosave-build VASSAL-3.8.0-SNAPSHOT-ea5e6a6-feature/log_autosave
  tar (child): tmp/VASSAL-3.8.0-SNAPSHOT-ea5e6a6-feature/log_autosave-linux.tar.bz2: Cannot open: No such file or directory
  tar (child): Error is not recoverable: exiting now
  tar: tmp/VASSAL-3.8.0-SNAPSHOT-ea5e6a6-feature/log_autosave-linux.tar.bz2: Cannot write: Broken pipe
  tar: Child returned status 2
  tar: Error is not recoverable: exiting now
  VASSAL-3.8.0-SNAPSHOT-ea5e6a6-feature/log_autosave/
  VASSAL-3.8.0-SNAPSHOT-ea5e6a6-feature/log_autosave/VASSAL.svg
  VASSAL-3.8.0-SNAPSHOT-ea5e6a6-feature/log_autosave/LICENSE
  make: *** [Makefile:209: tmp/VASSAL-3.8.0-SNAPSHOT-ea5e6a6-feature/log_autosave-linux.tar.bz2] Error 2
```



