### PR TITLE
13584 Render a decks cards from the bottom of visible stack to the top

### DIFF
--- a/vassal-app/src/main/java/VASSAL/counters/Deck.java
+++ b/vassal-app/src/main/java/VASSAL/counters/Deck.java
@@ -1407,6 +1407,7 @@ public class Deck extends Stack implements PlayerRoster.SideChangeListener {
   @Override
   public void draw(java.awt.Graphics g, int x, int y, Component obs, double zoom) {
     final int count = Math.min(getPieceCount(), maxStack);
+    int bottomIndex = Math.max(getPieceCount() - maxStack, 0);
     final GamePiece top = (nextDraw != null && !nextDraw.isEmpty()) ?
       nextDraw.get(0) : topPiece();
 
@@ -1417,7 +1418,7 @@ public class Deck extends Stack implements PlayerRoster.SideChangeListener {
       final Rectangle r = top.getShape().getBounds();
       r.setLocation(x + (int) (zoom * (r.x)), y + (int) (zoom * (r.y)));
       r.setSize((int) (zoom * r.width), (int) (zoom * r.height));
-      for (int i = 0; i < count - 1; ++i) {
+      for (int i = 0; bottomIndex < getPieceCount() - 1; ++i, ++bottomIndex) {
         if (blankColor != null) {
           g.setColor(blankColor);
           g.fillRect(r.x + (int) (zoom * 2 * i), r.y - (int) (zoom * 2 * i), r.width, r.height);
@@ -1428,7 +1429,7 @@ public class Deck extends Stack implements PlayerRoster.SideChangeListener {
           top.draw(g, x + (int) (zoom * 2 * i), y - (int) (zoom * 2 * i), obs, zoom);
         }
         else {
-          getPieceAt(count - i - 1).draw(g, x + (int) (zoom * 2 * i), y - (int) (zoom * 2 * i), obs, zoom);
+          getPieceAt(bottomIndex).draw(g, x + (int) (zoom * 2 * i), y - (int) (zoom * 2 * i), obs, zoom);
         }
       }
       top.draw(g, x + (int) (zoom * 2 * (count - 1)), y - (int) (zoom * 2 * (count - 1)), obs, zoom);


### PR DESCRIPTION
The pieces in the deck were drawn top down. This is not obvious until different sized pieces are on a face up deck. Since the top piece is drawn last after the loop, on a uniform deck it obscures all of the same sized pieces underneath it. Pieces/cards should be drawn bottom up such that the cards above render over the lower ones.

There was also an off-by-one error in that the drawing stopped at the second last card. Placing a smaller piece on the top of the deck made that second last card bleed to the top. The pieces in the underlying array are correct. It was just that rendering was out of order.

Added a log file to issue 13584 to demonstrate the problem. Closes #13584