### PR TITLE
13846 Fix the width of a text label and wrap text

### DIFF
--- a/vassal-app/src/main/java/VASSAL/counters/Labeler.java
+++ b/vassal-app/src/main/java/VASSAL/counters/Labeler.java
@@ -79,6 +79,9 @@ import java.util.List;
 import java.util.Objects;
 import java.util.function.DoubleConsumer;
 
+import static VASSAL.tools.image.LabelUtils.findHtmlStyle;
+import static VASSAL.tools.image.LabelUtils.getPreferredSize;
+
 /**
  * d/b/a "Text Label"
  *
@@ -647,7 +650,31 @@ public class Labeler extends Decorator implements TranslatablePiece, Loopable {
       final JLabel l = new JLabel(txt);
       l.setForeground(fg);
       l.setFont(font);
-      l.setSize(l.getPreferredSize());
+
+      // Search for css styling defining any dimensions.
+      int maxWidth = 0;
+      int height = 0;
+      try {
+        String result = findHtmlStyle(txt, "max-width");
+        if (!result.isEmpty()) {
+          maxWidth = Integer.parseUnsignedInt(result);
+        }
+        result = findHtmlStyle(txt, "height");
+        if (!result.isEmpty()) {
+          height = Integer.parseUnsignedInt(result);
+        }
+      }
+      catch (NumberFormatException ex) {
+        maxWidth = 0;
+        height = 0;
+      }
+
+      if (maxWidth > 0 || height > 0) {
+        l.setSize(getPreferredSize(l, maxWidth, height));
+      }
+      else {
+        l.setSize(l.getPreferredSize());
+      }
       return l;
     }
 


### PR DESCRIPTION
This is a proposal for fixing the width of a text label, wrapping the text and permitting the height to grow adding as many lines as needed to fit all the text.

Since html in the Label text field has some control over the layout of the text, it made sense to add a width specification here. The proposal is a fixed width specifier, in pixels, using the 'max-width' style property. For example, to set a 40 pixel width:
```
<html><span style="max-width:40">This is an exceedingly long label for some silly counter</span></html>
```
The underlying Swing html parser ignores unknown/unsupported style properties, so the extra styling has no effect. However, the width value can be extracted by Vassal which can fix the one dimension and then query the Swing component for the other dimension. The final dimensions are set as the preferred dimensions.

Line breaks after paragraphs `<p>` and line breaks `<br>` are still honoured. The `max-width` style can appear in any element and applies to the entire label. Somewhat of a break from the typical where the style applies only to the containing element. Purist may object.

Since the Label's text field is a Beanshell expression, the width can be specified as the result of some calculation.

This pull request adds the same feature to mouse-over. There are so many configuration options that this is not fully tested.

If it is possible to set a fixed width, then so can the height. The module designer could specify the `height` style fixing the height and making the width variable. Not sure how useful this is. Already included but it could be dropped.

For the width specifier, I used `max-width` since the `<pre>` tag supports a width attribute. But I don't see this as a conflict anymore. `max-width` could change to `width` if that is the consensus.

I have not updated the help files yet. Waiting if/until this is considered a workable and worthwhile addition.
Closes: #13846
