### PR TITLE
Release 3.7 - revert to standard text select

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/module/map/Zoomer.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/Zoomer.java
@@ -430,19 +430,6 @@ public class Zoomer extends AbstractConfigurable implements GameComponent {
       levelField.setMaximumSize(new Dimension(
         Integer.MAX_VALUE, levelField.getPreferredSize().height));
 
-      // Edit box selects all text when first focused
-      levelField.addFocusListener(new java.awt.event.FocusAdapter() {
-        @Override
-        public void focusGained(java.awt.event.FocusEvent evt) {
-          SwingUtilities.invokeLater(new Runnable() {
-            @Override
-            public void run() {
-              levelField.selectAll();
-            }
-          });
-        }
-      });
-
       // validator for the level entry field
       levelField.getDocument().addDocumentListener(new DocumentListener() {
         @Override

--- a/vassal-app/src/main/java/VASSAL/configure/BeanShellExpressionConfigurer.java
+++ b/vassal-app/src/main/java/VASSAL/configure/BeanShellExpressionConfigurer.java
@@ -62,7 +62,6 @@ public class BeanShellExpressionConfigurer extends StringConfigurer {
 
   /**
    * enum describing any special processing that needs to be done for particular expression types
-   *
    * NONE = No special handling
    *  PME = Property Match Expression handling.
    */
@@ -466,7 +465,7 @@ public class BeanShellExpressionConfigurer extends StringConfigurer {
 
       @Override
       public void run() {
-        if (getValueString().length() == 0) {
+        if (getValueString().isEmpty()) {
           validator.setStatus(UNKNOWN);
           setDetails();
         }

--- a/vassal-app/src/main/java/VASSAL/configure/BeanShellExpressionConfigurer.java
+++ b/vassal-app/src/main/java/VASSAL/configure/BeanShellExpressionConfigurer.java
@@ -256,19 +256,6 @@ public class BeanShellExpressionConfigurer extends StringConfigurer {
         }
       });
 
-      // Edit box selects all text when first focused
-      nameField.addFocusListener(new java.awt.event.FocusAdapter() {
-        @Override
-        public void focusGained(java.awt.event.FocusEvent evt) {
-          SwingUtilities.invokeLater(new Runnable() {
-            @Override
-            public void run() {
-              nameField.selectAll();
-            }
-          });
-        }
-      });
-
       panel.add(validator);
       panel.add(extraDetails);
       expressionPanel.add(panel, "grow"); // NON-NLS

--- a/vassal-app/src/main/java/VASSAL/configure/FileConfigurer.java
+++ b/vassal-app/src/main/java/VASSAL/configure/FileConfigurer.java
@@ -27,6 +27,7 @@ import javax.swing.JButton;
 import javax.swing.JFrame;
 import javax.swing.JPanel;
 import javax.swing.JTextField;
+import javax.swing.event.DocumentEvent;
 import javax.swing.event.DocumentListener;
 import java.awt.Component;
 import java.io.File;

--- a/vassal-app/src/main/java/VASSAL/configure/FileConfigurer.java
+++ b/vassal-app/src/main/java/VASSAL/configure/FileConfigurer.java
@@ -27,8 +27,6 @@ import javax.swing.JButton;
 import javax.swing.JFrame;
 import javax.swing.JPanel;
 import javax.swing.JTextField;
-import javax.swing.SwingUtilities;
-import javax.swing.event.DocumentEvent;
 import javax.swing.event.DocumentListener;
 import java.awt.Component;
 import java.io.File;
@@ -134,20 +132,6 @@ public class FileConfigurer extends Configurer {
 
       tf = new JTextField(getValueString());
       tf.setEditable(editable);
-      if (editable) {
-        // Edit box selects all text when first focused
-        tf.addFocusListener(new java.awt.event.FocusAdapter() {
-          @Override
-          public void focusGained(java.awt.event.FocusEvent evt) {
-            SwingUtilities.invokeLater(new Runnable() {
-              @Override
-              public void run() {
-                tf.selectAll();
-              }
-            });
-          }
-        });
-      }
       tf.setMaximumSize(new java.awt.Dimension(tf.getMaximumSize().width,
                                                tf.getPreferredSize().height));
       tf.getDocument().addDocumentListener(new DocumentListener() {
@@ -168,7 +152,7 @@ public class FileConfigurer extends Configurer {
 
         public void update() {
           final String text = tf.getText();
-          final File f = text != null && text.length() > 0 && !"null".equals(text) ? new File(text) : null; // NON-NLS
+          final File f = text != null && !text.isEmpty() && !"null".equals(text) ? new File(text) : null; // NON-NLS
           noUpdate = true;
           setValue(f);
           noUpdate = false;

--- a/vassal-app/src/main/java/VASSAL/configure/ListKeyCommandsDialog.java
+++ b/vassal-app/src/main/java/VASSAL/configure/ListKeyCommandsDialog.java
@@ -49,7 +49,6 @@ import javax.swing.JScrollPane;
 import javax.swing.JTable;
 import javax.swing.JTextField;
 import javax.swing.RowFilter;
-import javax.swing.SwingUtilities;
 import javax.swing.event.DocumentEvent;
 import javax.swing.event.DocumentListener;
 import javax.swing.table.AbstractTableModel;
@@ -89,19 +88,6 @@ public class ListKeyCommandsDialog extends JDialog {
     this.owner = owner;
 
     final JTextField filter = new JTextField(25);
-
-    // Edit box selects all text when first focused
-    filter.addFocusListener(new java.awt.event.FocusAdapter() {
-      @Override
-      public void focusGained(java.awt.event.FocusEvent evt) {
-        SwingUtilities.invokeLater(new Runnable() {
-          @Override
-          public void run() {
-            filter.selectAll();
-          }
-        });
-      }
-    });
 
     tmod = new MyTableModel(rows);
     final JTable table = new JTable(tmod) {
@@ -168,7 +154,7 @@ public class ListKeyCommandsDialog extends JDialog {
       }
     });
 
-    final TableRowSorter trs = new TableRowSorter<>(tmod);
+    final TableRowSorter<MyTableModel> trs = new TableRowSorter<>(tmod);
     table.setRowSorter(trs);
     trs.setSortsOnUpdates(true);
 

--- a/vassal-app/src/main/java/VASSAL/configure/NamedHotKeyConfigurer.java
+++ b/vassal-app/src/main/java/VASSAL/configure/NamedHotKeyConfigurer.java
@@ -33,6 +33,7 @@ import javax.swing.JLayer;
 import javax.swing.JPanel;
 import javax.swing.JTextField;
 import javax.swing.KeyStroke;
+import javax.swing.plaf.LayerUI;
 import javax.swing.text.AbstractDocument;
 import javax.swing.text.AttributeSet;
 import javax.swing.text.BadLocationException;

--- a/vassal-app/src/main/java/VASSAL/configure/NamedHotKeyConfigurer.java
+++ b/vassal-app/src/main/java/VASSAL/configure/NamedHotKeyConfigurer.java
@@ -33,8 +33,6 @@ import javax.swing.JLayer;
 import javax.swing.JPanel;
 import javax.swing.JTextField;
 import javax.swing.KeyStroke;
-import javax.swing.SwingUtilities;
-import javax.swing.plaf.LayerUI;
 import javax.swing.text.AbstractDocument;
 import javax.swing.text.AttributeSet;
 import javax.swing.text.BadLocationException;
@@ -51,10 +49,8 @@ import java.awt.event.KeyEvent;
 /**
  * A configurer for Configuring Key Strokes. It allows the entry of either
  * a standard keystroke, or a Named command.
- *
  * It contains two separate Text fields, one for the Name and one for the keystroke.
  * A user can fill in one or the other. Filling in one, clears the other.
- *
  * This Configurer has a limited undo function. Whenever one of the two fields gains focus,
  * the current state of the Configurer is saved and the Undo button enabled.
  * The undo button will return to the state when that field gained focus.
@@ -87,7 +83,7 @@ public class NamedHotKeyConfigurer extends Configurer implements FocusListener {
 
   public static String getFancyString(NamedKeyStroke k) {
     String s = getString(k);
-    if (s.length() > 0) {
+    if (!s.isEmpty()) {
       s = "[" + s + "]";
     }
     return s;
@@ -219,19 +215,6 @@ public class NamedHotKeyConfigurer extends Configurer implements FocusListener {
       keyName.setText(getValueNamedKeyStroke() == null ? null : getValueNamedKeyStroke().getName());
       ((AbstractDocument) keyName.getDocument()).setDocumentFilter(new KeyNameFilter());
       keyName.addFocusListener(this);
-
-      // Edit box selects all text when first focused
-      keyName.addFocusListener(new java.awt.event.FocusAdapter() {
-        @Override
-        public void focusGained(FocusEvent evt) {
-          SwingUtilities.invokeLater(new Runnable() {
-            @Override
-            public void run() {
-              keyName.selectAll();
-            }
-          });
-        }
-      });
 
       final JPanel panel = new JPanel(new MigLayout("ins 0", "[fill,grow]0[]0[fill,grow]0[]")); // NON-NLS
 

--- a/vassal-app/src/main/java/VASSAL/configure/NamedHotKeyConfigurer.java
+++ b/vassal-app/src/main/java/VASSAL/configure/NamedHotKeyConfigurer.java
@@ -357,7 +357,7 @@ public class NamedHotKeyConfigurer extends Configurer implements FocusListener {
     @Override
     public void paint(Graphics g, JComponent c) {
       super.paint(g, c);
-      final Component cc = ((JLayer) c).getView();
+      final Component cc = ((JLayer<?>) c).getView();
       if (parent.isHighlighted()) {
         final Dimension d = cc.getSize();
         g.setColor(Color.red);

--- a/vassal-app/src/main/java/VASSAL/configure/StringConfigurer.java
+++ b/vassal-app/src/main/java/VASSAL/configure/StringConfigurer.java
@@ -23,8 +23,6 @@ import javax.swing.JComponent;
 import javax.swing.JLayer;
 import javax.swing.JPanel;
 import javax.swing.JTextField;
-import javax.swing.SwingUtilities;
-import javax.swing.event.DocumentEvent;
 import javax.swing.event.DocumentListener;
 import javax.swing.plaf.LayerUI;
 import java.awt.Color;
@@ -112,23 +110,10 @@ public class StringConfigurer extends Configurer {
 
       nameField = buildTextField();
       nameField.setMaximumSize(new Dimension(
-        nameField.getMaximumSize().width,
-        nameField.getPreferredSize().height
+              nameField.getMaximumSize().width,
+              nameField.getPreferredSize().height
       ));
       nameField.setText(getValueString());
-
-      // Edit box selects all text when first focused
-      nameField.addFocusListener(new java.awt.event.FocusAdapter() {
-        @Override
-        public void focusGained(java.awt.event.FocusEvent evt) {
-          SwingUtilities.invokeLater(new Runnable() {
-            @Override
-            public void run() {
-              nameField.selectAll();
-            }
-          });
-        }
-      });
 
       SwingUtils.allowUndo(nameField);
       if (!GraphicsEnvironment.isHeadless()) {
@@ -214,7 +199,7 @@ public class StringConfigurer extends Configurer {
     @Override
     public void paint(Graphics g, JComponent c) {
       super.paint(g, c);
-      final Component cc = ((JLayer) c).getView();
+      final Component cc = ((JLayer<?>) c).getView();
       if (parent.isHighlighted()) {
         final Dimension d = cc.getSize();
         g.setColor(Color.red);

--- a/vassal-app/src/main/java/VASSAL/configure/StringConfigurer.java
+++ b/vassal-app/src/main/java/VASSAL/configure/StringConfigurer.java
@@ -23,6 +23,7 @@ import javax.swing.JComponent;
 import javax.swing.JLayer;
 import javax.swing.JPanel;
 import javax.swing.JTextField;
+import javax.swing.event.DocumentEvent;
 import javax.swing.event.DocumentListener;
 import javax.swing.plaf.LayerUI;
 import java.awt.Color;


### PR DESCRIPTION
Reverting to standard text select (per vassal 3.6.7). After this reversion, focus does not interfere. Triple click to select all text.

This PR will impact PR #12924 which may be revised to focus on tab and insert key actions.

Includes minor mods to satisfy intellij advisories.