### PR TITLE
13682 Prevent Hotkey from restarting an open log file

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/module/BasicLogger.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/BasicLogger.java
@@ -673,7 +673,9 @@ public class BasicLogger implements Logger, Buildable, GameComponent, CommandEnc
 
     @Override
     public void actionPerformed(ActionEvent e) {
-      beginOutput();
+      if (isEnabled()) {
+        beginOutput();
+      }
     }
   };
 


### PR DESCRIPTION
The menu system prevents the user from clicking 'Begin Logfile' when a log file is already open. Hotkeys were not restricted and could restart the log file. Closes #13682

This change only affects the 'Begin Logfile' command. We could instead replace this check with one in `KeyStrokeListener.keyPressed()` to  prevent the actions of any and all disabled KeyStrokeListeners. Not sure if that is a breaking change and/or desirable. Any thoughts are appreciated.