### PR TITLE
Embed the org.netbeans.*.wizard package fully

### DIFF
--- a/vassal-app/pom.xml
+++ b/vassal-app/pom.xml
@@ -125,11 +125,6 @@
             <version>1.0</version>
         </dependency>
         <dependency>
-            <groupId>org.netbeans</groupId>
-            <artifactId>wizard</artifactId>
-            <version>0.998.1</version>
-        </dependency>
-        <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-artifact</artifactId>
             <version>3.9.9</version>
@@ -378,6 +373,7 @@
                 </executions>
             </plugin>
             <plugin>
+              <!-- This does not work with Java 25 -->
                 <groupId>com.github.spotbugs</groupId>
                 <artifactId>spotbugs-maven-plugin</artifactId>
                 <configuration>

--- a/vassal-app/src/main/java/org/netbeans/api/wizard/WizardDisplayer.java
+++ b/vassal-app/src/main/java/org/netbeans/api/wizard/WizardDisplayer.java
@@ -1,0 +1,237 @@
+/*  The contents of this file are subject to the terms of the Common Development
+and Distribution License (the License). You may not use this file except in
+compliance with the License.
+    You can obtain a copy of the License at http://www.netbeans.org/cddl.html
+or http://www.netbeans.org/cddl.txt.
+    When distributing Covered Code, include this CDDL Header Notice in each file
+and include the License file at http://www.netbeans.org/cddl.txt.
+If applicable, add the following below the CDDL Header, with the fields
+enclosed by brackets [] replaced by your own identifying information:
+"Portions Copyrighted [year] [name of copyright owner]" */
+package org.netbeans.api.wizard;
+
+import java.awt.Container;
+import java.awt.Rectangle;
+import java.awt.event.ActionListener;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Map;
+import javax.swing.Action;
+import org.netbeans.api.wizard.displayer.WizardDisplayerImpl;
+import org.netbeans.modules.wizard.NbBridge;
+import org.netbeans.spi.wizard.Wizard;
+
+
+/**
+ * <h2>Displaying Wizards</h2>
+ * Factory which can display a <code>Wizard</code> in a dialog onscreen or in an ad-hoc
+ * container.  Usage:
+ * <pre>
+ * Wizard wizard = WizardPage.createWizard (new Class[] {WizardPageSubclass1.class,
+ *     WizardPageSubclass2.class, WizardPageSubclass3.class}, 
+ *     new MyWizardResultProducer();
+ * WizardDisplayer.showWizard (wizard);
+ * </pre>
+ * Alternately you can implement <code>WizardPanelProvider</code> instead of
+ * <code>WizardPage</code> to provide the panels of the wizard.
+ * <p>
+ * To use a <code>Wizard</code> in a <code>JInternalFrame</code> or similar, use
+ * <code>WizardDisplayer.installInContainer()</code>.  You will need to implement
+ * <code>WizardResultReceiver</code> which will me notified when the wizard
+ * is finished or cancelled, to close the internal frame or whatever UI is
+ * showing the wizard.
+ * <p>
+ * <h2>Customizing the default implementation</h2>
+ * The image on the left panel of the default implementation can be customized
+ * in the following ways:
+ * <ul>
+ * <li>Put an instance of <code>java.awt.image.BufferedImage</code> into 
+ * UIManager with the key <code>wizard.sidebar.image</code>, i.e.
+ * <pre>
+ *    BufferedImage img = ImageIO.read (getClass().getResource ("MySideImage.png");
+ *    UIManager.put ("wizard.sidebar.image", img);
+ * </pre>
+ * </li>
+ * <li>Use the system property <code>wizard.sidebar.image</code> to set a path
+ *     within a JAR on the classpath to the image.  The image must be visible
+ *     to the classloader which loads <code>WizardDisplayer</code>, so this
+ *     may not work in environments which manage the classpath.  i.e.
+ * <pre>
+ *    System.setProperty ("wizard.sidebar.image", "com/foo/myapp/MySideImage.png");
+ * </pre>
+ * </li>
+ * </ul>
+ * 
+ * <h2>Providing a custom WizardDisplayer:</h2>
+ * The implementation of <code>WizardDisplayer</code> is pluggable.  While the
+ * default implementation should be adequate for most cases, it is possible
+ * that in some cases one might want to completely replace the UI, buttons,
+ * etc. with custom UI code.  To do that:
+ * <ul>
+ *     <li>If the NetBeans Lookup library (<code>org.openide.util.Lookup</code>
+ *     is on the classpath, the default implementation will be found in
+ *     the default lookup (i.e. META-INF/services, same as
+ *     JDK 6's ServiceLoader)</li>
+ *    <li>If Lookup is not available or not found, <code>WizardDisplayer</code>
+ *     will check the system
+ *     property <code>WizardDisplayer.default</code> for a fully qualified
+ *     class name of a subclass of <code>WizardDisplayer</code>.
+ *    </li>
+ *    <li>If no other implementation of <code>WizardDisplayer</code> is found
+ *     by the above methods, the default implementation contained in this
+ *     library will be used.</li>
+ * </ul>
+ * 
+ * @author Tim Boudreau
+ */
+public abstract class WizardDisplayer {
+    protected WizardDisplayer() {
+    }
+    private static final String SYSPROP_KEY = "WizardDisplayer.default";
+    
+    /**
+     * Display a wizard in a dialog, using the default implementation of
+     * WizardDisplayer.
+     * @param wizard The wizard to show.  Must not be null
+     * @param rect The rectangle on screen for the wizard, may be null for default size
+     * @param help An action to invoke if the user presses the help button
+     * @param initialProperties are the initial values for properties to be shown
+     * and entered in the wizard.  May be null.
+     */
+    public static Object showWizard (Wizard wizard, Rectangle rect, Action help, Map initialProperties) {
+       // assert nonBuggyWizard (wizard);
+        // validate it
+        nonBuggyWizard (wizard);
+
+        WizardDisplayer defaultInstance = getDefault();
+        
+        return defaultInstance.show (wizard, rect, help, initialProperties);
+    }
+    
+    private static WizardDisplayer getDefault() {
+        WizardDisplayer factory = NbBridge.getFactoryViaLookup();
+        if (factory == null) {
+            String wdProp = System.getProperty (SYSPROP_KEY);
+            if (wdProp != null) {
+                try {
+                    factory = (WizardDisplayer) 
+                            Class.forName (wdProp).newInstance();
+                } catch (Exception e) {
+                    System.err.println("Could not instantiate " + wdProp);
+                    System.setProperty (SYSPROP_KEY, null);
+                    e.printStackTrace();
+                }
+            }
+        }
+        
+        if (factory == null) {
+            factory = // new DefaultWizardDisplayer();
+                new WizardDisplayerImpl();
+        }
+        return factory;
+    }
+    
+    /** Show a wizard with default window placement and no Help button */
+    public static Object showWizard (Wizard wizard) {
+        return showWizard (wizard, null, null, null);
+    }
+    
+    /** Show a wizard with default window placement, showing the help button,
+     * which will invoke the passed action.
+     * @param wizard The wizard to show
+     * @param help An action to invoke if the user presses the help button
+     * @return The result of Wizard.finish()
+     */
+    public static Object showWizard (Wizard wizard, Action help) {
+        return showWizard (wizard, null, help, null);
+    }
+    
+    /** Show a wizard in the passed location on screen with no help button 
+     * @param wizard The wizard to show
+     * @param r The rectangle on screen for the wizard
+     * @return The result of Wizard.finish()
+     */
+    public static Object showWizard (Wizard wizard, Rectangle r) {
+        return showWizard (wizard, r, null, null);
+    }
+    
+    /**
+     * Show a wizard.
+     * @param wizard the Wizard to show
+     * @param r the bounding rectangle for the wizard dialog on screen, null means "computed from first panel size"
+     * @param help An action to be called if the Help button is pressed
+     * @param initialProperties are used to set initial values for screens within the wizard.
+     * This may be null.
+     * @return Whatever object the wizard returns from its <code>finish()</code>
+     *  method, if the Wizard was completed by the user.
+     */
+    protected abstract Object show (Wizard wizard, Rectangle r, Action help, Map initialProperties);
+    
+    /**
+     * Install a panel representing a Wizard in a user-supplied container
+     * with a user-supplied layout constraint.
+     * @param c The container the wizard panel should be added to.  May not
+     *   be null.
+     * @param layoutConstraint The argument to use when adding the wizard's
+     *   ui component to the container.  May be null.
+     * @param helpAction An action that should be invoked when the help button
+     *   is clicked (if null, no help button will be displayed)
+     * @param initialProperties A set of properties that should be pre-set upon
+     *   entering the wizard.  May be null.
+     * @param receiver An object which will be called when the Finish or 
+     *   Cancel buttons are pressed.  May not be null.
+     */ 
+    public static WizardDisplayer installInContainer (Container c,
+	    Object layoutConstraint, 
+            Wizard awizard,
+            Action helpAction, Map initialProperties, 
+            WizardResultReceiver receiver) {
+	final WizardDisplayer displayer = getDefault();
+        displayer.install (c, layoutConstraint, awizard, helpAction, 
+                initialProperties, receiver);
+	return displayer;
+    }
+    
+    /**
+     * Instance implementation of installInContainer().
+     */ 
+    protected abstract void install (Container c, Object layoutConstraint,
+            Wizard awizard, Action helpAction, Map initialProperties,  
+            WizardResultReceiver receiver);
+    
+    /**
+     * Assigns a handler used to close the wizard.
+     * @param l ActionListener to be invoked when the wizard is to be closed.
+     *   The event passed to the handler will typically be an ACTION_PERFORMED
+     *   on the cancel/close button.
+     * @return the handler replaced by this method invocation
+     */
+    // public abstract ActionListener setCloseHandler(ActionListener l);
+        
+    
+
+    private static boolean nonBuggyWizard (Wizard wizard) {
+        String[] s = wizard.getAllSteps();
+        // assert new HashSet(Arrays.asList(s)).size() == s.length;
+        // for JDK 1.4.2: replace assert with runtime exception
+        if (new HashSet(Arrays.asList(s)).size() != s.length)
+        {
+            throw new RuntimeException ("steps are duplicated: " + Arrays.toString(s));
+        }
+        if (s.length == 1 && Wizard.UNDETERMINED_STEP.equals(s[0])) {
+           // assert false : "Only ID may not be UNDETERMINED_ID"; //NOI18N
+            throw new RuntimeException ("Only ID may not be UNDETERMINED_ID");
+        }
+        for (int i=0; i < s.length; i++) {
+            if (Wizard.UNDETERMINED_STEP.equals(s[i]) && i != s.length - 1) {
+             //  assert false :  "UNDETERMINED_ID may only be last element in" + //NOI18N
+               //        " ids array " + Arrays.asList(s); //NOI18N
+                throw new RuntimeException ( "UNDETERMINED_ID may only be last element in" + //NOI18N
+                                             " ids array " + Arrays.toString(s)); //NOI18N)
+            }
+        }
+        return true;
+    }
+
+    
+}

--- a/vassal-app/src/main/java/org/netbeans/api/wizard/WizardResultReceiver.java
+++ b/vassal-app/src/main/java/org/netbeans/api/wizard/WizardResultReceiver.java
@@ -1,0 +1,45 @@
+/*
+ * The contents of this file are subject to the terms of the Common Development
+ * and Distribution License (the License). You may not use this file except in
+ * compliance with the License.
+ *
+ * You can obtain a copy of the License at http://www.netbeans.org/cddl.html
+ * or http://www.netbeans.org/cddl.txt.
+ *
+ * When distributing Covered Code, include this CDDL Header Notice in each file
+ * and include the License file at http://www.netbeans.org/cddl.txt.
+ * If applicable, add the following below the CDDL Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyrighted [year] [name of copyright owner]"
+ *
+ * The Original Software is NetBeans. The Initial Developer of the Original
+ * Software is Sun Microsystems, Inc. Portions Copyright 1997-2006 Sun
+ * Microsystems, Inc. All Rights Reserved.
+ */
+package org.netbeans.api.wizard;
+
+import java.util.Map;
+
+/**
+ * Object which is called when the wizard is completed or cancelled.  Only
+ * useful if you want to call WizardDisplayer.installInContainer() to install
+ * a wizard in a custom container (such as a JInternalDialog) - this class
+ * is a callback to notify the caller that the Finish or Cancel button has
+ * been pressed.
+ *
+ * @author Tim Boudreau
+ */
+public interface WizardResultReceiver {
+    /**
+     * Called when the wizard has been completed, providing whatever object
+     * the wizard created as its result.
+     * @param wizardResult The object created by Wizard.finish()
+     */ 
+    void finished (Object wizardResult);
+    /**
+     * Called when the wizard has been cancelled.
+     * @param settings The settings that were gathered thus far in the
+     *  wizard
+     */ 
+    void cancelled (Map settings);
+}

--- a/vassal-app/src/main/java/org/netbeans/api/wizard/displayer/InstructionsPanel.java
+++ b/vassal-app/src/main/java/org/netbeans/api/wizard/displayer/InstructionsPanel.java
@@ -1,0 +1,37 @@
+/*
+ * To change this template, choose Tools | Templates
+ * and open the template in the editor.
+ */
+
+package org.netbeans.api.wizard.displayer;
+
+import java.awt.Container;
+
+/**
+ * Interface for providing the UI for instructions displayed in a wizard.
+ *
+ * @author Tim Boudreau
+ */
+public interface InstructionsPanel {
+    /**
+     * Get the component that will actually display the instructions.
+     * Note that this component should have a layout manager that can position
+     * a single component in a location that will not obscure the instructions,
+     * for showing a progress bar.
+     * 
+     * This method should always return the same component.
+     * 
+     * @return A component that can listen to the wizard, display the steps
+     * in that wizard, notice and update when they change, and optionally
+     * highlight the current step.
+     */
+    public Container getComponent();
+    /**
+     * Set whether or not the panel is in the summary page at the end of a
+     * wizard (in which case it should add a &quot;summary&quot; item to its
+     * list of steps and highlight that).
+     * 
+     * @param val Whether or not the wizard has navigated to a summary page.
+     */
+    public void setInSummaryPage (boolean val);
+}

--- a/vassal-app/src/main/java/org/netbeans/api/wizard/displayer/NavButtonManager.java
+++ b/vassal-app/src/main/java/org/netbeans/api/wizard/displayer/NavButtonManager.java
@@ -1,0 +1,755 @@
+/*
+ * NavButtonManager.java       created on Dec 9, 2006
+ * 
+ */
+
+package org.netbeans.api.wizard.displayer;
+
+import java.awt.Container;
+import java.awt.Cursor;
+import java.awt.Dimension;
+import java.awt.Insets;
+import java.awt.Window;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.util.NoSuchElementException;
+import java.util.logging.Logger;
+
+import javax.swing.Action;
+import javax.swing.BorderFactory;
+import javax.swing.JButton;
+import javax.swing.JComponent;
+import javax.swing.JDialog;
+import javax.swing.JOptionPane;
+import javax.swing.JPanel;
+import javax.swing.JRootPane;
+import javax.swing.UIManager;
+
+import org.netbeans.api.wizard.WizardDisplayer;
+import org.netbeans.modules.wizard.MergeMap;
+import org.netbeans.modules.wizard.NbBridge;
+import org.netbeans.spi.wizard.DeferredWizardResult;
+import org.netbeans.spi.wizard.Summary;
+import org.netbeans.spi.wizard.Wizard;
+import org.netbeans.spi.wizard.WizardException;
+import org.netbeans.spi.wizard.WizardObserver;
+import org.netbeans.spi.wizard.WizardPanel;
+import org.netbeans.spi.wizard.WizardPanelNavResult;
+
+/**
+ * Manage the button state and interaction with the wizard.
+ * <p>
+ * <b><i><font color="red">This class is NOT AN API CLASS.  There is no
+ * commitment that it will remain backward compatible or even exist in the
+ * future.  The API of this library is in the packages <code>org.netbeans.api.wizard</code>
+ * and <code>org.netbeans.spi.wizard</code></font></i></b>.
+ *
+ * @author stanley@stanleyknutson.com
+ */
+public class NavButtonManager implements ActionListener
+{
+    static final String NAME_NEXT      = "next";
+
+    static final String NAME_PREV      = "prev";
+
+    static final String NAME_FINISH    = "finish";
+
+    static final String NAME_CANCEL    = "cancel";
+
+    static final String NAME_CLOSE     = "close";
+    
+    /** Prefix for the name in deferredStatus */
+    static final String DEFERRED_FAILED = "FAILED_";
+
+
+    private static final Logger logger =
+        Logger.getLogger(NavButtonManager.class.getName());
+
+    JButton             next           = null;
+
+    JButton             prev           = null;
+
+    JButton             finish         = null;
+
+    JButton             cancel         = null;
+
+    JButton             help           = null;
+
+    JPanel              buttons        = null;
+
+    // container can be JDialog or JFrame
+    private Window      window;
+
+    WizardDisplayerImpl parent;
+
+    String              closeString    = NbBridge.getString("org/netbeans/api/wizard/Bundle", // NOI18N
+                                                            WizardDisplayer.class, "Close"); // NOI18N
+
+    boolean suppressMessageDialog = false;
+    /**
+     * Deferred status of not null means we are waiting for a deferred result to
+     * be completed as part of the handling for some button Value of the
+     * deferredStatus is the NAME_* constant that triggered the deferred
+     * operation.
+     */
+    String              deferredStatus = null;
+
+    private ActionListener closeHandler = new ActionListener() {
+        public void actionPerformed(final ActionEvent e) {
+	    final Container top = ((JComponent)e.getSource()).getTopLevelAncestor();
+	    if (top instanceof Window) {
+		final Window win = (Window) top;
+		win.setVisible(false);
+		win.dispose();
+	    }
+	}
+    };
+
+
+    NavButtonManager(WizardDisplayerImpl impl)
+    {
+        parent = impl;
+    }
+
+    protected void buildButtons(Action helpAction)
+    {
+
+        next = new JButton(NbBridge.getString("org/netbeans/api/wizard/Bundle", // NOI18N
+                                              WizardDisplayer.class, "Next_>")); // NOI18N
+        next.setName(NAME_NEXT);
+        next.setMnemonic(NbBridge.getString("org/netbeans/api/wizard/Bundle", // NOI18N
+                                              WizardDisplayer.class, "Next_mnemonic").charAt(0)); // NOI18N
+
+        prev = new JButton(NbBridge.getString("org/netbeans/api/wizard/Bundle", // NOI18N
+                                              WizardDisplayer.class, "<_Prev")); // NOI18N
+        prev.setName(NAME_PREV);
+        prev.setMnemonic(NbBridge.getString("org/netbeans/api/wizard/Bundle", // NOI18N
+                                              WizardDisplayer.class, "Prev_mnemonic").charAt(0)); // NOI18N
+
+        finish = new JButton(NbBridge.getString("org/netbeans/api/wizard/Bundle", // NOI18N
+                                                WizardDisplayer.class, "Finish")); // NOI18N
+        finish.setName(NAME_FINISH);
+        finish.setMnemonic(NbBridge.getString("org/netbeans/api/wizard/Bundle", // NOI18N
+                                              WizardDisplayer.class, "Finish_mnemonic").charAt(0)); // NOI18N
+
+        cancel = new JButton(NbBridge.getString("org/netbeans/api/wizard/Bundle", // NOI18N
+                                                WizardDisplayer.class, "Cancel")); // NOI18N
+        cancel.setName(NAME_CANCEL);
+        cancel.setMnemonic(NbBridge.getString("org/netbeans/api/wizard/Bundle", // NOI18N
+                                              WizardDisplayer.class, "Cancel_mnemonic").charAt(0)); // NOI18N
+
+        help = new JButton();
+        if (helpAction != null)
+        {
+            help.setAction(helpAction);
+            if (helpAction.getValue(Action.NAME) == null)
+            {
+                help.setText(NbBridge.getString("org/netbeans/api/wizard/Bundle", // NOI18N
+                                                WizardDisplayer.class, "Help")); // NOI18N
+                help.setMnemonic(NbBridge.getString("org/netbeans/api/wizard/Bundle", // NOI18N
+                                                      WizardDisplayer.class, "Help_mnemonic").charAt(0)); // NOI18N
+            }
+        }
+        else
+        {
+            help.setText(NbBridge.getString("org/netbeans/api/wizard/Bundle", // NOI18N
+                                            WizardDisplayer.class, "Help")); // NOI18N
+            help.setMnemonic(NbBridge.getString("org/netbeans/api/wizard/Bundle", // NOI18N
+                                              WizardDisplayer.class, "Help_mnemonic").charAt(0)); // NOI18N
+        }
+
+        next.setDefaultCapable(true);
+        prev.setDefaultCapable(true);
+
+        help.setVisible(helpAction != null);
+
+        // Use standard default-button-last order on Aqua L&F
+        final boolean aqua = "Aqua".equals(UIManager.getLookAndFeel().getID()); // NOI18N
+
+        buttons = new JPanel()
+        {
+            private static final long serialVersionUID = -1219524604575467507L;
+
+            public void doLayout()
+            {
+                Insets ins = getInsets();
+                JButton b = aqua ? finish : cancel;
+
+                Dimension n = b.getPreferredSize();
+                int y = ((getHeight() - (ins.top + ins.bottom)) / 2) - (n.height / 2);
+                int gap = 5;
+                int x = getWidth() - (12 + ins.right + n.width);
+
+                b.setBounds(x, y, n.width, n.height);
+
+                b = aqua ? next : finish;
+                n = b.getPreferredSize();
+                x -= n.width + gap;
+                b.setBounds(x, y, n.width, n.height);
+
+                b = aqua ? prev : next;
+                n = b.getPreferredSize();
+                x -= n.width + gap;
+                b.setBounds(x, y, n.width, n.height);
+
+                b = aqua ? cancel : prev;
+                n = b.getPreferredSize();
+                x -= n.width + gap;
+                b.setBounds(x, y, n.width, n.height);
+
+                b = help;
+                n = b.getPreferredSize();
+                x -= n.width + (gap * 2);
+                b.setBounds(x, y, n.width, n.height);
+            }
+        };
+        buttons.setBorder(BorderFactory.createMatteBorder(1, 0, 0, 0, UIManager
+            .getColor("textText"))); // NOI18N
+
+        buttons.add(prev);
+        buttons.add(next);
+        buttons.add(finish);
+        buttons.add(cancel);
+        buttons.add(help);
+
+        next.addActionListener(this);
+        prev.addActionListener(this);
+        finish.addActionListener(this);
+        cancel.addActionListener(this);
+    }
+
+    void connectListener()
+    {
+        NavWizardObserver l = new NavWizardObserver();
+        Wizard wizard = parent.getWizard();
+        l.stepsChanged(wizard);
+        l.navigabilityChanged(wizard);
+        l.selectionChanged(wizard);
+        wizard.addWizardObserver(l);
+    }
+
+    private static void configureNavigationButtons(final Wizard wizard, final JButton prev,
+                                                   final JButton next, final JButton finish)
+    {
+        final String nextStep = wizard.getNextStep();
+        final int fwdNavMode = wizard.getForwardNavigationMode();
+
+        WizardDisplayerImpl.checkLegalNavMode(fwdNavMode);
+
+        final String problem = wizard.getProblem();
+
+        boolean canContinue = (fwdNavMode & Wizard.MODE_CAN_CONTINUE) != 0;
+        boolean canFinish = (fwdNavMode & Wizard.MODE_CAN_FINISH) != 0;
+        boolean enableFinish = canFinish && problem == null;
+        boolean enableNext = nextStep != null && canContinue && problem == null;
+        next.setEnabled(enableNext);
+        prev.setEnabled(wizard.getPreviousStep() != null);
+        finish.setEnabled(enableFinish);
+        JRootPane root = next.getRootPane();
+        if (root != null)
+        {
+            if (next.isEnabled())
+            {
+                root.setDefaultButton(next);
+            }
+            else if (finish.isEnabled())
+            {
+                root.setDefaultButton(finish);
+            }
+            else if (prev.isEnabled())
+            {
+                root.setDefaultButton(prev);
+            }
+            else
+            {
+                root.setDefaultButton(null);
+            }
+        }
+    }
+
+    public void actionPerformed(ActionEvent event)
+    {
+        // probably an error status
+        if (deferredStatus != null)
+        {
+            deferredResultFinished(event);
+            return;
+        }
+        
+        JButton button = (JButton) event.getSource();
+
+        String name = button.getName();
+        if (NAME_NEXT.equals(name))
+        {
+            processNext();
+        }
+        else if (NAME_PREV.equals(name))
+        {
+            processPrev();
+        }
+        else if (NAME_FINISH.equals(name))
+        {
+            processFinish(event);
+        }
+        else if (NAME_CANCEL.equals(name))
+        {
+            processCancel(event, true);
+        }
+        else if (NAME_CLOSE.equals(name))
+        {
+            processClose(event);
+        }
+        // else ignore, we don't know it
+
+        parent.updateProblem();
+    }
+
+    void deferredResultFailed(boolean canGoBack)
+    {
+        if (!canGoBack)
+        {
+            getCancel().setText(closeString);
+        }
+        getPrev().setEnabled(true);
+        getNext().setEnabled(false);
+        getCancel().setEnabled(true);
+        getFinish().setEnabled(false);
+
+        if (NAME_CLOSE.equals(deferredStatus))
+        {
+            // no action
+        }
+        else
+        {
+            deferredStatus = DEFERRED_FAILED + deferredStatus;
+        }
+        
+    }
+
+    void deferredResultFinished(Object o)
+    {
+        String name = deferredStatus;
+        deferredStatus = null;
+        
+        if (name.startsWith(DEFERRED_FAILED))
+        {
+            // Cancel clicked after a deferred failure
+            if (o instanceof ActionEvent)
+            {
+                JButton button = (JButton) ((ActionEvent) o).getSource();
+                name = button.getName();
+                if (NAME_CANCEL.equals(name))
+                {
+                    processCancel(o instanceof ActionEvent ? (ActionEvent) o
+                            : null, false);
+                    return;
+                }
+            }
+            // in failed state, so we always reload the current step's screen
+            String currentStep = parent.getCurrentStep();
+            parent.navigateTo(currentStep);
+            return;
+        }
+        
+        if (NAME_NEXT.equals(name))
+        {
+            processNextProceed(o);
+        }
+        else if (NAME_PREV.equals(name))
+        {
+            processPrevProceed(o);
+        }
+        else if (NAME_CANCEL.equals(name))
+        {
+            processCancel(o instanceof ActionEvent ? (ActionEvent)o
+                    : null, false);
+        }
+        else if (NAME_FINISH.equals(name))
+        {
+            // allowFinish on the "down" click of the finish button
+            processFinishProceed(o);
+        }
+        else if (NAME_CLOSE.equals(name))
+        {
+            // the "up" click of the finish button: wizard.finish was a deferred result
+            Window dlg = getWindow();
+            dlg.setVisible(false);
+            dlg.dispose();
+        }
+        // else ignore, we don't know it
+
+        parent.updateProblem();
+    }
+
+    protected void processNext()
+    {
+        WizardPanel panel = parent.getCurrentWizardPanel();
+        Wizard wizard = parent.getWizard();
+        MergeMap settings = parent.getSettings();
+
+        WizardPanelNavResult proceed = WizardPanelNavResult.PROCEED;
+        if (panel != null)
+        {
+            String currentStep = parent.getCurrentStep();
+            proceed = panel.allowNext(currentStep, settings, wizard);
+            if (proceed.isDeferredComputation())
+            {
+                deferredStatus = NAME_NEXT;
+                // Remove boolean argument  - cholmcc
+                // parent.handleDeferredWizardResult(proceed, false);
+                parent.handleDeferredWizardResult(proceed);
+                return;
+            }
+        }
+
+        processNextProceed (proceed);
+    }
+
+    protected void processNextProceed(Object result)
+    {
+        Wizard wizard = parent.getWizard();
+        MergeMap settings = parent.getSettings();
+
+        if (WizardPanelNavResult.REMAIN_ON_PAGE.equals(result))
+        {
+            // leave current panel displayed, assume problem is being shown
+            return;
+        }
+        // ignore other results
+        
+        String nextId = wizard.getNextStep();
+        settings.push(nextId);
+        parent.navigateTo(nextId);
+        parent.setInSummary(false);
+    }
+
+    protected void processPrev()
+    {
+        WizardPanel panel = parent.getCurrentWizardPanel();
+        Wizard wizard = parent.getWizard();
+        MergeMap settings = parent.getSettings();
+
+        WizardPanelNavResult proceed = WizardPanelNavResult.PROCEED;
+        if (panel != null)
+        {
+            String currentStep = parent.getCurrentStep();
+            proceed = panel.allowBack(currentStep, settings, wizard);
+            if (proceed.isDeferredComputation())
+            {
+                deferredStatus = NAME_PREV;
+                // Remove boolean arg - cholmcc
+                //parent.handleDeferredWizardResult(proceed,false);
+                parent.handleDeferredWizardResult(proceed);
+                return;
+            }
+        }
+
+        processPrevProceed (proceed);
+    }
+
+    protected void processPrevProceed(Object result)
+    {
+        Wizard wizard = parent.getWizard();
+        MergeMap settings = parent.getSettings();
+
+        if (WizardPanelNavResult.REMAIN_ON_PAGE.equals(result))
+        {
+            // leave current panel displayed, assume problem is being shown
+            return;
+        }
+        // ignore other results
+
+        String prevId = wizard.getPreviousStep();
+        settings.popAndCalve();
+        // Remove the call 
+        // parent.abortDeferredResult();
+        parent.navigateTo(prevId);
+        parent.setInSummary(false);
+    }
+
+    protected void processFinish(ActionEvent event)
+    {
+        WizardPanel panel = parent.getCurrentWizardPanel();
+        Wizard wizard = parent.getWizard();
+        MergeMap settings = parent.getSettings();
+
+        WizardPanelNavResult proceed = WizardPanelNavResult.PROCEED;
+        if (panel != null)
+        {
+            String currentStep = parent.getCurrentStep();
+            proceed = panel.allowFinish(currentStep, settings, wizard);
+            if (proceed.isDeferredComputation())
+            {
+                deferredStatus = NAME_FINISH;
+                // Remove boolean arg - cholmcc
+                // parent.handleDeferredWizardResult((DeferredWizardResult) proceed,false);
+                parent.handleDeferredWizardResult((DeferredWizardResult) proceed);
+                return;
+            }
+        }
+
+        processFinishProceed (proceed);
+    }
+
+    
+    protected void processFinishProceed(Object result)
+    {
+        Wizard wizard = parent.getWizard();
+        MergeMap settings = parent.getSettings();
+
+        if (WizardPanelNavResult.REMAIN_ON_PAGE.equals(result))
+        {
+            // leave current panel displayed, assume problem is being shown
+            return;
+        }
+        try
+        {
+            Object o = wizard.finish(settings);
+            // System.err.println("WIZARD FINISH GOT ME A " + o);
+
+            boolean closeWindow = true;
+
+            if (o instanceof DeferredWizardResult)
+            {
+                final DeferredWizardResult r = (DeferredWizardResult) o;
+                finish.setEnabled(false);
+                cancel.setEnabled(r.canAbort());
+                prev.setEnabled(false);
+                next.setEnabled(false);
+
+                // the button still says "cancel"
+                deferredStatus = NAME_CANCEL;
+                // deferredStatus = NAME_CLOSE;
+                // Remove boolean arg - cholmcc
+                // parent.handleDeferredWizardResult(r, true);
+                parent.handleDeferredWizardResult(r);
+
+                closeWindow = false;
+            }
+            else if (o instanceof Summary)
+            {
+                parent.handleSummary((Summary) o);
+                parent.setWizardResult(((Summary) o).getResult());
+                // setSummaryShowingMode will be called
+                // need to share code with NavProgress.finished code path
+                closeWindow = false;
+            }
+            else
+            {
+                parent.setWizardResult(o);
+            }
+
+            if (closeWindow)
+            {
+                // do cancel processing as well
+                processCancel(null, false);
+            }
+        }
+        catch (WizardException we)
+        {
+            if (!suppressMessageDialog) {
+                JOptionPane.showMessageDialog(next, we.getLocalizedMessage());
+            }
+            String id = we.getStepToReturnTo();
+            String curr = settings.currID();
+            try
+            {
+                while (id != null && !id.equals(curr))
+                {
+                    curr = settings.popAndCalve();
+                }
+                settings.push(id);
+                parent.navigateTo(id);
+                return;
+            }
+            catch (NoSuchElementException ex)
+            {
+                IllegalStateException e = new IllegalStateException("Exception " + // NOI18N
+                    "said to return to " + id + " but no such " + // NOI18N
+                    "step found"); // NOI18N
+                e.initCause(ex);
+                throw e;
+            }
+        }
+    }
+
+    protected void processCancel(ActionEvent event, boolean reallyCancel)
+    {
+    	
+        DeferredWizardResult deferredResult = parent.getDeferredResult();
+        if (deferredResult != null && deferredResult.canAbort())
+        {
+            deferredResult.abort();
+        }
+        Wizard wizard = parent.getWizard();
+        MergeMap settings = parent.getSettings();
+        
+        // System.err.println("ProcessCancel " + reallyCancel + " receiver " + parent.receiver);
+        boolean closeWindow = false;
+        
+        if (reallyCancel && parent.cancel()) 
+        {
+            // System.err.println("DO CANCEL");
+            logger.fine("calling wizard cancel method on " + wizard);
+            wizard.cancel (settings);
+            return;
+        }
+        
+        closeWindow = reallyCancel ? wizard.cancel(settings) : parent.receiver == null;
+
+        // if we have the event (allowFinish was not deferred) then be very sure to close the proper dialog
+        if (closeWindow) {
+            Window win = event != null ? (Window) ((JComponent) event.getSource()).getTopLevelAncestor()
+                : getWindow();
+            win.setVisible(false);
+            win.dispose();
+        }
+    }
+
+    /**
+     * Assigns a handler used to carry out the close action.
+     * @param l ActionListener to be invoked when the wizard is to be closed.
+     * @return the handler replaced by this method invocation
+     */
+    public ActionListener setCloseHandler(final ActionListener l) {
+    	final ActionListener old = closeHandler;
+    	closeHandler = l;
+    	return old;
+    }
+    
+
+    protected void processClose(ActionEvent event) {
+	closeHandler.actionPerformed(event);
+    }
+
+    void updateButtons()
+    {
+        Wizard wizard = parent.getWizard();
+        if (!wizard.isBusy())
+        {
+            configureNavigationButtons(wizard, prev, next, finish);
+        }
+    }
+
+    void setSummaryShowingMode ()
+    {
+        next.setEnabled(false);
+        prev.setEnabled(false);
+        cancel.setEnabled(true);
+        finish.setEnabled(false);
+        if (window != null && parent.receiver == null && window instanceof JDialog) {
+            ((JDialog) window).getRootPane().setDefaultButton(cancel);
+        }
+
+        cancel.setText(closeString); // NOI18N
+        cancel.setMnemonic(NbBridge.getString("org/netbeans/api/wizard/Bundle", // NOI18N
+                                              WizardDisplayer.class, "Close_mnemonic").charAt(0)); // NOI18N
+        cancel.setName(NAME_CLOSE);
+        deferredStatus = null;  // ?? should summary be different
+    }
+    
+    void setWindow(Window dlg)
+    {
+        this.window = dlg;
+    }
+
+    public JPanel getButtons()
+    {
+        return buttons;
+    }
+
+    public JButton getCancel()
+    {
+        return cancel;
+    }
+
+    public String getCloseString()
+    {
+        return closeString;
+    }
+
+    public Window getWindow()
+    {
+        return window;
+    }
+
+    public JButton getFinish()
+    {
+        return finish;
+    }
+
+    public JButton getHelp()
+    {
+        return help;
+    }
+
+    public JButton getNext()
+    {
+        return next;
+    }
+
+    public WizardDisplayerImpl getParent()
+    {
+        return parent;
+    }
+
+    public JButton getPrev()
+    {
+        return prev;
+    }
+
+    public void initializeNavigation()
+    {
+        Wizard wizard = parent.getWizard();
+        prev.setEnabled(false);
+        next.setEnabled(wizard.getNextStep() != null);
+        int fwdNavMode = wizard.getForwardNavigationMode();
+        WizardDisplayerImpl.checkLegalNavMode(fwdNavMode);
+
+        finish.setEnabled((fwdNavMode & Wizard.MODE_CAN_FINISH) != 0);
+
+        connectListener();
+    }
+
+    // -------------------------------------
+    /**
+     * Listener for wizard changages that affect button state
+     */
+    class NavWizardObserver implements WizardObserver
+    {
+        boolean wasBusy = false;
+
+        public void stepsChanged(Wizard wizard)
+        {
+            // do nothing
+        }
+
+        public void navigabilityChanged(Wizard wizard)
+        {
+            if (wizard.isBusy())
+            {
+                next.setEnabled(false);
+                prev.setEnabled(false);
+                finish.setEnabled(false);
+                cancel.setEnabled(false);
+                parent.getOuterPanel().setCursor(Cursor.getPredefinedCursor(Cursor.WAIT_CURSOR));
+                wasBusy = true;
+                return;
+            }
+            else if (wasBusy)
+            {
+                cancel.setEnabled(true);
+                parent.getOuterPanel().setCursor(Cursor.getPredefinedCursor(Cursor.DEFAULT_CURSOR));
+            }
+            configureNavigationButtons(wizard, prev, next, finish);
+
+            parent.updateProblem();
+        }
+
+        public void selectionChanged(Wizard wizard)
+        {
+            // do nothing
+        }
+    }
+
+}

