### PR TITLE
Reset map on a piece that has lost its way

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/module/map/MenuDisplayer.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/MenuDisplayer.java
@@ -270,9 +270,10 @@ public class MenuDisplayer extends MouseAdapter implements Buildable {
         return;
       }
 
-      // workaround for https://github.com/vassalengine/vassal/issues/12033
-      if (!map.equals(p.getMap())) { // Piece is not actually on this map, do nothing
-        return;
+      // FIXME: workaround for https://github.com/vassalengine/vassal/issues/12033
+      // Undo sometimes corrupts a pieces Map.
+      if (!map.equals(p.getMap())) {
+        p.setMap(map);
       }
 
       final Point epos = e.getPoint();

--- a/vassal-app/src/main/java/VASSAL/build/module/map/MenuDisplayer.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/MenuDisplayer.java
@@ -188,7 +188,7 @@ public class MenuDisplayer extends MouseAdapter implements Buildable {
           }
         }
         if (keyCommand.getName() != null &&
-            keyCommand.getName().length() > 0 &&
+                !keyCommand.getName().isEmpty() &&
             item != null) {
           final List<JMenuItem> l = commandNames.computeIfAbsent(keyCommand.getName(), k -> new ArrayList<>());
           l.add(item);
@@ -267,6 +267,11 @@ public class MenuDisplayer extends MouseAdapter implements Buildable {
         return;
       }
       if (map.getKeyBufferer().isLasso()) { // If we dragged a selection box
+        return;
+      }
+
+      // workaround for https://github.com/vassalengine/vassal/issues/12033
+      if (!map.equals(p.getMap())) { // Piece is not actually on this map, do nothing
         return;
       }
 


### PR DESCRIPTION
Undo bug appears to cause a piece to lose its map reference part way through a menu display. This workaround restores the current map to the piece, allowing the rest of the menu display method to proceed (assuming there's no other critical data corrupted).