### PR TITLE
Fix a bad reference manual link

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/module/StartupGlobalKeyCommand.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/StartupGlobalKeyCommand.java
@@ -161,7 +161,7 @@ public class StartupGlobalKeyCommand extends GlobalKeyCommand implements GameCom
 
   @Override
   public HelpFile getHelpFile() {
-    return HelpFile.getReferenceManualPage("Map.html", "StartupGlobalKeyCommand"); //NON-NLS
+    return HelpFile.getReferenceManualPage("GlobalKeyCommands.html", "StartupGlobalKeyCommand"); //NON-NLS
   }
 
   @SuppressWarnings("removal")

--- a/vassal-app/src/main/java/VASSAL/build/module/StartupGlobalKeyCommand.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/StartupGlobalKeyCommand.java
@@ -161,7 +161,7 @@ public class StartupGlobalKeyCommand extends GlobalKeyCommand implements GameCom
 
   @Override
   public HelpFile getHelpFile() {
-    return HelpFile.getReferenceManualPage("GlobalKeyCommands.html", "StartupGlobalKeyCommand"); //NON-NLS
+    return HelpFile.getReferenceManualPage("GlobalKeyCommands.html", "startup"); //NON-NLS
   }
 
   @SuppressWarnings("removal")

--- a/vassal-app/src/main/java/VASSAL/build/module/documentation/HelpFile.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/documentation/HelpFile.java
@@ -91,7 +91,7 @@ public class HelpFile extends AbstractConfigurable {
 
   public HelpFile(String title, File contents, String ref)
                                 throws MalformedURLException {
-    this(title, new URL(URLUtils.toURL(contents), ref));
+    this(title, new URL(URLUtils.toURL(contents + ref), ref));
   }
 
   public HelpFile(String title, File contents) throws MalformedURLException {

--- a/vassal-app/src/main/java/VASSAL/build/module/documentation/HelpFile.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/documentation/HelpFile.java
@@ -38,8 +38,6 @@ import java.io.File;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.List;
 import javax.swing.AbstractAction;
@@ -319,7 +317,7 @@ public class HelpFile extends AbstractConfigurable {
     dir = new File(dir, "ReferenceManual"); //$NON-NLS-1$
     try {
       return anchor == null ? new HelpFile(null, new File(dir, page)) :
-                              new HelpFile(null, new File(dir, page), URLEncoder.encode(anchor, StandardCharsets.UTF_8));
+                              new HelpFile(null, new File(dir, page), anchor);
     }
     catch (MalformedURLException ex) {
       ErrorDialog.bug(ex);

--- a/vassal-app/src/main/java/VASSAL/build/module/documentation/HelpFile.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/documentation/HelpFile.java
@@ -91,7 +91,7 @@ public class HelpFile extends AbstractConfigurable {
 
   public HelpFile(String title, File contents, String ref)
                                 throws MalformedURLException {
-    this(title, new URL(URLUtils.toURL(contents + ref), ref));
+    this(title, new URL(URLUtils.toURL(contents + ref),""));
   }
 
   public HelpFile(String title, File contents) throws MalformedURLException {

--- a/vassal-app/src/main/java/VASSAL/build/module/documentation/HelpFile.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/documentation/HelpFile.java
@@ -32,17 +32,18 @@ import VASSAL.tools.ReadErrorDialog;
 import VASSAL.tools.URLUtils;
 import VASSAL.tools.menu.MenuItemProxy;
 import VASSAL.tools.menu.MenuManager;
-
-import javax.swing.AbstractAction;
-import javax.swing.Action;
 import java.awt.Dialog;
 import java.awt.event.ActionEvent;
 import java.io.File;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.List;
+import javax.swing.AbstractAction;
+import javax.swing.Action;
 
 /**
  * Places an entry in the <code>Help</code> menu.  Selecting the entry
@@ -91,7 +92,7 @@ public class HelpFile extends AbstractConfigurable {
 
   public HelpFile(String title, File contents, String ref)
                                 throws MalformedURLException {
-    this(title, new URL(URLUtils.toURL(contents + ref),""));
+    this(title, new URL(URLUtils.toURL(contents), ref));
   }
 
   public HelpFile(String title, File contents) throws MalformedURLException {
@@ -318,7 +319,7 @@ public class HelpFile extends AbstractConfigurable {
     dir = new File(dir, "ReferenceManual"); //$NON-NLS-1$
     try {
       return anchor == null ? new HelpFile(null, new File(dir, page)) :
-                              new HelpFile(null, new File(dir, page), anchor);
+                              new HelpFile(null, new File(dir, page), URLEncoder.encode(anchor, StandardCharsets.UTF_8));
     }
     catch (MalformedURLException ex) {
       ErrorDialog.bug(ex);

--- a/vassal-doc/src/main/readme-referencemanual/ReferenceManual/GlobalKeyCommands.adoc
+++ b/vassal-doc/src/main/readme-referencemanual/ReferenceManual/GlobalKeyCommands.adoc
@@ -268,7 +268,7 @@ Startup GKCs are run automatically when a game is started or loaded. They can be
 
 Otherwise, it works as a standard Global Key Command, but has no associated toolbar, unless the Global Hotkey mode is enabled.
 
-Unlike other Global Key Commands, a Startup HKC can be configured to send a Global Hotkey (to affect toolbar buttons and Decks) rather than a Global Key Command (which affects pieces). See the second example below.
+Unlike other Global Key Commands, a Startup GKC can be configured to send a Global Hotkey (to affect toolbar buttons and Decks) rather than a Global Key Command (which affects pieces). See the second example below.
 
 NOTE: Any Startup GKCs configured are guaranteed to run in the order they are defined in the module.
 

--- a/vassal-doc/src/main/readme-referencemanual/ReferenceManual/GlobalKeyCommands.adoc
+++ b/vassal-doc/src/main/readme-referencemanual/ReferenceManual/GlobalKeyCommands.adoc
@@ -268,7 +268,7 @@ Startup GKCs are run automatically when a game is started or loaded. They can be
 
 Otherwise, it works as a standard Global Key Command, but has no associated toolbar, unless the Global Hotkey mode is enabled.
 
-Unlike other Global Key Commands, a Startup HKC can be confuigured to send a Global Hotkey (to affect toolbar buttons and Decks) rather than a Global Key Command (which affects pieces). See the second example below.
+Unlike other Global Key Commands, a Startup HKC can be configured to send a Global Hotkey (to affect toolbar buttons and Decks) rather than a Global Key Command (which affects pieces). See the second example below.
 
 NOTE: Any Startup GKCs configured are guaranteed to run in the order they are defined in the module.
 


### PR DESCRIPTION
Startup GKC help link needs to go via GlobalKeyCommands.html not via Map.html.