### PR TITLE
Fix mac build

### DIFF
--- a/dist/macos/Info.plist
+++ b/dist/macos/Info.plist
@@ -49,6 +49,5 @@ com/DTDs/PropertyList-1.0.dtd">
     <string>arm64</string>
     <string>x86_64</string>
   </array>
-  <true/>
 </dict>
 </plist>


### PR DESCRIPTION
Fixes an issue with PR #[13650](https://github.com/vassalengine/vassal/pull/13650) (spurious tag in the Mac plist).