### PR TITLE
14065 Remove whitespace characters from internationalized Dice Summary strings

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/module/DiceButton.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/DiceButton.java
@@ -335,9 +335,11 @@ public class DiceButton extends AbstractToolbarItem {
 
     for (int i = 0; i < sortedKeys.length; i++) {
       if (i > 0) {
-        summaryVal.append(Resources.getString("Dice.summary_separator"));
+        summaryVal.append(Resources.getString("Dice.summary_separator"))
+                .append(' ');
       }
       summaryVal.append(sortedKeys[i])
+              .append(' ')
               .append(Resources.getString("Dice.summary_times"))
               .append(resultCounts.get(sortedKeys[i]));
     }

--- a/vassal-app/src/main/java/VASSAL/build/module/RandomTextButton.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/RandomTextButton.java
@@ -164,8 +164,12 @@ public class RandomTextButton extends DiceButton {
     }
 
     for (int i = 0; i < summaryKeys.length; i++) {
-      if (i > 0) summaryResult.append(Resources.getString("Dice.summary_separator"));
+      if (i > 0) {
+        summaryResult.append(Resources.getString("Dice.summary_separator"))
+                .append(' ');
+      }
       summaryResult.append(summaryKeys[i])
+              .append(' ')
               .append(Resources.getString("Dice.summary_times"))
               .append(resultCounts.get(summaryKeys[i]));
     }

--- a/vassal-app/src/main/resources/VASSAL/i18n/VASSAL.properties
+++ b/vassal-app/src/main/resources/VASSAL/i18n/VASSAL.properties
@@ -642,8 +642,8 @@ Dice.add_to_each_side=Add to each die
 Dice.add_to_total=Add to overall total
 Dice.random_text_non_numeric=Numeric Random Text Button [%1$s] has a non-numeric face
 Dice.random_text_too_few_faces=Random Text Button [%1$s] has too few faces for roll
-Dice.summary_separator=,\n
-Dice.summary_times=\nx
+Dice.summary_separator=,
+Dice.summary_times=x
 
 # Documentation
 Documentation.about_module=About Module


### PR DESCRIPTION
Removed the linefeed characters from the Dice Summary delimiters in the i18n file. Without digging into command parsing, it looks like the linefeed characters confused the parser. This then blocks the update of the die roll result on the other player's screen.

Leading and trailing whitespace in i18n properties files is problematic. These strings can be modified inadvertently. Some editors can automatically remove trailing plain whitespace depending on their configuration. Whitespace can be escaped but some editors may interpret and replace these. Leading or trailing whitespace may not be obvious to translators. Best to avoid leading and trailing whitespace in the i18n files.

As an aside, the adoc should indicate that the summary is internationalized and parsing should be discouraged.
