### PR TITLE
Fix Turn Counter displaying hidden list items

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/module/turn/CounterTurnLevel.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/turn/CounterTurnLevel.java
@@ -52,12 +52,14 @@ public class CounterTurnLevel extends TurnLevel {
   @Override
   protected void setLow() {
     current = start;
+    rolledOver = false;
     super.setLow();
   }
 
   @Override
   protected void setHigh() {
     current = loopLimit;
+    rolledOver = false;
     super.setHigh();
   }
   /*

--- a/vassal-app/src/main/java/VASSAL/build/module/turn/ListTurnLevel.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/turn/ListTurnLevel.java
@@ -79,15 +79,24 @@ public class ListTurnLevel extends TurnLevel implements ActionListener {
   @Override
   protected void setLow() {
     current = first;
+    rolledOver = false;
+    if (current < active.length && !active[current]) {
+      // first is not active. Find the next active index.
+      advance();
+    }
     super.setLow();
   }
 
   @Override
   protected void setHigh() {
+    rolledOver = false;
     current = first;
     current--;
     if (current < 0) {
       current = list.length - 1;
+    }
+    if (current < active.length && !active[current]) {
+      retreat();
     }
     super.setHigh();
   }

--- a/vassal-app/src/main/java/VASSAL/build/module/turn/TurnLevel.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/turn/TurnLevel.java
@@ -120,15 +120,23 @@ public abstract class TurnLevel extends TurnComponent {
     rolledOver = false;
     subLevelRolledOver = false;
     if (getTurnLevelCount() > 0) {
-      final TurnLevel subLevel = getTurnLevel(currentSubLevel);
+      final int initialLevel = currentSubLevel;
+      TurnLevel subLevel = getTurnLevel(currentSubLevel);
       subLevel.advance();
-      if (subLevel.hasRolledOver()) {
+      while (subLevel.hasRolledOver()) {
         currentSubLevel++;
         if (currentSubLevel >= getTurnLevelCount()) {
           currentSubLevel = 0;
           subLevelRolledOver = true;
         }
-        getTurnLevel(currentSubLevel).setLow();
+        subLevel = getTurnLevel(currentSubLevel);
+        if (initialLevel != currentSubLevel) {
+          subLevel.setLow();
+        }
+        else {
+          // Prevent an infinite loop if all are inactive.
+          break;
+        }
       }
     }
   }
@@ -137,15 +145,23 @@ public abstract class TurnLevel extends TurnComponent {
     rolledOver = false;
     subLevelRolledOver = false;
     if (getTurnLevelCount() > 0) {
-      final TurnLevel subLevel = getTurnLevel(currentSubLevel);
+      final int initialLevel = currentSubLevel;
+      TurnLevel subLevel = getTurnLevel(currentSubLevel);
       subLevel.retreat();
-      if (subLevel.hasRolledOver()) {
+      while (subLevel.hasRolledOver()) {
         currentSubLevel--;
         if (currentSubLevel < 0) {
           currentSubLevel = getTurnLevelCount() - 1;
           subLevelRolledOver = true;
         }
-        getTurnLevel(currentSubLevel).setHigh();
+        subLevel = getTurnLevel(currentSubLevel);
+        if (initialLevel != currentSubLevel) {
+          subLevel.setHigh();
+        }
+        else {
+          // Prevent an infinite loop if all are inactive.
+          break;
+        }
       }
     }
   }

--- a/vassal-app/src/main/java/VASSAL/build/module/turn/TurnTracker.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/turn/TurnTracker.java
@@ -712,14 +712,23 @@ public class TurnTracker extends TurnComponent implements CommandEncoder, GameCo
       return;
     }
 
-    final TurnLevel level = getTurnLevel(currentLevel);
+    TurnLevel level = getTurnLevel(currentLevel);
+    final int initialLevel = currentLevel;
     level.advance();
-    if (level.hasRolledOver()) {
+    while (level.hasRolledOver()) {
       currentLevel++;
       if (currentLevel >= getTurnLevelCount()) {
         currentLevel = 0;
       }
-      getTurnLevel(currentLevel).setLow();
+      level = getTurnLevel(currentLevel);
+
+      if (initialLevel != currentLevel) {
+        level.setLow();
+      }
+      else {
+        // Prevent an infinite loop if all are inactive.
+        break;
+      }
     }
 
     updateTurnDisplay(NEXT);
@@ -732,14 +741,24 @@ public class TurnTracker extends TurnComponent implements CommandEncoder, GameCo
       return;
     }
 
-    final TurnLevel level = getTurnLevel(currentLevel);
+    TurnLevel level = getTurnLevel(currentLevel);
+    final int initialLevel = currentLevel;
     level.retreat();
-    if (level.hasRolledOver()) {
+    while (level.hasRolledOver()) {
       currentLevel--;
       if (currentLevel < 0) {
         currentLevel = getTurnLevelCount() - 1;
       }
-      getTurnLevel(currentLevel).setHigh();
+
+      level = getTurnLevel(currentLevel);
+
+      if (initialLevel != currentLevel) {
+        level.setHigh();
+      }
+      else {
+        // Prevent an infinite loop if all are inactive.
+        break;
+      }
     }
 
     updateTurnDisplay(PREV);

--- a/vassal-app/src/test/java/VASSAL/build/module/turn/CounterTurnTrackerTest.java
+++ b/vassal-app/src/test/java/VASSAL/build/module/turn/CounterTurnTrackerTest.java
@@ -15,11 +15,6 @@ public class CounterTurnTrackerTest {
   // A helper class to access protected functions.
   static class TurnTrackerAccessor extends TurnTracker {
 
-    public TurnTrackerAccessor() {
-      super();
-      turnWindow = new TurnWindow();
-    }
-
     public void next() {
       super.next();
     }
@@ -30,6 +25,10 @@ public class CounterTurnTrackerTest {
 
     public String getTurnString() {
       return super.getTurnString().trim();
+    }
+
+    public void SetTurnWindow(TurnWindow tw) {
+      turnWindow = tw;
     }
   }
 
@@ -47,6 +46,13 @@ public class CounterTurnTrackerTest {
       when(gm.getPrefs()).thenReturn(prefs);
 
       TurnTrackerAccessor tracker = new TurnTrackerAccessor();
+
+      final TurnTracker.TurnWindow tw = mock(TurnTracker.TurnWindow.class);
+      tracker.SetTurnWindow(tw);
+
+      doNothing().when(tw).pack();
+      doNothing().when(tw).setFocusable(isA(boolean.class));
+      doNothing().when(tw).requestFocus();
 
       // Top level counter wraps with sequence 10, 30, 50.
       CounterTurnLevel level1 = new CounterTurnLevel();

--- a/vassal-app/src/test/java/VASSAL/build/module/turn/CounterTurnTrackerTest.java
+++ b/vassal-app/src/test/java/VASSAL/build/module/turn/CounterTurnTrackerTest.java
@@ -10,7 +10,10 @@ import org.mockito.Mockito;
 
 import javax.swing.JToolBar;
 
+import java.awt.Component;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -36,10 +39,11 @@ public class CounterTurnTrackerTest {
   final GameState gameState = new GameState();
   final Prefs prefs = new Prefs(new PrefsEditor(), "");
 
-  private void testSetup() {
-    when(GameModule.getGameModule().getPrefs()).thenReturn(prefs);
-    when(GameModule.getGameModule().getToolBar()).thenReturn(toolbar);
-    when(GameModule.getGameModule().getGameState()).thenReturn(gameState);
+  private void testSetup(GameModule gm) {
+    when(gm.getPrefs()).thenReturn(prefs);
+    when(gm.getGameState()).thenReturn(gameState);
+    when(gm.getToolBar()).thenReturn(toolbar);
+    when(toolbar.add(any(Component.class))).thenReturn(null);
   }
 
   @Test
@@ -50,7 +54,7 @@ public class CounterTurnTrackerTest {
       final GameModule gm = mock(GameModule.class);
       staticGm.when(GameModule::getGameModule).thenReturn(gm);
 
-      testSetup();
+      testSetup(gm);
 
       TurnTrackerAccessor tracker = new TurnTrackerAccessor();
       tracker.addTo(gm);

--- a/vassal-app/src/test/java/VASSAL/build/module/turn/CounterTurnTrackerTest.java
+++ b/vassal-app/src/test/java/VASSAL/build/module/turn/CounterTurnTrackerTest.java
@@ -32,8 +32,8 @@ public class CounterTurnTrackerTest {
   }
 
   // Mocked GameModule members required by the TurnTracker constructor.
+  final JToolBar toolbar = mock(JToolBar.class);
   final GameState gameState = new GameState();
-  final JToolBar toolbar = new JToolBar();
   final Prefs prefs = new Prefs(new PrefsEditor(), "");
 
   private void testSetup() {

--- a/vassal-app/src/test/java/VASSAL/build/module/turn/CounterTurnTrackerTest.java
+++ b/vassal-app/src/test/java/VASSAL/build/module/turn/CounterTurnTrackerTest.java
@@ -1,0 +1,101 @@
+package VASSAL.build.module.turn;
+
+import VASSAL.build.GameModule;
+import VASSAL.build.module.GameState;
+import VASSAL.preferences.Prefs;
+import VASSAL.preferences.PrefsEditor;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import javax.swing.JToolBar;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class CounterTurnTrackerTest {
+
+  // A helper class to access protected functions.
+  static class TurnTrackerAccessor extends TurnTracker {
+    public void next() {
+      super.next();
+    }
+
+    public void prev() {
+      super.prev();
+    }
+
+    public String getTurnString() {
+      return super.getTurnString().trim();
+    }
+  }
+
+  // Mocked GameModule members required by the TurnTracker constructor.
+  final GameState gameState = new GameState();
+  final JToolBar toolbar = new JToolBar();
+  final Prefs prefs = new Prefs(new PrefsEditor(), "");
+
+  private void testSetup() {
+    when(GameModule.getGameModule().getPrefs()).thenReturn(prefs);
+    when(GameModule.getGameModule().getToolBar()).thenReturn(toolbar);
+    when(GameModule.getGameModule().getGameState()).thenReturn(gameState);
+  }
+
+  @Test
+  public void nestedCounterTurnTracker() {
+    // Test the wrapping of two CounterTurnTrackers where one
+    // is a sibling of the other.
+    try (MockedStatic<GameModule> staticGm = Mockito.mockStatic(GameModule.class)) {
+      final GameModule gm = mock(GameModule.class);
+      staticGm.when(GameModule::getGameModule).thenReturn(gm);
+
+      testSetup();
+
+      TurnTrackerAccessor tracker = new TurnTrackerAccessor();
+      tracker.addTo(gm);
+
+      // Top level counter wraps with sequence 10, 30, 50.
+      CounterTurnLevel level1 = new CounterTurnLevel();
+      level1.setAttribute(CounterTurnLevel.START, 10);
+      level1.setAttribute(CounterTurnLevel.INCR, 20);
+      level1.addTo(tracker);
+
+      // Sibling counter wraps with sequence 1,2,3.
+      CounterTurnLevel level2 = new CounterTurnLevel();
+      level2.setAttribute(CounterTurnLevel.START, 1);
+      level2.setAttribute(CounterTurnLevel.INCR, 1);
+      level2.addTo(level1);
+
+      // Set start and end values, with wrapping enabled.
+      tracker.setState("0|10;0;true;50;1\\;0\\;true\\;3");
+      tracker.setAttribute(TurnTracker.TURN_FORMAT, "$level1$-$level2$");
+
+      // Check initial conditions and advance to next.
+      for (int i = 0; i < 3; ++i) {
+        for (int j = 0; j < 3; ++j) {
+          String expected = String.format("%d-%d", (i*20)+10, j+1);
+          assertEquals(expected, tracker.getTurnString());
+          tracker.next();
+        }
+      }
+
+      // Should be wrapped back to starting conditions.
+      assertEquals("10-1", tracker.getTurnString());
+      tracker.prev();
+
+      // Check previous command.
+      for (int i = 2; i >= 0; --i) {
+        for (int j = 2; j >= 0; --j) {
+          String expected = String.format("%d-%d", (i*20)+10, j+1);
+          assertEquals(expected, tracker.getTurnString());
+          tracker.prev();
+        }
+      }
+
+      // Go back to initial conditions.
+      tracker.next();
+      assertEquals("10-1", tracker.getTurnString());
+    }
+  }
+}

--- a/vassal-app/src/test/java/VASSAL/build/module/turn/CounterTurnTrackerTest.java
+++ b/vassal-app/src/test/java/VASSAL/build/module/turn/CounterTurnTrackerTest.java
@@ -15,6 +15,11 @@ public class CounterTurnTrackerTest {
   // A helper class to access protected functions.
   static class TurnTrackerAccessor extends TurnTracker {
 
+    public TurnTrackerAccessor() {
+      super();
+      turnWindow = tw;
+    }
+
     public void next() {
       super.next();
     }
@@ -26,33 +31,21 @@ public class CounterTurnTrackerTest {
     public String getTurnString() {
       return super.getTurnString().trim();
     }
-
-    public void SetTurnWindow(TurnWindow tw) {
-      turnWindow = tw;
-    }
   }
 
-  // Mocked GameModule members required by the TurnTracker
-  final Prefs prefs = new Prefs(new PrefsEditor(), "");
+  // Mocked members of GameModule and TurnTracker
+  static final Prefs prefs = new Prefs(new PrefsEditor(), "");
+  static final TurnTracker.TurnWindow tw = mock(TurnTracker.TurnWindow.class);
 
+  // Test the wrapping of two CounterTurnTrackers with a parent-child relationship.
   @Test
   public void nestedCounterTurnTracker() {
-    // Test the wrapping of two CounterTurnTrackers where one
-    // is a sibling of the other.
-    try (MockedStatic<GameModule> staticGm = Mockito.mockStatic(GameModule.class)) {
+     try (MockedStatic<GameModule> staticGm = Mockito.mockStatic(GameModule.class)) {
       final GameModule gm = mock(GameModule.class);
       staticGm.when(GameModule::getGameModule).thenReturn(gm);
-
       when(gm.getPrefs()).thenReturn(prefs);
 
-      TurnTrackerAccessor tracker = new TurnTrackerAccessor();
-
-      final TurnTracker.TurnWindow tw = mock(TurnTracker.TurnWindow.class);
-      tracker.SetTurnWindow(tw);
-
-      doNothing().when(tw).pack();
-      doNothing().when(tw).setFocusable(isA(boolean.class));
-      doNothing().when(tw).requestFocus();
+      final TurnTrackerAccessor tracker = new TurnTrackerAccessor();
 
       // Top level counter wraps with sequence 10, 30, 50.
       CounterTurnLevel level1 = new CounterTurnLevel();

--- a/vassal-app/src/test/java/VASSAL/build/module/turn/CounterTurnTrackerTest.java
+++ b/vassal-app/src/test/java/VASSAL/build/module/turn/CounterTurnTrackerTest.java
@@ -1,26 +1,25 @@
 package VASSAL.build.module.turn;
 
 import VASSAL.build.GameModule;
-import VASSAL.build.module.GameState;
 import VASSAL.preferences.Prefs;
 import VASSAL.preferences.PrefsEditor;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
-import javax.swing.JToolBar;
-
-import java.awt.Component;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 public class CounterTurnTrackerTest {
 
   // A helper class to access protected functions.
   static class TurnTrackerAccessor extends TurnTracker {
+
+    public TurnTrackerAccessor() {
+      super();
+      turnWindow = new TurnWindow();
+    }
+
     public void next() {
       super.next();
     }
@@ -34,17 +33,8 @@ public class CounterTurnTrackerTest {
     }
   }
 
-  // Mocked GameModule members required by the TurnTracker constructor.
-  final JToolBar toolbar = mock(JToolBar.class);
-  final GameState gameState = new GameState();
+  // Mocked GameModule members required by the TurnTracker
   final Prefs prefs = new Prefs(new PrefsEditor(), "");
-
-  private void testSetup(GameModule gm) {
-    when(gm.getPrefs()).thenReturn(prefs);
-    when(gm.getGameState()).thenReturn(gameState);
-    when(gm.getToolBar()).thenReturn(toolbar);
-    when(toolbar.add(any(Component.class))).thenReturn(null);
-  }
 
   @Test
   public void nestedCounterTurnTracker() {
@@ -54,10 +44,9 @@ public class CounterTurnTrackerTest {
       final GameModule gm = mock(GameModule.class);
       staticGm.when(GameModule::getGameModule).thenReturn(gm);
 
-      testSetup(gm);
+      when(gm.getPrefs()).thenReturn(prefs);
 
       TurnTrackerAccessor tracker = new TurnTrackerAccessor();
-      tracker.addTo(gm);
 
       // Top level counter wraps with sequence 10, 30, 50.
       CounterTurnLevel level1 = new CounterTurnLevel();

--- a/vassal-app/src/test/java/VASSAL/build/module/turn/ListTurnTrackerTest.java
+++ b/vassal-app/src/test/java/VASSAL/build/module/turn/ListTurnTrackerTest.java
@@ -1,15 +1,11 @@
 package VASSAL.build.module.turn;
 
 import VASSAL.build.GameModule;
-import VASSAL.build.module.GameState;
 import VASSAL.preferences.Prefs;
 import VASSAL.preferences.PrefsEditor;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
-
-import javax.swing.JToolBar;
-import java.awt.Component;
 
 import java.util.Iterator;
 import java.util.List;
@@ -40,6 +36,12 @@ public class ListTurnTrackerTest {
 
   // A helper class to access protected functions.
   static class TurnTrackerAccessor extends TurnTracker {
+
+    public TurnTrackerAccessor() {
+      super();
+      turnWindow = tw;
+    }
+
     public void next() {
       super.next();
     }
@@ -48,39 +50,31 @@ public class ListTurnTrackerTest {
       super.prev();
     }
 
+    public void reset() { super.reset(); }
+
     public String getTurnString() {
       return super.getTurnString().trim();
     }
   }
 
-  // Mocked GameModule members required by the TurnTracker constructor.
-  final JToolBar toolbar = mock(JToolBar.class);
-  final GameState gameState = new GameState();
-  final Prefs prefs = new Prefs(new PrefsEditor(), "");
-
-  private void testSetup(GameModule gm) {
-    when(gm.getPrefs()).thenReturn(prefs);
-    when(gm.getGameState()).thenReturn(gameState);
-    when(gm.getToolBar()).thenReturn(toolbar);
-    when(toolbar.add(any(Component.class))).thenReturn(null);
-  }
+  // Mocked members of GameModule and TurnTracker
+  static final Prefs prefs = new Prefs(new PrefsEditor(), "");
+  static final TurnTracker.TurnWindow tw = mock(TurnTracker.TurnWindow.class);
 
   @Test
   public void turnTrackerNext() {
     try (MockedStatic<GameModule> staticGm = Mockito.mockStatic(GameModule.class)) {
       final GameModule gm = mock(GameModule.class);
       staticGm.when(GameModule::getGameModule).thenReturn(gm);
-
-      testSetup(gm);
+      when(gm.getPrefs()).thenReturn(prefs);
 
       final TurnTrackerAccessor tracker = new TurnTrackerAccessor();
-      tracker.addTo(gm);
 
       final String turnNames = String.join(",", turnList);
       final ListTurnLevel level = new ListTurnLevel();
       level.setAttribute("list", turnNames);
       level.addTo(tracker);
-      tracker.setup(false);
+      tracker.reset();
 
       // Check initial conditions, check advance to next, and one wrap around.
       for (int i = 0; i <= turnList.size(); ++i) {
@@ -95,17 +89,15 @@ public class ListTurnTrackerTest {
     try (MockedStatic<GameModule> staticGm = Mockito.mockStatic(GameModule.class)) {
       final GameModule gm = mock(GameModule.class);
       staticGm.when(GameModule::getGameModule).thenReturn(gm);
-
-      testSetup(gm);
+      when(gm.getPrefs()).thenReturn(prefs);
 
       final TurnTrackerAccessor tracker = new TurnTrackerAccessor();
-      tracker.addTo(gm);
 
       final String turnNames = String.join(",", turnList);
       final ListTurnLevel level = new ListTurnLevel();
       level.setAttribute("list", turnNames);
       level.addTo(tracker);
-      tracker.setup(false);
+      tracker.reset();
 
       // Check initial conditions, wrap backwards and check backwards movement through the list.
       for (int i = turnList.size(); i >= 0; --i) {
@@ -121,11 +113,9 @@ public class ListTurnTrackerTest {
     try (MockedStatic<GameModule> staticGm = Mockito.mockStatic(GameModule.class)) {
       final GameModule gm = mock(GameModule.class);
       staticGm.when(GameModule::getGameModule).thenReturn(gm);
-
-      testSetup(gm);
+      when(gm.getPrefs()).thenReturn(prefs);
 
       final TurnTrackerAccessor tracker = new TurnTrackerAccessor();
-      tracker.addTo(gm);
 
       final String turnNames = String.join(",", turnList);
       final ListTurnLevel level = new ListTurnLevel();
@@ -137,7 +127,7 @@ public class ListTurnTrackerTest {
       other.setAttribute("list", dayNames);
       other.addTo(tracker);
 
-      tracker.setup(false); // alpha
+      tracker.reset(); // alpha
       tracker.next(); // beta
       tracker.next(); // gamma
       assertEquals("gamma", tracker.getTurnString());
@@ -163,11 +153,9 @@ public class ListTurnTrackerTest {
     try (MockedStatic<GameModule> staticGm = Mockito.mockStatic(GameModule.class)) {
       final GameModule gm = mock(GameModule.class);
       staticGm.when(GameModule::getGameModule).thenReturn(gm);
-
-      testSetup(gm);
+      when(gm.getPrefs()).thenReturn(prefs);
 
       final TurnTrackerAccessor tracker = new TurnTrackerAccessor();
-      tracker.addTo(gm);
 
       final String turnNames = String.join(",", turnList);
       final ListTurnLevel level = new ListTurnLevel();
@@ -217,11 +205,9 @@ public class ListTurnTrackerTest {
     try (MockedStatic<GameModule> staticGm = Mockito.mockStatic(GameModule.class)) {
       final GameModule gm = mock(GameModule.class);
       staticGm.when(GameModule::getGameModule).thenReturn(gm);
-
-      testSetup(gm);
+      when(gm.getPrefs()).thenReturn(prefs);
 
       final TurnTrackerAccessor tracker = new TurnTrackerAccessor();
-      tracker.addTo(gm);
 
       final String turnNames = String.join(",", turnList);
       final ListTurnLevel level = new ListTurnLevel();
@@ -267,17 +253,15 @@ public class ListTurnTrackerTest {
     }
   }
 
-  // Test for inactive element at the start of a level.
+  // Test for inactive element in the first position of a level.
   @Test
   public void turnTrackerNextFirstInactive() {
     try (MockedStatic<GameModule> staticGm = Mockito.mockStatic(GameModule.class)) {
       final GameModule gm = mock(GameModule.class);
       staticGm.when(GameModule::getGameModule).thenReturn(gm);
-
-      testSetup(gm);
+      when(gm.getPrefs()).thenReturn(prefs);
 
       final TurnTrackerAccessor tracker = new TurnTrackerAccessor();
-      tracker.addTo(gm);
 
       final String turnNames = String.join(",", turnList);
       final ListTurnLevel level = new ListTurnLevel();
@@ -304,11 +288,9 @@ public class ListTurnTrackerTest {
     try (MockedStatic<GameModule> staticGm = Mockito.mockStatic(GameModule.class)) {
       final GameModule gm = mock(GameModule.class);
       staticGm.when(GameModule::getGameModule).thenReturn(gm);
-
-      testSetup(gm);
+      when(gm.getPrefs()).thenReturn(prefs);
 
       final TurnTrackerAccessor tracker = new TurnTrackerAccessor();
-      tracker.addTo(gm);
 
       final String turnNames = String.join(",", turnList);
       final ListTurnLevel level = new ListTurnLevel();
@@ -330,11 +312,9 @@ public class ListTurnTrackerTest {
     try (MockedStatic<GameModule> staticGm = Mockito.mockStatic(GameModule.class)) {
       final GameModule gm = mock(GameModule.class);
       staticGm.when(GameModule::getGameModule).thenReturn(gm);
-
-      testSetup(gm);
+      when(gm.getPrefs()).thenReturn(prefs);
 
       final TurnTrackerAccessor tracker = new TurnTrackerAccessor();
-      tracker.addTo(gm);
 
       final String turnNames = String.join(",", turnList);
       final ListTurnLevel level = new ListTurnLevel();
@@ -346,7 +326,7 @@ public class ListTurnTrackerTest {
       level2.setAttribute("list", numberNames);
       level.addLevel(level2);
 
-      tracker.setup(false);
+      tracker.reset();
 
       for (int i = 0; i < turnList.size(); ++i) {
         for (int j = 0; j < numbersList.size(); ++j) {
@@ -365,11 +345,9 @@ public class ListTurnTrackerTest {
     try (MockedStatic<GameModule> staticGm = Mockito.mockStatic(GameModule.class)) {
       final GameModule gm = mock(GameModule.class);
       staticGm.when(GameModule::getGameModule).thenReturn(gm);
-
-      testSetup(gm);
+      when(gm.getPrefs()).thenReturn(prefs);
 
       final TurnTrackerAccessor tracker = new TurnTrackerAccessor();
-      tracker.addTo(gm);
 
       final String turnNames = String.join(",", turnList);
       final ListTurnLevel level = new ListTurnLevel();
@@ -405,11 +383,9 @@ public class ListTurnTrackerTest {
     try (MockedStatic<GameModule> staticGm = Mockito.mockStatic(GameModule.class)) {
       final GameModule gm = mock(GameModule.class);
       staticGm.when(GameModule::getGameModule).thenReturn(gm);
-
-      testSetup(gm);
+      when(gm.getPrefs()).thenReturn(prefs);
 
       final TurnTrackerAccessor tracker = new TurnTrackerAccessor();
-      tracker.addTo(gm);
 
       final String turnNames = String.join(",", turnList);
       final ListTurnLevel level = new ListTurnLevel();
@@ -460,11 +436,9 @@ public class ListTurnTrackerTest {
     try (MockedStatic<GameModule> staticGm = Mockito.mockStatic(GameModule.class)) {
       final GameModule gm = mock(GameModule.class);
       staticGm.when(GameModule::getGameModule).thenReturn(gm);
-
-      testSetup(gm);
+      when(gm.getPrefs()).thenReturn(prefs);
 
       final TurnTrackerAccessor tracker = new TurnTrackerAccessor();
-      tracker.addTo(gm);
 
       final String turnNames = String.join(",", turnList);
       final ListTurnLevel level = new ListTurnLevel();
@@ -512,11 +486,9 @@ public class ListTurnTrackerTest {
     try (MockedStatic<GameModule> staticGm = Mockito.mockStatic(GameModule.class)) {
       final GameModule gm = mock(GameModule.class);
       staticGm.when(GameModule::getGameModule).thenReturn(gm);
-
-      testSetup(gm);
+      when(gm.getPrefs()).thenReturn(prefs);
 
       final TurnTrackerAccessor tracker = new TurnTrackerAccessor();
-      tracker.addTo(gm);
 
       final ListTurnLevel level = new ListTurnLevel();
       level.setAttribute("list", "alpha,bravo");

--- a/vassal-app/src/test/java/VASSAL/build/module/turn/ListTurnTrackerTest.java
+++ b/vassal-app/src/test/java/VASSAL/build/module/turn/ListTurnTrackerTest.java
@@ -9,6 +9,8 @@ import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
 import javax.swing.JToolBar;
+import java.awt.Component;
+
 import java.util.Iterator;
 import java.util.List;
 
@@ -56,10 +58,11 @@ public class ListTurnTrackerTest {
   final GameState gameState = new GameState();
   final Prefs prefs = new Prefs(new PrefsEditor(), "");
 
-  private void testSetup() {
-    when(GameModule.getGameModule().getPrefs()).thenReturn(prefs);
-    when(GameModule.getGameModule().getToolBar()).thenReturn(toolbar);
-    when(GameModule.getGameModule().getGameState()).thenReturn(gameState);
+  private void testSetup(GameModule gm) {
+    when(gm.getPrefs()).thenReturn(prefs);
+    when(gm.getGameState()).thenReturn(gameState);
+    when(gm.getToolBar()).thenReturn(toolbar);
+    when(toolbar.add(any(Component.class))).thenReturn(null);
   }
 
   @Test
@@ -68,7 +71,7 @@ public class ListTurnTrackerTest {
       final GameModule gm = mock(GameModule.class);
       staticGm.when(GameModule::getGameModule).thenReturn(gm);
 
-      testSetup();
+      testSetup(gm);
 
       final TurnTrackerAccessor tracker = new TurnTrackerAccessor();
       tracker.addTo(gm);
@@ -93,7 +96,7 @@ public class ListTurnTrackerTest {
       final GameModule gm = mock(GameModule.class);
       staticGm.when(GameModule::getGameModule).thenReturn(gm);
 
-      testSetup();
+      testSetup(gm);
 
       final TurnTrackerAccessor tracker = new TurnTrackerAccessor();
       tracker.addTo(gm);
@@ -119,7 +122,7 @@ public class ListTurnTrackerTest {
       final GameModule gm = mock(GameModule.class);
       staticGm.when(GameModule::getGameModule).thenReturn(gm);
 
-      testSetup();
+      testSetup(gm);
 
       final TurnTrackerAccessor tracker = new TurnTrackerAccessor();
       tracker.addTo(gm);
@@ -161,7 +164,7 @@ public class ListTurnTrackerTest {
       final GameModule gm = mock(GameModule.class);
       staticGm.when(GameModule::getGameModule).thenReturn(gm);
 
-      testSetup();
+      testSetup(gm);
 
       final TurnTrackerAccessor tracker = new TurnTrackerAccessor();
       tracker.addTo(gm);
@@ -215,7 +218,7 @@ public class ListTurnTrackerTest {
       final GameModule gm = mock(GameModule.class);
       staticGm.when(GameModule::getGameModule).thenReturn(gm);
 
-      testSetup();
+      testSetup(gm);
 
       final TurnTrackerAccessor tracker = new TurnTrackerAccessor();
       tracker.addTo(gm);
@@ -271,7 +274,7 @@ public class ListTurnTrackerTest {
       final GameModule gm = mock(GameModule.class);
       staticGm.when(GameModule::getGameModule).thenReturn(gm);
 
-      testSetup();
+      testSetup(gm);
 
       final TurnTrackerAccessor tracker = new TurnTrackerAccessor();
       tracker.addTo(gm);
@@ -302,7 +305,7 @@ public class ListTurnTrackerTest {
       final GameModule gm = mock(GameModule.class);
       staticGm.when(GameModule::getGameModule).thenReturn(gm);
 
-      testSetup();
+      testSetup(gm);
 
       final TurnTrackerAccessor tracker = new TurnTrackerAccessor();
       tracker.addTo(gm);
@@ -328,7 +331,7 @@ public class ListTurnTrackerTest {
       final GameModule gm = mock(GameModule.class);
       staticGm.when(GameModule::getGameModule).thenReturn(gm);
 
-      testSetup();
+      testSetup(gm);
 
       final TurnTrackerAccessor tracker = new TurnTrackerAccessor();
       tracker.addTo(gm);
@@ -363,7 +366,7 @@ public class ListTurnTrackerTest {
       final GameModule gm = mock(GameModule.class);
       staticGm.when(GameModule::getGameModule).thenReturn(gm);
 
-      testSetup();
+      testSetup(gm);
 
       final TurnTrackerAccessor tracker = new TurnTrackerAccessor();
       tracker.addTo(gm);
@@ -403,7 +406,7 @@ public class ListTurnTrackerTest {
       final GameModule gm = mock(GameModule.class);
       staticGm.when(GameModule::getGameModule).thenReturn(gm);
 
-      testSetup();
+      testSetup(gm);
 
       final TurnTrackerAccessor tracker = new TurnTrackerAccessor();
       tracker.addTo(gm);
@@ -458,7 +461,7 @@ public class ListTurnTrackerTest {
       final GameModule gm = mock(GameModule.class);
       staticGm.when(GameModule::getGameModule).thenReturn(gm);
 
-      testSetup();
+      testSetup(gm);
 
       final TurnTrackerAccessor tracker = new TurnTrackerAccessor();
       tracker.addTo(gm);
@@ -510,7 +513,7 @@ public class ListTurnTrackerTest {
       final GameModule gm = mock(GameModule.class);
       staticGm.when(GameModule::getGameModule).thenReturn(gm);
 
-      testSetup();
+      testSetup(gm);
 
       final TurnTrackerAccessor tracker = new TurnTrackerAccessor();
       tracker.addTo(gm);

--- a/vassal-app/src/test/java/VASSAL/build/module/turn/ListTurnTrackerTest.java
+++ b/vassal-app/src/test/java/VASSAL/build/module/turn/ListTurnTrackerTest.java
@@ -52,8 +52,8 @@ public class ListTurnTrackerTest {
   }
 
   // Mocked GameModule members required by the TurnTracker constructor.
+  final JToolBar toolbar = mock(JToolBar.class);
   final GameState gameState = new GameState();
-  final JToolBar toolbar = new JToolBar();
   final Prefs prefs = new Prefs(new PrefsEditor(), "");
 
   private void testSetup() {

--- a/vassal-app/src/test/java/VASSAL/build/module/turn/ListTurnTrackerTest.java
+++ b/vassal-app/src/test/java/VASSAL/build/module/turn/ListTurnTrackerTest.java
@@ -1,0 +1,549 @@
+package VASSAL.build.module.turn;
+
+import VASSAL.build.GameModule;
+import VASSAL.build.module.GameState;
+import VASSAL.preferences.Prefs;
+import VASSAL.preferences.PrefsEditor;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import javax.swing.JToolBar;
+import java.util.Iterator;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+
+public class ListTurnTrackerTest {
+
+  private final List<String> turnList = List.of(
+          "alpha",
+          "beta",
+          "gamma"
+  );
+
+  // A subset of days.
+  private final List<String> dayList = List.of(
+          "Monday",
+          "Tuesday",
+          "Wednesday"
+  );
+
+  private final List<String> numbersList = List.of(
+          "one",
+          "two",
+          "three"
+  );
+
+  // A helper class to access protected functions.
+  static class TurnTrackerAccessor extends TurnTracker {
+    public void next() {
+      super.next();
+    }
+
+    public void prev() {
+      super.prev();
+    }
+
+    public String getTurnString() {
+      return super.getTurnString().trim();
+    }
+  }
+
+  // Mocked GameModule members required by the TurnTracker constructor.
+  final GameState gameState = new GameState();
+  final JToolBar toolbar = new JToolBar();
+  final Prefs prefs = new Prefs(new PrefsEditor(), "");
+
+  private void testSetup() {
+    when(GameModule.getGameModule().getPrefs()).thenReturn(prefs);
+    when(GameModule.getGameModule().getToolBar()).thenReturn(toolbar);
+    when(GameModule.getGameModule().getGameState()).thenReturn(gameState);
+  }
+
+  @Test
+  public void turnTrackerNext() {
+    try (MockedStatic<GameModule> staticGm = Mockito.mockStatic(GameModule.class)) {
+      final GameModule gm = mock(GameModule.class);
+      staticGm.when(GameModule::getGameModule).thenReturn(gm);
+
+      testSetup();
+
+      final TurnTrackerAccessor tracker = new TurnTrackerAccessor();
+      tracker.addTo(gm);
+
+      final String turnNames = String.join(",", turnList);
+      final ListTurnLevel level = new ListTurnLevel();
+      level.setAttribute("list", turnNames);
+      level.addTo(tracker);
+      tracker.setup(false);
+
+      // Check initial conditions, check advance to next, and one wrap around.
+      for (int i = 0; i <= turnList.size(); ++i) {
+        assertEquals(turnList.get(i % turnList.size()), level.getTurnString());
+        tracker.next();
+      }
+    }
+  }
+
+  @Test
+  public void turnTrackerPrev() {
+    try (MockedStatic<GameModule> staticGm = Mockito.mockStatic(GameModule.class)) {
+      final GameModule gm = mock(GameModule.class);
+      staticGm.when(GameModule::getGameModule).thenReturn(gm);
+
+      testSetup();
+
+      final TurnTrackerAccessor tracker = new TurnTrackerAccessor();
+      tracker.addTo(gm);
+
+      final String turnNames = String.join(",", turnList);
+      final ListTurnLevel level = new ListTurnLevel();
+      level.setAttribute("list", turnNames);
+      level.addTo(tracker);
+      tracker.setup(false);
+
+      // Check initial conditions, wrap backwards and check backwards movement through the list.
+      for (int i = turnList.size(); i >= 0; --i) {
+        assertEquals(turnList.get(i % turnList.size()), level.getTurnString());
+        tracker.prev();
+      }
+    }
+  }
+
+  // Move forward on a turn tracker with two lists that are siblings.
+  @Test
+  public void siblingListTurnTrackerNext() {
+    try (MockedStatic<GameModule> staticGm = Mockito.mockStatic(GameModule.class)) {
+      final GameModule gm = mock(GameModule.class);
+      staticGm.when(GameModule::getGameModule).thenReturn(gm);
+
+      testSetup();
+
+      final TurnTrackerAccessor tracker = new TurnTrackerAccessor();
+      tracker.addTo(gm);
+
+      final String turnNames = String.join(",", turnList);
+      final ListTurnLevel level = new ListTurnLevel();
+      level.setAttribute("list", turnNames);
+      level.addTo(tracker);
+
+      final String dayNames = String.join(",", dayList);
+      final ListTurnLevel other = new ListTurnLevel();
+      other.setAttribute("list", dayNames);
+      other.addTo(tracker);
+
+      tracker.setup(false); // alpha
+      tracker.next(); // beta
+      tracker.next(); // gamma
+      assertEquals("gamma", tracker.getTurnString());
+      tracker.next(); // Monday
+      tracker.next(); // Tuesday
+      Iterator<TurnLevel> levels = tracker.getTurnLevels();
+      assertEquals("alpha", levels.next().getTurnString());
+      assertEquals("Tuesday", levels.next().getTurnString());
+      assertEquals("Tuesday", tracker.getTurnString());
+      tracker.next(); // Wednesday
+      tracker.next(); // wrap
+      levels = tracker.getTurnLevels();
+      assertEquals("alpha", levels.next().getTurnString());
+      assertEquals("Monday", levels.next().getTurnString());
+      assertEquals("alpha", tracker.getTurnString());
+    }
+  }
+
+  // Move forward on a turn tracker with two lists that are siblings.
+  // First and last elements are not active.
+  @Test
+  public void siblingListInactiveElements() {
+    try (MockedStatic<GameModule> staticGm = Mockito.mockStatic(GameModule.class)) {
+      final GameModule gm = mock(GameModule.class);
+      staticGm.when(GameModule::getGameModule).thenReturn(gm);
+
+      testSetup();
+
+      final TurnTrackerAccessor tracker = new TurnTrackerAccessor();
+      tracker.addTo(gm);
+
+      final String turnNames = String.join(",", turnList);
+      final ListTurnLevel level = new ListTurnLevel();
+      level.setAttribute("list", turnNames);
+      level.addTo(tracker);
+
+      final String dayNames = String.join(",", dayList);
+      final ListTurnLevel other = new ListTurnLevel();
+      other.setAttribute("list", dayNames);
+      other.addTo(tracker);
+
+      // Active elements are:
+      // beta -> gamma -> Monday -> Tuesday
+      tracker.setState("0|0;0;0;false,true,true|0;1;0;true,true,false");
+
+      tracker.next(); // beta
+      tracker.next(); // gamma
+      assertEquals("gamma", tracker.getTurnString());
+      tracker.next(); // Monday
+      tracker.next(); // Tuesday
+      Iterator<TurnLevel> levels = tracker.getTurnLevels();
+      assertEquals("beta", levels.next().getTurnString());
+      assertEquals("Tuesday", levels.next().getTurnString());
+      assertEquals("Tuesday", tracker.getTurnString());
+      tracker.next(); // wrap
+      levels = tracker.getTurnLevels();
+      assertEquals("beta", levels.next().getTurnString());
+      assertEquals("Monday", levels.next().getTurnString());
+      assertEquals("beta", tracker.getTurnString());
+      tracker.prev(); // wrap backwards
+      levels = tracker.getTurnLevels();
+      assertEquals("gamma", levels.next().getTurnString());
+      assertEquals("Tuesday", levels.next().getTurnString());
+      assertEquals("Tuesday", tracker.getTurnString());
+      tracker.prev();
+      assertEquals("Monday", tracker.getTurnString());
+      tracker.prev();
+      assertEquals("gamma", tracker.getTurnString());
+    }
+  }
+
+  // Move forward on a turn track with two lists that are siblings.
+  // Part 1: All elements in the second list are inactive.
+  // Part 2: All elements of both lists are inactive.
+  @Test
+  public void siblingListInactiveList() {
+    try (MockedStatic<GameModule> staticGm = Mockito.mockStatic(GameModule.class)) {
+      final GameModule gm = mock(GameModule.class);
+      staticGm.when(GameModule::getGameModule).thenReturn(gm);
+
+      testSetup();
+
+      final TurnTrackerAccessor tracker = new TurnTrackerAccessor();
+      tracker.addTo(gm);
+
+      final String turnNames = String.join(",", turnList);
+      final ListTurnLevel level = new ListTurnLevel();
+      level.setAttribute("list", turnNames);
+      level.addTo(tracker);
+
+      final ListTurnLevel other = new ListTurnLevel();
+      other.setAttribute("list", "1,2,3");
+      other.addTo(tracker);
+
+      tracker.setState("0|0;0;0;true,true,true|0;1;0;false,false,false");
+
+      // Forward direction
+      for (int i = 0; i < turnList.size() * 2; ++i) {
+        assertEquals(turnList.get(i % turnList.size()), tracker.getTurnString());
+        tracker.next();
+      }
+
+      // The previous advance skips 1,2,3 and wraps to alpha.
+      assertEquals(turnList.get(0), tracker.getTurnString());
+
+      // Reverse direction
+      for (int i = turnList.size()-1; i >= 0; --i) {
+        tracker.prev();
+        assertEquals(turnList.get(i), tracker.getTurnString());
+      }
+
+      // Part 2
+      // Beta is current, all inactive.
+      tracker.setState("0|1;0;0;false,false,false|0;1;0;false,false,false");
+
+      // Forward
+      for (int i = 0; i < turnList.size() ; ++i) {
+        assertEquals(turnList.get(1), tracker.getTurnString());
+        tracker.next();
+      }
+
+      // Reverse
+      for (int i = 0; i < turnList.size() ; ++i) {
+        assertEquals(turnList.get(1), tracker.getTurnString());
+        tracker.prev();
+      }
+    }
+  }
+
+  // Test for inactive element at the start of a level.
+  @Test
+  public void turnTrackerNextFirstInactive() {
+    try (MockedStatic<GameModule> staticGm = Mockito.mockStatic(GameModule.class)) {
+      final GameModule gm = mock(GameModule.class);
+      staticGm.when(GameModule::getGameModule).thenReturn(gm);
+
+      testSetup();
+
+      final TurnTrackerAccessor tracker = new TurnTrackerAccessor();
+      tracker.addTo(gm);
+
+      final String turnNames = String.join(",", turnList);
+      final ListTurnLevel level = new ListTurnLevel();
+      level.setAttribute("list", turnNames);
+      level.addTo(tracker);
+
+      // The first element is not active.
+      tracker.setState("0|0;0;0;false,true,true");
+
+      // setState can select inactive levels.
+      assertEquals("alpha", level.getTurnString());
+      tracker.next(); // beta
+      assertEquals("beta", level.getTurnString());
+      tracker.prev(); // wrap around backwards skipping alpha
+      assertEquals("gamma", level.getTurnString());
+      tracker.next(); // beta
+      assertEquals("beta", level.getTurnString());
+    }
+  }
+
+  // Test for inactive element at the end of a level.
+  @Test
+  public void turnTrackerPrevLastInactive() {
+    try (MockedStatic<GameModule> staticGm = Mockito.mockStatic(GameModule.class)) {
+      final GameModule gm = mock(GameModule.class);
+      staticGm.when(GameModule::getGameModule).thenReturn(gm);
+
+      testSetup();
+
+      final TurnTrackerAccessor tracker = new TurnTrackerAccessor();
+      tracker.addTo(gm);
+
+      final String turnNames = String.join(",", turnList);
+      final ListTurnLevel level = new ListTurnLevel();
+      level.setAttribute("list", turnNames);
+      level.addTo(tracker);
+      tracker.setState("0|0;0;0;true,true,false");
+
+      assertEquals("alpha", level.getTurnString());
+      tracker.prev(); // wrap around backwards to beta
+      assertEquals("beta", level.getTurnString());
+      tracker.next(); // skips gamma
+      assertEquals("alpha", level.getTurnString());
+
+    }
+  }
+
+  @Test
+  public void turnTrackerNextNestedLists() {
+    try (MockedStatic<GameModule> staticGm = Mockito.mockStatic(GameModule.class)) {
+      final GameModule gm = mock(GameModule.class);
+      staticGm.when(GameModule::getGameModule).thenReturn(gm);
+
+      testSetup();
+
+      final TurnTrackerAccessor tracker = new TurnTrackerAccessor();
+      tracker.addTo(gm);
+
+      final String turnNames = String.join(",", turnList);
+      final ListTurnLevel level = new ListTurnLevel();
+      level.setAttribute("list", turnNames);
+      level.addTo(tracker);
+
+      final String numberNames = String.join(",", numbersList);
+      final ListTurnLevel level2 = new ListTurnLevel();
+      level2.setAttribute("list", numberNames);
+      level.addLevel(level2);
+
+      tracker.setup(false);
+
+      for (int i = 0; i < turnList.size(); ++i) {
+        for (int j = 0; j < numbersList.size(); ++j) {
+          assertEquals(turnList.get(i), level.getTurnString());
+          assertEquals(numbersList.get(j), level2.getTurnString());
+          tracker.next();
+        }
+      }
+      assertEquals("alpha", level.getTurnString());
+      assertEquals("one", level2.getTurnString());
+    }
+  }
+
+  @Test
+  public void nestedListInactiveElement() {
+    try (MockedStatic<GameModule> staticGm = Mockito.mockStatic(GameModule.class)) {
+      final GameModule gm = mock(GameModule.class);
+      staticGm.when(GameModule::getGameModule).thenReturn(gm);
+
+      testSetup();
+
+      final TurnTrackerAccessor tracker = new TurnTrackerAccessor();
+      tracker.addTo(gm);
+
+      final String turnNames = String.join(",", turnList);
+      final ListTurnLevel level = new ListTurnLevel();
+      level.setAttribute("list", turnNames);
+      level.addTo(tracker);
+
+      final String numberNames = String.join(",", numbersList);
+      final ListTurnLevel level2 = new ListTurnLevel();
+      level2.setAttribute("list", numberNames);
+      level.addLevel(level2);
+
+      // First element of the child list is inactive.
+      tracker.setState("0|0;0;0;true,true,true;0\\;0\\;0\\;false,true,true");
+
+      assertEquals("alpha", level.getTurnString());
+      assertEquals("one", level2.getTurnString());
+      tracker.next();
+
+      for (int i = 0; i < turnList.size(); ++i) {
+        for (int j = 1; j < numbersList.size(); ++j) {
+          assertEquals(turnList.get(i), level.getTurnString());
+          assertEquals(numbersList.get(j), level2.getTurnString());
+          tracker.next();
+        }
+      }
+      assertEquals("alpha", level.getTurnString());
+      assertEquals("two", level2.getTurnString());
+    }
+  }
+
+  @Test
+  public void twoNestedListsOneInactive() {
+    try (MockedStatic<GameModule> staticGm = Mockito.mockStatic(GameModule.class)) {
+      final GameModule gm = mock(GameModule.class);
+      staticGm.when(GameModule::getGameModule).thenReturn(gm);
+
+      testSetup();
+
+      final TurnTrackerAccessor tracker = new TurnTrackerAccessor();
+      tracker.addTo(gm);
+
+      final String turnNames = String.join(",", turnList);
+      final ListTurnLevel level = new ListTurnLevel();
+      level.setAttribute("list", turnNames);
+      level.addTo(tracker);
+
+      final ListTurnLevel inactiveList = new ListTurnLevel();
+      inactiveList.setAttribute("list", "odd_ball");
+      level.addLevel(inactiveList);
+
+      final String numberNames = String.join(",", numbersList);
+      final ListTurnLevel level2 = new ListTurnLevel();
+      level2.setAttribute("list", numberNames);
+      level.addLevel(level2);
+
+      // The top level list starts at beta and first is beta.
+      // The first and only element of the first child list is inactive.
+      tracker.setState("0|1;0;1;true,true,true;0\\;0\\;0\\;false;0\\;1\\;0\\;true,true,true");
+
+      assertEquals("beta", level.getTurnString());
+      assertEquals("odd_ball", inactiveList.getTurnString());
+      assertEquals("one", level2.getTurnString());
+      assertEquals("beta odd_ball", tracker.getTurnString());
+
+      // Forward
+      for (int i = 0; i < turnList.size(); ++i) {
+        for (String s : numbersList) {
+          tracker.next();
+          final String expected = turnList.get((i + 1) % turnList.size()) + " " + s;
+          assertEquals(expected, tracker.getTurnString());
+        }
+      }
+
+      // Reverse
+      for (int i = turnList.size(); i > 0; --i) {
+        for (int j = numbersList.size() - 1; j >= 0; --j) {
+          final String expected = turnList.get(i % turnList.size()) + " " + numbersList.get(j);
+          assertEquals(expected, tracker.getTurnString());
+          tracker.prev();
+        }
+      }
+    }
+  }
+
+  // Multiple sub-lists with all inactive.
+  @Test
+  public void allNestedListsInactive() {
+    try (MockedStatic<GameModule> staticGm = Mockito.mockStatic(GameModule.class)) {
+      final GameModule gm = mock(GameModule.class);
+      staticGm.when(GameModule::getGameModule).thenReturn(gm);
+
+      testSetup();
+
+      final TurnTrackerAccessor tracker = new TurnTrackerAccessor();
+      tracker.addTo(gm);
+
+      final String turnNames = String.join(",", turnList);
+      final ListTurnLevel level = new ListTurnLevel();
+      level.setAttribute("list", turnNames);
+      level.addTo(tracker);
+
+      final ListTurnLevel inactiveList = new ListTurnLevel();
+      inactiveList.setAttribute("list", "odd_ball");
+      level.addLevel(inactiveList);
+
+      final String numberNames = String.join(",", numbersList);
+      final ListTurnLevel level2 = new ListTurnLevel();
+      level2.setAttribute("list", numberNames);
+      level.addLevel(level2);
+
+      // The top level list starts at gamma and first is beta.
+      // The first and only element of the first child list is inactive.
+      tracker.setState("0|2;0;1;true,true,true;0\\;0\\;0\\;false;0\\;1\\;0\\;false,false,false");
+
+      assertEquals("gamma", level.getTurnString());
+      assertEquals("odd_ball", inactiveList.getTurnString());
+      assertEquals("one", level2.getTurnString());
+      assertEquals("gamma odd_ball", tracker.getTurnString());
+
+      // Forward
+      for (int i = 0; i < turnList.size(); ++i) {
+        tracker.next();
+        final String expected = turnList.get(i) + " odd_ball";
+        assertEquals(expected, tracker.getTurnString());
+      }
+
+      // Reverse
+      for (int i = turnList.size()-1; i >= 0; --i) {
+        final String expected = turnList.get(i % turnList.size()) + " odd_ball";
+        assertEquals(expected, tracker.getTurnString());
+        tracker.prev();
+      }
+    }
+  }
+
+  // A four levels deep turn list with all levels set to the last value.
+  // Test that the next advance resets all levels.
+  @Test
+  public void turnTrackerNextWrapAll() {
+    try (MockedStatic<GameModule> staticGm = Mockito.mockStatic(GameModule.class)) {
+      final GameModule gm = mock(GameModule.class);
+      staticGm.when(GameModule::getGameModule).thenReturn(gm);
+
+      testSetup();
+
+      final TurnTrackerAccessor tracker = new TurnTrackerAccessor();
+      tracker.addTo(gm);
+
+      final ListTurnLevel level = new ListTurnLevel();
+      level.setAttribute("list", "alpha,bravo");
+      level.addTo(tracker);
+
+      final ListTurnLevel level2 = new ListTurnLevel();
+      level2.setAttribute("list", "charlie,delta");
+      level.addLevel(level2);
+
+      final ListTurnLevel level3 = new ListTurnLevel();
+      level3.setAttribute("list", "echo,foxtrot");
+      level2.addLevel(level3);
+
+      final ListTurnLevel level4 = new ListTurnLevel();
+      level4.setAttribute("list", "golf,hotel");
+      level3.addLevel(level4);
+
+      tracker.setState("0|1;0;0;true,true;1\\;0\\;0\\;true,true\\;1\\\\;0\\\\;0\\\\;true,true\\\\;1\\\\\\;0\\\\\\;0\\\\\\;true,true");
+
+      assertEquals("bravo", level.getTurnString());
+      assertEquals("delta", level2.getTurnString());
+      assertEquals("foxtrot", level3.getTurnString());
+      assertEquals("hotel", level4.getTurnString());
+
+      tracker.next();
+
+      assertEquals("alpha", level.getTurnString());
+      assertEquals("charlie", level2.getTurnString());
+      assertEquals("echo", level3.getTurnString());
+      assertEquals("golf", level4.getTurnString());
+    }
+  }
+}


### PR DESCRIPTION
The List Turn Tracker has an option to allow players to turn off items in the list. The first and last items in the list do not always honour this flag. When traversing in the forward direction on rollover back the start of the list, the first item is always shown regardless. On a backwards traversal, the item before the first item is always shown (if the index of the first item is zero, it's the last item that's shown).  Hence a one item list cannot be turned off.

Features of this merge request:
1. Skip over consecutive inactive items across multiple lists.
2. Search for and select the first active list item on a forward traversal.
3. Search for and select the last active list item on a reverse traversal.
4. If all items are inactive the list item remains unchanged.
5. Add unit tests to demonstrate the original bug.

Closes #13154 
