### PR TITLE
Mark as moved when moving a piece between mats within the same location

### DIFF
--- a/vassal-app/src/main/java/VASSAL/counters/EditablePiece.java
+++ b/vassal-app/src/main/java/VASSAL/counters/EditablePiece.java
@@ -112,7 +112,7 @@ public interface EditablePiece extends GamePiece {
 
     if ((loc == null) || loc.equals(oldLoc)) {
       if (GameModule.getGameModule().isMatSupport()) {
-        final String mat = (String) getProperty(Mat.MAT_ID);
+        final String mat = (String) getProperty(MatCargo.CURRENT_MAT_ID);
         final String oldMat = (String) getProperty(BasicPiece.OLD_MAT_ID);
         if ((mat == null) || mat.equals(oldMat)) {
           return null;


### PR DESCRIPTION
This seems like a bug due to a comparison of dissimilar properties. `MAT_ID` is a mat property while `OLD_MAT_ID` is mat cargo. To compare new and old mat IDs for mat cargo, the correct property is `CURRENT_MAT_ID`.

With this change implemented, pieces will now be marked moved when moving between mats that are located in the same location and "Mark When Moved" has the option "Ignore moves which don't change either Location Name or Mat' checked.