### PR TITLE
Filter out null sender in sendToOthers(Command)

### DIFF
--- a/vassal-app/src/main/java/VASSAL/chat/node/NodeClient.java
+++ b/vassal-app/src/main/java/VASSAL/chat/node/NodeClient.java
@@ -287,7 +287,14 @@ public class NodeClient implements LockableChatServerConnection,
 
   @Override
   public void sendToOthers(Command c) {
-    sendToOthers(encoder.encode(c));
+    if (sender == null) {
+      // tolerate https://github.com/vassalengine/vassal/issues/13666
+      propSupport.firePropertyChange(STATUS, null, Resources.getString(
+              "Chat.disconnected")); //$NON-NLS-1$
+    }
+    else {
+      sendToOthers(encoder.encode(c));
+    }
   }
 
   public void sendToAll(String msg) {
@@ -298,7 +305,7 @@ public class NodeClient implements LockableChatServerConnection,
     }
   }
 
-  public void forward(String receipientPath, String msg) {
+  public void forward(String recipientPath, String msg) {
     if (isConnected() && currentRoom != null && msg != null) {
       msg = checker.filter(msg, defaultRoomName, currentRoom.getName());
       if (msg.length() > compressionLimit) {
@@ -312,7 +319,7 @@ public class NodeClient implements LockableChatServerConnection,
           e.printStackTrace();
         }
       }
-      send(Protocol.encodeForwardCommand(receipientPath, msg));
+      send(Protocol.encodeForwardCommand(recipientPath, msg));
     }
   }
 


### PR DESCRIPTION
Possible null sender solution, providing that sender is never valid as null when sendToOthers() is called. See related issues; presumably the null exception will occur in any of the usage cases.

Usages, for reference:
<img width="695" alt="image" src="https://github.com/user-attachments/assets/bfcc3e6d-8620-4401-bfbb-a395acbbe719" />

Query whether a simple "Disconnected." message is enough feedback to prompt the user to re-try connecting to the Vassal server and that no more helpful action is possible.

Also, corrects  spelling error in a parameter name (self contained with a method).