### PR TITLE
Do not subject Continuation file to online restrictions.

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/module/GameState.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/GameState.java
@@ -204,6 +204,7 @@ public class GameState implements CommandEncoder {
 
       @Override
       public void actionPerformed(ActionEvent e) {
+        //  Load Continuation is excused the restrictions that apply to new games & log files in online rooms
         if (loadContinuation.isEnabled() || isNewGameAllowed()) {
           loadGame(true);
         }

--- a/vassal-app/src/main/java/VASSAL/build/module/GameState.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/GameState.java
@@ -204,7 +204,7 @@ public class GameState implements CommandEncoder {
 
       @Override
       public void actionPerformed(ActionEvent e) {
-        if (isNewGameAllowed()) {
+        if (loadContinuation.isEnabled() || isNewGameAllowed()) {
           loadGame(true);
         }
       }

--- a/vassal-app/src/main/resources/VASSAL/i18n/VASSAL.properties
+++ b/vassal-app/src/main/resources/VASSAL/i18n/VASSAL.properties
@@ -788,7 +788,7 @@ GameState.simple_save_append=?<b>Game loaded but included no logging information
 GameState.open_recent=Open Recent...
 GameState.new_game_not_allowed_title=New Game Not Allowed
 GameState.new_game_not_allowed_heading=New Game Not Allowed
-GameState.new_game_not_allowed_warning=You may not start a new game, or load a continuation unless you are the owner of the this room. Use the Synchronize option to re-join the game in progress. 
+GameState.new_game_not_allowed_warning=You may not start a new game or load a logfile in this room. Ask the room owner or use the Synchronize option to re-join the game in progress. 
 
 # GlobalOptions
 GlobalOptions.use_combined=Use combined application window (requires restart)


### PR DESCRIPTION
Skips online check if we're only doing a Load Continuation. New Game & loading a Log file remain barred to room guests.