### PR TITLE
Property sheet trait improvement

### DIFF
--- a/vassal-app/src/main/java/VASSAL/counters/PropertySheet.java
+++ b/vassal-app/src/main/java/VASSAL/counters/PropertySheet.java
@@ -1043,7 +1043,7 @@ public class PropertySheet extends Decorator implements TranslatablePiece {
         if (i > 0) {
           buf.append(STATE_DELIMITOR);
         }
-        String value = (String) propertyTable.getValueAt(i, 2);
+        final String value = (String) propertyTable.getValueAt(i, 2);
         if (value == null || value.isEmpty()) {
           continue;
         }

--- a/vassal-app/src/main/java/VASSAL/counters/PropertySheet.java
+++ b/vassal-app/src/main/java/VASSAL/counters/PropertySheet.java
@@ -927,11 +927,13 @@ public class PropertySheet extends Decorator implements TranslatablePiece {
     private final JButton colorCtrl;
     private final JTable propertyTable;
     private final JComboBox commitCtrl;
+    private final String previousState;
 
-    static final String[] COLUMN_NAMES = {Resources.getString("Editor.PropertySheet.name"), Resources.getString("Editor.PropertySheet.type")};
+    static final String[] COLUMN_NAMES = {Resources.getString("Editor.PropertySheet.name"), Resources.getString("Editor.PropertySheet.type"), Resources.getString("Editor.PropertySheet.state")};
     static final String[] DEFAULT_ROW = {Resources.getString("Editor.PropertySheet.new_property"), Resources.getString("Editor.PropertySheet.text")};
 
     public Ed(PropertySheet propertySheet) {
+      previousState = propertySheet.state;
       m_panel = new PropertyPanel();
       descCtrl = m_panel.addStringCtrl(Resources.getString("Editor.description_label"), propertySheet.description, "Editor.description_hint");
       menuNameCtrl = m_panel.addStringCtrl(Resources.getString("Editor.menu_command"), propertySheet.menuName, "Editor.menu_command_hint");
@@ -952,18 +954,21 @@ public class PropertySheet extends Decorator implements TranslatablePiece {
 
     protected String[][] getTableData(String definition) {
       final SequenceEncoder.Decoder decoder = new SequenceEncoder.Decoder(definition, DEF_DELIMITOR);
+      final SequenceEncoder.Decoder stateDecoder = new SequenceEncoder.Decoder(previousState, STATE_DELIMITOR);
 
       int numRows = !definition.equals("") && decoder.hasMoreTokens() ? 1 : 0;
       for (int iDef = -1; (iDef = definition.indexOf(DEF_DELIMITOR, iDef + 1)) >= 0;) {
         ++numRows;
       }
 
-      final String[][] rows = new String[numRows][2];
+      final String[][] rows = new String[numRows][3];
 
       for (int iRow = 0; decoder.hasMoreTokens() && iRow < numRows; ++iRow) {
         final String token = decoder.nextToken();
+        final String stateToken= stateDecoder.nextToken();
         rows[iRow][0] = token.substring(1);
         rows[iRow][1] = TYPE_VALUES[token.charAt(0) - '0'];
+        rows[iRow][2] = stateToken;
       }
 
       return rows;
@@ -1030,13 +1035,20 @@ public class PropertySheet extends Decorator implements TranslatablePiece {
       return ID + typeEncoder.getValue();
     }
 
-    /** returns a default value-string for the given definition */
+    /** Returns the current state */
     @Override
     public String getState() {
       final StringBuilder buf = new StringBuilder();
-      buf.append(
-        String.valueOf(STATE_DELIMITOR).repeat(Math.max(0, propertyTable.getRowCount())));
-
+      for (int i = 0; i < propertyTable.getRowCount(); i++) {
+        if (i > 0) {
+          buf.append(STATE_DELIMITOR);
+        }
+        String value = (String) propertyTable.getValueAt(i, 2);
+        if (value == null || value.isEmpty()) {
+          continue;
+        }
+        buf.append(value);
+      }
       return buf.toString();
     }
   }

--- a/vassal-app/src/main/java/VASSAL/counters/PropertySheet.java
+++ b/vassal-app/src/main/java/VASSAL/counters/PropertySheet.java
@@ -965,7 +965,7 @@ public class PropertySheet extends Decorator implements TranslatablePiece {
 
       for (int iRow = 0; decoder.hasMoreTokens() && iRow < numRows; ++iRow) {
         final String token = decoder.nextToken();
-        final String stateToken= stateDecoder.nextToken();
+        final String stateToken = stateDecoder.nextToken();
         rows[iRow][0] = token.substring(1);
         rows[iRow][1] = TYPE_VALUES[token.charAt(0) - '0'];
         rows[iRow][2] = stateToken;

--- a/vassal-app/src/main/resources/VASSAL/i18n/Editor.properties
+++ b/vassal-app/src/main/resources/VASSAL/i18n/Editor.properties
@@ -1943,6 +1943,7 @@ Editor.PropertySheet.delete_row=Delete Row
 Editor.PropertySheet.property_sheet_item=Property Sheet item
 Editor.PropertySheet.name=Name
 Editor.PropertySheet.type=Type
+Editor.PropertySheet.State=State
 Editor.PropertySheet.new_property=*new property*
 Editor.PropertySheet.text=Text
 Editor.PropertySheet.commit_on=Commit changes on


### PR DESCRIPTION
This pull request is intended to address the same issue as PR #11974 

It introduces changes to the `PropertySheet` class to include a new "state" property for each row in the property table. The most important changes include adding a new member variable to store the previous state, updating the table data structure to include the state, and modifying the method to retrieve the current state.

Changes made to the state of properties in the property sheet window are reflected when accessing them via the gamepiece and vice versa. 

After a bit of testing, it seems like these changes are quite tolerant to faulty user input. 


Fixes #11861 