### PR TITLE
Add Startup GKC for when a player joins, retires, or changes sides V2

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/module/PlayerRoster.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/PlayerRoster.java
@@ -506,6 +506,7 @@ public class PlayerRoster extends AbstractToolbarItem implements CommandEncoder,
 
       final Add a = new Add(this, GameModule.getActiveUserId(), GlobalOptions.getInstance().getPlayerId(), newSide);
       a.execute();
+      fireSideChange(null, newSide);
       gm.sendAndLog(a);
 
       pickedSide = true;

--- a/vassal-app/src/main/java/VASSAL/build/module/StartupGlobalKeyCommand.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/StartupGlobalKeyCommand.java
@@ -32,6 +32,7 @@ import VASSAL.i18n.Resources;
 import VASSAL.tools.NamedKeyStroke;
 import VASSAL.tools.SequenceEncoder;
 import VASSAL.tools.UniqueIdManager;
+import org.apache.commons.lang3.StringUtils;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -48,7 +49,9 @@ import java.util.List;
  * @author Pieter Geerkens, Brian Reynolds
  *
  */
-public class StartupGlobalKeyCommand extends GlobalKeyCommand implements GameComponent, CommandEncoder, UniqueIdManager.Identifyable {
+public class StartupGlobalKeyCommand extends GlobalKeyCommand
+        implements GameComponent,
+        CommandEncoder, UniqueIdManager.Identifyable, PlayerRoster.SideChangeListener {
   public static final String WHEN_TO_APPLY                   = "whenToApply";          //NON-NLS
   public static final String APPLY_FIRST_LAUNCH_OF_SESSION   = "firstLaunchOfSession"; //NON-NLS
   public static final String APPLY_EVERY_LAUNCH_OF_SESSION   = "everyLaunchOfSession"; //NON-NLS
@@ -77,6 +80,7 @@ public class StartupGlobalKeyCommand extends GlobalKeyCommand implements GameCom
 
   private boolean hasEverApplied     = false;  // Has ever been applied during this session   (NOT saved with game state)
   private boolean hasAppliedThisGame = false;  // Has ever been applied during this *game*    (Saved with game state)
+  private String sideChangedSummary;
 
   public static class Prompt extends TranslatableStringEnum {
     @Override
@@ -149,6 +153,10 @@ public class StartupGlobalKeyCommand extends GlobalKeyCommand implements GameCom
     super.addTo(parent);
     GameModule.getGameModule().getGameState().addGameComponent(this);
     GameModule.getGameModule().addCommandEncoder(this);
+    // Attach the listener only for the side change startup GKC.
+    if (APPLY_SIDE_CHANGE.equals(whenToApply)) {
+      GameModule.getGameModule().addSideChangeListenerToPlayerRoster(this);
+    }
   }
 
   @Override
@@ -266,6 +274,13 @@ public class StartupGlobalKeyCommand extends GlobalKeyCommand implements GameCom
     }
   }
 
