### PR TITLE
A Beanshell Sleep(0) (and equivalent Audit or Alert calls) should only refresh the screen.

### DIFF
--- a/vassal-app/src/main/java/VASSAL/tools/swing/DialogCloser.java
+++ b/vassal-app/src/main/java/VASSAL/tools/swing/DialogCloser.java
@@ -34,11 +34,12 @@ public class DialogCloser implements Runnable {
 
   @Override
   public void run() {
-    try {
-      Thread.sleep(ms);
-    }
-    catch (InterruptedException e) {
-      throw new RuntimeException(e);
+    if (ms > 1) { // Zero means no sleep - refresh only
+      try {
+        Thread.sleep(ms);
+      } catch (InterruptedException e) {
+        throw new RuntimeException(e);
+      }
     }
     dialog.setVisible(false);
     dialog.dispose();

--- a/vassal-app/src/main/java/VASSAL/tools/swing/DialogCloser.java
+++ b/vassal-app/src/main/java/VASSAL/tools/swing/DialogCloser.java
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright (c) 2008-2023 by The VASSAL Development Team
+ * Copyright (c) 2008-2024 by The VASSAL Development Team
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -29,15 +29,16 @@ public class DialogCloser implements Runnable {
 
   public DialogCloser(JDialog dialog, int ms) {
     this.dialog = dialog;
-    this.ms = ms < 0 ? 500 : ms;
+    this.ms = ms;
   }
 
   @Override
   public void run() {
-    if (ms > 1) { // Zero means no sleep - refresh only
+    if (ms > 0) {
       try {
         Thread.sleep(ms);
-      } catch (InterruptedException e) {
+      }
+      catch (InterruptedException e) {
         throw new RuntimeException(e);
       }
     }


### PR DESCRIPTION
This PR bypasses Thread.sleep() in DialogCloser.java for intervals less than 1 ms.

Previously an interval of zero was passed, for no apparent gain (a sleep interval is relatively unpredictable at short durations).
Also, a negative interval was overridden as 500ms. This change treats a negative value the same as zero.