### PR TITLE
Add Beanshell performance health warning to Text Label trait

### DIFF
--- a/vassal-doc/src/main/readme-referencemanual/ReferenceManual/Label.adoc
+++ b/vassal-doc/src/main/readme-referencemanual/ReferenceManual/Label.adoc
@@ -23,7 +23,7 @@ The text of the label can be fixed or specifiable by a player at game time.
 . If no check is true the entered string is displayed.
 
 ****
-**Note!** _Label Text_ will be reevaluated every time a piece bearing the Text Label trait is  drawn, which will occur frequently in a typical module whenever such a piece is displayed. Therefore, longer, more convoluted Beanshell expressions (e.g., comparisons, arithmetic, Count/Sums etc.) may affect performance, especially with widespread use.
+**Note!** _Label Text_ will be reevaluated every time a piece bearing the Text Label trait is  drawn, which will occur frequently in a typical module whenever such a piece is on display. Therefore, longer, more convoluted Beanshell expressions (e.g., comparisons, arithmetic, Count/Sums etc.) may affect performance, especially with widespread use.
 ****
 
 A known limitation of the evaluation order above is that if you enter a sequence of digits starting with 0s, these will be removed when the string is evaluated as integer.

--- a/vassal-doc/src/main/readme-referencemanual/ReferenceManual/Label.adoc
+++ b/vassal-doc/src/main/readme-referencemanual/ReferenceManual/Label.adoc
@@ -22,9 +22,12 @@ The text of the label can be fixed or specifiable by a player at game time.
 . Check if the entered label is a $$ Variable Substitution (defined by a string enclosed between $ characters). This allows <<Properties.adoc#top,Properties>> of the piece to be substituted with $..$ notation, as in a <<MessageFormat.adoc#top,Message Format>>
 . If no check is true the entered string is displayed.
 
+****
+**Note!** _Label Text_ will be reevaluated every time a piece bearing the Text Label trait is  drawn, which will occur frequently in a typical module whenever such a piece is displayed. Therefore, longer, more convoluted Beanshell expressions (e.g., comparisons, arithmetic, Count/Sums etc.) may affect performance, especially with widespread use.
+****
+
 A known limitation of the evaluation order above is that if you enter a sequence of digits starting with 0s, these will be removed when the string is evaluated as integer.
 A workaround to this is to enter the same string via a Beanshell expression. For example to display a sequence of 3 zeroes as label text you can use *{"000"}*.
-Note that the Beanshell expressions should be preferred to $$ Variable Substitutions. The latter are only available for historical reasons.
 
 By enclosing the text within tags, you can use simple HTML format to specify various colors, fonts and sizes.
 


### PR DESCRIPTION
Also, remove Beanshell preference advice as it is not relevant here, except specifically the bit on leading zeros. Generic advice on Beanshell vs Legacy is given in the general section on expressions.