+  /**
+   * Listen for player side changes.
+   */
+  @Override
+  public void sideChanged(String oldSide, String newSide) {
+    sideChangedSummary = newSide;
+  }
 
   /**
    * Apply the command, but only if it hasn't been marked as already-applied (by whatever its when-to-apply parameters are)
@@ -282,6 +297,16 @@ public class StartupGlobalKeyCommand extends GlobalKeyCommand implements GameCom
         return false;
       }
     }
+    else if (APPLY_SIDE_CHANGE.equals(whenToApply)) {
+      if (StringUtils.isEmpty(sideChangedSummary)) {
+        return false;
+      }
+      else {
+        sideChangedSummary = null;
+        apply();
+        return true;
+      }
+    }
     hasEverApplied = true;     // This one will be false again next time anything calls GameState.setup(true)
     hasAppliedThisGame = true; // This one will be remembered as part of the game state (i.e. even after loading a game)
     apply();
@@ -296,8 +321,13 @@ public class StartupGlobalKeyCommand extends GlobalKeyCommand implements GameCom
     if (!APPLY_START_GAME_OR_SIDE_CHANGE.equals(whenToApply) && !APPLY_SIDE_CHANGE.equals(whenToApply)) {
       return false;
     }
-    hasEverApplied     = true;
-    hasAppliedThisGame = true;
+    if (APPLY_SIDE_CHANGE.equals(whenToApply)) {
+      sideChangedSummary = null;
+    }
+    else {
+      hasEverApplied = true;
+      hasAppliedThisGame = true;
+    }
     apply();
     return true;
   }

--- a/vassal-app/src/main/java/VASSAL/build/module/StartupGlobalKeyCommand.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/StartupGlobalKeyCommand.java
@@ -54,6 +54,7 @@ public class StartupGlobalKeyCommand extends GlobalKeyCommand implements GameCom
   public static final String APPLY_EVERY_LAUNCH_OF_SESSION   = "everyLaunchOfSession"; //NON-NLS
   public static final String APPLY_START_OF_GAME_ONLY        = "startOfGameOnly";      //NON-NLS
   public static final String APPLY_START_GAME_OR_SIDE_CHANGE = "sideChange";           //NON-NLS
+  public static final String APPLY_SIDE_CHANGE               = "onlySideChange";       //NON-NLS
   public static final String GLOBAL_HOTKEY                   = "globalHotkey";         //NON-NLS
   public static final String HOTKEY_OR_KEY_COMMAND           = "hotkeyOrKeyCommand";   //NON-NLS
 
@@ -80,7 +81,8 @@ public class StartupGlobalKeyCommand extends GlobalKeyCommand implements GameCom
   public static class Prompt extends TranslatableStringEnum {
     @Override
     public String[] getValidValues(AutoConfigurable target) {
-      return new String[]{ APPLY_FIRST_LAUNCH_OF_SESSION, APPLY_EVERY_LAUNCH_OF_SESSION, APPLY_START_OF_GAME_ONLY, APPLY_START_GAME_OR_SIDE_CHANGE };
+      return new String[]{ APPLY_FIRST_LAUNCH_OF_SESSION, APPLY_EVERY_LAUNCH_OF_SESSION, APPLY_START_OF_GAME_ONLY, APPLY_START_GAME_OR_SIDE_CHANGE,
+                           APPLY_SIDE_CHANGE};
     }
 
     @Override
@@ -89,7 +91,8 @@ public class StartupGlobalKeyCommand extends GlobalKeyCommand implements GameCom
         "Editor.StartupGlobalKeyCommand.first_launch_of_session",
         "Editor.StartupGlobalKeyCommand.every_launch_of_session",
         "Editor.StartupGlobalKeyCommand.start_of_game_only",
-        "Editor.StartupGlobalKeyCommand.start_or_side_change"
+        "Editor.StartupGlobalKeyCommand.start_or_side_change",
+        "Editor.StartupGlobalKeyCommand.only_side_change"
       };
     }
   }
@@ -279,7 +282,6 @@ public class StartupGlobalKeyCommand extends GlobalKeyCommand implements GameCom
         return false;
       }
     }
-
     hasEverApplied = true;     // This one will be false again next time anything calls GameState.setup(true)
     hasAppliedThisGame = true; // This one will be remembered as part of the game state (i.e. even after loading a game)
     apply();
@@ -291,7 +293,7 @@ public class StartupGlobalKeyCommand extends GlobalKeyCommand implements GameCom
    * @return true if command was applied
    */
   public boolean applyPlayerChange() {
-    if (!APPLY_START_GAME_OR_SIDE_CHANGE.equals(whenToApply)) {
+    if (!APPLY_START_GAME_OR_SIDE_CHANGE.equals(whenToApply) && !APPLY_SIDE_CHANGE.equals(whenToApply)) {
       return false;
     }
     hasEverApplied     = true;

--- a/vassal-app/src/main/resources/VASSAL/i18n/Editor.properties
+++ b/vassal-app/src/main/resources/VASSAL/i18n/Editor.properties
@@ -2261,6 +2261,7 @@ Editor.StartupGlobalKeyCommand.first_launch_of_session=On First Game Launch/Load
 Editor.StartupGlobalKeyCommand.every_launch_of_session=On Every Game Launch/Load Of Session
 Editor.StartupGlobalKeyCommand.start_of_game_only=At Start Of Every Fresh Game Only
 Editor.StartupGlobalKeyCommand.start_or_side_change=At Start of Fresh Game or Player Join/Side-Change
+Editor.StartupGlobalKeyCommand.only_side_change=When player joins, retires or changes sides
 Editor.StartupGlobalKeyCommand.global_hotkey=Global Hot Key
 Editor.StartupGlobalKeyCommand.send_key_command=Global Key Command (to matching pieces)
 Editor.StartupGlobalKeyCommand.send_hotkey=Global Hot Key (to toolbar buttons and decks)

--- a/vassal-doc/src/main/readme-referencemanual/ReferenceManual/GlobalKeyCommands.adoc
+++ b/vassal-doc/src/main/readme-referencemanual/ReferenceManual/GlobalKeyCommands.adoc
@@ -297,6 +297,9 @@ NOTE: A new game started from a <<GameModule.adoc#PredefinedSetup, Pre-defined S
 | At Start of Fresh Game or Player Join/Side-Change
 | Run only when a _new game_ is starting _OR_ a new player joins or a player changes sides.
 
+| When a Player joins, retires or changes sides
+| Run whenever a player joins, retires, or changes sides. This includes joining as a non-player type such as an observer.
+
 |===
 
 *Startup GKC example 2:*


### PR DESCRIPTION
This is different from the existing Startup GKC in that it does not fire on start of fresh game. This GKC fires as players join at startup via the wizard and anytime during the game when any player(s) retires, joins or changes side. Closes #13903

I neglected to add a reference to the original PR for Startup GKC on fresh game or player join/retire #11918
