### PR TITLE
14070 Do not display blank or empty tooltips

### DIFF
--- a/vassal-app/src/main/java/VASSAL/tools/LaunchButton.java
+++ b/vassal-app/src/main/java/VASSAL/tools/LaunchButton.java
@@ -26,6 +26,7 @@ import VASSAL.configure.StringConfigurer;
 import VASSAL.i18n.Localization;
 import VASSAL.i18n.Resources;
 import VASSAL.script.expression.Auditable;
+import org.apache.commons.lang3.StringUtils;
 
 import javax.swing.Icon;
 import javax.swing.JButton;
@@ -250,7 +251,7 @@ public class LaunchButton extends JButton implements Auditable {
       }
     }
     // Don't show empty tooltips
-    if (text != null && text.trim().isEmpty()) {
+    if (StringUtils.isBlank(text)) {
       text = null;
     }
     super.setToolTipText(text);

--- a/vassal-app/src/main/java/VASSAL/tools/LaunchButton.java
+++ b/vassal-app/src/main/java/VASSAL/tools/LaunchButton.java
@@ -249,6 +249,10 @@ public class LaunchButton extends JButton implements Auditable {
         text += "[" + NamedHotKeyConfigurer.getString(keyListener.getKeyStroke()) + "]"; //$NON-NLS-1$ //$NON-NLS-2$
       }
     }
+    // Don't show empty tooltips
+    if (text != null && text.trim().isEmpty()) {
+      text = null;
+    }
     super.setToolTipText(text);
   }
 


### PR DESCRIPTION
Don't display an empty tooltip when pointer hovers over a toolbar button.

Closes #14070
