### PR TITLE
allow player to modify popup during game

### DIFF
--- a/vassal-app/src/main/java/VASSAL/counters/KeyCommand.java
+++ b/vassal-app/src/main/java/VASSAL/counters/KeyCommand.java
@@ -18,9 +18,11 @@
 package VASSAL.counters;
 
 import java.awt.event.ActionEvent;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import java.awt.event.MouseListener;
 
-import javax.swing.AbstractAction;
-import javax.swing.KeyStroke;
+import javax.swing.*;
 
 import VASSAL.build.GameModule;
 import VASSAL.command.Command;
@@ -29,6 +31,7 @@ import VASSAL.tools.NamedKeyStroke;
 
 public class KeyCommand extends AbstractAction {
   private static final long serialVersionUID = 1L;
+  private boolean visible; // Add a visibility flag
 
   public static final KeyCommand[] NONE = new KeyCommand[0];
 


### PR DESCRIPTION
I have implemented a function to allow the player to modify the popup menu during gameplay to deal with the problem of some menus being way too long. Basically, I created an "unwanted" menu and the player can move items to that submenu during gameplay to reduce clutter and customize as he likes. The code is currently functional but needs more work, I was just wondering if this is a feature that any other game actually needs. 

If not then I will implement in the VASL code which is probably doable if not ideal. What would be the best way to remove the following element added by the Map class

    addChild(new MenuDisplayer());

within the ASLMap class so that I can add my own ASLMenuDisplayer()?

![Screenshot 2024-11-15 000842](https://github.com/user-attachments/assets/cc3d6290-5d2e-41ff-acfd-68441a86532a)
