### PR TITLE
Sleep() performance improvement 

### DIFF
--- a/vassal-app/src/main/java/VASSAL/script/ExpressionInterpreter.java
+++ b/vassal-app/src/main/java/VASSAL/script/ExpressionInterpreter.java
@@ -1047,7 +1047,7 @@ public class ExpressionInterpreter extends AbstractInterpreter implements Loopab
    *
    * @param property      Property Name to sum
    * @param locationName  Location Name to match
-   * @param mapName       Map to check
+   * @param map       Map to check
    * @param filter        Optional PieceFilter to check expression match
    * @return
    */
@@ -1131,7 +1131,7 @@ public class ExpressionInterpreter extends AbstractInterpreter implements Loopab
    * Lowest-level CountLocation function called by all other versions
    * @param locationName Location Name to search for
    * @param map          Map to search on
-   * @param propValue    null if no property was supplied, or property name if supplied
+   * @param property    null if no property was supplied, or property name if supplied
    * @param filter       Option filter implementing Property Match Expression
    * @return             Count of pieces
    */
@@ -1183,8 +1183,8 @@ public class ExpressionInterpreter extends AbstractInterpreter implements Loopab
    * Lowest-level SumZone function called by all other versions
    *
    * @param property      Property Name to sum
-   * @param zone          Zone Name to match
-   * @param mapName       Map to check
+   * @param zoneName          Zone Name to match
+   * @param map       Map to check
    * @param filter        Optional PieceFilter to check expression match
    * @return
    */
@@ -1267,7 +1267,7 @@ public class ExpressionInterpreter extends AbstractInterpreter implements Loopab
    * Lowest-level CountZone function called by all other versions
    * @param zoneName     Zone Name to search for
    * @param map          Map to search on
-   * @param propValue    null if no property was supplied, or value of supplied property
+   * @param property     if no property was supplied, or value of supplied property
    * @param filter       Option filter implementing Property Match Expression
    * @return             Count of pieces
    */
@@ -1326,7 +1326,7 @@ public class ExpressionInterpreter extends AbstractInterpreter implements Loopab
    * Lowest-level SumMap function called by all other versions
    * @param propertyName Property to sum
    * @param map          Map to search on
-   * @param propValue    null if no property was supplied, or value of supplied property
+   * @param propertyName null if no property was supplied, or value of supplied property
    * @param filter       Option filter implementing Property Match Expression
    * @return             Count of pieces
    */
@@ -1419,9 +1419,8 @@ public class ExpressionInterpreter extends AbstractInterpreter implements Loopab
 
   /**
    * Lowest-level CountMap function called by all other versions
-   * @param propertyName Property to sum
    * @param map          Map to search on
-   * @param propValue    null if no property was supplied, or value of supplied property
+   * @param propertyName null if no property was supplied, or value of supplied property
    * @param filter       Option filter implementing Property Match Expression
    * @return             Count of pieces
    */
@@ -2012,7 +2011,7 @@ public class ExpressionInterpreter extends AbstractInterpreter implements Loopab
    * Refresh the screen, then delay for the specified number of milliseconds
    *
    * This is not pretty, but is the only way I have found to force a proper UI refresh
-   * - Open a modal dialog box way offscreen. This forces a an actual real Swing UI refresh, then hangs the UI
+   * - Open a modal dialog box way off-screen. This forces a real Swing UI refresh, then hangs the UI
    * - Start a new thread that closes the dialog box after a specified delay
    *
    * @param ms  Milliseconds to delay
@@ -2023,7 +2022,8 @@ public class ExpressionInterpreter extends AbstractInterpreter implements Loopab
 
     final int milliSeconds = IntPropValue(ms);
     final JDialog dialog = new JDialog(GameModule.getGameModule().getPlayerWindow(), true);
-    dialog.setLocation(-5000, -5000);
+    dialog.setLocation(-5000, -5000); // but, note! OS can't be relied on to put the window "off-screen". e.g. MacOS does 0,0
+    dialog.setUndecorated(true); // keeps the dialog box invisible by virtue of zero content, perhaps making relocation redundant.
     SwingUtilities.invokeLater(new DialogCloser(dialog, milliSeconds));
 
     dialog.setVisible(true);

--- a/vassal-app/src/main/java/VASSAL/tools/swing/DialogCloser.java
+++ b/vassal-app/src/main/java/VASSAL/tools/swing/DialogCloser.java
@@ -37,7 +37,8 @@ public class DialogCloser implements Runnable {
     if (ms > 0) { // zero or less *really* means no sleep (retaining execution priority)
       try {
         Thread.sleep(ms);
-      } catch (InterruptedException e) {
+      }
+      catch (InterruptedException e) {
         throw new RuntimeException(e);
       }
     }

--- a/vassal-app/src/main/java/VASSAL/tools/swing/DialogCloser.java
+++ b/vassal-app/src/main/java/VASSAL/tools/swing/DialogCloser.java
@@ -20,7 +20,7 @@ package VASSAL.tools.swing;
 import javax.swing.JDialog;
 
 /**
- * Close a Dialog Box after a specified delay interval
+ * Close Dialog Box after a specified delay interval
  */
 public class DialogCloser implements Runnable {
 
@@ -29,16 +29,17 @@ public class DialogCloser implements Runnable {
 
   public DialogCloser(JDialog dialog, int ms) {
     this.dialog = dialog;
-    this.ms = ms < 0 ? 500 : ms;
+    this.ms = ms;
   }
 
   @Override
   public void run() {
-    try {
-      Thread.sleep(ms);
-    }
-    catch (InterruptedException e) {
-      throw new RuntimeException(e);
+    if (ms > 0) { // zero or less *really* means no sleep (retaining execution priority)
+      try {
+        Thread.sleep(ms);
+      } catch (InterruptedException e) {
+        throw new RuntimeException(e);
+      }
     }
     dialog.setVisible(false);
     dialog.dispose();


### PR DESCRIPTION
Redrafted #13804 (originally #13710) for a clean 3.7 build.

Testing indicates a performance improvement where Sleep(0) is used to force a screen refresh, at least on a Mac where the 3.7.15 will display a dummy window on the physical screen. This artefact is removed by the revised approach in this PR. The improvement is particularly noticeable on a 2016 MacBook with the C&C Napoleonics module v5.1.

Also, tested independently by a PC Windows user. There the artefact doesn't seem to occur and this change seems to be transparent.

Other changes to the affected components are Javadoc corrections.