### PR TITLE
Fix13036 show image file name for button icons 3 7b

### DIFF
--- a/vassal-app/src/main/java/VASSAL/configure/AutoConfigurer.java
+++ b/vassal-app/src/main/java/VASSAL/configure/AutoConfigurer.java
@@ -20,6 +20,7 @@ package VASSAL.configure;
 import VASSAL.build.AutoConfigurable;
 import VASSAL.build.Configurable;
 import VASSAL.build.GameModule;
+import VASSAL.configure.button.ToolTipConfigurer;
 import VASSAL.i18n.Resources;
 import VASSAL.script.expression.FormattedStringExpression;
 import VASSAL.tools.NamedKeyStroke;
@@ -108,6 +109,7 @@ public class AutoConfigurer extends Configurer
         final JLabel label = new JLabel(prompt[i]);
         label.setLabelFor(config.getControls());
         labels.put(name[i], label);
+        ToolTipConfigurer.addToolTipToButtonIcon(prompt[i], config);
         p.add(label);
         p.add(config.getControls(), "wrap,grow"); // NON-NLS
         configurers.add(config);

--- a/vassal-app/src/main/java/VASSAL/configure/IconConfigurer.java
+++ b/vassal-app/src/main/java/VASSAL/configure/IconConfigurer.java
@@ -111,6 +111,12 @@ public class IconConfigurer extends Configurer {
     return controls;
   }
 
+  public void setToolTipText(String toolTipText) {
+    if (holdingPanel != null) {
+      holdingPanel.setToolTipText(toolTipText);
+    }
+  }
+
   private static final int MAX_ICON_DISPLAY_SIZE = 128;
 
   private void setSize() {

--- a/vassal-app/src/main/java/VASSAL/configure/button/ToolTipConfigurer.java
+++ b/vassal-app/src/main/java/VASSAL/configure/button/ToolTipConfigurer.java
@@ -1,0 +1,22 @@
+package VASSAL.configure.button;
+
+import VASSAL.configure.Configurer;
+import VASSAL.configure.IconConfigurer;
+import VASSAL.i18n.Resources;
+
+import javax.swing.ImageIcon;
+
+public class ToolTipConfigurer {
+
+    private ToolTipConfigurer() {
+    }
+
+    public static void addToolTipToButtonIcon(String promptValue, Configurer config) {
+        if (Resources.getString(Resources.BUTTON_ICON).equals(promptValue)
+                && config instanceof IconConfigurer
+                && ((IconConfigurer) config).getIconValue() instanceof ImageIcon) {
+            ((IconConfigurer) config).setToolTipText(config.getValueString());
+        }
+    }
+
+}

--- a/vassal-app/src/main/java/VASSAL/configure/button/ToolTipConfigurer.java
+++ b/vassal-app/src/main/java/VASSAL/configure/button/ToolTipConfigurer.java
@@ -8,15 +8,14 @@ import javax.swing.ImageIcon;
 
 public class ToolTipConfigurer {
 
-    private ToolTipConfigurer() {
-    }
+  private ToolTipConfigurer() {
+  }
 
-    public static void addToolTipToButtonIcon(String promptValue, Configurer config) {
-        if (Resources.getString(Resources.BUTTON_ICON).equals(promptValue)
-                && config instanceof IconConfigurer
-                && ((IconConfigurer) config).getIconValue() instanceof ImageIcon) {
-            ((IconConfigurer) config).setToolTipText(config.getValueString());
-        }
+  public static void addToolTipToButtonIcon(String promptValue, Configurer config) {
+    if (Resources.getString(Resources.BUTTON_ICON).equals(promptValue) && config instanceof IconConfigurer &&
+      ((IconConfigurer) config).getIconValue() instanceof ImageIcon) {
+      ((IconConfigurer) config).setToolTipText(config.getValueString());
     }
+  }
 
 }


### PR DESCRIPTION
Added a tooltip to button icon showing image filename as suggested in https://github.com/vassalengine/vassal/issues/13036

Branch name fixed.
Checkstyle formatting applied.