### PR TITLE
Property ModuleGameFileName makes last opened game file name available to the  current player

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/GameModule.java
+++ b/vassal-app/src/main/java/VASSAL/build/GameModule.java
@@ -225,6 +225,8 @@ public class GameModule extends AbstractConfigurable
   public static final String DRAWING_MOUSEOVER_PROPERTY = "DrawingMouseover"; //NON-NLS
   public static final String DRAWING_MOUSEOVER_INDEX_PROPERTY = "DrawingMouseoverIndex"; //NON-NLS
 
+  private static final String GAME_FILENAME_PROPERTY = "ModuleGameFileName"; //NON-NLS
+
   public static final String IS_VISIBLE = "_isVisible"; //NON-NLS
 
   public static final String UI_PIECE_COUNT = "UiPieceCount";
@@ -264,7 +266,7 @@ public class GameModule extends AbstractConfigurable
 
   private static GameModule theModule;
 
-  private static String DEFAULT_MODULE_VERSION = "0.0"; //$NON-NLS-1$
+  private static final String DEFAULT_MODULE_VERSION = "0.0"; //$NON-NLS-1$
 
   private String moduleVersion = DEFAULT_MODULE_VERSION;
   private String vassalVersionCreated = "0.0";  //$NON-NLS-1$
@@ -771,7 +773,7 @@ public class GameModule extends AbstractConfigurable
      */
     if (e != null) {
       gameName = e.getAttribute(MODULE_NAME).strip();
-      if (e.getAttribute(VASSAL_VERSION_CREATED).length() > 0) {
+      if (e.getAttribute(VASSAL_VERSION_CREATED).isEmpty()) {
         vassalVersionCreated = e.getAttribute(VASSAL_VERSION_CREATED);
       }
     }
@@ -2290,6 +2292,9 @@ public class GameModule extends AbstractConfigurable
     else if (DRAWING_MOUSEOVER_INDEX_PROPERTY.equals(key)) {
       return CounterDetailViewer.isDrawingMouseOver() ? "2" : "1";
     }
+    else if (GAME_FILENAME_PROPERTY.equals(key)) {
+      return gameFile;
+    }
     else if (UI_PIECE_COUNT.equals(key)) {
       return String.valueOf(getUiPieceCount());
     }
@@ -2397,6 +2402,7 @@ public class GameModule extends AbstractConfigurable
     l.add(MODULE_CURRENT_LOCALE_NAME);
     l.add(MODULE_VASSAL_VERSION_CREATED_PROPERTY);
     l.add(MODULE_VASSAL_VERSION_RUNNING_PROPERTY);
+    l.add(GAME_FILENAME_PROPERTY);
     l.add(UI_PIECE_COUNT);
     l.add(UI_PIECE_INDEX);
 

--- a/vassal-doc/src/main/readme-referencemanual/ReferenceManual/Properties.adoc
+++ b/vassal-doc/src/main/readme-referencemanual/ReferenceManual/Properties.adoc
@@ -172,6 +172,7 @@ A string that uniquely identifies an individual piece and is guaranteed to never
 |*CurrentLanguage* |<<GameModule.adoc#top,Game Module>>| Module| The 2 letter language code for the language selected by the current player.
 |*CurrentLanguageName* |<<GameModule.adoc#top,Game Module>>| Module| The name of the language seleted by the current player.
 |*ModuleDescription* |<<GameModule.adoc#top,Game Module>>| Module| The Module description text from the main <<GameModule.adoc#top, Game Module>> component.
+|*ModuleGameFileName* |<<GameModule.adoc#top,Game Module>>| Module| The last game file opened by the current player.
 |*ModuleName* |<<GameModule.adoc#top,Game Module>>| Module| The Module name text from the main <<GameModule.adoc#top, Game Module>> component.
 |*ModuleOther1* |<<GameModule.adoc#top,Game Module>>| Module| The Additional Module Info 1 text from the main <<GameModule.adoc#top, Game Module>> component.
 |*ModuleOther2* |<<GameModule.adoc#top,Game Module>>| Module| The Additional Module Info 2 text from the main <<GameModule.adoc#top, Game Module>> component.


### PR DESCRIPTION
Bring forward ModuleGameFileName in response to recent forum request.

This change has been held in the 3.8 queue. I propose it for 3.7 as it has no effect except for a module designer who specifically uses it, and can therefore insist that module users update their version of Vassal.