--- a/vassal-app/src/main/java/org/netbeans/api/wizard/displayer/NavProgress.java
+++ b/vassal-app/src/main/java/org/netbeans/api/wizard/displayer/NavProgress.java
@@ -1,0 +1,208 @@
+package org.netbeans.api.wizard.displayer;
+
+import java.awt.Container;
+import java.awt.EventQueue;
+import java.lang.reflect.InvocationTargetException;
+import java.util.logging.Logger;
+
+import javax.swing.BoxLayout;
+import javax.swing.Icon;
+import javax.swing.ImageIcon;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JProgressBar;
+import javax.swing.border.EmptyBorder;
+
+import org.netbeans.api.wizard.WizardDisplayer;
+import org.netbeans.modules.wizard.NbBridge;
+import org.netbeans.spi.wizard.ResultProgressHandle;
+import org.netbeans.spi.wizard.Summary;
+
+/**
+ * Show progress bar for deferred results, with a label showing percent done and progress bar.
+ * 
+ * <p>
+ * <b><i><font color="red">This class is NOT AN API CLASS.  There is no
+ * commitment that it will remain backward compatible or even exist in the
+ * future.  The API of this library is in the packages <code>org.netbeans.api.wizard</code>
+ * and <code>org.netbeans.spi.wizard</code></font></i></b>.
+
+ * @author stanley@stanleyknutson.com
+ * @author Kevin A. Archie <karchie@wustl.edu>
+ */
+public class NavProgress implements ResultProgressHandle
+{
+    private static final Logger logger = Logger.getLogger(NavProgress.class.getName());
+    private static final Icon busyIcon =  new ImageIcon(NavProgress.class.getResource("busy.gif"));
+    private static final String MESSAGE_SPACE = // 64 underscores
+        "________________________________________________________________";
+    
+    private final JPanel panel = new JPanel();
+    private final JProgressBar progressBar = new JProgressBar();
+    private final JLabel messageLabel = new JLabel(MESSAGE_SPACE);
+    private final JLabel busyLabel = new JLabel();
+
+    private final WizardDisplayerImpl parent;
+
+    private final boolean disableUIWhileBusy;
+    
+    /** isRunning is true until finished or failed is called */
+    private boolean isRunning = true;
+    
+    NavProgress(final WizardDisplayerImpl impl, final boolean disableUIWhileBusy) {
+        this.parent = impl;
+        this.disableUIWhileBusy = disableUIWhileBusy;
+        panel.setOpaque(false);
+        panel.setLayout(new BoxLayout(panel, BoxLayout.Y_AXIS));
+        panel.add(messageLabel);
+        if (disableUIWhileBusy) {
+            panel.add(busyLabel);
+        } else {
+            panel.add(progressBar);
+        }
+        setBusy();
+    }
+    
+    public void addProgressComponents(final Container container) {
+        container.add(panel);
+        container.invalidate();
+    }
+
+    public void setProgress(final String description, final int currentStep, final int totalSteps)
+    {
+        Runnable r = new Runnable()
+        {
+            public void run()
+            {
+                messageLabel.setText(description == null ? " " : description); // NOI18N
+                messageLabel.revalidate();
+                setProgress(currentStep, totalSteps);
+                panel.repaint();
+            }
+        };
+        invoke(r);
+    }
+
+    public void setProgress(final int currentStep, final int totalSteps) {
+        if (totalSteps == -1) {
+            setBusy();
+        } else {
+            if (currentStep > totalSteps || currentStep < 0) {
+                throw new IllegalArgumentException("Bad step values: " // NOI18N
+                        + currentStep + " out of " + totalSteps); // NOI18N
+            }
+
+            invoke(new Runnable() {
+                public void run() {
+                    if (disableUIWhileBusy) {
+                        busyLabel.setIcon(null);
+                    } else {
+                        progressBar.setIndeterminate(false);
+                        progressBar.setMaximum(totalSteps);
+                        progressBar.setValue(currentStep);
+                    }
+                    panel.repaint();
+                }
+            });
+        }
+    }
+
+    private void setBusy() {
+        invoke(new Runnable() {
+            public void run() {
+                if (disableUIWhileBusy) {
+                    busyLabel.setIcon(busyIcon);
+                } else {
+                    progressBar.setIndeterminate(true);
+                }
+            }
+        });
+    }
+    
+    public void setBusy (final String description) {
+        invoke(new Runnable() {
+            public void run() {
+                messageLabel.setText(description == null ? " " : description); // NOI18N
+                setBusy();
+            }
+        });
+    }
+        
+    private void invoke(Runnable r)
+    {
+        if (EventQueue.isDispatchThread())
+        {
+            r.run();
+        }
+        else
+        {
+            try
+            {
+                EventQueue.invokeAndWait(r);
+            }
+            catch (InvocationTargetException ex)
+            {
+                ex.printStackTrace();
+                logger.severe("Error invoking operation " + ex.getClass().getName() + " " + ex.getMessage());
+            }
+            catch (InterruptedException ex)
+            {
+                logger.severe("Error invoking operation " + ex.getClass().getName() + " " + ex.getMessage());
+                ex.printStackTrace();
+            }
+        }
+    }
+
+    public void finished(final Object o)
+    {
+        isRunning = false;
+        Runnable r = new Runnable()
+        {
+            public void run()
+            {
+                if (o instanceof Summary)
+                {
+                    Summary summary = (Summary) o;
+                    parent.handleSummary(summary);
+                    parent.setWizardResult(summary.getResult());
+                }
+                else if (parent.getDeferredResult() != null)
+                {
+                    parent.setWizardResult(o);
+
+                    // handle result based on which button was pushed
+                    parent.getButtonManager().deferredResultFinished(o);
+                }
+            }
+        };
+        invoke(r);
+    }
+
+    public void failed(final String message, final boolean canGoBack)
+    {
+        isRunning = false;
+
+        Runnable r = new Runnable()
+        {
+            public void run()
+            {
+                // cheap word wrap
+                JLabel comp = new JLabel("<html><body>" + message + "</body></html>"); // NOI18N
+                comp.setBorder(new EmptyBorder(5, 5, 5, 5));
+                parent.setCurrentWizardPanel(comp);
+                parent.getTtlLabel().setText(
+                                             NbBridge
+                                                 .getString("org/netbeans/api/wizard/Bundle", // NOI18N
+                                                            WizardDisplayer.class, "Failed")); // NOI18N
+                NavButtonManager bm = parent.getButtonManager();
+                bm.deferredResultFailed(canGoBack);
+            }
+        };
+        invoke(r);
+    }
+
+    public boolean isRunning()
+    {
+        return isRunning;
+    }
+}

--- a/vassal-app/src/main/java/org/netbeans/modules/wizard/InstructionsPanelImpl.java
+++ b/vassal-app/src/main/java/org/netbeans/modules/wizard/InstructionsPanelImpl.java
@@ -1,0 +1,487 @@
+/*  The contents of this file are subject to the terms of the Common Development
+and Distribution License (the License). You may not use this file except in
+compliance with the License.
+    You can obtain a copy of the License at http://www.netbeans.org/cddl.html
+or http://www.netbeans.org/cddl.txt.
+    When distributing Covered Code, include this CDDL Header Notice in each file
+and include the License file at http://www.netbeans.org/cddl.txt.
+If applicable, add the following below the CDDL Header, with the fields
+enclosed by brackets [] replaced by your own identifying information:
+"Portions Copyrighted [year] [name of copyright owner]" */
+/*
+ * InstructionsPanel.java
+ *
+ * Created on March 4, 2005, 8:59 PM
+ */
+
+package org.netbeans.modules.wizard;
+import java.awt.Color;
+import java.awt.Component;
+import java.awt.Container;
+import java.awt.Dimension;
+import java.awt.Font;
+import java.awt.FontMetrics;
+import java.awt.Graphics;
+import java.awt.Graphics2D;
+import java.awt.IllegalComponentStateException;
+import java.awt.Insets;
+import java.awt.image.BufferedImage;
+import java.io.IOException;
+import java.net.URL;
+import java.util.Locale;
+import java.util.Arrays;
+import javax.accessibility.Accessible;
+import javax.accessibility.AccessibleContext;
+import javax.accessibility.AccessibleRole;
+import javax.accessibility.AccessibleState;
+import javax.accessibility.AccessibleStateSet;
+import javax.accessibility.AccessibleText;
+import javax.imageio.ImageIO;
+import javax.swing.CellRendererPane;
+import javax.swing.JComponent;
+import javax.swing.JEditorPane;
+import javax.swing.UIManager;
+import org.netbeans.api.wizard.displayer.InstructionsPanel;
+import org.netbeans.spi.wizard.Wizard;
+import org.netbeans.spi.wizard.WizardObserver;
+
+/**
+ * A panel that displays a background image and optionally instructions
+ * from a wizard, tracking the selected panel and showing that in bold.
+ * <p/>
+ * <b><i><font color="red">This class is NOT AN API CLASS.  There is no
+ * commitment that it will remain backward compatible or even exist in the
+ * future.  The API of this library is in the packages <code>org.netbeans.api.wizard</code>
+ * and <code>org.netbeans.spi.wizard</code></font></i></b>.
+ * <p/>
+ * There is currently a single use-case for subclassing this - a navigation
+ * panel that wants to display a different image for each step.
+ *
+ * @author Tim Boudreau
+ */
+public class InstructionsPanelImpl extends JComponent implements WizardObserver, Accessible, InstructionsPanel {
+    private final BufferedImage img;
+    private final Wizard wizard;
+    private static final int MARGIN = 5;
+
+    public InstructionsPanelImpl (Wizard wiz) {
+        this (null, wiz);
+        Font f = UIManager.getFont ("Tree.font"); //NOI18N
+        if (f != null) {
+            setFont (f);
+        }
+    }
+    
+    /**
+     * Get the wizard this panel is monitoring.
+     * @return
+     */
+    protected final Wizard getWizard() {
+        return wizard;
+    }
+
+    public final Container getComponent() {
+        return this;
+    }
+
+    /**
+     * Overridden to start listening to the wizard when added to a container
+     */
+    public void addNotify() {
+        super.addNotify();
+        wizard.addWizardObserver (this);
+    }
+    
+    /**
+     * Overridden to stop listening to the wizard when removed from a container
+     */
+    public void removeNotify() {
+        wizard.removeWizardObserver (this);
+        super.removeNotify();
+    }
+    
+    /**
+     * Get the image to be displayed.  Note that unpredictable behavior
+     * may result if all images returned from this method are not the 
+     * same size.  Override to display a different wizard depending on the
+     * step.
+     * 
+     * @return
+     */
+    protected BufferedImage getImage() { //for unit test
+        return img;
+    }
+    
+    public InstructionsPanelImpl(BufferedImage img, Wizard wizard) {
+        if (img == null) {
+            //In the event of classloader issues, also have a way to get
+            //the image from UIManager - slightly more portable for large
+            //apps
+            img = (BufferedImage) UIManager.get ("wizard.sidebar.image"); //NOI18N
+        }
+        
+        String imgStr = System.getProperty("wizard.sidebar.image"); //NOI18N
+        //image has not been loaded and user wishes to supply their own image
+        if (img == null && imgStr != null) {
+            //get an URL, works for jars
+            ClassLoader cl = this.getClass().getClassLoader();
+            URL url = cl.getResource(imgStr);
+            //successfully parsed the URL
+            if(url != null){
+                try {
+                    img = ImageIO.read(url);
+                } catch (IOException ioe) {
+                    System.err.println("Could not load wizard image " + //NOI18N
+                            ioe.getMessage());
+                    System.setProperty("wizard.sidebar.image", null); //NOI18N
+                    img = null; //error loading img, set to null to use default
+                }
+            } else { //URL was not successfully parsed, set img to null to use default
+                System.err.println("Bad URL for wizard image " + imgStr); //NOI18N
+                System.setProperty("wizard.sidebar.image", null); //NOI18N
+                img = null;
+            }
+        }
+        if (img == null) {
+            try {
+                img = ImageIO.read(InstructionsPanelImpl.class.getResourceAsStream(
+                        "defaultWizard.png")); //NOI18N
+            } catch (IOException ioe) {
+                ioe.printStackTrace();
+            }
+        }
+        this.img = img;
+        this.wizard = wizard;
+    }
+
+    
+    public boolean isOpaque() {
+        return img != null;
+    }
+    
+    /**
+     * Paints the background image for this component, or fills the
+     * background with a color if no image present.
+     * 
+     * @param g A Graphic2D to paint into
+     * @param x The x coordinate of the area that should contain the image
+     * @param y The y coordinate of the area that should contain the image
+     * @param w The width of the area that should contain the image
+     * @param h The height of the area that should contain the image
+     */
+    protected void paintImage(Graphics2D g, int x, int y, int w, int h) {
+        BufferedImage image = getImage();
+        if (image != null) {
+            g.drawImage(image, x, y, w, h, this);
+        } else {
+            Color c = g.getColor();
+            g.setColor (Color.WHITE);
+            g.fillRect (x, y, w, h);
+            g.setColor (c);
+        }
+    }
+    
+    String[] steps = new String[0];
+    public final void paintComponent(Graphics g) {
+        Graphics2D g2d = (Graphics2D) g;
+        Font f = getFont() != null ? getFont() : UIManager.getFont("controlFont"); //NOI18N
+        FontMetrics fm = g.getFontMetrics (f);
+        Insets ins = getInsets();
+        int dx = ins.left;
+        int dy = ins.top;
+        int w = getWidth() - (ins. left + ins.right);
+        int hh = getHeight() - (ins.top + ins.bottom);
+        paintImage(g2d, dx, dy, w, hh);
+        String currentStep = wizard.getCurrentStep();
+        if (!inSummaryPage) {
+            //Don't fetch step list if in summary page, there will
+            //only be the base ones
+            steps = wizard.getAllSteps();
+        }
+        String steps[] = this.steps;
+        if (inSummaryPage) {
+            String summaryStep = NbBridge.getString(
+                    "org/netbeans/modules/wizard/Bundle", //NOI18N
+                    InstructionsPanelImpl.class, "Summary"); //NOI18N
+            String[] nue = new String[steps.length + 1];
+            System.arraycopy(steps, 0, nue, 0, steps.length);
+            nue[nue.length - 1] = summaryStep;
+            steps = nue;
+        }
+        int y = fm.getMaxAscent() + ins.top + MARGIN;
+        int x = ins.left + MARGIN;
+        int h = fm.getMaxAscent() + fm.getMaxDescent() + 3;
+        
+        Font boldFont = f.deriveFont (Font.BOLD);
+        
+        g.setFont (boldFont);
+        g.drawString (NbBridge.getString ("org/netbeans/modules/wizard/Bundle", //NOI18N
+                InstructionsPanelImpl.class, "Steps"), x, y); //NOI18N
+        
+        int underlineY = ins.top + MARGIN + fm.getAscent() + 3;
+        g.drawLine (x, underlineY, x + (getWidth() - (x + ins.left + MARGIN)), 
+                underlineY);
+        
+        int bottom = getComponentCount() == 0 ? getHeight() - getInsets().bottom :
+            getHeight() - getInsets().bottom - getComponents()[0].getPreferredSize().height;
+        
+        y += h + 10;
+        int first = 0;
+        int stop = steps.length;
+        String elipsis = NbBridge.getString("org/netbeans/modules/wizard/Bundle", //NOI18N
+                            InstructionsPanelImpl.class, "elipsis"); //NOI18N
+        boolean wontFit = y + (h * (steps.length)) > getHeight();
+        if (wontFit) {
+            //try to center the current step
+            int availHeight = bottom - y;
+            int willFit = availHeight / h;
+            int currStepIndex = Arrays.asList (steps).indexOf(currentStep);
+            int rangeStart = Math.max (0, currStepIndex - (willFit / 2));
+            int rangeEnd = Math.min (rangeStart + willFit, steps.length);
+            if (rangeStart + willFit > steps.length) {
+                //Don't scroll off if there's room
+                rangeStart = steps.length - willFit;
+                rangeEnd = steps.length;
+            }
+            steps = (String[]) steps.clone();
+            if (rangeStart != 0) {
+                steps[rangeStart] = elipsis;
+                first = rangeStart;
+            }
+            if (rangeEnd != steps.length && rangeEnd > 0) {
+                steps[rangeEnd - 1] = elipsis;
+                stop = rangeEnd;
+            }
+        }
+        /*
+        if (wontFit) {
+            int currStepIndex = Arrays.asList (steps).indexOf(currentStep);
+            if (currStepIndex != -1) { //shouldn't happen
+                steps = (String[]) steps.clone();
+                first = Math.max (0, currStepIndex - 2);
+                if (first != 0) {
+                    if (y + ((currStepIndex - first) * h) > getHeight()) {
+                        //Best effort to keep current step on screen
+                        first++;
+                    }
+                    if (first != currStepIndex) {
+                        steps[first] = elipsis;
+                    }
+                }
+            }
+        }
+        if (y + ((stop - first) * h) > bottom) {
+            int avail = bottom - y;
+            int willFit = avail / h;
+            int last = first + willFit - 1;
+            if (last < steps.length - 1) {
+                steps[last] = elipsis;
+                stop = last + 1;
+            }
+        }
+         */ 
+        
+        g.setFont (getFont());
+        g.setColor (getForeground());
+        
+        for (int i=first; i < stop; i++) {
+            boolean isUndetermined = Wizard.UNDETERMINED_STEP.equals(steps[i]);
+            boolean canOnlyFinish = wizard.getForwardNavigationMode() ==
+                    Wizard.MODE_CAN_FINISH;
+            if (isUndetermined && canOnlyFinish) {
+                break;
+            }
+            String curr;
+            if (!elipsis.equals(steps[i])) {
+                if (inSummaryPage && i == this.steps.length) {
+                    curr = (i + 1) + ". " + steps[i];
+                } else {
+                    curr = (i + 1) + ". " + (isUndetermined ?
+                        NbBridge.getString("org/netbeans/modules/wizard/Bundle",  //NOI18N
+                        InstructionsPanelImpl.class, "elipsis") :  //NOI18N
+                        steps[i].equals(elipsis) ? elipsis : 
+                        wizard.getStepDescription(steps[i])); //NOI18N
+                }
+            } else {
+                curr = elipsis;
+            }
+            if (curr != null) {
+                boolean selected = (steps[i].equals (currentStep) && !inSummaryPage) || 
+                        (inSummaryPage && i == steps.length - 1);
+                if (selected) {
+                    g.setFont (boldFont);
+                }
+                
+                int width = fm.stringWidth(curr);
+                while (width > getWidth() - (ins.left + ins.right) && curr.length() > 5) {
+                    curr = curr.substring(0, curr.length() - 5) + 
+                            NbBridge.getString(
+                                "org/netbeans/modules/wizard/Bundle", //NOI18N
+                                InstructionsPanelImpl.class, "elipsis"); //NOI18N
+                }
+                
+                g.drawString (curr, x, y);
+                if (selected) {
+                    g.setFont (f);
+                }
+                y += h;
+            }
+        }
+    }
+    
+    private int historicWidth = Integer.MIN_VALUE;
+    public final Dimension getPreferredSize() {
+        Font f = getFont() != null ? getFont() : 
+            UIManager.getFont("controlFont"); //NOI18N
+        
+        Graphics g = getGraphics();
+        if (g == null) {
+            g = new BufferedImage (1, 1, BufferedImage.TYPE_INT_ARGB).getGraphics();
+        }
+        f = f.deriveFont (Font.BOLD);
+        FontMetrics fm = g.getFontMetrics(f);
+        Insets ins = getInsets();
+        int h = fm.getHeight();
+        
+        String[] steps = wizard.getAllSteps();
+        int w = Integer.MIN_VALUE;
+        for (int i=0; i < steps.length; i++) {
+            String desc = i + ". " + (Wizard.UNDETERMINED_STEP.equals(steps[i]) ?
+                NbBridge.getString ("org/netbeans/modules/wizard/Bundle",  //NOI18N
+                InstructionsPanelImpl.class, "elipsis") :  //NOI18N
+                wizard.getStepDescription(steps[i]));
+            if (desc != null) {
+                w = Math.max (w, fm.stringWidth(desc) + MARGIN);
+            }
+        }
+        if (Integer.MIN_VALUE == w) {
+            w = 250;
+        }
+        BufferedImage img = getImage();
+        if (img != null) {
+            w = Math.max (w, img.getWidth());
+        }
+        //Make sure we can grow but not shrink
+        w = Math.max (w, historicWidth);
+        historicWidth = w;
+        return new Dimension (w,  ins.top + ins.bottom + ((h + 3) * steps.length));
+    }
+    
+    private boolean inSummaryPage;
+    public void setInSummaryPage (boolean val) {
+        this.inSummaryPage = val;
+        repaint();
+    }
+    
+    public final Dimension getMinimumSize() {
+        return getPreferredSize();
+    }
+    
+    public void stepsChanged(Wizard wizard) {
+        repaint();
+    }
+    
+    public void navigabilityChanged (Wizard wizard) {
+        //do nothing
+    }
+
+    public void selectionChanged(Wizard wizard) {
+        repaint();
+    }
+    
+    public final void doLayout() {
+        Component[] c = getComponents();
+        Insets ins = getInsets();
+        int y = getHeight() - (MARGIN + ins.bottom);
+        int x = MARGIN + ins.left;
+        int w = getWidth() - ((MARGIN * 2) + ins.left + ins.right);
+        if (w < 0) w = 0;
+        for (int i=c.length-1; i >= 0; i--) {
+            Dimension d = c[i].getPreferredSize();
+            c[i].setBounds (x, y - d.height, w, d.height);
+            y -= d.height;
+        }
+    }
+    
+    public final AccessibleContext getAccessibleContext() {
+        return new ACI (this);
+    }
+    
+    private static final class ACI extends AccessibleContext {
+        private final Wizard wizard;
+        private final InstructionsPanelImpl panel;
+        public ACI(InstructionsPanelImpl pnl) {
+            this.wizard = pnl.wizard;
+            panel = pnl;
+            if (pnl.getParent() instanceof Accessible) {
+                setAccessibleParent ((Accessible) pnl.getParent());
+            }
+            setAccessibleName (NbBridge.getString(
+                    "org/netbeans/modules/wizard/Bundle", //NOI18N
+                    InstructionsPanelImpl.class, "ACN_InstructionsPanel")); //NOI18N
+            setAccessibleDescription (NbBridge.getString(
+                    "org/netbeans/modules/wizard/Bundle", //NOI18N
+                    InstructionsPanelImpl.class, "ACSD_InstructionsPanel")); //NOI18N
+        }
+        
+        JEditorPane pane;
+        public AccessibleText getAccessibleText() {
+            if (pane == null) {
+                //Cheat just a bit here - will do for now - the text is
+                //there, more or less where it should be, and a screen
+                //reader should be able to find it;  exact bounds don't
+                //make much difference
+                pane = new JEditorPane();
+                pane.setBounds (panel.getBounds());
+                pane.getAccessibleContext().getAccessibleText();
+                pane.setFont (panel.getFont());
+                CellRendererPane cell = new CellRendererPane();
+                cell.add (pane);
+            }
+            pane.setText(getText());
+            pane.selectAll();
+            pane.validate();
+            return pane.getAccessibleContext().getAccessibleText();
+        }
+        
+        public String getText() {
+            StringBuffer sb = new StringBuffer();
+            String[] s = wizard.getAllSteps();
+            for (int i = 0; i < s.length; i++) {
+                sb.append (wizard.getStepDescription(s[i]));
+                sb.append ('\n');
+            }
+            return sb.toString();
+        }
+        
+        public AccessibleRole getAccessibleRole() {
+            return AccessibleRole.LIST;
+        }
+
+        public AccessibleStateSet getAccessibleStateSet() {
+            AccessibleState[] states = new AccessibleState[] {
+                AccessibleState.VISIBLE,
+                AccessibleState.OPAQUE,
+                AccessibleState.SHOWING,
+                AccessibleState.MULTI_LINE,
+            };
+            return new AccessibleStateSet (states);
+        }
+
+        public int getAccessibleIndexInParent() {
+            return -1;
+        }
+
+        public int getAccessibleChildrenCount() {
+            return 0;
+        }
+
+        public Accessible getAccessibleChild(int i) {
+            throw new IndexOutOfBoundsException("" + i);
+        }
+
+        public Locale getLocale() throws IllegalComponentStateException {
+            return Locale.getDefault();
+        }
+    }
+}

