### PR TITLE
13857 MUST have matching module version and reasonably matching (same minor version) Vassal in order to join Multiplayer

### DIFF
--- a/vassal-app/src/main/java/VASSAL/chat/ui/JoinRoomAction.java
+++ b/vassal-app/src/main/java/VASSAL/chat/ui/JoinRoomAction.java
@@ -25,11 +25,11 @@ import VASSAL.chat.node.NodeRoom;
 import VASSAL.i18n.Resources;
 import VASSAL.tools.swing.Dialogs;
 
+import javax.swing.AbstractAction;
+import javax.swing.JOptionPane;
 import java.awt.event.ActionEvent;
 import java.util.ArrayList;
 import java.util.List;
-import javax.swing.AbstractAction;
-import javax.swing.JOptionPane;
 
 /**
  * When invoked, will join a game room on the server
@@ -68,6 +68,7 @@ public class JoinRoomAction extends AbstractAction {
           Resources.getString("Chat.vassal_configuration_error"),
           sb.toString(),
           JOptionPane.INFORMATION_MESSAGE);
+        return; // No game for you! Come back when you've updated...
       }
     }
 

--- a/vassal-app/src/main/resources/VASSAL/i18n/VASSAL.properties
+++ b/vassal-app/src/main/resources/VASSAL/i18n/VASSAL.properties
@@ -547,7 +547,7 @@ Chat.join_not_ok=ADVICE: %1$s is not using the same Vassal or Module versions as
 #
 Chat.vassal_configuration_error=Possible VASSAL Configuration Error
 Chat.join_issue=Your VASSAL or Module version does not match that of the owner of room '%1$s'.
-Chat.are_you_sure=This is likely to cause problems; we strongly recommend resolving the mismatches noted below before playing.
+Chat.are_you_sure=You cannot join because the game will only work correctly with matching versions.
 Chat.copy=Copy selected log text
 Chat.save_to_text_file=Save log as text file
 Chat.save_to_html_file=Save log as html file

--- a/vassal-app/src/main/resources/VASSAL/i18n/VASSAL.properties
+++ b/vassal-app/src/main/resources/VASSAL/i18n/VASSAL.properties
@@ -547,7 +547,7 @@ Chat.join_not_ok=ADVICE: %1$s is not using the same Vassal or Module versions as
 #
 Chat.vassal_configuration_error=Possible VASSAL Configuration Error
 Chat.join_issue=Your VASSAL or Module version does not match that of the owner of room '%1$s'.
-Chat.are_you_sure=If you find this causes unpredictable problems, resolve the mismatches noted above.
+Chat.are_you_sure=This is likely to cause problems; we strongly recommend resolving the mismatches noted below before playing.
 Chat.copy=Copy selected log text
 Chat.save_to_text_file=Save log as text file
 Chat.save_to_html_file=Save log as html file


### PR DESCRIPTION
Replaces #13194 with a 3.7 version. Essentially tie a bow on 3.7 in expectation there might not be 3.8.