### PR TITLE
14222 Don't report changes to scenario options when report text is empty

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/module/properties/AbstractScenarioProperty.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/properties/AbstractScenarioProperty.java
@@ -169,7 +169,9 @@ public abstract class AbstractScenarioProperty extends GlobalProperty {
         reportFormat.setProperty(ScenarioPropertiesOptionTab.REPORT_OLD_VALUE, oldValue);
         reportFormat.setProperty(ScenarioPropertiesOptionTab.REPORT_NEW_VALUE, newValue.toString());
         final String report = reportFormat.getLocalizedText(this, "Editor.ScenarioOption.report_format");
-        c = c.append(new Chatter.DisplayText(gm.getChatter(), "* " + report));
+        if (!report.isEmpty()) {
+          c = c.append(new Chatter.DisplayText(gm.getChatter(), "* " + report));
+        }
       }
 
       // Perform the property change and report on our client and save the command


### PR DESCRIPTION
Suppress reporting scenario option changes when the report text is empty. This change is similar to the change in `DoActionButton` to prevent empty lines in the chat.

Closes #14222 