--- a/vassal-app/src/main/java/org/netbeans/modules/wizard/MergeMap.java
+++ b/vassal-app/src/main/java/org/netbeans/modules/wizard/MergeMap.java
@@ -1,0 +1,290 @@
+/*  The contents of this file are subject to the terms of the Common Development
+and Distribution License (the License). You may not use this file except in
+compliance with the License.
+    You can obtain a copy of the License at http://www.netbeans.org/cddl.html
+or http://www.netbeans.org/cddl.txt.
+    When distributing Covered Code, include this CDDL Header Notice in each file
+and include the License file at http://www.netbeans.org/cddl.txt.
+If applicable, add the following below the CDDL Header, with the fields
+enclosed by brackets [] replaced by your own identifying information:
+"Portions Copyrighted [year] [name of copyright owner]" */
+/*
+ * MergeMap.java
+ *
+ * Created on February 22, 2005, 4:06 PM
+ */
+
+package org.netbeans.modules.wizard;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Set;
+import java.util.Stack;
+
+/**
+ * A map which proxies a collection of sub-maps each of which has a 
+ * unique id.  Submaps can be added or removed en banc.  Values from
+ * removed maps are retained;  if push ("someKnownId") happens, the
+ * values previously added to the map while that ID was active reappear.
+ * <p>
+ * This allows us to implement backward/forward semantics for wizards,
+ * in which each pane (identified with a unique ID) can add its own
+ * settings to the settings map, but if the user presses the Back 
+ * button, the settings from the formerly active pane can disappear - 
+ * but if the user moves forward again, they are not lost.
+ * <p>
+ * Calling remove("someKeyBelongingToAnEarlierId") will completely
+ * remove that value;  calling put ("someKeyBelongingToAnEarlierId", "newValue")
+ * replaces the earler value permanently.
+ * <p>
+ * <b><i><font color="red">This class is NOT AN API CLASS.  There is no
+ * commitment that it will remain backward compatible or even exist in the
+ * future.  The API of this library is in the packages <code>org.netbeans.api.wizard</code>
+ * and <code>org.netbeans.spi.wizard</code></font></i></b>. 
+ *
+ * @author Tim Boudreau
+ */
+public class MergeMap implements Map {
+    private Stack order = new Stack();
+    private Map id2map = new HashMap();
+    
+    /** Creates a new instance of MergeMap */
+    public MergeMap(String currID) {
+        push (currID);
+    }
+    
+    private static final String BASE = "__BASE"; //NOI18N
+    /**
+     * Creates a MergeMap with a set of key/value pairs that are
+     * always there (they came from a legacy wizard - used for bridging the
+     * old NetBeans wizards API and this one - some bridged wizards will
+     * have a first panel that gathered some settings using the old APIs
+     * framework, and we need to inject them here.
+     */
+    public MergeMap(String currId, Map everpresent) {
+        order.push(BASE);
+        id2map.put (BASE, everpresent);
+        push (currId);
+    }
+    
+    /**
+     * Move to a different ID (meaning add a new named map to proxy which can be
+     * calved off if necessary).
+     */
+    public Map push (String id) {
+        // assert !order.contains(id) : id + " already present"; //NOI18N
+        if (order.contains(id)) {
+            throw new RuntimeException (id + " already present"); //NOI18N
+        }
+//        assert !order.contains(id) : id + " already present"; //NOI18N
+        if (!order.isEmpty() && id.equals(order.peek())) {
+            return (Map) id2map.get(id);
+        }
+        Map result = (Map) id2map.get(id);
+        if (result == null) {
+            result = new HashMap();
+            id2map.put (id, result);
+        }
+        order.push (id);
+        return result;
+    }
+    
+    /**
+     * Get the ID of the current sub-map being written into.
+     */
+    public String currID() {
+        return (String) order.peek();
+    }
+    
+    /**
+     * Remove the current sub-map.  Removes all of its settings from the
+     * MergedMap, but if push() is called with the returned value, the
+     * values associated with the ID being removed will be restored.
+     */
+    public String popAndCalve() {
+        if (order.size() == 0) {
+            throw new NoSuchElementException ("Cannot back out past first " + //NOI18N
+                    "entry"); //NOI18N
+        }
+        //Get the current map
+        String result = (String) order.peek();
+        Map curr = (Map) id2map.get (result);
+        order.pop();
+        
+        //Though unlikely, it is possible that a later step in a wizard
+        //overwrote a key/value pair from a previous step of the wizard.
+        //We do not want to revert that write, so iterate all the keys
+        //we're removing, and if any of them are in steps lower on the 
+        //stack, change those lower steps values to whatever was written
+        //into the map we're calving off
+        
+        Set keysForCurr = curr.keySet();
+        for (Iterator i=orderIterator(); i.hasNext();) {
+            Map other = (Map) id2map.get(i.next());
+            for (Iterator j=curr.keySet().iterator(); j.hasNext();) {
+                Object key = j.next();
+                if (other.containsKey(key)) {
+                    other.put (key, curr.get(key));
+                }
+            }
+        }
+        return result;
+    }
+
+    public void clear() {
+        throw new UnsupportedOperationException();
+    }
+
+    public boolean containsKey(Object obj) {
+        for (Iterator i = orderIterator(); i.hasNext();) {
+            Map curr = (Map) id2map.get(i.next());
+            if (curr.containsKey(obj)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public boolean containsValue(Object obj) {
+        for (Iterator i = orderIterator(); i.hasNext();) {
+            Map curr = (Map) id2map.get(i.next());
+            if (curr.containsValue(obj)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public java.util.Set entrySet() {
+        HashSet result = new HashSet();
+        for (Iterator i = orderIterator(); i.hasNext();) {
+            Map curr = (Map) id2map.get(i.next());
+            result.addAll (curr.entrySet());
+        }
+        return result;
+    }
+
+    public Object get(Object obj) {
+        for (Iterator i = orderIterator(); i.hasNext();) {
+            String id = (String) i.next();
+            Map curr = (Map) id2map.get(id);
+            Object result = curr.get(obj);
+            if (result != null) {
+                return result;
+            }
+        }
+        return null;
+    }
+
+    public boolean isEmpty() {
+        return size() == 0;
+    }
+
+    public Set keySet() {
+        HashSet result = new HashSet();
+        for (Iterator i = orderIterator(); i.hasNext();) {
+            Map curr = (Map) id2map.get(i.next());
+            result.addAll (curr.keySet());
+        }
+        return result;
+    }
+
+    public Object put(Object obj, Object obj1) {
+        Map curr = (Map) id2map.get (order.peek());
+        return curr.put (obj, obj1);
+    }
+
+    public void putAll(Map map) {
+        Map curr = (Map) id2map.get (order.peek());
+        curr.putAll (map);
+    }
+
+    private Object doRemove(Object obj) {
+        Map curr = (Map) id2map.get (order.peek());
+        Object result = curr.remove (obj);
+        if (result == null) {
+            for (Iterator i = orderIterator(); i.hasNext();) {
+                curr = (Map) id2map.get(i.next());
+                result = curr.remove (obj);
+                if (result != null) {
+                    break;
+                }
+            }
+        }
+        return result;
+    }
+    
+    public Object remove(Object obj) {
+        //Ensure we remove any duplicates in upper arrays
+        Object result = get(obj);
+        while (get(obj) != null) {
+            doRemove (obj);
+        }
+        return result;
+    }
+
+    public int size() {
+        //using keySet() prunes duplicates
+        return keySet().size();
+    }
+
+    public Collection values() {
+        HashSet result = new HashSet();
+        Set keys = keySet();
+        for (Iterator i = keys.iterator(); i.hasNext();) {
+            result.add (get(i.next()));
+        }
+        return result;
+    }
+    
+    private Iterator orderIterator() {
+        return new ReverseIterator(order);
+    }
+    
+    private static final class ReverseIterator implements Iterator {
+        private int pos;
+        private List l;
+        public ReverseIterator (Stack s) {
+            pos = s.size()-1;
+            l = new ArrayList(s);
+        }
+        
+        public boolean hasNext() {
+            return pos != -1;
+        }
+        
+        public Object next() {
+            if (pos < 0) {
+                throw new NoSuchElementException();
+            }
+            Object result = l.get(pos);
+            pos--;
+            return result;
+        } 
+        
+        public void remove() {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    public String toString() {
+        StringBuffer sb = new StringBuffer();
+        for (Iterator i = keySet().iterator(); i.hasNext();) {
+            Object key = (Object) i.next();
+            sb.append ('[');
+            sb.append (key);
+            sb.append('=');
+            sb.append(get(key));
+            sb.append(']');
+            if (i.hasNext()) sb.append (',');
+        }
+        return sb.toString();
+    }
+    
+}

--- a/vassal-app/src/main/java/org/netbeans/spi/wizard/BranchingWizard.java
+++ b/vassal-app/src/main/java/org/netbeans/spi/wizard/BranchingWizard.java
@@ -1,0 +1,349 @@
+/*  The contents of this file are subject to the terms of the Common Development
+and Distribution License (the License). You may not use this file except in
+compliance with the License.
+    You can obtain a copy of the License at http://www.netbeans.org/cddl.html
+or http://www.netbeans.org/cddl.txt.
+    When distributing Covered Code, include this CDDL Header Notice in each file
+and include the License file at http://www.netbeans.org/cddl.txt.
+If applicable, add the following below the CDDL Header, with the fields
+enclosed by brackets [] replaced by your own identifying information:
+"Portions Copyrighted [year] [name of copyright owner]" */
+
+/*
+ * BranchingWizard.java
+ *
+ * Created on March 4, 2005, 10:56 PM
+ */
+
+package org.netbeans.spi.wizard;
+
+import javax.swing.*;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * A Wizard with indeterminate branches.  The actual branch decision-making
+ * is done by the WizardBranchController passed to the constructor.
+ * <p/>
+ * Wizards with arbitrary numbers of branches can be handled by a
+ * WizardBranchController by returning wizards created by
+ * another WizardBranchController's <code>createWizard()</code> method.
+ * <p/>
+ * One important point: There should be no duplicate IDs between steps of
+ * this wizard.
+ *
+ * @author Tim Boudreau
+ */
+final class BranchingWizard implements WizardImplementation {
+    private final List listenerList = Collections.synchronizedList (
+            new LinkedList());
+
+    private final WizardBranchController brancher;
+    final WizardImplementation initialSteps;
+
+    private WizardImplementation subsequentSteps;
+    private WizardImplementation activeWizard;
+    private WL wl;
+
+    private String currStep;
+    private Map wizardData;
+
+    public BranchingWizard(WizardBranchController brancher) {
+        this.brancher = brancher;
+        initialSteps = new SimpleWizard(brancher.getBase(), true);
+        setCurrent(initialSteps);
+    }
+
+    protected final WizardImplementation createSecondary(Map settings) {
+        Wizard wiz = brancher.getWizardForStep(currStep, settings);
+        return wiz == null ? null : wiz.impl;
+    }
+
+    private void checkForSecondary() {
+        if (wizardData == null) {
+            return;
+        }
+
+        WizardImplementation newSecondary = createSecondary(wizardData);
+
+        /* 
+         * johnflournoy 7/20/07
+         * check for secondary should be adding the secondary to the activeWizard
+         * not the initial wizard.  Adding it to the initial wizard was breaking
+         * multiple branching - to accomplish this created a new method:
+         * setSecondary()
+         */
+        if (activeWizard instanceof BranchingWizard) {
+            ((BranchingWizard) activeWizard).setSecondary(newSecondary);
+        } else {
+           this.setSecondary(newSecondary);
+        }
+    }
+    
+    /**
+     * Set the secondary for this <code>BranchingWizard</code>.  
+     * @param newSecondary is a WizardImplementation.
+     */
+    private void setSecondary(WizardImplementation newSecondary) {
+        /* johnflournoy added additional condition: secondary != this */
+        if ((((subsequentSteps == null) != (newSecondary == null)) 
+            || (subsequentSteps != null && !subsequentSteps.equals(newSecondary)))
+            && !this.equals(newSecondary)) {
+        
+             /* 
+              * johnflournoy: only set the subsequent steps if it 
+              * this wizard owns the current step.
+              */    
+             if (Arrays.asList(initialSteps.getAllSteps()).contains(currStep)) {
+                subsequentSteps = newSecondary;
+                fireStepsChanged();
+            }
+        }
+    }
+    
+
+    public int getForwardNavigationMode() {
+        return activeWizard.getForwardNavigationMode();
+    }
+
+    private void setCurrent(WizardImplementation wizard) {
+        if (activeWizard == wizard) {
+            return;
+        }
+
+        if (wizard == null) {
+            throw new NullPointerException("Can't set current wizard to null");
+        }
+
+        if ((activeWizard != null) && (wl != null)) {
+            activeWizard.removeWizardObserver(wl);
+        }
+
+        activeWizard = wizard;
+
+        if (wl == null) {
+            wl = new WL();
+        }
+
+        activeWizard.addWizardObserver(wl);
+    }
+
+    public final boolean isBusy() {
+        return activeWizard.isBusy();
+    }
+
+    public final Object finish(Map settings) throws WizardException {
+        try {
+            Object result = activeWizard.finish(settings);
+            initialSteps.removeWizardObserver(wl);
+            //Can be null, we allow bail-out with finish mid-wizard now
+            if (subsequentSteps != null) {
+                subsequentSteps.removeWizardObserver(wl);
+            }
+            return result;
+        } catch (WizardException we) {
+            if (we.getStepToReturnTo() != null) {
+                initialSteps.addWizardObserver(wl);
+                //Can be null, we allow bail-out with finish mid-wizard now
+                if (subsequentSteps != null) {
+                    subsequentSteps.addWizardObserver(wl);
+                }
+            }
+            throw we;
+        }
+    }
+
+    public final String[] getAllSteps() {
+        String[] result;
+        if (subsequentSteps == null) {
+            String[] bsteps = initialSteps.getAllSteps();
+            result = new String[bsteps.length + 1];
+            System.arraycopy(bsteps, 0, result, 0, bsteps.length);
+            result[result.length - 1] = UNDETERMINED_STEP;
+        } else {
+            String[] bsteps = initialSteps.getAllSteps();
+            String[] csteps = subsequentSteps.getAllSteps();
+            result = new String[bsteps.length + csteps.length];
+            System.arraycopy(bsteps, 0, result, 0, bsteps.length);
+            System.arraycopy(csteps, 0, result, bsteps.length, csteps.length);
+        }
+        return result;
+    }
+
+    public String getCurrentStep() {
+        return currStep;
+    }
+
+    public final String getNextStep() {
+        String result;
+        if (currStep == null) {
+            result = getAllSteps()[0];
+        } else {
+            String[] steps = getAllSteps();
+            int idx = Arrays.asList(steps).indexOf(currStep);
+            if (idx == -1) {
+                throw new IllegalStateException("Current step not in" + //NOI18N
+                        " available steps:  " + currStep + " not in " + //NOI18N
+                        Arrays.asList(steps));
+            } else {
+                if (idx == steps.length - 1) {
+                    if (subsequentSteps == null) {
+                        result = UNDETERMINED_STEP;
+                    } else {
+                        result = subsequentSteps.getNextStep();
+                    }
+                } else {
+                    WizardImplementation w = ownerOf(currStep);
+                    if (w == initialSteps && idx == initialSteps.getAllSteps().length - 1) {
+                        checkForSecondary();
+                        if (subsequentSteps != null) {
+                            result = subsequentSteps.getAllSteps()[0];
+                        } else {
+                            result = UNDETERMINED_STEP;
+                        }
+                    } else {
+                        result = w.getNextStep();
+                    }
+                }
+            }
+        }
+        return getProblem() == null ? result : UNDETERMINED_STEP.equals(result) ? result : null;
+    }
+
+    public final String getPreviousStep() {
+        if (activeWizard == subsequentSteps && subsequentSteps.getAllSteps()[0].equals(currStep)) {
+            return initialSteps.getAllSteps()[initialSteps.getAllSteps().length - 1];
+        } else {
+            return activeWizard.getPreviousStep();
+        }
+    }
+
+    public final String getProblem() {
+        return activeWizard.getProblem();
+    }
+
+    public final String getStepDescription(String id) {
+        WizardImplementation w = ownerOf(id);
+        if (w == null) {
+            return null;
+        }
+        return w.getStepDescription(id);
+    }
+    
+    public final String getLongDescription(String id) {
+        WizardImplementation w = ownerOf(id);
+        if (w == null) {
+            return null;
+        }
+        return w.getLongDescription(id);
+    }
+
+    private WizardImplementation ownerOf(String id) {
+        if (UNDETERMINED_STEP.equals(id)) {
+            checkForSecondary();
+            return subsequentSteps;
+        }
+        if (Arrays.asList(initialSteps.getAllSteps()).contains(id)) {
+            return initialSteps;
+        } else {
+            /*
+             * johnflournoy 
+             * need to check an existing subsequentsteps to see if
+             * we can find the owner of "id", otherwise we were losing
+             * a wizard if we had multiple branches and we backed up to an 
+             * earlier wizard and then went down the same path again.
+             */
+            if (subsequentSteps != null) {
+                if (!Arrays.asList(subsequentSteps.getAllSteps()).contains(id)) {
+                    checkForSecondary();
+                }
+            } else {
+                checkForSecondary();
+            }
+            
+            return subsequentSteps;
+        }
+    }
+
+    public final String getTitle() {
+        return activeWizard.getTitle();
+    }
+
+    public final JComponent navigatingTo(String id, Map settings) {
+        if (id == null) {
+            throw new NullPointerException();
+        }
+        currStep = id;
+        wizardData = settings;
+
+        WizardImplementation impl = ownerOf (id);
+        if (impl == null) {
+            throw new NullPointerException ("No owning WizardImplementation for" +
+                    " id " + id);
+        }
+        setCurrent(impl);
+
+        return activeWizard.navigatingTo(id, settings);
+    }
+
+    public final void removeWizardObserver (WizardObserver observer) {
+        listenerList.remove(observer);
+    }
+
+    public final void addWizardObserver (WizardObserver observer) {
+        listenerList.add(observer);
+    }
+
+    private void fireStepsChanged() {
+        WizardObserver[] listeners = (WizardObserver[]) 
+                listenerList.toArray (new WizardObserver[0]);
+
+        for (int i = listeners.length - 1; i >= 0; i --) {
+            WizardObserver l = (WizardObserver) listeners[i];
+            l.stepsChanged(null);
+        }
+    }
+
+    private void fireNavigabilityChanged() {
+        checkForSecondary();
+
+        WizardObserver[] listeners = (WizardObserver[]) 
+                listenerList.toArray (new WizardObserver[0]);
+
+        for (int i = listeners.length - 1; i >= 0; i --) {
+            WizardObserver l = (WizardObserver) listeners[i];
+            l.navigabilityChanged(null);
+        }
+    }
+
+    private void fireSelectionChanged() {
+        WizardObserver[] listeners = (WizardObserver[]) 
+                listenerList.toArray (new WizardObserver[0]);
+
+        for (int i = listeners.length - 1; i >= 0; i --) {
+            WizardObserver l = (WizardObserver) listeners[i];
+            l.selectionChanged(null);
+        }
+    }
+
+    public boolean cancel(Map settings) {
+        return activeWizard == null ? true : activeWizard.cancel(settings);
+    }
+
+    private class WL implements WizardObserver {
+        public void stepsChanged(Wizard wizard) {
+            fireStepsChanged();
+        }
+
+        public void navigabilityChanged(Wizard wizard) {
+            fireNavigabilityChanged();
+        }
+
+        public void selectionChanged(Wizard wizard) {
+            fireSelectionChanged();
+        }
+    }
+}

--- a/vassal-app/src/main/java/org/netbeans/spi/wizard/DeferredWizardResult.java
+++ b/vassal-app/src/main/java/org/netbeans/spi/wizard/DeferredWizardResult.java
@@ -1,0 +1,155 @@
+/*  The contents of this file are subject to the terms of the Common Development
+and Distribution License (the License). You may not use this file except in
+compliance with the License.
+    You can obtain a copy of the License at http://www.netbeans.org/cddl.html
+or http://www.netbeans.org/cddl.txt.
+    When distributing Covered Code, include this CDDL Header Notice in each file
+and include the License file at http://www.netbeans.org/cddl.txt.
+If applicable, add the following below the CDDL Header, with the fields
+enclosed by brackets [] replaced by your own identifying information:
+"Portions Copyrighted [year] [name of copyright owner]" */
+
+/*
+ * DeferredWizardResult.java
+ *
+ * Created on September 24, 2006, 3:42 AM
+ *
+ * To change this template, choose Tools | Template Manager
+ * and open the template in the editor.
+ */
+
+package org.netbeans.spi.wizard;
+
+import java.util.Map;
+
+
+/**
+ * Object which can be returned from 
+ * <code>WizardPage.WizardResultProducer.finish()</code>
+ * or <code>WizardPanelProvider.finish()</code>.  A DeferredWizardResult does
+ * not immediately calculate its result;  it is used for cases where some
+ * time consuming work needs to be performed to compute the result (such as
+ * creating files on disk), and a progress bar should be shown until the work
+ * is completed.
+ * @see org.netbeans.spi.wizard.ResultProgressHandle
+ *
+ * @author Tim Boudreau
+ */
+public abstract class DeferredWizardResult {
+    private final boolean canAbort;
+    private final boolean disableUIWhileBusy;
+    /** 
+     * Creates a new instance of DeferredWizardResult which cannot be 
+     * aborted and shows a progress bar.
+     */
+    public DeferredWizardResult() {
+        this(false, false);
+    }
+    
+    /** Creates a new instance of DeferredWizardResult which may or may not
+     * be able to be aborted. 
+     * @param canAbort determine if background computation can be aborted by
+     * calling the <code>abort()</code> method
+     */
+    public DeferredWizardResult (boolean canAbort) {
+        this(canAbort, false);
+    }
+    
+    /** Creates a new instance of DeferredWizardResult which may or may not
+     * be able to be aborted, and which may simply disable the wizard's UI
+     * instead of showing a progress bar while the background work runs.
+     * 
+     * @param canAbort
+     * @param disableUIWhileBusy
+     */
+    public DeferredWizardResult (boolean canAbort, boolean disableUIWhileBusy) {
+        this.canAbort = canAbort;
+        this.disableUIWhileBusy = disableUIWhileBusy;
+    }
+    
+    
+    /** 
+     * Begin computing the result.  This method is called on a background
+     * thread, not the AWT event thread, and computation can immediately begin.
+     * Use the progress handle to set progress as the work progresses. 
+     * 
+     * IMPORTANT: This method MUST call either progress.finished with the result,
+     * or progress.failed with an error message.  If this method returns without
+     * calling either of those methods, it will be assumed to have failed.
+     * 
+     * @param settings The settings gathered over the course of the wizard
+     * @param progress A handle which can be used to affect the progress bar.
+     */
+    public abstract void start (Map settings, ResultProgressHandle progress);
+    
+    /**
+     * If true, the background thread can be aborted.  If it is possible to 
+     * abort, then the UI may allow the dialog to be closed while the result
+     * is being computed.
+     */ 
+    public final boolean canAbort() {
+        return canAbort;
+    }
+    
+    /**
+     * Abort computation of the result.  This method will usually be called on
+     * the event thread, after <code>start()<code> has been called, and before
+     * <code>finished()</code> has been called on the <code>ResultProgressHandle</code>
+     * that is passed to <code>start()</code>, for example, if the user clicks
+     * the close button on the dialog showing the wizard while the result is
+     * being computed.
+     * <p>
+     * <b>This method does <i>nothing</i> by default</b> - it is left empty so
+     * that people who do not want to support aborting background work do not
+     * have to override it.  It is up to the implementor
+     * to set a flag or otherwise notify the background thread to halt 
+     * computation.  A simple method for doing so is as follows:
+     * <pre>
+     * volatile Thread thread;
+     * public void start (Map settings, ResultProgressHandle handle) {
+     * try {
+     *  synchronized (this) {
+     *     thread = Thread.currentThread();
+     *  }
+     *  
+     *  //do the background computation, update progress.  Every so often, 
+     *  //check Thread.interrupted() and exit if true
+     * } finally {
+     *    synchronized (this) {
+     *       thread = null;
+     *    }
+     *  }
+     * }
+     * 
+     * public synchronized void abort() {
+     *  if (thread != null) thread.interrupt();
+     * }
+     * </pre>
+     * or you can use a <code>volatile boolean</code> flag that you set in
+     * <code>abort()</code> and periodically check in the body of <code>start()</code>.
+     * 
+     */ 
+    public void abort() {
+        //do nothing
+    }
+
+    /**
+     * Determine if the UI should be completely disabled while the background
+     * work is running (i.e. you do not want a progress bar, you just want all
+     * navigation disabled [note on some window managers, the user will still
+     * be able to click the dialog's window drag-bar close button, so you still
+     * should override abort() to stop computation if possible]).
+     * 
+     * @return true if no progress bar should be displayed and the UI should
+     * just disable itself
+     */
+    public final boolean disableUIWhileBusy()
+    {
+        return disableUIWhileBusy;
+    }
+    // alias for the above
+    public final boolean isUseBusy()
+    {
+        return disableUIWhileBusy();
+    }
+}

--- a/vassal-app/src/main/java/org/netbeans/spi/wizard/ResultProgressHandle.java
+++ b/vassal-app/src/main/java/org/netbeans/spi/wizard/ResultProgressHandle.java
@@ -1,0 +1,89 @@
+package org.netbeans.spi.wizard;
+
+import java.awt.Container;
+
+/**
+ * A controller for the progress bar shown in the user interface.  Used in
+ * conjunction with <code>DeferredWizardResult</code> for cases where at
+ * the conclusion of the wizard, the work to create the final wizard result
+ * will take a while and needs to happen on a background thread.
+ * @author Tim Boudreau
+ */ 
+public interface ResultProgressHandle {
+    
+    /**
+     * Set the current position and total number of steps.  Note it is
+     * inadvisable to be holding any locks when calling this method, as it
+     * may immediately update the GUI using 
+     * <code>EventQueue.invokeAndWait()</code>.
+     * 
+     * @param currentStep the current step in the progress of computing the
+     * result.
+     * @param totalSteps the total number of steps.  Must be greater than
+     *  or equal to currentStep.
+     */
+    public abstract void setProgress (int currentStep, int totalSteps);
+    
+    /** 
+     * Set the current position and total number of steps, and description 
+     * of what the computation is doing.  Note it is
+     * inadvisable to be holding any locks when calling this method, as it
+     * may immediately update the GUI using 
+     * <code>EventQueue.invokeAndWait()</code>.         
+     * @param description Text to describe what is being done, which can
+     *  be displayed in the UI.
+     * @param currentStep the current step in the progress of computing the
+     *  result.
+     * @param totalSteps the total number of steps.  Must be greater than
+     *  or equal to currentStep.
+     */
+    public abstract void setProgress (String description, int currentStep, int totalSteps);
+    
+    /**
+     * Set the status as "busy" - a rotating icon will be displayed instead
+     * of a percent complete progress bar.
+     * 
+     * Note it is inadvisable to be holding any locks when calling this method, as it
+     * may immediately update the GUI using 
+     * <code>EventQueue.invokeAndWait()</code>.         
+     * @param description Text to describe what is being done, which can
+     *  be displayed in the UI.
+     */
+    public abstract void setBusy (String description);
+    
+    /**
+     * Call this method when the computation is complete, and pass in the 
+     * final result of the computation.  The method doing the computation
+     * (<code>DeferredWizardResult.start()</code> or something it 
+     * called) should exit immediately after calling this method.  If the
+     * <code>failed()</code> method is called after this method has been
+     * called, a runtime exception may be thrown.
+     * @param result the Object which was computed, if any.
+     */ 
+    public abstract void finished(Object result);
+    /**
+     * Call this method if computation fails.  The message may be some text
+     * describing what went wrong, or null if no description.
+     * @param message The text to display to the user. The method 
+     * doing the computation (<code>DeferredWizardResult.start()</code> or something it 
+     * called).  If the <code>finished()</code> method is called after this
+     * method has been called, a runtime exception may be thrown.
+     * should exit immediately after calling this method.
+     * It is A description of what went wrong, or null.
+     * @param canNavigateBack whether or not the Prev button should be 
+     *  enabled.
+     */ 
+    public abstract void failed (String message, boolean canNavigateBack);
+    
+    /**
+     * Add the component to show for the progress display to the instructions panel. 
+     */
+    public abstract void addProgressComponents (Container panel);
+    
+    /**
+     * Returns true if the computation is still running, i.e., if neither finished or failed have been called.
+     *
+     * @return true if there is no result yet.
+     */
+    public boolean isRunning();
+}

--- a/vassal-app/src/main/java/org/netbeans/spi/wizard/SimpleWizard.java
+++ b/vassal-app/src/main/java/org/netbeans/spi/wizard/SimpleWizard.java
@@ -1,0 +1,211 @@
+/*  The contents of this file are subject to the terms of the Common Development
+and Distribution License (the License). You may not use this file except in
+compliance with the License.
+    You can obtain a copy of the License at http://www.netbeans.org/cddl.html
+or http://www.netbeans.org/cddl.txt.
+    When distributing Covered Code, include this CDDL Header Notice in each file
+and include the License file at http://www.netbeans.org/cddl.txt.
+If applicable, add the following below the CDDL Header, with the fields
+enclosed by brackets [] replaced by your own identifying information:
+"Portions Copyrighted [year] [name of copyright owner]" */
+/*
+ * SimpleWizard.java
+ *
+ * Created on February 22, 2005, 2:33 PM
+ */
+
+package org.netbeans.spi.wizard;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import javax.swing.JComponent;
+
+/**
+ * A simple implementation of Wizard for use in wizards which have a 
+ * straightforward set of steps with no branching.  To use, implement the
+ * simplified interface SimpleWizard.Info and pass that to the constructor.
+ *
+ * @see SimpleWizardInfo
+ * @author Tim Boudreau
+ */
+final class SimpleWizard implements WizardImplementation {
+    private final List listenerList = 
+            Collections.synchronizedList (new LinkedList());
+    private final Map ids2panels = new HashMap();
+
+    final SimpleWizardInfo info;
+
+    private String currID = null;
+    private boolean subwizard;
+    
+    public SimpleWizard (WizardPanelProvider prov) {
+        this (new SimpleWizardInfo (prov), false);
+    }
+        
+    /** Creates a new instance of SimpleWizard */
+    public SimpleWizard(SimpleWizardInfo info) {
+        this.info = info;
+        info.setWizard (this);
+    }
+    
+    /** Creates a new instance of SimpleWizard */
+    public SimpleWizard(SimpleWizardInfo info, boolean subwizard) {
+        this.info = info;
+        this.subwizard = subwizard;
+        info.setWizard (this);
+    }    
+
+    public void addWizardObserver (WizardObserver observer) {
+        listenerList.add(observer);
+    }
+    
+    public void removeWizardObserver (WizardObserver observer) {
+        listenerList.remove(observer);
+    }    
+    
+    public int getForwardNavigationMode() {
+        int result = info.getFwdNavMode();
+        if (!subwizard && ((result & WizardController.MODE_CAN_CONTINUE) != 0) && isLastStep()) {
+            result = WizardController.MODE_CAN_FINISH;
+        }
+        return result;
+    }
+    
+    boolean isLastStep() {
+        String[] steps = info.getSteps();
+        return currID != null && steps.length > 0 && currID.equals(steps[steps.length-1]);
+    }
+
+    public String[] getAllSteps() {
+        String[] allSteps = info.getSteps();
+        String[] result = new String[allSteps.length];
+        //Defensive copy
+        System.arraycopy(allSteps, 0, result, 0, allSteps.length);
+        return result;
+    }
+
+    public String getStepDescription(String id) {
+        int idx = Arrays.asList(info.getSteps()).indexOf (id);
+        if (idx == -1) {
+            throw new IllegalArgumentException ("Undefined id: " + id);
+        }
+        return info.getDescriptions()[idx];
+    }
+    
+    public String getLongDescription(String id) {
+        return info.getLongDescription (id);
+    }
+    
+    public JComponent navigatingTo(String id, Map settings) {
+//        assert SwingUtilities.isEventDispatchThread();
+
+        // if info.getSteps() does not yet contain the ID, then create it
+        JComponent result = (JComponent) ids2panels.get(id);
+        currID = id;
+        if (result == null) {
+            result = info.createPanel(id, settings);
+            ids2panels.put (id, result);
+        } else {
+            info.update();
+            info.recycleExistingPanel(id, settings, result);
+        }
+        fireSelectionChanged();
+        return result;
+    }
+
+    public String getCurrentStep() {
+        return currID;
+    }
+
+    public String getNextStep() {
+        if (!info.isValid()) {
+            return null;
+        }
+        if ((info.getFwdNavMode() & WizardController.MODE_CAN_CONTINUE) == 0) {
+            return null;
+        }
+
+        int idx = currentStepIndex();
+        if (idx < info.getSteps().length - 1) {
+            return info.getSteps() [idx + 1];
+        } else {
+            return null;
+        }
+    }
+
+    public String getPreviousStep() {
+        int idx = currentStepIndex();
+        if (idx < info.getSteps().length && idx > 0) {
+            return info.getSteps() [idx - 1];
+        } else {
+            return null;
+        }
+    }
+    
+    int currentStepIndex() {
+        int idx = 0;
+        if (currID != null) {
+            idx = Arrays.asList(info.getSteps()).indexOf (currID);
+        }
+        return idx;
+    }
+
+    void fireNavigability() {
+        WizardObserver[] listeners = (WizardObserver[]) 
+                listenerList.toArray (new WizardObserver[0]);
+
+        for (int i = listeners.length - 1; i >= 0; i --) {
+            WizardObserver l = (WizardObserver) listeners[i];
+            l.navigabilityChanged(null);
+        }
+    }
+
+    private void fireSelectionChanged() {
+        WizardObserver[] listeners = (WizardObserver[]) 
+                listenerList.toArray (new WizardObserver[0]);
+
+        for (int i = listeners.length - 1; i >= 0; i --) {
+            WizardObserver l = (WizardObserver) listeners[i];
+            l.selectionChanged(null);
+        }
+    }
+
+    public Object finish(Map settings) throws WizardException {
+        return info.finish(settings);
+    }
+
+    public boolean cancel(Map settings) {
+        return info.cancel(settings);
+    }
+    
+    public String getTitle() {
+        return info.getTitle();
+    }
+    
+    public String getProblem() {
+        return info.getProblem();
+    }
+    
+    public boolean isBusy() {
+        return info.isBusy();
+    }
+    
+    public int hashCode() {
+        return info.hashCode() ^ 17;
+    }
+    
+    public boolean equals (Object o) {
+        if (o instanceof SimpleWizard) {
+            return ((SimpleWizard) o).info.equals (info);
+        } else {
+            return false;
+        }
+    }
+    
+    public String toString() {
+        return "SimpleWizard for " + info;
+    }
+}

--- a/vassal-app/src/main/java/org/netbeans/spi/wizard/SimpleWizardInfo.java
+++ b/vassal-app/src/main/java/org/netbeans/spi/wizard/SimpleWizardInfo.java
@@ -1,0 +1,342 @@
+/*  The contents of this file are subject to the terms of the Common Development
+and Distribution License (the License). You may not use this file except in
+compliance with the License.
+    You can obtain a copy of the License at http://www.netbeans.org/cddl.html
+or http://www.netbeans.org/cddl.txt.
+    When distributing Covered Code, include this CDDL Header Notice in each file
+and include the License file at http://www.netbeans.org/cddl.txt.
+If applicable, add the following below the CDDL Header, with the fields
+enclosed by brackets [] replaced by your own identifying information:
+"Portions Copyrighted [year] [name of copyright owner]" */
+
+/*
+ * SimpleWizardInfo.java
+ *
+ * Created on March 4, 2005, 9:46 PM
+ */
+
+package org.netbeans.spi.wizard;
+
+import java.awt.Color;
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.lang.ref.WeakReference;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Map;
+import javax.swing.BorderFactory;
+import javax.swing.JComponent;
+import javax.swing.JScrollPane;
+import javax.swing.JTextArea;
+
+/**
+ * Provides information about a simple wizard.  Wraps a 
+ * WizardPanelProvider and provides a connection to the instance of
+ * SimpleWizard created for it, acting as the WizardController for
+ * calls to WizardPanelProvider.createPanel().
+ */
+final class SimpleWizardInfo implements WizardControllerImplementation {
+    private WeakReference wizard = null;
+    private final String[] descriptions;
+    private final String[] steps;
+    final int[] navModeByPanel;
+    private String problem = null;
+    private final String title;
+    private final WizardPanelProvider provider;
+    private boolean busy = false;
+
+    SimpleWizardInfo (WizardPanelProvider provider) {
+        this (provider.title, provider.steps, provider.descriptions, provider);
+    }
+    
+    /**
+     * Create an instance of Info, which will provide panels for a simple,
+     * non-branching wizard, passing a localized title, a list of steps
+     * and descriptions.
+     */
+    protected SimpleWizardInfo (String title, String[] steps, String[] descriptions, WizardPanelProvider provider) {
+        if (steps == null) {
+            throw new NullPointerException ("Null steps");
+        }
+        if (descriptions == null) {
+            throw new NullPointerException ("Null descriptions");
+        }
+        this.steps = steps;
+        this.descriptions = descriptions;
+        if (new HashSet(Arrays.asList(steps)).size() < steps.length) {
+            throw new IllegalArgumentException ("Duplicate ID: " + Arrays.asList(steps));
+        }
+        if (descriptions.length != steps.length) {
+            if (steps.length != descriptions.length + 1 && !WizardImplementation.UNDETERMINED_STEP.equals(steps[steps.length-1])) {
+                throw new IllegalArgumentException ("Steps and descriptions " +
+                        "array lengths not equal: " + Arrays.asList(steps) + ":"
+                        + Arrays.asList(descriptions));
+            }
+        }
+        navModeByPanel = new int [steps.length];
+        Arrays.fill (navModeByPanel, -1);
+        this.title = title;
+        this.provider = provider;
+    }
+
+
+    final void setWizard (SimpleWizard wizard) {
+        this.wizard = new WeakReference(wizard);
+    }
+
+    final SimpleWizard getWizard() {
+        return wizard != null ? (SimpleWizard) wizard.get() : null;
+    }
+    
+    final SimpleWizard createWizard() {
+        return new SimpleWizard(this);
+    }
+   
+    //pkg private for unit tests
+    final WizardController controller = new WizardController(this);
+    /**
+     * Create a panel that represents a named step in the wizard.
+     * This method will be called exactly <i>once</i> in the life of 
+     * a wizard.  The panel should retain the passed settings Map, and
+     * add/remove values from it as the user enters information, calling
+     * <code>setProblem()</code> and <code>setCanFinish()</code> as
+     * appropriate in response to user input.
+     * 
+     * @param id The name of the step, as supplied in the constructor
+     * @param settings A Map containing settings from earlier steps in
+     *   the wizard
+     * @return A JComponent
+     */
+    protected JComponent createPanel (String id, Map settings) {
+        try {
+            JComponent result = provider.createPanel(controller, id, settings);
+            if (result instanceof WizardPage) {
+                ((WizardPage) result).setController(controller);
+                ((WizardPage) result).setWizardDataMap(settings);
+            }
+            return result;
+        } catch (RuntimeException re) {
+            JTextArea jta = new JTextArea();
+            jta.setBorder (BorderFactory.createMatteBorder(2,2,2,2,Color.RED));
+            ByteArrayOutputStream buf = new ByteArrayOutputStream();
+            PrintStream str = new PrintStream(buf);
+            re.printStackTrace(str);
+            jta.setText (new String(buf.toByteArray()));
+            setProblem(re.getLocalizedMessage());
+            return new JScrollPane(jta);
+        }
+    }
+
+    /**
+     * Instantiate whatever object (if any) the wizard creates from its
+     * gathered data.
+     */
+    protected Object finish (Map settings) throws WizardException {
+        //XXX fixme
+//        assert canFinish();
+        
+        // SKNUTSON: the "canFinish" behavior is not working
+        // instead, panels must implement the WizardPanel interface
+        // and have allowFinish return false
+//        if ( ! canFinish())
+//        {
+//            throw new RuntimeException ("Can't finish right now");
+//        }
+        return provider.finish (settings);
+    }
+    
+    public String getLongDescription (String id) {
+        return provider.getLongDescription (id);
+    }
+
+    /**
+     * The method provides a chance to call setProblem() or setCanFinish() when
+     * the user re-navigates to a panel they've already seen - in the case 
+     * that the user pressed the Previous button and then the Next button.
+     * <p>
+     * The default implementation does nothing, which is sufficient for 
+     * most implementations.  If whether this panel is valid or not could
+     * have changed because of changed data from a previous panel,
+     * you may want to override this method to ensure validity and currNavMode
+     * are set correctly.
+     * <p>
+     * This method will <i>not</i> be called when a panel is first instantiated - 
+     * <code>createPanel()</code> is expected to set validity and currNavMode
+     * appropriately.
+     * <p>
+     * The settings Map passed to this method will always be the same 
+     * Settings map instance that was passed to <code>createPanel()</code>
+     * when the panel was created.
+     */
+    protected void recycleExistingPanel (String id, Map settings, JComponent panel) {
+        provider.recycle(id, controller, settings, panel);
+    }
+
+    private int index() {
+        SimpleWizard wizard = getWizard();
+        if (wizard != null) {
+            return wizard.currentStepIndex();
+        } else {
+            return 0;
+        }
+    }
+
+    public final void setBusy (boolean value) {
+        if (value != busy) {
+            busy = value;
+            fire();
+        }
+    }
+    
+    /**
+     * Set whether or not the contents of this panel are valid.  When
+     * user-entered information in a panel changes, call this method as
+     * appropriate.
+     */
+    public final void setProblem (String value) {
+        this.problem = value;
+        int idx = index();
+        provider.setKnownProblem(problem, idx);
+        fire();
+    }
+
+    private int currNavMode = WizardController.MODE_CAN_CONTINUE;
+
+    /**
+     * Set whether or not the Finish button should be enabled.  Neither 
+     * the Finish nor Next buttons will be enabled if setProblem has 
+     * been called with non-null.
+     * <p>
+     * Legal values are: WizardController.MODE_CAN_CONTINUE,
+     * WizardController.MODE_CAN_FINISH or 
+     * WizardController.MODE_CAN_CONTINUE_OR_FINISH.
+     * <p>
+     * This method is used to set what means of forward navigation should
+     * be available if the current panel is in a valid state (problem is
+     * null).  It is <i>not</i> a way to disable both the next button 
+     * and the finish button, only a way to choose either or both.
+     * 
+     * @param value The forward navigation mode
+     * @see setProblem
+     */
+    public final void setForwardNavigationMode (int value) {
+        switch (value) {
+            case WizardController.MODE_CAN_CONTINUE :
+            case WizardController.MODE_CAN_FINISH :
+            case WizardController.MODE_CAN_CONTINUE_OR_FINISH :
+                break;
+            default :
+                throw new IllegalArgumentException (Integer.toString(value));
+        }
+        if (currNavMode != value) {
+            currNavMode = value;
+            fire();
+        }
+        navModeByPanel[index()] = value;
+    }
+    
+    public final int getFwdNavMode() {
+        return currNavMode;
+    }
+
+    final String getTitle() {
+        return title;
+    }
+
+    final void update() {
+        int idx = index();
+        boolean change = navModeByPanel[idx] != -1 && currNavMode != navModeByPanel[idx];
+        setProblem (provider.getKnownProblem(idx));
+        currNavMode = navModeByPanel[idx] == -1 ? WizardController.MODE_CAN_CONTINUE : navModeByPanel[idx];
+        if (change) {
+            fire();
+        }
+    }
+    
+    final void fire() {
+        WizardImplementation wiz = getWizard();
+        if (wiz != null) {
+            getWizard().fireNavigability();
+        }
+    }
+
+    final boolean isValid() {
+        return getProblem() == null;
+    }
+
+    final boolean canFinish() {
+        return isValid() && (currNavMode != -1 && (currNavMode & 
+                WizardController.MODE_CAN_FINISH) != 0);
+    }
+    
+    final boolean canContinue() {
+        return isValid() && (currNavMode == -1 || (currNavMode & 
+                WizardController.MODE_CAN_CONTINUE) != 0);
+    }
+
+    String[] getDescriptions() {
+        return descriptions;
+    }
+
+    String[] getSteps() {
+        return steps;
+    }
+    
+    // lookup the step by name
+    boolean containsStep (String name)
+    {
+        for (int i = 0; i < steps.length; i++)
+        {
+            String step = steps[i];
+            if (name.equals(step))
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    final String getProblem() {
+        return problem;
+    }
+    
+    boolean isBusy() {
+        return busy;
+    }
+    
+    public boolean equals (Object o) {
+        if (o != null && o.getClass() == getClass()) {
+            SimpleWizardInfo info = (SimpleWizardInfo) o;
+            
+            // assert info.descriptions != null : "Info.descriptions == null";
+            // assert info.steps != null : "Info.steps == null";
+            if (info.descriptions == null || info.steps == null)
+            {
+                throw new RuntimeException ("Invalid info object");
+            }
+
+            return Arrays.equals(info.descriptions, descriptions) &&
+                   Arrays.equals(info.steps, steps) &&
+                   info.title == title;
+        } else {
+            return false;
+        }
+    }
+    
+    public int hashCode() {
+        int result = 0;
+        for (int i=0; i < steps.length; i++) {
+            result += (steps[i].hashCode() * (i+1)) ^ 31;
+        }
+        return result + (title == null ? 0 : title.hashCode());
+    }    
+
+    boolean cancel(Map settings) {
+        return provider.cancel(settings);
+    }
+    
+    public String toString() {
+        return "SimpleWizardInfo@" + System.identityHashCode(this) + " for " +
+                provider;
+    }
+}

--- a/vassal-app/src/main/java/org/netbeans/spi/wizard/Summary.java
+++ b/vassal-app/src/main/java/org/netbeans/spi/wizard/Summary.java
@@ -1,0 +1,149 @@
+/*  The contents of this file are subject to the terms of the Common Development
+and Distribution License (the License). You may not use this file except in
+compliance with the License.
+    You can obtain a copy of the License at http://www.netbeans.org/cddl.html
+or http://www.netbeans.org/cddl.txt.
+    When distributing Covered Code, include this CDDL Header Notice in each file
+and include the License file at http://www.netbeans.org/cddl.txt.
+If applicable, add the following below the CDDL Header, with the fields
+enclosed by brackets [] replaced by your own identifying information:
+"Portions Copyrighted [year] [name of copyright owner]" */
+/*
+ * Summary.java
+ *
+ * Created on September 24, 2006, 4:05 AM
+ *
+ * To change this template, choose Tools | Template Manager
+ * and open the template in the editor.
+ */
+
+package org.netbeans.spi.wizard;
+
+import java.awt.Component;
+import java.awt.Font;
+import javax.swing.JList;
+import javax.swing.JScrollPane;
+import javax.swing.JTextArea;
+import javax.swing.UIManager;
+
+/**
+ * Object which may be returned from <code>WizardPage.WizardResultProducer.finish()</code>
+ * or <code>WizardPanelProvider.finish()</code>, or passed to 
+ * <code>DeferredWizardResult.ResultProgressHandle.finish()</code>.  If an 
+ * instance of <code>Summary</code> is used, then the UI should, rather 
+ * than disappearing, show the component provided by the <code>Summary</code> 
+ * object.  Convenience constructors are provided for plain text and list style
+ * views.
+ *
+ * @author Tim Boudreau
+ */
+public class Summary {
+    private final Component comp;
+    private Object result;
+    
+    //constructors package private - only unit tests should be able to subclass
+    //Summary
+    
+    Summary(String text, Object result) {
+        //XXX this is creating components off the AWT thread - needs to change
+        //to use invokeAndWait where appropriate
+        if (text == null) {
+            throw new NullPointerException ("Text is null"); //NOI18N
+        }
+        if (text.trim().length() == 0) {
+            throw new IllegalArgumentException ("Text is empty or all " + //NOI18N
+                    "whitespace"); //NOI18N
+        }
+        this.result = result;
+        JTextArea jta = new JTextArea();
+        jta.setText (text);
+        jta.setWrapStyleWord(true);
+        jta.setLineWrap(true);
+        jta.getCaret().setBlinkRate(0);
+        jta.setEditable(false);
+        jta.getCaret().setVisible(true);
+        Font f = UIManager.getFont ("Label.font");
+        if (f != null) { //may be on old GTK L&F, etc.
+            jta.setFont (f);
+        }
+        comp = new JScrollPane (jta);
+    }
+    
+    Summary(String[] items, Object result) {
+        if (items == null) {
+            throw new NullPointerException ("Items array null"); //NOI18N
+        }
+        if (items.length == 0) {
+            throw new IllegalArgumentException ("Items array empty"); //NOI18N
+        }
+        this.result = result;
+        JList list = new JList(items);
+        comp = new JScrollPane (list);
+    }
+    
+    Summary(Component comp, Object result) {
+        this.result = result;
+        this.comp = comp;
+        if (comp == null) {
+            throw new NullPointerException ("Null component"); //NOI18N
+        }
+    }
+    
+    /**
+     * Create a <code>Summary</code> object that will display the passed 
+     * <code>String</code>s in a <code>JList</code> or similar.
+     * @param items A non-null list of one or more Strings to be displayed
+     * @param result The result that should be returned when the Wizard is 
+     *  closed
+     * @return the requested <code>Summary</code> object
+     */ 
+    public static Summary create (String[] items, Object result) {
+        return new Summary (items, result);
+    }
+    
+    /**
+     * Create a <code>Summary</code> object that will display the passed component.
+     * @param comp A custom component to show on the summary page after the
+     *  Wizard has been completed
+     * @param result The result that should be returned when the <code>Wizard</code> is 
+     *  closed
+     * @return the requested <code>Summary</code> object
+     */ 
+    public static Summary create (Component comp, Object result) {
+        return new Summary (comp, result);
+    }
+    
+    /**
+     * Create a <code>Summary</code> object which will display the 
+     * passed <code>String</code> in a text component of some sort.
+     * @param text The text to display - must be non-null, greater than zero
+     *  length and not completely whitespace
+     * @param result The result that should be returned when the Wizard is 
+     *  closed
+     * @return the requested <code>Summary</code> object
+     */ 
+    public static Summary create (String text, Object result) {
+        return new Summary (text, result);
+    }
+    
+    /**
+     * Get the component that will display the summary information.
+     * @return an appropriate component, the type of which may differ depending
+     *  on the factory method used to create this component
+     */ 
+    public Component getSummaryComponent() {
+        return comp;
+    }
+    
+    /**
+     * Get the object that represents the actual result of whatever the <code>Wizard</code>
+     * that created this <code>Summary</code> object computes.  Note this method may not
+     * return another instance of <code>Summary</code> or an instance of 
+     * <code>DeferredWizardResult</code>.
+     * @return the object passed to the factory method that created this 
+     *  Summary object, or null.
+     */ 
+    public Object getResult() {
+        return result;
+    }
+}

--- a/vassal-app/src/main/java/org/netbeans/spi/wizard/Util.java
+++ b/vassal-app/src/main/java/org/netbeans/spi/wizard/Util.java
@@ -1,0 +1,174 @@
+/*
+ * To change this template, choose Tools | Templates
+ * and open the template in the editor.
+ */
+
+package org.netbeans.spi.wizard;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ *
+ * @author Tim Boudreau
+ */
+final class Util {
+    private Util(){}
+    
+    /**
+     * Get an array of step ids from an array of WizardPages
+     */
+    static String[] getSteps(WizardPage[] pages) {
+        String[] result = new String[pages.length];
+
+        Set uniqueNames = new HashSet(pages.length);
+        for (int i = 0; i < pages.length; i++) {
+            result[i] = pages[i].id();
+            if (result[i] == null || uniqueNames.contains(result[i])) {
+                result[i] = uniquify (getIDFromStaticMethod(pages[i].getClass()), 
+                        uniqueNames);
+                pages[i].id = result[i];
+            }
+            uniqueNames.add (result[i]);
+        }
+        return result;
+    }
+    
+    static String uniquify (String s, Set /* <String> */ used) {
+        String test = s;
+        if (test != null) {
+            int ix = 0;
+            while (used.contains(test)) {
+                test = s + "_" + ix++;
+            }
+        }
+        return test;
+    }
+
+    /**
+     * Get an array of descriptions from an array of WizardPages
+     */
+    static String[] getDescriptions(WizardPage[] pages) {
+        String[] result = new String[pages.length];
+
+        for (int i = 0; i < pages.length; i++) {
+            result[i] = pages[i].description();
+            if (result[i] == null) {
+                result[i] = getDescriptionFromStaticMethod (pages[i].getClass());
+            }
+        }
+
+        return result;
+    }
+
+    static String getIDFromStaticMethod (Class clazz) {
+        // System.err.println("GetID by method for " + clazz);
+        String result = null;
+        try {
+            Method m = clazz.getDeclaredMethod("getStep", new Class[] {});
+            // assert m.getReturnType() == String.class;
+            result = (String) m.invoke(clazz, (Object[]) null);
+            if (result == null) {
+                throw new NullPointerException ("getStep may not return null");
+            }
+        } catch (Exception ex) {
+            //do nothing
+        }
+        return result == null ? clazz.getName() : result;
+    }
+
+    /**
+     * Get an array of steps by looking for a static method getID() on each
+     * class object passed
+     */
+    static String[] getSteps(Class[] pages) {
+        if (pages == null) {
+            throw new NullPointerException("Null array of classes"); //NOI18N
+        }
+
+        String[] result = new String[pages.length];
+
+        Set used = new HashSet (pages.length);
+        for (int i = 0; i < pages.length; i++) {
+            if (pages[i] == null) {
+                throw new NullPointerException("Null at " + i + " in array " + //NOI18N
+                        "of panel classes"); //NOI18N
+            }
+
+            if (!WizardPage.class.isAssignableFrom(pages[i])) {
+                throw new IllegalArgumentException(pages[i] +
+                        " is not a subclass of WizardPage"); //NOI18N
+            }
+            result[i] = uniquify (getIDFromStaticMethod (pages[i]), used);
+            if (result[i] == null) {
+                result[i] = pages[i].getName();
+            }
+        }
+        // System.err.println("Returning " + Arrays.asList(result));
+        return result;
+    }
+
+//    /** Determine if a default constructor is present for a class */
+//    private static boolean hasDefaultConstructor (Class clazz) {
+//        try {
+//            Constructor c = clazz.getConstructor(new Class[0]);
+//            return c != null;
+//        } catch (Exception e) {
+//            return false;
+//        }
+//    }
+
+    /**
+     * Get an array of descriptions by looking for the static method
+     * getDescription() on each passed class object
+     */
+    static String[] getDescriptions(Class[] pages) {
+        String[] result = new String[pages.length];
+
+        for (int i = 0; i < pages.length; i++) {
+            result[i] = getDescriptionFromStaticMethod(pages[i]);
+        }
+
+        return result;
+    }
+
+    static String getDescriptionFromStaticMethod(Class clazz) {
+        String result = null;
+        Method m;
+        try {
+            m = clazz.getDeclaredMethod("getDescription", (Class[]) null); //NOI18N
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Could not find or access " + //NOI18N
+                    "public static String " + clazz.getName() +  //NOI18N
+                    ".getDescription() - make sure it exists"); //NOI18N
+        }
+
+        if (m.getReturnType() != String.class) {
+            throw new IllegalArgumentException("getStep has wrong " //NOI18N
+                    + " return type: " + m.getReturnType() + " on " + //NOI18N
+                    clazz);
+        }
+
+        if (!Modifier.isStatic(m.getModifiers())) {
+            throw new IllegalArgumentException("getStep is not " + //NOI18N
+                    "static on " + clazz); //NOI18N
+        }
+
+        try {
+            m.setAccessible(true);
+            result= (String) m.invoke(null, (Object[]) null);
+        } catch (InvocationTargetException ite) {
+            throw new IllegalArgumentException("Could not invoke " + //NOI18N
+                    "public static String " + clazz.getName() +  //NOI18N
+                    ".getDescription() - make sure it exists."); //NOI18N
+        } catch (IllegalAccessException iae) {
+            throw new IllegalArgumentException("Could not invoke " + //NOI18N
+                    "public static String " + clazz.getName() +  //NOI18N
+                    ".getDescription() - make sure it exists."); //NOI18N
+        }
+        return result;
+    }
+}

--- a/vassal-app/src/main/java/org/netbeans/spi/wizard/Wizard.java
+++ b/vassal-app/src/main/java/org/netbeans/spi/wizard/Wizard.java
@@ -1,0 +1,364 @@
+/*  The contents of this file are subject to the terms of the Common Development
+and Distribution License (the License). You may not use this file except in
+compliance with the License.
+    You can obtain a copy of the License at http://www.netbeans.org/cddl.html
+or http://www.netbeans.org/cddl.txt.
+    When distributing Covered Code, include this CDDL Header Notice in each file
+and include the License file at http://www.netbeans.org/cddl.txt.
+If applicable, add the following below the CDDL Header, with the fields
+enclosed by brackets [] replaced by your own identifying information:
+"Portions Copyrighted [year] [name of copyright owner]" */
+
+package org.netbeans.spi.wizard;
+
+import java.awt.Rectangle;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import javax.swing.Action;
+import javax.swing.JComponent;
+import org.netbeans.api.wizard.WizardDisplayer;
+
+/**
+ * Encapsulates the logic and state of a Wizard.  A Wizard gathers information
+ * into a Map, and then performs some action with that information when the
+ * user clicks Finish.  To display a wizard, pass it to one of the methods
+ * on <code>WizardDisplayer.getDefault()</code>.
+ * <p>
+ * A Wizard is a series of one or more steps represented
+ * by panels in the user interface.  Each step is identified by a unique String ID.
+ * Panels are created, usually on-demand, as the user navigates through
+ * the UI of the wizard.  Panels typically listen on components they contain
+ * and put values into the Map where the wizard gathers data.  Note that if the
+ * user navigates <i>backward</i>, data entered on pages after the current one
+ * disappears from the Map.
+ * <p>
+ * To create a Wizard, you do not implement or instantiate this class directly,
+ * but rather, use one of the convenience classes in this package.  There are
+ * three:
+ * <ul>
+ * <li><code>WizardPage</code> - use or subclass WizardPage, and pass an array
+ * of instances, or an array of the <code>Class</code> objects of your subclasses
+ * to <code>WizardPage.createWizard()</code>.  This class offers the added
+ * convenience that standard Swing components will be listened to automatically,
+ * and if their Name property is set, the value from the component will be
+ * automatically put into the settings map. 
+ * </li>
+ *
+ * <li><code>WizardPanelProvider</code> - subclass this to create a Wizard
+ * with a fixed set of steps.  You provide a set of unique ID strings to the
+ * constructor, for all of the steps in the wizard, and override
+ * createPanel() to create the GUI component that should be displayed for
+ * each step - it will be called on demand as the user moves through the
+ * wizard</li>
+ *
+ * <li><code>WizardBranchController</code> - this is for creating complex
+ * wizards with decision points after which the future steps change, depending
+ * on what the user chooses.  Create a simple wizard using WizardPage or
+ * WizardPanelProvider to represent the initial steps.
+ * Then override <code>getWizardForStep()</code> or
+ * <code>getPanelProviderForStep()</code> to return a different Wizard to
+ * represent the remaining steps at any point where the set of future steps
+ * changes.  You can have as many branch points as you want, simply by
+ * using WizardBranchController to create the wizards for different decision
+ * points.
+ * <p>
+ * In other words, a wizard with a different set of panels (or number of steps)
+ * depending on the user's decision is really three wizards composed into one -
+ * one wizard that provides the initial set of steps, and then two others, one
+ * or the other of which will actually provide the steps/panels after the
+ * decision point (the Wizards are created on demand, for efficiency, so if
+ * the user never changes his or her mind at the decision point, only two
+ * of the three Wizards are ever actually created).
+ * </li></ul>
+ *
+ * @see org.netbeans.api.wizard.WizardDisplayer
+ * @see WizardPage
+ * @see WizardPanelProvider
+ * @see WizardBranchController
+ *
+ * @author Timothy Boudreau
+ */
+public final class Wizard {
+    /**
+     * Constant that can be returned by <code>getForwardNavigationMode()</code>
+     * to indicate that the Next button can be enabled (or the Finish button
+     * if the current panel is the last one in the wizard).
+     */ 
+    public static final int MODE_CAN_CONTINUE = 
+            WizardController.MODE_CAN_CONTINUE;
+
+    /**
+     * Constant that can be returned by <code>getForwardNavigationMode</code> to indicate
+     * that the Finish button can be enabled if the problem string is null.
+     */
+    public static final int MODE_CAN_FINISH =
+            WizardController.MODE_CAN_FINISH;
+    /**
+     * Constant that can be returned by <code>getForwardNavigationMode</code> to indicate
+     * that both the Finish and Next buttons can be enabled if the problem 
+     * string is null.  This value is a bitmask - i.e. 
+     * <code>MODE_CAN_CONTINUE_OR_FINISH == MODE_CAN_CONTINUE | 
+     * MODE_CAN_FINISH</code>
+     */
+    public static final int MODE_CAN_CONTINUE_OR_FINISH = 
+            WizardController.MODE_CAN_CONTINUE_OR_FINISH;
+    
+    /**
+     * Special panel ID key indicating a branch point in the wizard,
+     * after which the next step(s) are unknown.
+     */
+    public static final String UNDETERMINED_STEP = "_#UndeterminedStep";
+    
+
+    final WizardImplementation impl; //package private for unit tests
+    
+    /** Creates a new instance of Wizard */
+    Wizard(WizardImplementation impl) {
+        this.impl = impl;
+        if (impl == null) {
+            throw new NullPointerException();
+        }
+    }
+
+    /**
+     * Notify the wizard that the user is navigating to a different panel,
+     * as identified by the passed <code>id</code>.
+     * @param id The id of the panel being navigated to
+     * @param wizardData The data gathered thus far as the user has progressed
+     *  through the wizard.  The contents of this map should not contain any
+     *  key/values that were assigned on future panels, if the user is 
+     *  navigating backward.
+     * @return The component that should be shown for step <code>id</code>
+     *  of the <code>Wizard</code>
+     */ 
+    public JComponent navigatingTo(String id, Map wizardData) {
+        return impl.navigatingTo(id, wizardData);
+    }
+
+    /**
+     * Get the current step the wizard is on, as determined by the most recent
+     * call to <code>navigatingTo()</code>.
+     */ 
+    public String getCurrentStep() {
+        return impl.getCurrentStep();
+    }
+
+    /**
+     * Get the id of the step that comes after current step returned by
+     * <code>getCurrentStep()</code>.
+     * @return Null if this is the last step of the wizard;  
+     * <code>UNDETERMINED_STEP</code> if this is a branch point and the
+     * user yet needs to do some interaction with the UI of the current
+     * panel to trigger computation of the id of the next step;  otherwise,
+     * the unique id of the next step.
+     */ 
+    public String getNextStep() {
+        return impl.getNextStep();
+    }
+
+    /**
+     * Get the id of the preceding step to the current one as returned by
+     * <code>getCurrentStep()</code>, or null if the current step is the 
+     * first page of the wizard.
+     * @return the id of the previous step or null
+     */ 
+    public String getPreviousStep() {
+        return impl.getPreviousStep();
+    }
+
+    /**
+     * Get the problem string that should be displayed to the user.
+     * @return A string describing what the user needs to do to enable
+     * the Next or Finish buttons, or null if the buttons may be enabled
+     */ 
+    public String getProblem() {
+        return impl.getProblem();
+    }
+
+    /**
+     * Get the string IDs of all known steps in this wizard, terminating
+     * with <code>UNDETERMINED_STEP</code> if subsequent steps of the
+     * wizard depend on the user's interaction beyond that point.
+     * @return an array of strings which may individually be passed to
+     *   <code>navigatingTo</code> to change the current step of the wizard
+     */ 
+    public String[] getAllSteps() {
+        return impl.getAllSteps();
+    }
+    
+    /**
+     * Get a long description for this panel.  The long description should be
+     * used in preference to the short description in the top of a wizard
+     * panel in the UI, if it returns non-null.
+     * @param stepId The ID of the step for which a description is requested
+     * @return A more detailed localized description or null
+     */ 
+    public String getLongDescription(String stepId) {
+        return impl.getLongDescription (stepId);
+    }
+
+    /**
+     * Get a localized String description of the step for the passed id,
+     * which may be displayed in the UI of the wizard.
+     * @param id A step id among those returned by <code>getAllSteps()</code>
+     */ 
+    public String getStepDescription(String id) {
+        return impl.getStepDescription(id);
+    }
+
+    /**
+     * Called when the user has clicked the finish button.  This method
+     * computes whatever the result of the wizard is.
+     * @param settings The complete set of key-value pairs gathered by the
+     *   various panels as the user proceeded through the wizard
+     * @return An implementation-dependent object that is the outcome of
+     *  the wizard.  May be null.  Special return values are instances of
+     *  DeferredWizardResult and Summary which will affect the behavior of
+     *  the UI.
+     */ 
+    public Object finish(Map settings) throws WizardException {
+        return impl.finish(settings);
+    }
+
+    /**
+     * Called when the user has clicked the Cancel button in the wizard UI
+     * or otherwise closed the UI component without completing the wizard.
+     * @param settings The (possibly incomplete) set of key-value pairs gathered by the
+     *   various panels as the user proceeded through the wizard
+     * @return true if the UI may indeed be closed, false if closing should
+     *   not be permitted
+     */ 
+    public boolean cancel (Map settings) {
+        return impl.cancel(settings);
+    }
+
+    /**
+     * Get the title of the Wizard that should be displayed in its dialog
+     * titlebar (if any).
+     * @return A localized string
+     */ 
+    public String getTitle() {
+        return impl.getTitle();
+    }
+
+    /**
+     * Determine if the wizard is busy doing work in a background thread and
+     * all navigation controls should be disabled.
+     * @return whether or not the wizard is busy
+     */ 
+    public boolean isBusy() {
+        return impl.isBusy();
+    }
+
+    /**
+     * Get the navigation mode, which determines the enablement state of
+     * the Next and Finish buttons.
+     * @return one of the constants <code>MODE_CAN_CONTINUE</code>,
+     * <code>MODE_CAN_FINISH</code>, or <code>MODE_CAN_CONTINUE_OR_FINISH</code>.
+     */ 
+    public int getForwardNavigationMode() {
+        return impl.getForwardNavigationMode();
+    }
+
+    private volatile boolean listeningToImpl = false;
+    private final List listeners = Collections.synchronizedList (
+            new LinkedList());
+
+    private WizardObserver l = null;
+    /**
+     * Add a WizardObserver that will be notified of navigability and step
+     * changes.
+     * @param observer A WizardObserver
+     */ 
+    public void addWizardObserver(WizardObserver observer) {
+        listeners.add(observer);
+        if (!listeningToImpl) {
+            l = new ImplL();
+            impl.addWizardObserver(l);
+            listeningToImpl = true;
+        }
+    }
+
+    /**
+     * Remove a WizardObserver.
+     * @param observer A WizardObserver
+     */ 
+    public void removeWizardObserver(WizardObserver observer) {
+        listeners.remove(observer);
+        if (listeningToImpl && listeners.size() == 0) {
+            impl.removeWizardObserver(l);
+            l = null;
+            listeningToImpl = false;
+        }
+    }
+
+    private class ImplL implements WizardObserver {
+        public void stepsChanged(Wizard wizard) {
+            WizardObserver[] l = (WizardObserver[]) listeners.toArray(
+                    new WizardObserver[listeners.size()]);
+            for (int i = 0; i < l.length; i++) {
+                l[i].stepsChanged(Wizard.this);
+            }
+        }
+
+        public void navigabilityChanged(Wizard wizard) {
+            WizardObserver[] l = (WizardObserver[]) listeners.toArray(
+                    new WizardObserver[listeners.size()]);
+            for (int i = 0; i < l.length; i++) {
+                l[i].navigabilityChanged(Wizard.this);
+            }
+        }
+
+        public void selectionChanged(Wizard wizard) {
+            WizardObserver[] l = (WizardObserver[]) listeners.toArray(
+                    new WizardObserver[listeners.size()]);
+            for (int i = 0; i < l.length; i++) {
+                l[i].selectionChanged(Wizard.this);
+            }
+        }
+    }
+
+    public int hashCode() {
+        return impl.hashCode() * 17;
+    }
+
+    public boolean equals (Object o) {
+        if (o == this) {
+            return true;
+        } else if (o instanceof Wizard) {
+            return impl.equals (((Wizard)o).impl);
+        } else {
+            return false;
+        }
+    }
+
+    /**
+     * Delegates to WizardDisplayer.showWizard()
+     */ 
+    public void show () {
+        WizardDisplayer.showWizard(this);
+    }
+
+    /**
+     * Delegates to WizardDisplayer.showWizard()
+     */ 
+    public Object show (Wizard wizard, Action help) {
+        return WizardDisplayer.showWizard (wizard, help);
+    }
+
+    /**
+     * Delegates to WizardDisplayer.showWizard()
+     */ 
+    public Object show (Wizard wizard, Rectangle r) {
+        return WizardDisplayer.showWizard (wizard, r);
+    }
+
+    /**
+     * Delegates to WizardDisplayer.showWizard()
+     */ 
+    public Object show (Wizard wizard, Rectangle r, Action help) {
+        return WizardDisplayer.showWizard (wizard, r, help, null);
+    }
+}

--- a/vassal-app/src/main/java/org/netbeans/spi/wizard/WizardBranchController.java
+++ b/vassal-app/src/main/java/org/netbeans/spi/wizard/WizardBranchController.java
@@ -1,0 +1,164 @@
+/*  The contents of this file are subject to the terms of the Common Development
+and Distribution License (the License). You may not use this file except in
+compliance with the License.
+    You can obtain a copy of the License at http://www.netbeans.org/cddl.html
+or http://www.netbeans.org/cddl.txt.
+    When distributing Covered Code, include this CDDL Header Notice in each file
+and include the License file at http://www.netbeans.org/cddl.txt.
+If applicable, add the following below the CDDL Header, with the fields
+enclosed by brackets [] replaced by your own identifying information:
+"Portions Copyrighted [year] [name of copyright owner]" */
+/*
+ * WizardBranchController.java
+ *
+ * Created on March 5, 2005, 6:33 PM
+ */
+
+package org.netbeans.spi.wizard;
+import java.util.Map;
+
+/**
+ * Extend this class to create wizards which have branch points in them - 
+ * either override <code>getWizardForStep</code> to return one or another a wizard which
+ * represents the subsequent steps after a decision point, or override 
+ * <code>getPanelProviderForStep</code> to provide instances of <code>WizardPanelProvider</code>
+ * if there are no subsequent branch points and the continuation is a 
+ * simple wizard.
+ * <p>
+ * The basic idea is to supply a base wizard for the initial steps, stopping
+ * at the branch point.  The panel for the branch point should put enough
+ * information into the settings map that the WizardBranchController can 
+ * decide what to return as the remaining steps of the wizard.
+ * <p>
+ * The result is a <code>Wizard</code> which embeds sub-wizards; when the 
+ * <code>PanelProvider</code> passed to the constructor runs out of steps,
+ * the master <code>Wizard</code> will try to find a sub-<code>Wizard</code>
+ * by calling <code>getWizardForStep</code>.  If non-null, the user seamlessly
+ * continues in the returned wizard.  To create <code>Wizard</code>s with 
+ * multiple branches, simply override <code>getWizardForStep</code> to create
+ * another <code>WizardBranchController</code> and return the result of its
+ * <code>createWizard</code> method.
+ * <p>
+ * Note that it is important to cache the instances of <code>WizardPanelProvider</code>
+ * or <code>Wizard</code> which are returned here - this class's methods may
+ * be called frequently to determine if the sequence of steps (the next wizard)
+ * have changed.
+ * 
+ * @author Tim Boudreau
+ */
+public abstract class WizardBranchController {
+    private final SimpleWizardInfo base;
+
+    /**
+     * Create a new WizardBranchController.  The <code>base</code> argument
+     * provides the initial step(s) of the wizard up; when the user comes to
+     * the last step of the base wizard, this WizardBranchController will be
+     * asked for a wizard to provide subsequent panes.  So the base wizard
+     * should put some token into the settings map based on what the user
+     * selects on its final pane, which the WizardBranchController can use
+     * to decide what the next steps should be.
+     */
+    protected WizardBranchController (WizardPanelProvider base) {
+        this (new SimpleWizardInfo (base));
+    }
+
+    /**
+     * Create a new WizardBranchController using the passed WizardPage
+     * instances as the initial pages of the wizard.
+     * @param pages An array of WizardPage instances
+     */ 
+    protected WizardBranchController (WizardPage[] pages) {
+        this (WizardPage.createWizardPanelProvider(pages));
+    }
+
+    /**
+     * Create a new WizardBranchController using the passed WizardPage
+     * as the initial page of the wizard.  The initial page should
+     * determine the subsequent steps of the wizard.
+     * @param onlyPage An instance of WizardPage
+     */ 
+    protected WizardBranchController (WizardPage onlyPage) {
+        this (WizardPage.createWizardPanelProvider(onlyPage));
+    }    
+    /**
+     * Create a new WizardBranchController, using the passed <code>SimpleWizardInfo</code>
+     * for the initial panes of the wizard.
+     */
+    WizardBranchController (SimpleWizardInfo base) {
+        if (base == null) throw new NullPointerException ("No base");
+        this.base = base;
+    }
+    
+    /**
+     * Get the wizard which represents the subsequent panes after this step.
+     * The UI for the current step should have put sufficient data into the
+     * settings map to decide what to return;  return null if not.
+     * <p>
+     * The default implementation delegates to <code>getPanelProviderForStep()</code>
+     * and returns a <code>Wizard</code> representing the result of that
+     * call.  
+     * <p>
+     * <b>Note:</b>  This method can be called very frequently, to determine
+     * if the sequence of steps has changed - so it needs to run fast.  
+     * Returning the same instance every time the same arguments are passed 
+     * is highly recommended.  It will typically be called whenever a change
+     * is fired by the base wizard (i.e. every call <code>setProblem()</code>
+     * should generate a check to see if the navigation has changed).
+     * <p>
+     * Note that the wizard for the subsequent steps will be instantiated
+     * as soon as it is known what the user's choice is, so the list of 
+     * pending steps can be updated (this does not mean that all subsequent
+     * panel UI components of the wizard will be instantiated, just the
+     * Wizard object itself, which will create panels on demand if they
+     * have not already been created).
+     *
+     * @param step The current step the user is on in the wizard
+     * @param settings The settings map, which previous panes of the wizard
+     *  have been writing information into
+     */
+    protected Wizard getWizardForStep(String step, Map settings) {
+        WizardPanelProvider provider = getPanelProviderForStep(step, settings);
+        return provider == null ? null : provider.createWizard();
+    }
+
+    /**
+     * Override this method to return a <code>WizardPanelProvider</code> representing the 
+     * steps from here to the final step of the wizard, varying the returned
+     * object based on the contents of the map and the step in question.
+     * The default implementation of this method throws an <code>Error</code> - 
+     * either override this method, or override <code>getWizardForStep()</code>
+     * (in which case this method will not be called).
+     * <p>
+     * <b>Note:</b>  This method can be called very frequently, to determine
+     * if the sequence of steps has changed - so it needs to run fast.  
+     * Returning the same instance every time called with equivalent arguments
+     * is highly recommended.
+     * 
+     * @param step The string ID of the current step
+     * @param settings The settings map, which previous panes of the wizard
+     *   will have written content into
+     */
+    protected WizardPanelProvider getPanelProviderForStep(String step, Map settings) {
+        throw new Error ("Override either createInfoForStep or " +
+                "createWizardForStep");
+    }
+    
+    SimpleWizardInfo getBase() {
+        return base;
+    }
+
+    private WizardImplementation wizard = null;
+    private Wizard real = null;
+    /**
+     * Create a Wizard to represent this branch controller.  The resulting
+     * Wizard instance is cached; subsequent calls to this method will return
+     * the same instance.
+     */
+    public final Wizard createWizard() {
+        if (wizard == null) {
+            wizard = new BranchingWizard (this);
+            real = new Wizard (wizard);
+        }
+        return real;
+    }
+}

--- a/vassal-app/src/main/java/org/netbeans/spi/wizard/WizardController.java
+++ b/vassal-app/src/main/java/org/netbeans/spi/wizard/WizardController.java
@@ -1,0 +1,120 @@
+/*  The contents of this file are subject to the terms of the Common Development
+and Distribution License (the License). You may not use this file except in
+compliance with the License.
+    You can obtain a copy of the License at http://www.netbeans.org/cddl.html
+or http://www.netbeans.org/cddl.txt.
+    When distributing Covered Code, include this CDDL Header Notice in each file
+and include the License file at http://www.netbeans.org/cddl.txt.
+If applicable, add the following below the CDDL Header, with the fields
+enclosed by brackets [] replaced by your own identifying information:
+"Portions Copyrighted [year] [name of copyright owner]" */
+/*
+ * WizardController.java
+ *
+ * Created on March 5, 2005, 7:24 PM
+ */
+
+package org.netbeans.spi.wizard;
+
+/**
+ * Controller which can be used to modify the UI state of a wizard.  Passed
+ * as an argument to methods of <code>WizardPanelProvider</code>.  Use this 
+ * interface
+ * to determine whether the Next/Finish buttons should be enabled, and if some
+ * problem explanation text should be displayed.
+ * <p>
+ * If you are using {@link WizardPage WizardPage}, methods equivalent to this
+ * interface are available directly on instances of <code>WizardPage</code>.
+ *
+ * @see WizardPanelProvider
+ * @author Tim Boudreau
+ */
+public final class WizardController {
+    /**
+     * Constant that can be passed to <code>setForwardNavigationMode</code> to indicate
+     * that the Next button can be enabled if the problem string is null.
+     * Value is identical to the similarly named constant on <code>Wizard</code>.
+     */
+    public static final int MODE_CAN_CONTINUE = 1;
+    /**
+     * Constant that can be passed to <code>setForwardNavigationMode</code> to indicate
+     * that the Finish button can be enabled if the problem string is null.
+     * Value is identical to the similarly named constant on <code>Wizard</code>.
+     */
+    public static final int MODE_CAN_FINISH = 2;
+    /**
+     * Constant that can be passed to <code>setForwardNavigationMode</code> to indicate
+     * that both the Finish and Next buttons can be enabled if the problem 
+     * string is null.  This value is a bitmask - i.e. 
+     * <code>MODE_CAN_CONTINUE_OR_FINISH == MODE_CAN_CONTINUE | 
+     * MODE_CAN_FINISH</code>.
+     * Value is identical to the similarly named constant on 
+     * <code>Wizard</code>.
+     */
+    public static final int MODE_CAN_CONTINUE_OR_FINISH = 
+            MODE_CAN_CONTINUE | MODE_CAN_FINISH;
+
+    private final WizardControllerImplementation impl;
+    
+    WizardController (WizardControllerImplementation impl) {
+        this.impl = impl;
+    }
+    
+    /**
+     * Indicate that there is a problem with what the user has (or has not)
+     * input, such that the Next/Finish buttons should be disabled until the
+     * user has made some change.
+     * <p>
+     * If you want to disable the Next/Finish buttons, do that by calling
+     * this method with a short description of what is wrong.
+     * <p>
+     * Pass null to indicate there is no problem;  non-null indicates there is
+     * a problem - the passed string should be a localized, human-readable
+     * description that assists the user in correcting the situation.  It will
+     * be displayed in the UI.
+     */
+    public void setProblem (String value) {
+        impl.setProblem (value);
+    }
+    
+    /**
+     * Set the forward navigation mode.  This method determines whether 
+     * the Next button, the Finish button or both should be enabled if the
+     * problem string is set to null.  
+     * <p>
+     * On panels where, based on the UI state, the only reasonable next
+     * step is to finish the wizard (even though there may be more panels
+     * if the UI is in a different state), set the navigation mode to
+     * MODE_CAN_FINISH, and the Finish button will be enabled, and the
+     * Next button not.
+     * <p>
+     * On panels where, based on the UI state, the user could either continue
+     * or complete the wizard at that point, set the navigation mode to
+     * MODE_CAN_CONTINUE_OR_FINISH.
+     * <p>
+     * If the finish button should not be enabled, set the navigation mode
+     * to MODE_CAN_CONTINUE.  This is the default on any panel if no 
+     * explicit call to <code>setForwardNavigationMode()</code> has been made.
+     * 
+     * @param navigationMode Legal values are MODE_CAN_CONTINUE, 
+     *  MODE_CAN_FINISH or MODE_CAN_CONTINUE_OR_FINISH
+     */
+    public void setForwardNavigationMode (int navigationMode) {
+        impl.setForwardNavigationMode(navigationMode);
+    }
+    
+    /**
+     * Indicate that some sort of background process is happening (presumably
+     * a progress bar is being shown to the user) which cannot be interrupted.
+     * <i>Calling this menu disables all navigation and the ability to close
+     * the wizard dialog.  Use this option with caution and liberal use of
+     * <code>finally</code> to reenable navigation.</i>
+     */
+    public void setBusy (boolean busy) {
+        impl.setBusy (busy);
+    }
+    
+    WizardControllerImplementation getImpl() {
+        return impl;
+    }
+}

--- a/vassal-app/src/main/java/org/netbeans/spi/wizard/WizardControllerImplementation.java
+++ b/vassal-app/src/main/java/org/netbeans/spi/wizard/WizardControllerImplementation.java
@@ -1,0 +1,70 @@
+/*  The contents of this file are subject to the terms of the Common Development
+and Distribution License (the License). You may not use this file except in
+compliance with the License.
+    You can obtain a copy of the License at http://www.netbeans.org/cddl.html
+or http://www.netbeans.org/cddl.txt.
+    When distributing Covered Code, include this CDDL Header Notice in each file
+and include the License file at http://www.netbeans.org/cddl.txt.
+If applicable, add the following below the CDDL Header, with the fields
+enclosed by brackets [] replaced by your own identifying information:
+"Portions Copyrighted [year] [name of copyright owner]" */
+
+package org.netbeans.spi.wizard;
+
+/**
+ * Internal, non-public SPI for wizard controller;  allows the actual WizardController
+ * class to be final, so it does not imply that the API user should implement
+ * it, and methods can be added safely to it if desired.
+ *
+ * @see WizardController
+ * @author Tim Boudreau
+ */
+interface WizardControllerImplementation {
+    /**
+     * Indicate that there is a problem with what the user has (or has not)
+     * input, such that the Next/Finish buttons should be disabled until the
+     * user has made some change.
+     * <p>
+     * If you want to disable the Next/Finish buttons, do that by calling
+     * this method with a short description of what is wrong.
+     * <p>
+     * Pass null to indicate there is no problem;  non-null indicates there is
+     * a problem - the passed string should be a localized, human-readable
+     * description that assists the user in correcting the situation.  It will
+     * be displayed in the UI.
+     */
+    void setProblem (String value);
+    
+    /**
+     * Set the forward navigation mode.  This method determines whether 
+     * the Next button, the Finish button or both should be enabled if the
+     * problem string is set to null.  
+     * <p>
+     * On panels where, based on the UI state, the only reasonable next
+     * step is to finish the wizard (even though there may be more panels
+     * if the UI is in a different state), set the navigation mode to
+     * MODE_CAN_FINISH, and the Finish button will be enabled, and the
+     * Next button not.
+     * <p>
+     * On panels where, based on the UI state, the user could either continue
+     * or complete the wizard at that point, set the navigation mode to
+     * MODE_CAN_CONTINUE_OR_FINISH.
+     * <p>
+     * If the finish button should not be enabled, set the navigation mode
+     * to MODE_CAN_CONTINUE.  This is the default on any panel if no 
+     * explicit call to <code>setForwardNavigationMode()</code> has been made.
+     * 
+     * @param navigationMode Legal values are MODE_CAN_CONTINUE, 
+     *  MODE_CAN_FINISH or MODE_CAN_CONTINUE_OR_FINISH
+     */
+    void setForwardNavigationMode (int navigationMode);
+    
+    /**
+     * Indicate that some sort of background process is happening (presumably
+     * a progress bar is being shown to the user) which cannot be interrupted.
+     * <i>Calling this menu disables all navigation and the ability to close
+     * the wizard dialog.  Use this option with caution and liberal use of
+     * <code>finally</code> to reenable navigation.</i>
+     */
+    void setBusy (boolean busy);
+}

--- a/vassal-app/src/main/java/org/netbeans/spi/wizard/WizardException.java
+++ b/vassal-app/src/main/java/org/netbeans/spi/wizard/WizardException.java
@@ -1,0 +1,52 @@
+/*  The contents of this file are subject to the terms of the Common Development
+and Distribution License (the License). You may not use this file except in
+compliance with the License.
+    You can obtain a copy of the License at http://www.netbeans.org/cddl.html
+or http://www.netbeans.org/cddl.txt.
+    When distributing Covered Code, include this CDDL Header Notice in each file
+and include the License file at http://www.netbeans.org/cddl.txt.
+If applicable, add the following below the CDDL Header, with the fields
+enclosed by brackets [] replaced by your own identifying information:
+"Portions Copyrighted [year] [name of copyright owner]" */
+/*
+ * WizardException.java
+ *
+ * Created on February 22, 2005, 3:56 PM
+ */
+
+package org.netbeans.spi.wizard;
+
+/**
+ * Some arguments a user enters in a wizard may be too expensive to validate
+ * as the user is going through the wizard.  Therefore, Wizard.finish() throws
+ * WizardException.
+ * <p>
+ * Exceptions of this type always have a localized message, and optionally
+ * provide a step in the wizard that to return to, so that the user can
+ * enter corrected information.
+ *
+ * @author Tim Boudreau
+ */
+public final class WizardException extends Exception {
+    private final String localizedMessage;
+    private final String step;
+    /** Creates a new instance of WizardException */
+    public WizardException(String localizedMessage, String stepToReturnTo) {
+        super ("wizardException");
+        this.localizedMessage = localizedMessage;
+        this.step = stepToReturnTo;
+    }
+
+    public WizardException (String localizedMessage) {
+        this (localizedMessage, Wizard.UNDETERMINED_STEP);
+    }
+    
+    public String getLocalizedMessage() {
+        return localizedMessage;
+    }
+    
+    public String getStepToReturnTo() {
+        return step;
+    }
+
+}

--- a/vassal-app/src/main/java/org/netbeans/spi/wizard/WizardImplementation.java
+++ b/vassal-app/src/main/java/org/netbeans/spi/wizard/WizardImplementation.java
@@ -1,0 +1,246 @@
+/*  The contents of this file are subject to the terms of the Common Development
+and Distribution License (the License). You may not use this file except in
+compliance with the License.
+    You can obtain a copy of the License at http://www.netbeans.org/cddl.html
+or http://www.netbeans.org/cddl.txt.
+    When distributing Covered Code, include this CDDL Header Notice in each file
+and include the License file at http://www.netbeans.org/cddl.txt.
+If applicable, add the following below the CDDL Header, with the fields
+enclosed by brackets [] replaced by your own identifying information:
+"Portions Copyrighted [year] [name of copyright owner]" */
+/*
+ * Wizard.java
+ *
+ * Created on February 22, 2005, 2:18 PM
+ */
+
+package org.netbeans.spi.wizard;
+
+import java.util.Map;
+import javax.swing.JComponent;
+
+/**
+ * Non-public mirror interface to the final Wizard class.  A Wizard delegates to
+ * its WizardImplementation for all of its functions.  This interface is
+ * implemented by several internal classes.
+ * 
+ * @author Tim Boudreau
+ * @see Wizard
+ * @see WizardPage
+ * @see WizardPanelProvider
+ * @see WizardBranchController
+ * @see org.netbeans.api.wizard.WizardDisplayer
+ */
+interface WizardImplementation {
+    /**
+     * Constant that can be returned by <code>getForwardNavigationMode</code> to indicate
+     * that the Next button can be enabled if the problem string is null.
+     */
+    public static final int MODE_CAN_CONTINUE = 
+            WizardController.MODE_CAN_CONTINUE;
+
+    /**
+     * Constant that can be returned by <code>getForwardNavigationMode</code> to indicate
+     * that the Finish button can be enabled if the problem string is null.
+     */
+    public static final int MODE_CAN_FINISH =
+            WizardController.MODE_CAN_FINISH;
+    /**
+     * Constant that can be returned by <code>getForwardNavigationMode</code> to indicate
+     * that both the Finish and Next buttons can be enabled if the problem 
+     * string is null.  This value is a bitmask - i.e. 
+     * <code>MODE_CAN_CONTINUE_OR_FINISH == MODE_CAN_CONTINUE | 
+     * MODE_CAN_FINISH</code>
+     */
+    public static final int MODE_CAN_CONTINUE_OR_FINISH = 
+            WizardController.MODE_CAN_CONTINUE_OR_FINISH;
+    
+    /**
+     * Special panel ID key indicating a branch point in the wizard,
+     * after which the next step(s) are unknown.
+     */
+    public static final String UNDETERMINED_STEP = "_#UndeterminedStep";
+    
+    /**
+     * Set which step of the wizard is currently being displayed and get
+     * the component for that step.  This method is passed a Map into which
+     * panels may put key/value pairs that represent user input.  This Map
+     * is what the <code>finish()</code> method will use to decide what to
+     * do.  
+     * <p>
+     * The ID passed
+     * becomes the currently active step of the wizard as of this call.
+     * <p>
+     * If the user has already been to this step, and some key/value pairs
+     * were written to the wizard data map, and the user then
+     * then pressed the Back button, and later pressed Next again, the 
+     * wizard data map may already contain key/value pairs for this 
+     * step.  Panels whose components
+     * are affected by data entered in the map in preceding steps should
+     * update their UI based on the map's current contents, at the time a
+     * step is re-displayed, to ensure they are in
+     * sync with any changes the user may have made on preceding panels
+     * since the last time this panel was shown.
+     * <p>
+     * If this method is called as a result of
+     * the user pressing the Back button, the wizard data map will <i>not</i>
+     * contain any key/value pairs added by the subsequent panels.  It
+     * will only key/value pairs from
+     * panels that precede this one and any written the last time this
+     * panel was visited.  The wizard data map shall never contain
+     * keys and values from future steps in the wizard.
+     * <p>
+     * Implementations are expected to return the same component if 
+     * <code>navigatingTo()</code> is called repeatedly with the same ID.
+     * Components should be constructed once, then reused for the lifetime
+     * of the wizard.
+     * <blockquote>
+     * <b>Note:</b> The consequences of a later panel writing or deleting
+     * a key/value pair that was put into the wizard data map by 
+     * an earlier panel are
+     * undefined.  Each step should use only its own unique keys, not
+     * modify those from earlier steps.
+     * </blockquote>
+     * 
+     * 
+     * @param id The ID of the to-be-current panel
+     * @param wizardData The map into which panels should write key/value pairs
+     *   in response to user input - the place where user data is aggregated
+     * @return The UI component for this step, which should be displayed in
+     *   the wizard
+     */
+    public JComponent navigatingTo(String id, Map wizardData);
+
+    /**
+     * Get the String ID of the current panel.
+     * If there is no current panel, return null.
+     *
+     * @return The unique ID of the step currently
+     *  presented in the UI, as determined by the last call to
+     *  <code>navigateTo</code>
+     */
+    public String getCurrentStep();
+
+    /**
+     * Get the String ID of the next panel.  If the Next button should be
+     * disabled, or this is the final step of the wizard, return null.
+     *
+     * @return The unique ID of the step that follows the one currently
+     *  presented in the UI, as determined by the last call to 
+     *  <code>navigateTo</code>
+     */
+    public String getNextStep();
+
+    /**
+     * Get the String ID of the previous panel.  If the Prev button should
+     * be disabled, return null.
+     * @return the String ID of the step that precedes the one currently
+     *  presented in this <code>Wizard</code>s UI, or null if it is either
+     *  the first step or the preceding step is unknown, as determined by the last call to 
+     *  <code>navigateTo</code>
+     */
+    public String getPreviousStep();
+
+    /**
+     * Get a human readable description of the reason the Next/Finish button
+     * is not enabled (i.e. "#\foo is not a legal filename").
+     * @return A localized string that describes why the Next/Finish button
+     *  is not enabled, or null if one or the other or both should be enabled
+     */
+    public String getProblem();
+    
+    /**
+     * Get String IDs for the entire list of known steps in the 
+     * wizard (regardless of whether
+     * Finish/Next can be enabled or not).  If there is a branch point in
+     * the wizard and it cannot be determined what step will be next beyond
+     * that point, make the final entry in the returned array the constant
+     * UNDETERMINED_STEP, and fire <code>stepsChange()</code> to any listeners
+     * once the later steps become known.
+     * <p>
+     * The return value of this method must be an array of Strings at least
+     * one String in length.  If length == 1, the single step ID may not be
+     * UNDETERMINED_STEP; UNDETERMINED_STEP may only be the last ID, and only
+     * may be used if there is more than one step.
+     *
+     * @return An array of strings that constitute unique IDs of each step
+     *  in the wizard.  The returned array may not contain duplicate entries.
+     */
+    public String[] getAllSteps();
+    
+    /**
+     * Get a human-readable description for a given panel, as identified by
+     * the passed ID.
+     */
+    public String getStepDescription(String id);
+    
+    public String getLongDescription(String id);
+    
+    /**
+     * Add a listener for changes in the count or order of steps in this 
+     * wizard and for changes in Next/Previous/Finish button enablement.
+     * @param listener A listener to add
+     */
+    public void addWizardObserver(WizardObserver listener);
+    
+    /**
+     * Remove a listener for changes in the count or order of steps in this 
+     * wizard and for changes in Next/Previous/Finish button enablement.
+     * @param listener A listener to remove
+     */
+    public void removeWizardObserver(WizardObserver listener);
+    
+    /**
+     * Finish the wizard, (optionally) instantiating some Object and returning
+     * it.  For cases where the map may contain wizardData too expensive to
+     * validate on the fly, 
+     * this method may throw a WizardException with a localized message
+     * indicating the problem;  that exception can indicate a step in the
+     * wizard to return to to allow the user to correct the information.
+     * <p>
+     * No methods on a <code>Wizard</code> instance should be called after
+     * that <code>Wizard</code>'s <code>finish()</code> method has been 
+     * called - the results are undefined.
+     * 
+     * @param settings A map containing all of the wizardData the user has
+     *  entered as they traversed this wizard - presumably enough to do 
+     *  whatever this method needs to do (if not, that's a bug in the 
+     *  implementation of <code>Wizard</code>).
+     */
+    public Object finish(Map settings) throws WizardException;
+    
+    /** Get the title of the wizard.  
+     *  @return A human-readable, localized title that should be displayed
+     *   in any dialog showing this wizard
+     */
+    public String getTitle();
+    
+    /** Determine if all navigation buttons should be disabled - if the
+     * wizard is currently doing some kind of progress/background processing
+     * task that cannot be interrupted.
+     */
+    public boolean isBusy();
+    
+    /**
+     * Get the forward navigation mode of this wizard.  This 
+     * determines whether the Next button, the Finish button or both should
+     * be enabled, <i>if the problem string returned from <code>getProblem</code>
+     * is null</i>.  If the problem is set to non-null, the UI should disable
+     * all forward navigation.
+     * <p>
+     * This method should never return any value but 
+     * MODE_CAN_CONTINUE, MODE_CAN_FINISH or MODE_CAN_CONTINUE_OR_FINISH -
+     * it is not a mechanism for disabling all forward navigation (return 
+     * non null from <code>getProblem()</code> for that, or <code>true</code>
+     * from <code>isBusy()</code> to temporarily disable <i>all</i> navigation).
+     * <p>
+     * On the final step of the wizard, this method should always return
+     * MODE_CAN_FINISH.
+     */
+    public int getForwardNavigationMode();
+
+    /**
+     * Called when the user cancels the wizard.
+     */
+    public boolean cancel(Map settings);
+}

--- a/vassal-app/src/main/java/org/netbeans/spi/wizard/WizardObserver.java
+++ b/vassal-app/src/main/java/org/netbeans/spi/wizard/WizardObserver.java
@@ -1,0 +1,40 @@
+/*  The contents of this file are subject to the terms of the Common Development
+and Distribution License (the License). You may not use this file except in
+compliance with the License.
+    You can obtain a copy of the License at http://www.netbeans.org/cddl.html
+or http://www.netbeans.org/cddl.txt.
+    When distributing Covered Code, include this CDDL Header Notice in each file
+and include the License file at http://www.netbeans.org/cddl.txt.
+If applicable, add the following below the CDDL Header, with the fields
+enclosed by brackets [] replaced by your own identifying information:
+"Portions Copyrighted [year] [name of copyright owner]" */
+package org.netbeans.spi.wizard;
+
+/**
+ * Observer which can detect changes in the state of a wizard as the
+ * user proceeds.  Only likely to be used by implementations of
+ * <code>WizardDisplayer</code>.
+ */
+public interface WizardObserver {
+    /**
+     * Called when the number or names of the steps of the
+     * wizard changes (for example, the user made a choice in one pane which
+     * affects the flow of subsequent steps).
+     * @param wizard The wizard whose steps have changed
+     */
+    public void stepsChanged(Wizard wizard);
+    
+    /**
+     * Called when the enablement of the next/previous/finish buttons 
+     * change, or the problem text changes.
+     * @param wizard The wizard whose navigability has changed
+     */
+    public void navigabilityChanged(Wizard wizard);
+
+    /**
+     * Called whenever the current step changes.
+     *
+     * @param wizard The wizard whose current step has changed
+     */
+    public void selectionChanged(Wizard wizard);
+}

--- a/vassal-app/src/main/java/org/netbeans/spi/wizard/WizardPage.java
+++ b/vassal-app/src/main/java/org/netbeans/spi/wizard/WizardPage.java
@@ -1,0 +1,1181 @@
+/*  The contents of this file are subject to the terms of the Common Development
+and Distribution License (the License). You may not use this file except in
+compliance with the License.
+    You can obtain a copy of the License at http://www.netbeans.org/cddl.html
+or http://www.netbeans.org/cddl.txt.
+    When distributing Covered Code, include this CDDL Header Notice in each file
+and include the License file at http://www.netbeans.org/cddl.txt.
+If applicable, add the following below the CDDL Header, with the fields
+enclosed by brackets [] replaced by your own identifying information:
+"Portions Copyrighted [year] [name of copyright owner]" */
+/*
+ * FixedWizard.java
+ *
+ * Created on August 19, 2005, 9:11 PM
+ */
+
+package org.netbeans.spi.wizard;
+
+import java.beans.Beans;
+import javax.swing.*;
+import javax.swing.text.JTextComponent;
+import javax.swing.tree.TreePath;
+import java.awt.Color;
+import java.awt.Component;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+
+/**
+ * A convenience JPanel subclass that makes it easy to create wizard panels.
+ * This class provides a number of conveniences:
+ * <p/>
+ * <b>Automatic listening to child components</b><br>
+ * If you add an editable component (all standard Swing controls are supported)
+ * to a WizardPage or a child JPanel inside it,
+ * a listener is automatically attached to it.  If user input occurs, the
+ * following things happen, in order:
+ * <ul>
+ * <li>If the <code>name</code> property of the component has been set, then
+ * the value from the component (i.e. Boolean for checkboxes, selected item(s)
+ * for lists/combo boxes/trees, etc.) will automatically be added to the
+ * wizard settings map, with the component name as the key.</li>
+ * <li>Regardless of whether the <code>name</code> property is set,
+ * <code>validateContents()</code> will be called.  You can override that method
+ * to enable/disable the finish button, call <code>setProblem()</code> to
+ * disable navigation and display a string to the user, etc.
+ * </ul>
+ * <p/>
+ * The above behavior can be disabled by passing <code>false</code> to the
+ * appropriate constructor.  In that case, <code>validateContents</code> will
+ * never be called automatically.
+ * <p/>
+ * If you have custom components that WizardPage will not know how to listen
+ * to automatically, attach an appropriate listener to them and optionally
+ * call <code>userInputReceived()</code> with the component and the event if
+ * you want to run your automatic validation code.
+ * <p/>
+ * For convenience, this class implements the relevant methods for accessing
+ * the <code>WizardController</code> and the settings map for the wizard that
+ * the panel is a part of.
+ * <p/>
+ * Instances of WizardPage can be returned from a WizardPanelProvider;  this
+ * class also offers two methods for conveniently assembling a wizard:
+ * <ul>
+ * <li>Pass an array of already instantiated WizardPages to
+ * <code>createWizard()</code>.  Note that for large wizards, it is preferable
+ * to construct the panels on demand rather than at construction time.</li>
+ * <li>Construct a wizard out of WizardPages, instantiating the panels as
+ * needed:  Pass an array of classes all of which
+ * <ul>
+ * <li>Are subclasses of WizardPage</li>
+ * <li>Have a static method with the following signature:
+ * <ul>
+ * <li><code>public static String getDescription()</code></li>
+ * </ul>
+ * </li>
+ * </ul>
+ * </ul>
+ * <p/>
+ * Note that during development of a wizard, it is worthwhile to test/run with
+ * assertions enabled, as there is quite a bit of validity checking via assertions
+ * that can help find problems early.
+ * <h2>Using Custom Components</h2>
+ * If the <code>autoListen</code> constructor argument is true, a WizardPage
+ * will automatically listen to components which have a name, if they are
+ * standard Swing components it knows how to listen to.  If you are using
+ * custom components, implement WizardPage.CustomComponentListener and return
+ * it from <code>createCustomComponentListener()</code> to add supplementary
+ * listening code for custom components.
+ * <p/>
+ * Note: Swing components do not fire property changes when setName() is called.
+ * If your component's values are not being propagated into the settings map,
+ * make sure you are calling setName() <i>before</i> adding the component
+ * to the hierarchy.
+ * <p/>
+ * Also note that cell editors in tables and lists and so forth are always
+ * ignored by the automatic listening code.
+ *
+ * @author Tim Boudreau
+ */
+public class WizardPage extends JPanel implements WizardPanel {
+
+    private static final Logger logger =
+            Logger.getLogger(WizardPage.class.getName());
+
+    private final String description;
+    String id;
+
+    //Have an initial dummy map so it's never null.  We'll dump its contents
+    //into the real map the first time it's set
+    private Map wizardData;
+    //An initial wizardController that will dump its settings into the real
+    //one the first time it's set
+    private WizardControllerImplementation wc = new WC();
+    private WizardController controller = new WizardController(wc);
+
+    //Flag to make sure we don't reenter userInputReceieved from maybeUpdateMap()
+    private boolean inBeginUIChanged = false;
+    //Flag to make sure we don't reenter userInputReceived because the
+    //implementation of validateContents changed a component's value, triggering
+    //a new event on GenericListener
+    private boolean inUiChanged = false;
+    private CustomComponentListener ccl;
+    private boolean autoListen;
+
+    /**
+     * Create a WizardPage with the passed description and auto-listening
+     * behavior.
+     * 
+     * @param stepDescription the localized description of this step
+     * @param autoListen      if true, components added will automatically be
+     *                        listened to for user input
+     */ 
+    public WizardPage(String stepDescription, boolean autoListen) {
+        this (null, stepDescription, autoListen);
+    }
+    /**
+     * Construct a new WizardPage with the passed step id and description.
+     * Use this constructor for WizardPages which will be constructed ahead
+     * of time and passed in an array to <code>createWizard</code>.
+     *
+     * @param stepId          the unique ID for the step represented.  If null,
+     *                        the class name or a variant of it will be used
+     * @param stepDescription the localized description of this step
+     * @param autoListen      if true, components added will automatically be
+     *                        listened to for user input
+     * @see #validateContents
+     */
+    public WizardPage(String stepId, String stepDescription, boolean autoListen) {
+        id = stepId == null ? getClass().getName() : stepId;
+        this.autoListen = autoListen;
+        description = stepDescription;
+        
+    }
+
+    private boolean listening;
+    private void startListening() {
+        listening = true;
+        if (autoListen) {
+            //It will attach itself
+            GenericListener gl = new GenericListener(this, ccl = createCustomComponentListener(),
+                    ccl == null ? null : new CustomComponentNotifierImpl(this));
+            gl.attachToHierarchyOf(this);
+        } else {
+            if ((ccl = createCustomComponentListener()) != null) {
+                throw new IllegalStateException ("CustomComponentListener " +
+                        "will never be called if the autoListen parameter is " +
+                        "false");
+            }
+        }
+//        if (getClass() == WizardPage.class && stepId == null ||
+//                description == null) {
+//            throw new NullPointerException ("Step or ID is null"); //NOI18N
+//        }
+        setBorder(BorderFactory.createEmptyBorder(5, 5, 5, 5)); //XXX
+    }
+    
+    /**
+     * Create an auto-listening WizardPage with the passed description
+     * @param stepDescription the localized description of this step
+     */ 
+    public WizardPage (String stepDescription) {
+        this (null, stepDescription);
+    }
+
+    /**
+     * Create an auto-listening WizardPage with the passed description
+     * @param stepId The unique id for the step.  If null, an id will be
+     *               generated
+     * @param stepDescription the localized description of this step
+     * 
+     */ 
+    public WizardPage(String stepId, String stepDescription) {
+        this(stepId, stepDescription, true);
+    }
+
+    /**
+     * Use this constructor or the default constructor if you intend to
+     * pass an array of Class objects to lazily create WizardPanels.
+     */
+    protected WizardPage(boolean autoListen) {
+        this(null, null, autoListen);
+    }
+
+    /**
+     * Default constructor.  AutoListening will be on by default.
+     */
+    protected WizardPage() {
+        this(true);
+    }
+    
+    /**
+     * If you are using custom Swing or AWT components which the 
+     * WizardPage will not know how to automatically listen to, you
+     * may want to override this method, implement CustomComponentListener
+     * and return an instance of it.  
+     * @return A CustomComponentListener implementation, or null (the default).
+     */ 
+    protected CustomComponentListener createCustomComponentListener() {
+        return null;
+    }
+    
+    /**
+     * Implement this class if you are using custom Swing or AWT components,
+     * and return an instance of it from 
+     * <code>WizardPage.createCustomComponentListener()</code>.
+     */ 
+    public static abstract class CustomComponentListener {
+        /**
+         * Indicates that this CustomComponentListener will take responsibility
+         * for noticing events from the passed component, and that the 
+         * WizardPage should not try to automatically listen on it (which it
+         * can only do for standard Swing components and their children).
+         * <p>
+         * Note that this method may be called frequently and any test it
+         * does should be fast.
+         * <p>
+         * <b>Important:</b> The return value from this method should always
+         * be the same for any given component, for the lifetime of the
+         * WizardPage.
+         * 
+         * @param c A component
+         * @return Whether or not this CustomComponentListener will listen
+         *   on the passed component.  If true, the component will later be
+         *   passed to <code>startListeningTo()</code>
+         */ 
+        public abstract boolean accept (Component c);
+        /**
+         * Begin listening for events on the component.  When an event occurs,
+         * call the <code>eventOccurred()</code> method on the passed
+         * <code>CustomComponentNotifier</code>.
+         * @param c The component to start listening to
+         * @param n An object that can be called to update the settings map
+         *        when an interesting event occurs on the component
+         */ 
+        public abstract void startListeningTo (Component c, CustomComponentNotifier n);
+        /**
+         * Stop listening for events on a component.
+         * @param c The component to stop listening to
+         */ 
+        public abstract void stopListeningTo (Component c);
+        /**
+         * Determine if the passed component is a container whose children
+         * may need to be listened on.  Returns false by default.
+         * 
+         * @param c A component which might be a container
+         */ 
+        public boolean isContainer(Component c) {
+            return false;
+        }
+        /**
+         * Get the map key for this component's value.  By default, returns
+         * the component's name.  Will only
+         * be passed components which the <code>accept()</code> method 
+         * returned true for.
+         * <p>
+         * <b>Important:</b> The return value from this method should always
+         * be the same for any given component, for the lifetime of the
+         * WizardPage.
+         * @param c the component, which the accept method earlier returned
+         *   true for
+         * @return A string key that should be used in the Wizard's settings
+         *   map for the name of this component's value
+         */ 
+        public String keyFor (Component c) {
+            return c.getName();
+        }
+        /**
+         * Get the value currently set on the passed component.  Will only
+         * be passed components which the <code>accept()</code> method 
+         * returned true for, and which <code>keyFor()</code> returned non-null.
+         * @param c the component
+         * @return An object representing the current value of this component.
+         *   For example, if it were a <code>JTextComponent</code>, the value would likely
+         *   be the return value of <code>JTextComponent.getText()</code>
+         */ 
+        public abstract Object valueFor (Component c);
+    }
+    
+    /**
+     * Object which is passed to <code>CustomComponentListener.startListeningTo()</code>,
+     * which can be called when an event has occurred on a custom component the
+     * <code>CustomComponentListener</code> has claimed (by returning <code>true</code>
+     * from its <code>accept()</code> method).
+     */ 
+    public static abstract class CustomComponentNotifier {
+        private CustomComponentNotifier() {}
+        /**
+         * Method which may be called when an event occurred on a custom component.
+         * @param c the component
+         * @param eventObject the event object from the component, or null (with
+         *   the exception of <code>javax.swing.text.DocumentEvent</code>, it 
+         *   will likely be a subclass of <code>java.util.EventObject</code>).
+         */ 
+        public abstract void userInputReceived (Component c, Object eventObject);
+    }
+    
+    private static final class CustomComponentNotifierImpl extends CustomComponentNotifier {
+        private final WizardPage page;
+        private CustomComponentNotifierImpl (WizardPage page) {
+            this.page = page; //Slightly smaller footprint a nested, not inner class
+        }
+        
+        public void userInputReceived(Component c, Object event) {
+            if (!page.ccl.accept(c)) {
+                return;
+            }
+            page.userInputReceived (c, event);
+        }
+    }
+    
+    String id() {
+        return getID();
+    }
+    
+    String description() {
+        return getDescription();
+    }
+
+    private String getID() {
+        return id;
+    }
+
+    private String getDescription() {
+        return description;
+    }
+
+    public void addNotify() {
+        super.addNotify();
+        if (!listening) {
+            startListening();
+        }
+
+        renderingPage();
+        inValidateContents = true;
+        try {
+            setProblem(validateContents(null, null));
+        } finally {
+            inValidateContents = false;
+        }
+        validate();
+        repaint(0, 0, getWidth(), getHeight());
+    }
+
+    public WizardPanelNavResult allowBack(String stepName, Map settings, Wizard wizard) {
+        return WizardPanelNavResult.PROCEED;
+    }
+
+    public WizardPanelNavResult allowFinish(String stepName, Map settings, Wizard wizard) {
+        return WizardPanelNavResult.PROCEED;
+    }
+
+    public WizardPanelNavResult allowNext(String stepName, Map settings, Wizard wizard) {
+        return WizardPanelNavResult.PROCEED;
+    }
+
+    private boolean inValidateContents = false;
+
+    /**
+     * Called whenever the page is rendered.
+     * This can be used by the page as a notification
+     * to load page-specific information in its fields.
+     * <p/>
+     * By default, this method does nothing.
+     */
+    protected void renderingPage() {
+        // Empty
+    }
+
+    /**
+     * Create a simple Wizard from an array of <code>WizardPage</code>s
+     */
+    public static Wizard createWizard(WizardPage[] contents, WizardResultProducer finisher) {
+        return new WPP(contents, finisher).createWizard();
+    }
+
+    public static Wizard createWizard(String title, WizardPage[] contents, WizardResultProducer finisher) {
+        return new WPP(title, contents, finisher).createWizard();
+    }
+
+    public static Wizard createWizard(String title, WizardPage[] contents) {
+        return createWizard(title, contents, WizardResultProducer.NO_OP);
+    }
+
+    /**
+     * Create a simple Wizard from an array of WizardPages, with a
+     * no-op WizardResultProducer.
+     */
+    public static Wizard createWizard(WizardPage[] contents) {
+        return createWizard(contents, WizardResultProducer.NO_OP);
+    }
+
+    /**
+     * Create simple Wizard from an array of classes, each of which is a
+     * unique subclass of WizardPage.
+     */
+    public static Wizard createWizard(Class[] wizardPageClasses, WizardResultProducer finisher) {
+        return new CWPP(wizardPageClasses, finisher).createWizard();
+    }
+
+    /**
+     * Create simple Wizard from an array of classes, each of which is a
+     * unique subclass of WizardPage.
+     */
+    public static Wizard createWizard(String title, Class[] wizardPageClasses, WizardResultProducer finisher) {
+        return new CWPP(title, wizardPageClasses, finisher).createWizard();
+    }
+
+    /**
+     * Create simple Wizard from an array of classes, each of which is a
+     * unique subclass of WizardPage.
+     */
+    public static Wizard createWizard(String title, Class[] wizardPageClasses) {
+        return new CWPP(title, wizardPageClasses, 
+                WizardResultProducer.NO_OP).createWizard();
+    }
+    /**
+     * Create a simple Wizard from an array of classes, each of which is a
+     * unique subclass of WizardPage, with a
+     * no-op WizardResultProducer.
+     */
+    public static Wizard createWizard(Class[] wizardPageClasses) {
+        return createWizard(wizardPageClasses, WizardResultProducer.NO_OP);
+    }
+
+    /**
+     * Called by createPanelForStep, with whatever map is passed.  In the
+     * current impl this is always the same Map, but that is not guaranteed.
+     * If any content was added by calls to putWizardData() during the
+     * constructor, etc., such data is copied to the settings map the first
+     * time this method is called.
+     *
+     *  Subclasses do NOT need to override this method,
+     *  they can override renderPage which is always called AFTER the map has been made valid.
+     */
+    void setWizardDataMap(Map m) {
+        if (m == null) {
+            wizardData = new HashMap();
+        } else {
+            if (wizardData instanceof HashMap) {
+                // our initial map has keys for all of our components
+                // but with dummy empty values
+                // So make sure we don't override data that was put in as part of the initialProperties
+                for (Iterator iter = wizardData.entrySet().iterator(); iter.hasNext();)
+                {
+                    Map.Entry entry = (Map.Entry) iter.next();
+                    Object key = entry.getKey();
+                    if ( ! m.containsKey(key))
+                    {
+                        m.put(key, entry.getValue());
+                    }
+                }
+            }
+            wizardData = m;
+        }
+    }
+
+    /**
+     * Set the WizardController.  In the current impl, this is always the same
+     * object, but the API does not guarantee that.  The first time this is
+     * called, it will update the state of the passed controller to  match
+     * any state that was set by components during the construction of this
+     * component
+     */
+    void setController(WizardController controller) {
+        if (controller.getImpl() instanceof WC) {
+            ((WC) controller.getImpl()).configure(controller);
+        }
+
+        this.controller = controller;
+    }
+
+    /**
+     * Get the WizardController for interacting with the Wizard that
+     * contains this panel.
+     * Return value will never be null.
+     */
+    private WizardController getController() {
+        return controller;
+    }
+
+
+    /**
+     * Set the problem string.  Call this method if next/finish should be
+     * disabled.  The passed string will be visible to the user, and should
+     * be a short, localized description of what is wrong.
+     */
+    protected final void setProblem(String value) {
+        getController().setProblem(value);
+    }
+
+    /**
+     * Set whether the finish, next or both buttons should be enabled,
+     * assuming no problem string is set.
+     *
+     * @param value WizardController.MODE_CAN_CONTINUE,
+     *              WizardController.MODE_CAN_FINISH or
+     *              WizardController.MODE_CAN_CONTINUE_OR_FINISH;
+     */
+    protected final void setForwardNavigationMode(int value) {
+        getController().setForwardNavigationMode(value);
+    }
+
+    /**
+     * Disable all navigation.  Useful if some background task is being
+     * completed during which no navigation should be allowed.  Use with care,
+     * as it disables the cancel button as well.
+     */
+    protected final void setBusy(boolean busy) {
+        getController().setBusy(busy);
+    }
+
+    /**
+     * Store a value in response to user interaction with a GUI component.
+     */
+    protected final void putWizardData(Object key, Object value) {
+        logger.fine("putWizardData " + key + "=" + value); //NOI18N
+        getWizardDataMap().put(key, value);
+        if (!inBeginUIChanged && !inValidateContents) {
+            inValidateContents = true;
+            try {
+                setProblem(validateContents(null, null));
+            } finally {
+                inValidateContents = false;
+            }
+        }
+    }
+
+    /**
+     * Returns all of the keys in the wizard data map.
+     */
+    protected final Object[] getWizardDataKeys() {
+        return getWizardDataMap().keySet().toArray();
+    }
+
+    /**
+     * Retrieve a value stored in the wizard map, which may have been
+     * putWizardData there by this panel or any previous panel in the wizard which
+     * contains this panel.
+     */
+    protected final Object getWizardData(Object key) {
+        return getWizardDataMap().get(key);
+    }
+
+    /**
+     * Determine if the wizard map contains the requested key.
+     */
+    protected final boolean wizardDataContainsKey(Object key) {
+        return getWizardDataMap().containsKey(key);
+    }
+
+    /**
+     * Called when an event is received from one of the components in the
+     * panel that indicates user input.  Typically you won't need to touch this
+     * method, unless your panel contains custom components which are not
+     * subclasses of any standard Swing component, which the framework won't
+     * know how to listen for changes on.  For such cases, attach a listener
+     * to the custom component, and call this method with the event if you want
+     * validation to run when input happens.  Automatic updating of the
+     * settings map will not work for such custom components, for obvious
+     * reasons, so update the settings map, if needed, in validateContents
+     * for this case.
+     *
+     * @param source The component that the user interacted with (if it can
+     *               be determined from the event) or null
+     * @param event  Usually an instance of EventObject, except in the case of
+     *               DocumentEvent.
+     */
+    protected final void userInputReceived(Component source, Object event) {
+        if (inBeginUIChanged) {
+            logger.fine("Ignoring recursive entry to userInputReceived while updating map");
+            return;
+        }
+
+        //Update the map no matter what
+        inBeginUIChanged = true;
+
+        if (source != null) {
+            try {
+                maybeUpdateMap(source);
+            } finally {
+                inBeginUIChanged = false;
+            }
+        }
+
+        //Possibly some programmatic change from checkState could cause
+        //a recursive call
+        if (inUiChanged) {
+            logger.fine("Ignoring recursive entry to userInputReceieved from validateContents");
+            return;
+        }
+
+        inUiChanged = true;
+        inValidateContents = true;
+        try {
+            setProblem(validateContents(source, event));
+        } finally {
+            inUiChanged = false;
+            inValidateContents = false;
+        }
+    }
+
+    /**
+     * Puts the value from the component in the settings map if the
+     * component's name property is not null
+     */
+    void maybeUpdateMap(Component comp) {
+        if (logger.isLoggable(Level.FINE)) {
+            logger.fine("Maybe update map for " + comp.getClass().getName() +  //NOI18N
+                    " named " + comp.getName()); //NOI18N
+        }
+
+        Object mapKey = getMapKeyFor(comp);
+        // debug: System.err.println("MaybeUpdateMap " + mapKey + " from " + comp);
+        if (mapKey != null) {
+            Object value = valueFrom(comp);
+            if (logger.isLoggable(Level.FINE)) {
+                logger.fine("maybeUpdateMap putting " + mapKey + "," + value +
+                        " into settings"); //NOI18N
+            }
+            putWizardData(mapKey, value);
+        }
+    }
+
+    /**
+     * Callback for GenericListener to remove a component's value if its name
+     * changes or it is removed from the panel.
+     */
+    void removeFromMap(Object key) {
+        logger.fine("removeFromMap: " + key); //NOI18N
+        getWizardDataMap().remove(key);
+    }
+
+    /**
+     * Given an ad-hoc swing component, fetch the likely value based on its
+     * state.  The default implementation handles most common swing components.
+     * If you are using custom components and have assigned them names, override
+     * this method to handle getting an appropriate value out of your
+     * custom component and call super for the others.
+     */
+    protected Object valueFrom(Component comp) {
+        if (ccl != null && ccl.accept(comp)) {
+            return ccl.valueFor(comp);
+        }
+        if (comp instanceof JRadioButton || comp instanceof JCheckBox || comp instanceof JToggleButton) {
+            return ((AbstractButton) comp).getModel().isSelected() ? Boolean.TRUE : Boolean.FALSE;
+        } else if (comp instanceof JTree) {
+            TreePath path = ((JTree) comp).getSelectionPath();
+            if (path != null) {
+                return path.getLastPathComponent();
+            }
+        } else if (comp instanceof JFormattedTextField) {
+            return ((JFormattedTextField) comp).getValue();
+        } else if (comp instanceof JList) {
+            Object[] o = ((JList) comp).getSelectedValues();
+            if (o != null) {
+                if (o.length > 1) {
+                    return o;
+                } else if (o.length == 1) {
+                    return o[0];
+                }
+            }
+        } else if (comp instanceof JTextComponent) {
+            return ((JTextComponent) comp).getText();
+        } else if (comp instanceof JComboBox) {
+            return ((JComboBox) comp).getSelectedItem();
+        } else if (comp instanceof JColorChooser) {
+            return ((JColorChooser) comp).getSelectionModel().getSelectedColor();
+        } else if (comp instanceof JSpinner) {
+            return ((JSpinner) comp).getValue();
+        } else if (comp instanceof JSlider) {
+            return new Integer(((JSlider) comp).getValue());
+        }
+
+        return null;
+    }
+
+    /**
+     * Given an ad-hoc swing component, set the value as the property 
+     * from the settings.  The default implementation handles most common swing components.
+     * If you are using custom components and have assigned them names, override
+     * this method to handle getting an appropriate value out of your
+     * custom component and call super for the others.
+     */
+    protected void valueTo(Map settings, Component comp) {
+        String name = comp.getName();
+        Object value = settings.get(name);
+        if (comp instanceof JRadioButton || comp instanceof JCheckBox || comp instanceof JToggleButton) {
+            if (value instanceof Boolean)
+            {
+                ((AbstractButton) comp).getModel().setSelected(((Boolean) value).booleanValue());   
+            }
+// TOFIX: JTree
+        } else if (comp instanceof JFormattedTextField) {
+            ((JFormattedTextField) comp).setValue(value);
+//      }  else if (comp instanceof JTree) {
+//            TreePath path = ((JTree) comp).getSelectionPath();
+//            if (path != null) {
+//                return path.getLastPathComponent();
+//            }
+        } else if (comp instanceof JList) {
+            if (value instanceof Object[])
+            {
+                throw new IllegalArgumentException ("can't handle multi-select lists");
+            }
+            ((JList) comp).setSelectedValue(value, true);
+        } else if (comp instanceof JTextComponent) {
+            ((JTextComponent) comp).setText((String) value);
+        } else if (comp instanceof JComboBox) {
+            ((JComboBox) comp).setSelectedItem(value);
+        } else if (comp instanceof JColorChooser) {
+            ((JColorChooser) comp).getSelectionModel().setSelectedColor((Color)value);
+        } else if (comp instanceof JSpinner) {
+            ((JSpinner) comp).setValue(value);
+        } else if (comp instanceof JSlider) {
+            ((JSlider) comp).setValue(((Integer)value).intValue());
+        }
+    }
+
+    /**
+     * Get the map key that should be used to automatically put the value
+     * represented by this component into the wizard data map.
+     * <p/>
+     * The default implementation returns the result of <code>c.getName()</code>,
+     * which is almost always sufficient and convenient - just set the
+     * component names in a GUI builder and everything will be handled.
+     *
+     * @return null if the component's value should not be automatically
+     *         written to the wizard data map, or an object which is the key that
+     *         later code will use to find this value.  By default, it returns the
+     *         component's name.
+     */
+    protected Object getMapKeyFor(Component c) {
+        if (ccl != null && ccl.accept(c)) {
+            return ccl.keyFor(c);
+        } else {
+            return c.getName();
+        }
+    }
+
+    /**
+     * Called when user interaction has occurred on a component contained by this
+     * panel or one of its children.  Override this method to check if all of
+     * the values are legal, such that the Next/Finish button should be enabled,
+     * optionally calling <code>setForwardNavigationMode()</code> if warranted.
+     * <p/>
+     * This method also may be called with a null argument an effect of
+     * calling <code>putWizardData()</code> from someplace other than within
+     * this method.
+     * <p/>
+     * Note that this method may be called very frequently, so it is important
+     * that validation code be fast.  For cases such as <code>DocumentEvent</code>s,
+     * it may be desirable to delay validation with a timer, if the implementation
+     * of this method is too expensive to call on each keystroke.
+     * <p/>
+     * Either the component, or the event, or both may be null on some calls
+     * to this method (such as when it is called because the settings map
+     * has been written to).
+     * <p/>
+     * The default implementation returns null.
+     *
+     * @param component The component the user interacted with, if it can be
+     *                  determined.  The infrastructure does track the owners of list models
+     *                  and such, and can find the associated component, so this will usually
+     *                  (but not necessarily) be non-null.
+     * @param event     The event object (if any) that triggered this call to
+     *                  validateContents.  For most cases this will be an instance of
+     *                  EventObject, and can be used to directly detect what component
+     *                  the user interacted with.  Since javax.swing.text.DocumentEvent is
+     *                  not a subclass of EventObject, the type of the argument is Object,
+     *                  so these events may be passed.
+     * @return A localized string describing why navigation should be disabled,
+     *         or null if the state of the components is valid and forward navigation
+     *         should be enabled.
+     */
+    protected String validateContents(Component component, Object event) {
+        return null;
+    }
+
+    /**
+     * Called if the user is navigating into this panel when it has already
+     * been displayed at least once - the user has navigated back to this
+     * panel, or back past this panel and is now navigating forward again.
+     * <p/>
+     * If some of the UI needs to be set up based on values from earlier
+     * pages that may have changed, do that here, fetching values from the
+     * settings map by calling <code>getWizardData()</code>.
+     * <p/>
+     * The default implementation simply calls
+     * <code>validateContents (null, null)</code>.
+     */
+    protected void recycle() {
+        setProblem(validateContents(null, null));
+    }
+
+    /**
+     * Get the settings map into which the wizard gathers settings.
+     * Return value will never be null.
+     */
+    // the map is empty during construction, then later set to the map from the containing WizardController
+    protected Map getWizardDataMap() {
+        if (wizardData == null) {
+            wizardData = new HashMap();
+        }
+        return wizardData;
+    }
+    
+    private String longDescription;
+    /**
+     * Set the long description of this page.  This method may be called
+     * only once and should be called from within the constructor.
+     * @param desc The long description for this step
+     */ 
+    protected void setLongDescription(String desc) {
+        if (!Beans.isDesignTime() && this.longDescription != null) {
+            throw new IllegalStateException ("Long description already set to" +
+                    " " + desc);
+        }
+        this.longDescription = desc;
+    }
+    
+    /**
+     * Get the long description of this page, which should be used in the title
+     * area of the wizard's UI if non-null.  To use, call setLongDescription()
+     * in your WizardPage's constructor.  It may be set only once.
+     * 
+     * @return the description
+     */ 
+    public final String getLongDescription() {
+        return longDescription;
+    }
+
+    static WizardPanelProvider createWizardPanelProvider (WizardPage page) {
+        return new WPP (new WizardPage[] { page }, WizardResultProducer.NO_OP);
+    }
+
+    static WizardPanelProvider createWizardPanelProvider (WizardPage[] page) {
+        return new WPP (page, WizardResultProducer.NO_OP);
+    }
+
+
+    /**
+     * WizardPanelProvider that takes an array of already created WizardPages
+     */
+    static final class WPP extends WizardPanelProvider {
+        private final WizardPage[] pages;
+        private final WizardResultProducer finish;
+
+        WPP(WizardPage[] pages, WizardResultProducer finish) {
+            super(Util.getSteps(pages), Util.getDescriptions(pages));
+
+            //Fail-fast validation - don't wait until something goes wrong
+            //if the data are bad
+            // assert valid(pages) == null : valid(pages);
+            // assert finish != null;
+            String v = valid(pages);
+            if (v != null)
+            {
+                throw new RuntimeException (v);
+            }
+            if (finish == null)
+            {
+                throw new RuntimeException ("finish must not be null");
+            }
+            
+            this.pages = pages;
+            this.finish = finish;
+        }
+
+        WPP(String title, WizardPage[] pages, WizardResultProducer finish) {
+            super(title, Util.getSteps(pages), Util.getDescriptions(pages));
+
+            //Fail-fast validation - don't wait until something goes wrong
+            //if the data are bad
+            // assert valid(pages) == null : valid(pages);
+            // assert finish != null;
+            String v = valid(pages);
+            if (v != null)
+            {
+                throw new RuntimeException (v);
+            }
+            if (finish == null)
+            {
+                throw new RuntimeException ("finish must not be null");
+            }
+
+
+            this.pages = pages;
+            this.finish = finish;
+        }
+
+        protected JComponent createPanel(WizardController controller, String id,
+                                         Map wizardData) {
+            int idx = indexOfStep(id);
+
+            // assert idx != -1 : "Bad ID passed to createPanel: " + id; //NOI18N
+            if (idx == -1)
+            {
+                throw new RuntimeException ("Bad ID passed to createPanel: " + id); //NOI18N
+            }
+            pages[idx].setController(controller);
+            pages[idx].setWizardDataMap(wizardData);
+
+            return pages[idx];
+        }
+
+        /**
+         * Make sure we haven't been passed bogus data
+         */
+        private String valid(WizardPage[] pages) {
+            if (new HashSet(Arrays.asList(pages)).size() != pages.length) {
+                return "Duplicate entry in array: " +  //NOI18N
+                        Arrays.asList(pages);
+            }
+
+            for (int i = 0; i < pages.length; i++) {
+                if (pages[i] == null) {
+                    return "Null entry at " + i + " in pages array"; //NOI18N
+                }
+            }
+
+            return null;
+        }
+
+        protected Object finish(Map settings) throws WizardException {
+            return finish.finish(settings);
+        }
+
+        public boolean cancel(Map settings) {
+            return finish.cancel (settings);
+        }
+    
+        public String getLongDescription(String stepId) {
+            for (int i = 0; i < pages.length; i++) {
+                WizardPage wizardPage = pages[i];
+                if (stepId.equals(wizardPage.getID())) {
+                    return wizardPage.getLongDescription();
+                }
+            }
+            return null;
+        }
+    }
+
+    /**
+     * WizardPanelProvider that takes an array of WizardPage subclasses and
+     * instantiates them on demand
+     */
+    private static final class CWPP extends WizardPanelProvider {
+        private final Class[] classes;
+        private final WizardResultProducer finish;
+        private final String[] longDescriptions;
+
+        CWPP(String title, Class[] classes, WizardResultProducer finish) {
+            super(title, Util.getSteps(classes), Util.getDescriptions(classes));
+//            assert classes != null : "Class array may not be null";
+//            assert new HashSet(Arrays.asList(classes)).size() == classes.length :
+//                    "Duplicate entries in class array";
+//            assert finish != null : "WizardResultProducer may not be null";
+            
+            _validateArgs (classes, finish);
+            this.finish = finish;
+            this.classes = classes;
+            longDescriptions = new String [ classes.length ];
+        }
+
+        private void _validateArgs (Class [] classes, WizardResultProducer finish)
+        {
+//            assert classes != null : "Class array may not be null";
+//            assert new HashSet(Arrays.asList(classes)).size() == classes.length :
+//                    "Duplicate entries in class array";
+//            assert finish != null : "WizardResultProducer may not be null";
+
+            if (classes == null)
+            {
+                throw new RuntimeException ("Class array may not be null");
+            }
+            if ( new HashSet(Arrays.asList(classes)).size() != classes.length)
+            {
+                throw new RuntimeException ("Duplicate entries in class array");
+            }
+            if (finish == null)
+            {
+                throw new RuntimeException ("WizardResultProducer may not be null");
+            }
+        }
+        
+        CWPP(Class[] classes, WizardResultProducer finish) {
+            super(Util.getSteps(classes), Util.getDescriptions(classes));
+
+//            assert classes != null : "Class array may not be null";
+//            assert new HashSet(Arrays.asList(classes)).size() == classes.length :
+//                    "Duplicate entries in class array";
+//            assert finish != null : "WizardResultProducer may not be null";
+
+            longDescriptions = new String [ classes.length ];
+            _validateArgs (classes, finish);
+
+            this.classes = classes;
+            this.finish = finish;
+        }
+
+        
+        protected JComponent createPanel(WizardController controller, String id, Map wizardData) {
+            int idx = indexOfStep(id);
+
+            // assert idx != -1 : "Bad ID passed to createPanel: " + id; //NOI18N
+            if (idx == -1)
+            {
+                throw new RuntimeException ( "Bad ID passed to createPanel: " + id); //NOI18N
+            }
+            try {
+                WizardPage result = (WizardPage) classes[idx].newInstance();
+                longDescriptions[idx] = result.getLongDescription();
+                
+                result.setController(controller);
+                result.setWizardDataMap(wizardData);
+
+                return result;
+            } catch (Exception e) {
+                logger.log(Level.WARNING, "Could not instantiate " + classes[idx], e);
+                // really IllegalArgumentException, but we need to have the "cause" get shown in stack trace
+                throw new RuntimeException("Could not instantiate " + //NOI18N
+                        classes[idx], e);
+            }
+        }
+
+        protected Object finish(Map settings) throws WizardException {
+            return finish.finish(settings);
+        }
+        
+        public boolean cancel(Map settings) {
+            return finish.cancel(settings);
+        }
+        
+        public String toString() {
+            return super.toString() + " for " + finish;
+        }
+    
+        public String getLongDescription(String stepId) {
+            int idx = indexOfStep (stepId);
+            if (idx != -1) {
+                return longDescriptions[idx] == null ? descriptions [idx] :
+                    longDescriptions[idx];
+            }
+            return null;
+        }
+    }
+
+    /**
+     * A dummy wizard controller which is used until the panel has actually
+     * been put into use;  so state can be set during the constructor, etc.
+     * Its state will be dumped into the real one once there is a real one.
+     */
+    private static final class WC implements WizardControllerImplementation {
+        private String problem = null;
+        private int canFinish = -1;
+        private Boolean busy = null;
+
+        public void setProblem(String value) {
+            this.problem = value;
+        }
+
+        public void setForwardNavigationMode(int value) {
+            switch (value) {
+                case WizardController.MODE_CAN_CONTINUE :
+                case WizardController.MODE_CAN_FINISH :
+                case WizardController.MODE_CAN_CONTINUE_OR_FINISH :
+                    break;
+                default :
+                    throw new IllegalArgumentException(Integer.toString(value));
+            }
+
+            canFinish = value;
+        }
+
+        public void setBusy(boolean busy) {
+            this.busy = busy ? Boolean.TRUE : Boolean.FALSE;
+        }
+
+        void configure(WizardController other) {
+            if (other == null) {
+                return;
+            }
+
+            if (busy != null) {
+                other.setBusy(busy.booleanValue());
+            }
+
+            if (canFinish != -1) {
+                other.setForwardNavigationMode(canFinish);
+            }
+
+            if (problem != null) {
+                other.setProblem(problem);
+            }
+        }
+    }
+
+    /**
+     * Interface that is passed to WizardPage.createWizard().  For wizards
+     * created from a set of WizardPages or WizardPage subclasses, this is
+     * the object that whose code will be run to create or do whatever the
+     * wizard does when the user clicks the Finish button.
+     */
+    public static interface WizardResultProducer {
+        /**
+         * Conclude a wizard, doing whatever the wizard does with the data
+         * gathered into the map on the various panels.
+         * <p>
+         * If an instance of <code>Summary</code> is returned from this method, the
+         * UI shall display it on a final page and disable all navigation buttons
+         * except the Close/Cancel button.
+         * <p>
+         * If an instance of <code>DeferredWizardResult</code> is returned from this
+         * method, the UI shall display some sort of progress bar while the result 
+         * is computed in the background.  If that <code>DeferredWizardResult</code>
+         * produces a <code>Summary</code> object, that summary shall be displayed
+         * as described above.
+         * @param wizardData the map with key-value pairs which has been
+         *  populated by the UI as the user progressed through the wizard
+         * @return an object composed based on what the user entered in the wizard - 
+         *  somethingmeaningful to whatever code invoked the wizard, or null.  Note
+         *  special handling if an instance of <code>DeferredWizardResult</code>
+         *  or <code>Summary</code> is returned from this method.
+         */
+        Object finish(Map wizardData) throws WizardException;
+
+        /**
+         * Called when the user presses the cancel button.  Almost all
+         * implementations will want to return true.
+         */
+        boolean cancel(Map settings);
+
+        /**
+         * A no-op WizardResultProducer that returns null.
+         */
+        WizardResultProducer NO_OP = new WizardResultProducer() {
+            public Object finish(Map wizardData) {
+                return wizardData;
+            }
+
+            public boolean cancel (Map settings) {
+                return true;
+            }
+            
+            public String toString() {
+                return "NO_OP WizardResultProducer";
+            }
+        };
+    }
+
+}

--- a/vassal-app/src/main/java/org/netbeans/spi/wizard/WizardPanel.java
+++ b/vassal-app/src/main/java/org/netbeans/spi/wizard/WizardPanel.java
@@ -1,0 +1,89 @@
+/*  The contents of this file are subject to the terms of the Common Development
+and Distribution License (the License). You may not use this file except in
+compliance with the License.
+    You can obtain a copy of the License at http://www.netbeans.org/cddl.html
+or http://www.netbeans.org/cddl.txt.
+    When distributing Covered Code, include this CDDL Header Notice in each file
+and include the License file at http://www.netbeans.org/cddl.txt.
+*/
+
+package org.netbeans.spi.wizard;
+
+import java.util.Map;
+
+/**
+ * This is an optional interface for panels that want to be notified when
+ * the next and back buttons are pressed.
+ * 
+ * The WizardPanelProvider is NOT required to create panels that implement
+ * this interface.
+ * 
+ * Each of these methods returns a WizardPanelNavResult that can be used to
+ * indicate PROCEED or REMAIN_ON_PAGE.
+ * 
+ * The result can also be an instance of a subclass of WizardPanelNavResult
+ * that implements the <code>start</code> method to use a background thread
+ * to determine if the next page can be shown.  
+ * 
+ * @author stanley@stanleyknutson.com
+ */
+public interface WizardPanel
+{
+    /**
+     * This method is invoked when the "next" button has been pushed,
+     * to do a final validation of input (such as doing a database login).
+     * 
+     * If this method return false, then the "next" button will not change the 
+     * displayed panel.  Presumably some error will have been shown to the user.
+     * 
+     * @param stepName
+     * @param settings
+     * @param wizard
+     * @return WizardPanelNavResult.PROCEED if the "next" button should proceed,
+     * WizardPanelNavResult.REMAIN_ON_PAGE if "next" should not proceed,
+     * or a instance of subclass of WizardPanelResult that will do some background computation
+     * and call the progress.finished method with one of those constants
+     * (or call progress.failed with the error message)
+     */
+    public WizardPanelNavResult allowNext (String stepName, Map settings, Wizard wizard);
+
+    /**
+     * This method is invoked when the "back" button has been pushed,
+     * to discard any data from the setings that will not been needed and for which the
+     * normal "just hide that data" is not the desired behavior.
+     * (See MergeMap for discussion of the "hide the data" behavior)
+     * 
+     * If this method return false, then the "next" button will not change the 
+     * displayed panel.  Presumably some error will have been shown to the user.
+     * 
+     * @param stepName
+     * @param settings
+     * @param wizard
+     * @return WizardPanelNavResult.PROCEED if the "back" button should proceed,
+     * WizardPanelNavResult.REMAIN_ON_PAGE if "back" should not proceed,
+     * or a instance of subclass of WizardPanelResult that will do some background computation
+     * and call the progress.finished method with one of those constants.
+     * (or call progress.failed with the error message)
+     */
+    public WizardPanelNavResult allowBack (String stepName, Map settings, Wizard wizard);
+
+    /**
+     * This method is invoked when the "finish" button has been pushed,
+     * to allow veto of the finish action BEFORE the wizard finish method is invoked.
+     * 
+     * If this method return false, then the "finish" button will have no effect. 
+     * Presumably some error will have been shown to the user.
+     * 
+     * @param stepName
+     * @param settings
+     * @param wizard
+     * @return WizardPanelNavResult.PROCEED if the "finish" button should proceed,
+     * WizardPanelNavResult.REMAIN_ON_PAGE if "finish" should not proceed,
+     * or a instance of subclass of WizardPanelResult that will do some background computation
+     * and call the progress.finished method with one of those constants.
+     * (or call progress.failed with the error message)
+     */
+    public WizardPanelNavResult allowFinish (String stepName, Map settings, Wizard wizard);
+
+}
+

--- a/vassal-app/src/main/java/org/netbeans/spi/wizard/WizardPanelNavResult.java
+++ b/vassal-app/src/main/java/org/netbeans/spi/wizard/WizardPanelNavResult.java
@@ -1,0 +1,85 @@
+/*  The contents of this file are subject to the terms of the Common Development
+and Distribution License (the License). You may not use this file except in
+compliance with the License.
+    You can obtain a copy of the License at http://www.netbeans.org/cddl.html
+or http://www.netbeans.org/cddl.txt.
+    When distributing Covered Code, include this CDDL Header Notice in each file
+and include the License file at http://www.netbeans.org/cddl.txt.
+*/
+
+package org.netbeans.spi.wizard;
+
+import java.util.Map;
+
+/**
+ * Result class for the methods in WizardPanel.
+ * 
+ * For immediate action, one of the two constantants PROCEED or REMAIN_ON_PAGE
+ * should be returned.  Otherwise an instance of a subclass should be returned
+ * that computes a Boolean result.
+ * 
+ * @author stanley@stanleyknutson.com
+ */
+public abstract class WizardPanelNavResult extends DeferredWizardResult
+{
+    /**
+     * value for procced to next step in the wizard.
+     */
+    public static final WizardPanelNavResult PROCEED = new WPNRimmediate(true);
+    /**
+     * Value to remain on the current page in the wizard
+     */
+    public static final WizardPanelNavResult REMAIN_ON_PAGE = new WPNRimmediate(false);
+
+    public WizardPanelNavResult(boolean useBusy) {
+        super (false, useBusy);
+    }
+
+    public WizardPanelNavResult() {
+        super (false, false);
+    }
+    
+    public boolean isDeferredComputation()
+    {
+        return true;
+    }
+    
+    /*
+     * internal class for the constants only
+     */
+    private final static class WPNRimmediate extends WizardPanelNavResult
+    {
+        boolean value;
+        
+        WPNRimmediate (boolean v)
+        {
+            value = v;
+        }
+        public boolean isDeferredComputation()
+        {
+            return false;
+        }
+        
+        public boolean equals (Object o)
+        {
+            if (o instanceof WPNRimmediate && ((WPNRimmediate)o).value == value)
+            {
+                return true;
+            }
+            return false;
+        }
+        
+        public int hashCode()
+        {
+            return value ? 1 : 2;
+        }
+        
+        public void start(Map settings, ResultProgressHandle progress)
+        {
+            // Should never get here, this is supposed to be immediate!
+            throw new RuntimeException("Immediate result was called as deferral!");
+        }
+        
+    }
+}
+

--- a/vassal-app/src/main/java/org/netbeans/spi/wizard/WizardPanelProvider.java
+++ b/vassal-app/src/main/java/org/netbeans/spi/wizard/WizardPanelProvider.java
@@ -1,0 +1,323 @@
+/*  The contents of this file are subject to the terms of the Common Development
+and Distribution License (the License). You may not use this file except in
+compliance with the License.
+    You can obtain a copy of the License at http://www.netbeans.org/cddl.html
+or http://www.netbeans.org/cddl.txt.
+    When distributing Covered Code, include this CDDL Header Notice in each file
+and include the License file at http://www.netbeans.org/cddl.txt.
+If applicable, add the following below the CDDL Header, with the fields
+enclosed by brackets [] replaced by your own identifying information:
+"Portions Copyrighted [year] [name of copyright owner]" */
+/*
+ * PanelProvider.java
+ *
+ * Created on March 5, 2005, 7:25 PM
+ */
+
+package org.netbeans.spi.wizard;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Map;
+import javax.swing.JComponent;
+
+/**
+ * (Note:  <code>WizardPage</code> offers somewhat simpler functionality for
+ * creating a wizard than does WizardPanelProvider;  the only advantage of
+ * <code>WizardPanelProvider</code> is that it does not require one to
+ * subclass a panel component).
+ * <p>
+ * A simple interface for providing a fixed set of panels for a wizard.
+ * To use, simply implement <code>createPanel()</code> to create the 
+ * appropriate UI component for a given step (a unique String ID - one of the ones passed 
+ * in the constructor in the <code>steps</code> array), and implement 
+ * <code>finish()</code> to do whatever should be done when the wizard is
+ * finished.
+ * <p>
+ * To control whether the Next/Finish buttons are enabled, components 
+ * created in <code>createPanel()</code> should call methods on the <code>
+ * WizardController</code> passed.  The created panels should listen on the
+ * UI components they create, updating the settings Map when the user changes
+ * their input.
+ * <p>
+ * Super-simple one-pane wizard example - if the checkbox is checked, the user
+ * can continue:
+ * <pre>
+ * public class MyProvider extends WizardPanelProvider {
+ *    public MyProvider() {
+ *       <font color="gray">//here we pass a localized title for the wizard, 
+ *       //the ID of the one step it will have, and a localized description
+ *       //the wizard can show for that one step</font>
+ *       super ("Click the box", "click", "Click the checkbox");
+ *    }
+ *    protected JComponent createPanel (final WizardController controller, String id, final Map settings) {
+ *       <font color="gray">//A quick sanity check</font>
+ *       assert "click".equals (id);
+ *       <font color="gray">//Remember this method will only be called <i>once</i> for any panel</font>
+ *       final JCheckBox result = new JCheckBox();
+ *       result.addActionListener (new ActionListener() {
+ *          public void actionPerformed (ActionEvent ae) {
+ *             <font color="gray">//Typically you want to write the result of some user 
+ *             //action into the settings map as soon as they do it </font>
+ *             settings.put ("boxSelected", result.isSelected() ? Boolean.TRUE : Boolean.FALSE);
+ *             if (result.isSelected()) {
+ *                controller.setProblem(null);
+ *             } else {
+ *                controller.setProblem("The box is not checked");
+ *             }
+ *             controller.setCanFinish(true); <font color="gray">//won't matter if we called setProblem() with non-null</font>
+ *          }
+ *       });
+ *       return result;
+ *    }
+ *
+ *    protected Object finish (Map settings) throws WizardException {
+ *       <font color="gray">//if we had some interesting information (Strings a user put in a 
+ *       //text field or something, we'd generate some interesting object or
+ *       //create some files or something here</font>
+ *       return null;
+ *    }
+ * }
+ * </pre>
+ *
+ * @author Tim Boudreau
+ */
+public abstract class WizardPanelProvider {
+    final String title;
+    final String[] descriptions;
+    final String[] steps;
+    final String[] knownProblems;
+    
+    /**
+     * Create a WizardPanelProvider.  The passed array of steps and descriptions
+     * will be used as IDs and localized descriptions of the various steps in
+     * the wizard.  Use this constructor (which passes not title) for sub-wizards
+     * used in a <code>WizardBranchController</code>, where the first pane 
+     * will determine the title, and the titles of the sub-wizards will never be 
+     * shown.
+     * @param steps A set of unique IDs identifying each step of this wizard.  Each
+     *   ID must occur only once in the array of steps.
+     *   
+     * @param descriptions A set of human-readable descriptions corresponding
+     *  1:1 with the unique IDs passed as the <code>steps</code> parameter
+     */
+    protected WizardPanelProvider (String[] steps, String[] descriptions) {
+        this (null, steps, descriptions);
+    }
+    
+    /**
+     * Create a WizardPanelProvider with the provided title, steps and 
+     * descriptions.  The <code>steps</code> parameter are unique IDs of 
+     * panels, which will be passed to <code>createPanel</code> to create
+     * panels for various steps in the wizard, as the user navigates it.
+     * The <code>descriptions</code> parameter is a set of localized descriptions
+     * that can appear in the Wizard to describe each step.
+     * @param title A human readable title for the wizard dialog
+     * @param steps An array of unique IDs for the various panels of this 
+     *  wizard
+     * @param descriptions An array of descriptions corresponding 1:1 with the
+     *  unique IDs.  These must be human readable, localized strings.
+     */
+    protected WizardPanelProvider (String title, String[] steps, String[] descriptions) {
+        this.title = title;
+        this.steps = steps;
+        this.descriptions = descriptions;
+        knownProblems = new String[steps.length];
+        if (steps.length != descriptions.length) {
+            throw new IllegalArgumentException ("Length of steps and" +
+                    " descriptions arrays do not match");
+        }
+        // assert validData (steps, descriptions) == null : validData (steps, descriptions);
+        String v = validData (steps, descriptions);
+        if (v != null)
+        {
+            throw new RuntimeException (v);
+        }
+    }
+    
+    
+    private String validData (String[] steps, String[] descriptions) {
+        if (steps.length != descriptions.length) {
+            return steps.length + " steps but " + descriptions.length + 
+                    " descriptions";
+        }
+        for (int i=0; i < steps.length; i++) {
+            if (steps[i] == null) {
+                throw new NullPointerException ("Step id " + i + " is null");
+            }
+            if (descriptions[i] == null) {
+                throw new NullPointerException ("Description " + i + " is null");
+            }
+        }
+        if (new HashSet(Arrays.asList(steps)).size() != steps.length) {
+            return "Duplicate step ids: " + Arrays.asList(steps);
+        }
+        return null;
+    }
+    
+    /**
+     * Convenience constructor to create a WizardPanelProvider which has only
+     * one step to it.  Mainly useful for initial steps in a <code>WizardBranchController</code>.
+     * @param title A human readable title for the wizard dialog
+     * @param singleStep The unique ID of the only step this wizard has
+     * @param singleDescription The human-readable description of what the user
+     *  should do in the one step of this one-step wizard or sub-wizard
+     */
+    protected WizardPanelProvider (String title, String singleStep, String singleDescription) {
+        this (title, new String[] {singleStep}, new String[] {singleDescription});
+    }
+    
+    /**
+     * Create a panel that represents a named step in the wizard.
+     * This method will be called exactly <i>once</i> in the life of 
+     * a wizard.  The panel should retain the passed settings Map, and
+     * add/remove values from it as the user enters information, calling
+     * <code>setProblem()</code> and <code>setCanFinish()</code> as
+     * appropriate in response to user input.
+     * 
+     * @param controller - the object which controls whether the
+     *  Next/Finish buttons in the wizard are enabled, and what instructions
+     *  are displayed to the user if they are not
+     * @param id The name of the step, one of the array of steps passed in
+     *  the constructor
+     * @param settings A Map containing settings from earlier steps in
+     *   the wizard.  It is safe to retain a reference to this map and put
+     *   values in it as the user manipulates the UI;  the reference should
+     *   be refreshed whenever this method is called again.
+     * @return A JComponent that should be displayed in the center of the
+     *  wizard
+     */
+    protected abstract JComponent createPanel (WizardController controller, String id, Map settings);
+    
+    /**
+     * Instantiate whatever object (if any) the wizard creates from its
+     * gathered data.  The default implementation is a no-op that returns
+     * null.
+     * <p>
+     * If an instance of <code>Summary</code> is returned from this method, the
+     * UI shall display it on a final page and disable all navigation buttons
+     * except the Close/Cancel button.
+     * <p>
+     * If an instance of <code>DeferredWizardResult</code> is returned from this
+     * method, the UI shall display some sort of progress bar while the result 
+     * is computed in the background.  If that <code>DeferredWizardResult</code>
+     * produces a <code>Summary</code> object, that summary shall be displayed
+     * as described above.
+     * <p>
+     * The default implementation returns the settings map it is passed.
+     *
+     * @param settings The settings map, now fully populated with all settings needed
+     *  to complete the wizard (this method will only be called if 
+     *  <code>setProblem(null)</code> and <code>setCanFinish(true)</code> have
+     *  been called on the <code>WizardController</code> passed to 
+     *  <code>createPanel()</code>.  
+     * @return an object composed based on what the user entered in the wizard - 
+     *  somethingmeaningful to whatever code invoked the wizard, or null.  Note
+     *  special handling if an instance of <code>DeferredWizardResult</code>
+     *  or <code>Summary</code> is returned from this method.
+     */
+    protected Object finish (Map settings) throws WizardException {
+        return settings;
+    }
+
+    /**
+     * The method provides a chance to call setProblem() or setCanFinish() when
+     * the user re-navigates to a panel they've already seen - in the case 
+     * that the user pressed the Previous button and then the Next button.
+     * <p>
+     * The default implementation does nothing, which is sufficient for most
+     * cases.
+     * If whether this panel is valid or not could
+     * have changed because of changed data from a previous panel, or it
+     * displays data entered on previous panes which may have changed,
+     * you may want to override this method to ensure validity and canFinish
+     * are set correctly, and that the components have the correct text.
+     * <p>
+     * This method will <i>not</i> be called when a panel is first instantiated - 
+     * <code>createPanel()</code> is expected to set validity and canFinish
+     * appropriately.
+     * <p>
+     * The settings Map passed to this method will always be the same 
+     * Settings map instance that was passed to <code>createPanel()</code>
+     * when the panel was created.
+     * <p>
+     * If you are implementing WizardPanelProvider and some of the pages are
+     * <code>WizardPage</code>s, you should call the super implementation if
+     * you override this method.
+     */
+    protected void recycleExistingPanel (String id, WizardController controller, Map wizardData, JComponent panel) {
+        //do nothing
+    }
+
+    void recycle (String id, WizardController controller, Map wizardData, JComponent panel) {
+        if (panel instanceof WizardPage) {
+            WizardPage page = (WizardPage) panel;
+            page.setController(controller);
+            page.setWizardDataMap(wizardData);
+            page.recycle();
+        }
+        recycleExistingPanel (id, controller, wizardData, panel);
+    }
+    
+    private Wizard wizard;
+    /**
+     * Create a Wizard for this PanelProvider.  The instance created by this
+     * method is cached and the same instance will be returned on subsequent
+     * calls.
+     */
+    public final Wizard createWizard() {
+        if (wizard == null) {
+            wizard = new Wizard (new SimpleWizard (this));
+        }
+        return wizard;
+    }
+    
+    /**
+     * This method can optionally be overridden to provide a longer
+     * description of a step to be shown in the top of its panel.
+     * The default implementation returns null, indicating that the
+     * short description should be used.
+     * 
+     * @param stepId a unique id for one step of the wizard
+     * @return An alternate description for use in the top of the wizard
+     *   page when this page is the current one, or null
+     */ 
+    public String getLongDescription (String stepId) {
+        return null;
+    }
+    
+    /**
+     * Convenience method to get the index into the array of steps passed to
+     * the constructor of a specific step id.  
+     */
+    protected final int indexOfStep (String id) {
+        return Arrays.asList(steps).indexOf(id);
+    }
+    
+    void setKnownProblem (String problem, int idx) {
+        //Record a problem message so we can put it back if the user does
+        //prev and then next
+        if (idx >= 0) { //setProblem() can be called during initialization
+            knownProblems[idx] = problem;
+        }
+    }
+    
+    String getKnownProblem(int idx) {
+        return knownProblems[idx];
+    }
+
+    /**
+     * Called if the user invokes cancel.  The default impl returns
+     * true.
+     * @return false to abort cancellation (almost all implementations will
+     *  want to return true - this is really only applicable in cases such
+     *  as an OS installer or such).
+     */
+    public boolean cancel(Map settings) {
+        return true;
+    }
+    
+    public String toString() {
+        return super.toString() + " with wizard " + wizard;
+    }
+}

--- a/vassal-doc/pom.xml
+++ b/vassal-doc/pom.xml
@@ -37,6 +37,12 @@
                             <outputDirectory>${project.build.outputDirectory}</outputDirectory>
                             <backend>html</backend>
                             <preserveDirectories>true</preserveDirectories>
+                            <attributes>
+                              <!-- Disable due to bug in Ruby with
+                                   Java 17 and up - see
+                                   https://github.com/asciidoctor/asciidoctorj-pdf/issues/108 -->
+                              <optimize>false</optimize>
+                            </attributes>
                         </configuration>
                     </execution>
                     <execution>
@@ -51,6 +57,10 @@
                             <backend>pdf</backend>
                             <attributes>
                                 <project-version>${project.version}</project-version>
+                                <!-- Disable due to bug in Ruby with
+                                     Java 17 and up - see
+                                     https://github.com/asciidoctor/asciidoctorj-pdf/issues/108 -->
+                                <optimize>false</optimize>
                             </attributes>
                         </configuration>
                     </execution>


### PR DESCRIPTION
- This patch integrates the `Wizard` package directly into the source
  tree.   Closes #14099
  - The `Wizard` package is no longer maintained, though still available
    as binary only through Maven.
  - To ensure better bug handling and maintainance, this patch
    integrates the package into the VASSAL source tree.
  - The sources were taken from https://github.com/karchie/Wizard.
- Also, as a minor effect, disables - explicitly - optimisation of PDFs
  produced by `asciidoctor` because that fails with Java > 11 due to a
  bug in Ruby (see
  https://github.com/asciidoctor/asciidoctorj-pdf/issues/108)
- Note, `spotbug` does not work with Java 25. Probably a similar problem
  to https://github.com/spotbugs/spotbugs/issues/2567.  This is _not_
  addressed here.