### PR TITLE
No clicks, no drop!

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/module/map/PieceMover.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/PieceMover.java
@@ -1298,7 +1298,7 @@ public class PieceMover extends AbstractBuildable
     return !e.isConsumed() &&
       !e.isShiftDown() &&
       !SwingUtils.isSelectionToggle(e) &&
-      e.getClickCount() < 2 &&
+      e.getClickCount() == 1 &&                   // Previously also allowed a clickCount of zero here, causing https://github.com/vassalengine/vassal/issues/12480
       (e.getButton() == MouseEvent.NOBUTTON ||
         SwingUtils.isMainMouseButtonDown(e));
   }


### PR DESCRIPTION
Ensures zero getClickCount() is ignored for mouseReleased(). Investigation found that a zero getClickCount() is consistently associated with issue #12480 - the first such event being zero in a "double" event.

See this [post](https://forum.vassalengine.org/t/drag-drop-bug-piece-drops-through-to-an-underlying-window-advice-needed/84754/4?u=marktb1961) for evidence and some discussion of the issue.  Note that the latest evidence belies that the root cause is overlying windows, since a double event may be observed even when only one window is on screen.

The question of why a zero-click event is sometimes generated remains open. However, initial testing in modules where the fault is easily replicated demonstrates a successful workaround even if this is that case.