### PR TITLE
feat 13036 show image file name for button icons

### DIFF
--- a/vassal-app/src/main/java/VASSAL/configure/AutoConfigurer.java
+++ b/vassal-app/src/main/java/VASSAL/configure/AutoConfigurer.java
@@ -20,16 +20,16 @@ package VASSAL.configure;
 import VASSAL.build.AutoConfigurable;
 import VASSAL.build.Configurable;
 import VASSAL.build.GameModule;
+import VASSAL.configure.button.ToolTipConfigurer;
 import VASSAL.i18n.Resources;
 import VASSAL.script.expression.FormattedStringExpression;
 import VASSAL.tools.NamedKeyStroke;
 import VASSAL.tools.ReflectionUtils;
 import VASSAL.tools.swing.SwingUtils;
+import net.miginfocom.swing.MigLayout;
 
-import java.awt.Color;
-import java.awt.Component;
-import java.awt.Image;
-import java.awt.Window;
+import javax.swing.*;
+import java.awt.*;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.io.File;
@@ -37,14 +37,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
-import javax.swing.Icon;
-import javax.swing.JComponent;
-import javax.swing.JLabel;
-import javax.swing.JPanel;
-import javax.swing.KeyStroke;
-
-import net.miginfocom.swing.MigLayout;
 
 /**
  * A Configurer for configuring Configurable components
@@ -108,6 +100,7 @@ public class AutoConfigurer extends Configurer
         final JLabel label = new JLabel(prompt[i]);
         label.setLabelFor(config.getControls());
         labels.put(name[i], label);
+        ToolTipConfigurer.addToolTipToButtonIcon(prompt[i], config);
         p.add(label);
         p.add(config.getControls(), "wrap,grow"); // NON-NLS
         configurers.add(config);

--- a/vassal-app/src/main/java/VASSAL/configure/IconConfigurer.java
+++ b/vassal-app/src/main/java/VASSAL/configure/IconConfigurer.java
@@ -27,13 +27,8 @@ import VASSAL.tools.imageop.Op;
 import VASSAL.tools.imageop.OwningOpMultiResolutionImage;
 import net.miginfocom.swing.MigLayout;
 
-import javax.swing.Icon;
-import javax.swing.ImageIcon;
-import javax.swing.JButton;
-import javax.swing.JLabel;
-import javax.swing.JPanel;
-import java.awt.Component;
-import java.awt.Dimension;
+import javax.swing.*;
+import java.awt.*;
 import java.io.File;
 
 public class IconConfigurer extends Configurer {
@@ -109,6 +104,12 @@ public class IconConfigurer extends Configurer {
       }
     }
     return controls;
+  }
+
+  public void setToolTipText(String toolTipText) {
+    if (holdingPanel != null) {
+      holdingPanel.setToolTipText(toolTipText);
+    }
   }
 
   private static final int MAX_ICON_DISPLAY_SIZE = 128;

--- a/vassal-app/src/main/java/VASSAL/configure/button/ToolTipConfigurer.java
+++ b/vassal-app/src/main/java/VASSAL/configure/button/ToolTipConfigurer.java
@@ -1,0 +1,22 @@
+package VASSAL.configure.button;
+
+import VASSAL.configure.Configurer;
+import VASSAL.configure.IconConfigurer;
+import VASSAL.i18n.Resources;
+
+import javax.swing.*;
+
+public class ToolTipConfigurer {
+
+    private ToolTipConfigurer() {
+    }
+
+    public static void addToolTipToButtonIcon(String promptValue, Configurer config) {
+        if (Resources.getString(Resources.BUTTON_ICON).equals(promptValue)
+                && config instanceof IconConfigurer
+                && ((IconConfigurer) config).getIconValue() instanceof ImageIcon) {
+            ((IconConfigurer) config).setToolTipText(config.getValueString());
+        }
+    }
+
+}


### PR DESCRIPTION
Added a tooltip to button icon showing image filename as suggested in https://github.com/vassalengine/vassal/issues/13036

(repeated PR after renaming branch)