### PR TITLE
12051 Add Movement Trail option to keep only last position per location

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/module/map/PieceMover.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/PieceMover.java
@@ -61,7 +61,6 @@ import VASSAL.tools.image.ImageUtils;
 import VASSAL.tools.imageop.Op;
 import VASSAL.tools.swing.SwingUtils;
 
-import org.apache.commons.lang3.Strings;
 import org.apache.commons.lang3.SystemUtils;
 
 import javax.swing.ImageIcon;
@@ -778,7 +777,7 @@ public class PieceMover extends AbstractBuildable
         else {
           // Compare location names
           final String previousLocation = map.locationName(p.getPosition());
-          locDefinitelyChanged = !Strings.CS.equals(previousLocation, map.locationName(loc));
+          locDefinitelyChanged = (previousLocation == null) || !(previousLocation.equals(map.locationName(loc)));
           if (!locDefinitelyChanged && GameModule.getGameModule().isMatSupport()) {
             final String mat = (String) p.getProperty(MatCargo.CURRENT_MAT_ID);
             final String oldMat = (String) p.getProperty(BasicPiece.OLD_MAT_ID);

--- a/vassal-app/src/main/java/VASSAL/build/module/map/PieceMover.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/PieceMover.java
@@ -53,6 +53,7 @@ import VASSAL.counters.PieceVisitorDispatcher;
 import VASSAL.counters.Properties;
 import VASSAL.counters.PropertyExporter;
 import VASSAL.counters.Stack;
+import VASSAL.i18n.Resources;
 import VASSAL.tools.DebugControls;
 import VASSAL.tools.FormattedString;
 import VASSAL.tools.LaunchButton;
@@ -769,21 +770,18 @@ public class PieceMover extends AbstractBuildable
       boolean locDefinitelyChanged = false;
       final Map map = p.getMap();
       if (map != null) {
-        final Board board = map.findBoard(loc);
-        if (board == null) {
-          // Off board moves are always recorded by movement trails.
-          locDefinitelyChanged = true;
-        }
-        else {
-          // Compare location names
-          final String previousLocation = map.locationName(p.getPosition());
-          locDefinitelyChanged = (previousLocation == null) || !(previousLocation.equals(map.locationName(loc)));
-          if (!locDefinitelyChanged && GameModule.getGameModule().isMatSupport()) {
-            final String mat = (String) p.getProperty(MatCargo.CURRENT_MAT_ID);
-            final String oldMat = (String) p.getProperty(BasicPiece.OLD_MAT_ID);
-            if (mat != null && !mat.equals(oldMat)) {
-              locDefinitelyChanged = true;
-            }
+        // Compare location names
+        // Offboard moves are always considered as a changed location.
+        final String previousLocation = map.locationName(p.getPosition());
+        locDefinitelyChanged = (previousLocation == null)
+                || !(previousLocation.equals(map.locationName(loc)))
+                || previousLocation.equals(Resources.getString("Map.offboard"));
+
+        if (!locDefinitelyChanged && GameModule.getGameModule().isMatSupport()) {
+          final String mat = (String) p.getProperty(MatCargo.CURRENT_MAT_ID);
+          final String oldMat = (String) p.getProperty(BasicPiece.OLD_MAT_ID);
+          if (mat != null && !mat.equals(oldMat)) {
+            locDefinitelyChanged = true;
           }
         }
       }

--- a/vassal-app/src/main/java/VASSAL/counters/Footprint.java
+++ b/vassal-app/src/main/java/VASSAL/counters/Footprint.java
@@ -72,6 +72,7 @@ public class Footprint extends MovementMarkable {
   protected String startMapId = "";            // Map Id trail started on
                                                // List of points
   protected List<Point> pointList = new ArrayList<>();
+  private int lastPointListSize = 0;           // Index of the last removed point from pointList
 
   // Type Variables (Configured in Ed)
   protected NamedKeyStroke trailKey;           // Control Key to invoke
@@ -89,12 +90,14 @@ public class Footprint extends MovementMarkable {
   protected int edgePointBuffer;               // How far Off-map to draw trail points (pixels)?
   protected int edgeDisplayBuffer;             // How far Off-map to draw trail lines (pixels)?
   protected String description;                // Description for this movement trail
+  protected boolean keepLastPositionOnly = false;   // Only keep last position if location name does not change
 
   // Defaults for Type variables
   protected static final char DEFAULT_TRAIL_KEY = 'T';
   protected static final String DEFAULT_MENU_COMMAND = Resources.getString("Editor.Footprint.movement_trail");
   protected static final Boolean DEFAULT_INITIALLY_VISIBLE = Boolean.FALSE;
   protected static final Boolean DEFAULT_GLOBALLY_VISIBLE = Boolean.FALSE;
+  protected static final Boolean DEFAULT_KEEP_LAST_POSITION = Boolean.FALSE;
   protected static final int DEFAULT_CIRCLE_RADIUS = 10;
   protected static final Color DEFAULT_FILL_COLOR = Color.WHITE;
   protected static final Color DEFAULT_LINE_COLOR = Color.BLACK;
@@ -133,6 +136,7 @@ public class Footprint extends MovementMarkable {
   @Override
   public void mySetState(String newState) {
     pointList.clear();
+    lastPointListSize = 0;
     final SequenceEncoder.Decoder ss =
       new SequenceEncoder.Decoder(newState, ';');
     globalVisibility = ss.nextBoolean(initiallyVisible);
@@ -150,6 +154,7 @@ public class Footprint extends MovementMarkable {
       }
     }
     everInitialized = ss.nextBoolean(false);
+    lastPointListSize = ss.nextInt(items);
     requireNoOuterRotate();
   }
 
@@ -165,6 +170,7 @@ public class Footprint extends MovementMarkable {
     }
 
     se.append(everInitialized);
+    se.append(lastPointListSize);
 
     return se.getValue();
   }
@@ -193,6 +199,7 @@ public class Footprint extends MovementMarkable {
     trailKeyOff = st.nextNamedKeyStroke(null);
     trailKeyClear = st.nextNamedKeyStroke(null);
     description = st.nextToken("");
+    keepLastPositionOnly = st.nextBoolean(DEFAULT_KEEP_LAST_POSITION);
     commands = null;
     showTrailCommand = null;
     showTrailCommandOn = null;
@@ -221,7 +228,9 @@ public class Footprint extends MovementMarkable {
       .append(trailKeyOn)
       .append(trailKeyOff)
       .append(trailKeyClear)
-      .append(description);
+      .append(description)
+      .append(keepLastPositionOnly)
+    ;
     return ID + se.getValue();
   }
 
@@ -243,7 +252,16 @@ public class Footprint extends MovementMarkable {
 
   @Override
   public void setProperty(Object key, Object val) {
-    if (Properties.MOVED.equals(key) || Properties.MAYBE_MOVED.equals(key)) {
+    if (keepLastPositionOnly && Properties.MAYBE_MOVED.equals(key)) {
+      // Ignore moves within the same named location or mat.
+      if (pointList.size() > lastPointListSize) {
+        pointList.remove(pointList.size() - 1);
+        lastPointListSize = pointList.size();
+      }
+      piece.setProperty(key, val);
+      myBoundingBox = null;
+    }
+    else if (Properties.MOVED.equals(key) || Properties.MAYBE_MOVED.equals(key)) {
       setMoved(Boolean.TRUE.equals(val));
       piece.setProperty(key, val); // Pass on to MovementMarkable
       myBoundingBox = null;
@@ -316,6 +334,7 @@ public class Footprint extends MovementMarkable {
   protected void clearTrail() {
     myBoundingBox = null;
     pointList.clear();
+    lastPointListSize = 0;
     addPoint(getPosition());
     if (!initialized) {       //BR// Bug 12980 - prevent multiple re-initializations
       localVisibility = initiallyVisible;
@@ -805,6 +824,7 @@ public class Footprint extends MovementMarkable {
     if (! Objects.equals(trailKeyOff, c.trailKeyOff)) return false;
     if (! Objects.equals(trailKeyClear, c.trailKeyClear)) return false;
     if (! Objects.equals(description, c.description)) return false;
+    if (! Objects.equals(keepLastPositionOnly, c.keepLastPositionOnly)) return false;
 
     if (! Objects.equals(globalVisibility, c.globalVisibility)) return false;
     if (! Objects.equals(startMapId, c.startMapId)) return false;
@@ -826,6 +846,7 @@ public class Footprint extends MovementMarkable {
     private final StringConfigurer menuCommandConfig;
     private final BooleanConfigurer initiallyVisibleConfig;
     private final BooleanConfigurer globallyVisibleConfig;
+    private final BooleanConfigurer keepLastPositionConfig;
     private final IntConfigurer circleRadiusConfig;
     private final ColorConfigurer fillColorConfig;
     private final ColorConfigurer lineColorConfig;
@@ -862,6 +883,9 @@ public class Footprint extends MovementMarkable {
 
       globallyVisibleConfig = new BooleanConfigurer(p.globallyVisible);
       controls.add("Editor.Footprint.trails_are_visible_to_all_players", globallyVisibleConfig);
+
+      keepLastPositionConfig = new BooleanConfigurer(p.keepLastPositionOnly);
+      controls.add("Editor.MovementMarkable.ignore_same_location", keepLastPositionConfig);
 
       circleRadiusConfig = new IntConfigurer(p.circleRadius);
       controls.add("Editor.Footprint.circle_radius", circleRadiusConfig);
@@ -911,7 +935,8 @@ public class Footprint extends MovementMarkable {
         .append(trailKeyOn.getValueString())
         .append(trailKeyOff.getValueString())
         .append(trailKeyClear.getValueString())
-        .append(desc.getValueString());
+        .append(desc.getValueString())
+        .append(keepLastPositionConfig.getValueString());
       return ID + se.getValue();
     }
 

--- a/vassal-app/src/main/java/VASSAL/counters/Footprint.java
+++ b/vassal-app/src/main/java/VASSAL/counters/Footprint.java
@@ -90,14 +90,14 @@ public class Footprint extends MovementMarkable {
   protected int edgePointBuffer;               // How far Off-map to draw trail points (pixels)?
   protected int edgeDisplayBuffer;             // How far Off-map to draw trail lines (pixels)?
   protected String description;                // Description for this movement trail
-  protected boolean keepLastPositionOnly = false;   // Only keep last position if location name does not change
+  protected boolean ignoreSameLocation = false; // Only keep last position if location name does not change
 
   // Defaults for Type variables
   protected static final char DEFAULT_TRAIL_KEY = 'T';
   protected static final String DEFAULT_MENU_COMMAND = Resources.getString("Editor.Footprint.movement_trail");
   protected static final Boolean DEFAULT_INITIALLY_VISIBLE = Boolean.FALSE;
   protected static final Boolean DEFAULT_GLOBALLY_VISIBLE = Boolean.FALSE;
-  protected static final Boolean DEFAULT_KEEP_LAST_POSITION = Boolean.FALSE;
+  protected static final Boolean DEFAULT_IGNORE_SAME_LOCATION = Boolean.FALSE;
   protected static final int DEFAULT_CIRCLE_RADIUS = 10;
   protected static final Color DEFAULT_FILL_COLOR = Color.WHITE;
   protected static final Color DEFAULT_LINE_COLOR = Color.BLACK;
@@ -156,6 +156,10 @@ public class Footprint extends MovementMarkable {
     everInitialized = ss.nextBoolean(false);
     lastPointListSize = ss.nextInt(items);
     requireNoOuterRotate();
+    if (ignoreSameLocation) {
+      GameModule.getGameModule().setTrueMovedSupport(true);
+    }
+
   }
 
   @Override
@@ -199,7 +203,7 @@ public class Footprint extends MovementMarkable {
     trailKeyOff = st.nextNamedKeyStroke(null);
     trailKeyClear = st.nextNamedKeyStroke(null);
     description = st.nextToken("");
-    keepLastPositionOnly = st.nextBoolean(DEFAULT_KEEP_LAST_POSITION);
+    ignoreSameLocation = st.nextBoolean(DEFAULT_IGNORE_SAME_LOCATION);
     commands = null;
     showTrailCommand = null;
     showTrailCommandOn = null;
@@ -229,7 +233,7 @@ public class Footprint extends MovementMarkable {
       .append(trailKeyOff)
       .append(trailKeyClear)
       .append(description)
-      .append(keepLastPositionOnly)
+      .append(ignoreSameLocation)
     ;
     return ID + se.getValue();
   }
@@ -252,7 +256,7 @@ public class Footprint extends MovementMarkable {
 
   @Override
   public void setProperty(Object key, Object val) {
-    if (keepLastPositionOnly && Properties.MAYBE_MOVED.equals(key)) {
+    if (ignoreSameLocation && Properties.MAYBE_MOVED.equals(key)) {
       // Ignore moves within the same named location or mat.
       if (pointList.size() > lastPointListSize) {
         pointList.remove(pointList.size() - 1);
@@ -824,7 +828,7 @@ public class Footprint extends MovementMarkable {
     if (! Objects.equals(trailKeyOff, c.trailKeyOff)) return false;
     if (! Objects.equals(trailKeyClear, c.trailKeyClear)) return false;
     if (! Objects.equals(description, c.description)) return false;
-    if (! Objects.equals(keepLastPositionOnly, c.keepLastPositionOnly)) return false;
+    if (! Objects.equals(ignoreSameLocation, c.ignoreSameLocation)) return false;
 
     if (! Objects.equals(globalVisibility, c.globalVisibility)) return false;
     if (! Objects.equals(startMapId, c.startMapId)) return false;
@@ -846,7 +850,7 @@ public class Footprint extends MovementMarkable {
     private final StringConfigurer menuCommandConfig;
     private final BooleanConfigurer initiallyVisibleConfig;
     private final BooleanConfigurer globallyVisibleConfig;
-    private final BooleanConfigurer keepLastPositionConfig;
+    private final BooleanConfigurer sameLocationConfig;
     private final IntConfigurer circleRadiusConfig;
     private final ColorConfigurer fillColorConfig;
     private final ColorConfigurer lineColorConfig;
@@ -884,8 +888,8 @@ public class Footprint extends MovementMarkable {
       globallyVisibleConfig = new BooleanConfigurer(p.globallyVisible);
       controls.add("Editor.Footprint.trails_are_visible_to_all_players", globallyVisibleConfig);
 
-      keepLastPositionConfig = new BooleanConfigurer(p.keepLastPositionOnly);
-      controls.add("Editor.MovementMarkable.ignore_same_location", keepLastPositionConfig);
+      sameLocationConfig = new BooleanConfigurer(p.ignoreSameLocation);
+      controls.add("Editor.MovementMarkable.ignore_same_location", sameLocationConfig);
 
       circleRadiusConfig = new IntConfigurer(p.circleRadius);
       controls.add("Editor.Footprint.circle_radius", circleRadiusConfig);
@@ -936,7 +940,7 @@ public class Footprint extends MovementMarkable {
         .append(trailKeyOff.getValueString())
         .append(trailKeyClear.getValueString())
         .append(desc.getValueString())
-        .append(keepLastPositionConfig.getValueString());
+        .append(sameLocationConfig.getValueString());
       return ID + se.getValue();
     }
 

--- a/vassal-app/src/test/java/VASSAL/counters/FootprintTest.java
+++ b/vassal-app/src/test/java/VASSAL/counters/FootprintTest.java
@@ -17,14 +17,32 @@
 
 package VASSAL.counters;
 
+import VASSAL.build.GameModule;
+import VASSAL.build.module.GameState;
+import VASSAL.build.module.GlobalOptions;
+import VASSAL.build.module.Map;
+import VASSAL.build.module.index.IndexManager;
+import VASSAL.build.module.map.PieceMover;
+import VASSAL.build.module.map.boardPicker.Board;
+import VASSAL.build.module.map.boardPicker.board.SquareGrid;
+import VASSAL.build.module.map.boardPicker.board.mapgrid.SquareGridNumbering;
+import VASSAL.preferences.Prefs;
+import VASSAL.preferences.PrefsEditor;
 import VASSAL.tools.NamedKeyStroke;
 
 import java.awt.Color;
 import java.awt.Point;
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
+import java.util.List;
 
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import static VASSAL.counters.Properties.IGNORE_GRID;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
 
 public class FootprintTest extends DecoratorTest {
 
@@ -42,6 +60,7 @@ public class FootprintTest extends DecoratorTest {
     trait.menuCommand = "xyzzy"; // NON-NLS
     trait.initiallyVisible = true;
     trait.globallyVisible = true;
+    trait.keepLastPositionOnly = true;
     trait.circleRadius = 10;
     trait.fillColor = Color.blue;
     trait.lineColor = Color.cyan;
@@ -67,4 +86,195 @@ public class FootprintTest extends DecoratorTest {
 
   }
 
+  // Common setup for tests requiring a GameModule object.
+  private void runWithGameModule(Runnable testFunc) {
+    try (MockedStatic<GameModule> staticGm = Mockito.mockStatic(GameModule.class)) {
+
+      GameModule gm = mock(GameModule.class);
+
+      staticGm.when(GameModule::getGameModule).thenReturn(gm);
+      // Map.setUpView requires Prefs
+      Prefs prefs = new Prefs(new PrefsEditor(), "");
+      staticGm.when(gm::getPrefs).thenReturn(prefs);
+      // PieceMover.addTo requires GameState
+      GameState gameState = new GameState();
+      staticGm.when(gm::getGameState).thenReturn(gameState);
+      // required by PieceMover.movedPiece
+      DeckManager deckManager = new DeckManager();
+      staticGm.when(gm::getDeckManager).thenReturn(deckManager);
+      // Required by Map.addPiece
+      IndexManager indexManager = new IndexManager();
+      staticGm.when(gm::getIndexManager).thenReturn(indexManager);
+
+      // Turn off auto reporting since Map.idMgr is not initialized.
+      GlobalOptions.getInstance().setAttribute("autoReport", "Never");
+
+      testFunc.run();
+    }
+  }
+
+  // Create a board with a square grid.
+  private Board makeBoard(String name) {
+    final Board b = new Board();
+    b.setConfigureName(name);
+    SquareGrid grid = new SquareGrid();
+    SquareGridNumbering numbering = new SquareGridNumbering();
+    numbering.addTo(grid);
+    b.setGrid(grid);
+    return b;
+  }
+
+  // Check for non-movement where drag operation drops piece on its original location.
+  @Test
+  public void dragToSameLocationExpectNoTrail() {
+    runWithGameModule(() -> {
+      final Map map = new Map();
+      final Board b = makeBoard("board");
+      b.setMap(map);
+      map.setBoards(new ArrayList<>(List.of(b)));
+
+      Footprint trait = new Footprint();
+      // Initialize with movement trail enabled (i.e. the field after the description)..
+      trait.mySetType("footprint;;Name;true;false;10;255,255,255;0,0,0;100;50;20;30;1.0;;;;description;true");
+      trait.setInner(new DummyPiece());
+      trait.setId("footprint");
+      trait.setMap(map);
+      trait.setProperty(IGNORE_GRID, true);
+
+      Point p = trait.getPosition();
+      PieceMover pm = new PieceMover();
+      pm.addTo(map);
+      DragBuffer.getBuffer().clear();
+      DragBuffer.getBuffer().add(trait);
+      // Drag and drop the piece into the exact same spot.
+      pm.movePieces(map, p);
+      assertEquals(0, trait.pointList.size());
+    });
+  }
+
+  // Move the piece within the same location.
+  // Movement trail consists of only the initial location.
+  @Test
+  public void moveWithinSameLocationExpectEmptyTrail() {
+    runWithGameModule(() -> {
+      final Map map = new Map();
+      final Board b = makeBoard("board");
+      b.setMap(map);
+      map.setBoards(new ArrayList<>(List.of(b)));
+
+      Footprint trait = new Footprint();
+      // Initialize with movement trail enabled (i.e. the field after the description)..
+      trait.mySetType("footprint;;Name;true;false;10;255,255,255;0,0,0;100;50;20;30;1.0;;;;description;true");
+      trait.setInner(new DummyPiece());
+      trait.setId("footprint");
+      trait.setMap(map);
+      trait.setMoved(false);    // Reset movement trail
+      trait.setProperty(IGNORE_GRID, true);
+
+      Point p = trait.getPosition();
+      PieceMover pm = new PieceMover();
+      pm.addTo(map);
+      DragBuffer.getBuffer().clear();
+      DragBuffer.getBuffer().add(trait);
+      Point first = new Point(p);
+      // Multiple drag/drop actions without leaving the initial Location Name.
+      for (int i = 0; i < 4; ++i) {
+        p = new Point(p.x + 1, p.y + 1);
+        pm.movePieces(map, p);
+        trait.setPosition(p);
+      }
+      assertEquals(0, trait.pointList.size());
+    });
+  }
+
+  // Move in a circular path returning over the start location.
+
+  @Test
+  public void moveCircularPathExpectKeepAllPoints() {
+    runWithGameModule(() -> {
+      final Map map = new Map();
+      final Board b = makeBoard("board");
+      b.setMap(map);
+      map.setBoards(new ArrayList<>(List.of(b)));
+      int deltaX = (int) ((SquareGrid) b.getGrid()).getDx();
+      int deltaY = (int) ((SquareGrid) b.getGrid()).getDy();
+
+      Footprint trait = new Footprint();
+      trait.mySetType("footprint;;Name;true;false;10;255,255,255;0,0,0;100;50;20;30;1.0;;;;description;true");
+      trait.setInner(new DummyPiece());
+      trait.setId("footprint");
+      trait.setMap(map);
+      trait.setProperty(IGNORE_GRID, true);
+
+      // Define positions centered within each square.
+      List<Point> points = new ArrayList<>();
+      points.add(new Point(deltaX / 2, deltaY / 2));
+      points.add(new Point(deltaX * 3 / 2, deltaY / 2));
+      points.add(new Point(deltaX * 3 / 2, deltaY * 3 / 2));
+      points.add(new Point(deltaX / 2, deltaY / 2));
+      points.add(new Point(deltaX * 3 / 2, deltaY * 3 / 2));
+
+      PieceMover pm = new PieceMover();
+      pm.addTo(map);
+      DragBuffer.getBuffer().clear();
+      DragBuffer.getBuffer().add(trait);
+
+      trait.setPosition(points.get(0));
+      trait.setMoved(false);    // Reset movement trail
+      for (Point p : points) {
+        pm.movePieces(map, p);
+        trait.setPosition(p);
+      }
+      assertEquals(4, trait.pointList.size());
+      for (int i = 0; i < trait.pointList.size(); ++i) {
+        assertEquals(points.get(i), trait.pointList.get(i));
+      }
+    });
+  }
+
+  // Move in a circular path returning to the start location.
+  @Test
+  public void expectToKeepOffBoardMovement() {
+    runWithGameModule(() -> {
+      final Map map = new Map();
+      final Board b = makeBoard("board");
+      b.setMap(map);
+      map.setBoards(new ArrayList<>(List.of(b)));
+      int deltaX = (int) ((SquareGrid) b.getGrid()).getDx();
+      int deltaY = (int) ((SquareGrid) b.getGrid()).getDy();
+
+      Footprint trait = new Footprint();
+      trait.mySetType("footprint;;Name;true;false;10;255,255,255;0,0,0;100;50;20;30;1.0;;;;description;true");
+      trait.setInner(new DummyPiece());
+      trait.setId("footprint");
+      trait.setMap(map);
+      trait.setProperty(IGNORE_GRID, true);
+
+      // Define positions centered within each square.
+      List<Point> points = new ArrayList<>();
+      points.add(new Point(deltaX / 2, deltaY / 2));
+      points.add(new Point( b.getSize().width + 1, deltaY / 2));    // off-board
+      points.add(new Point(b.getSize().width + 1, deltaY * 3 / 2)); // off-board
+      points.add(new Point(deltaX / 2, deltaY * 3 / 2));
+
+      PieceMover pm = new PieceMover();
+      pm.addTo(map);
+      DragBuffer.getBuffer().clear();
+      DragBuffer.getBuffer().add(trait);
+
+      trait.setPosition(points.get(0));
+      trait.setMoved(false);    // Reset movement trail
+      for (Point p : points) {
+        pm.movePieces(map, p);
+        trait.setPosition(p);
+      }
+      assertEquals(3, trait.pointList.size());
+      for (int i = 0; i < trait.pointList.size(); ++i) {
+        assertEquals(points.get(i), trait.pointList.get(i));
+      }
+    });
+  }
+
+  static class DummyPiece extends BasicPiece {
+  }
 }

--- a/vassal-doc/src/main/readme-referencemanual/ReferenceManual/MovementTrail.adoc
+++ b/vassal-doc/src/main/readme-referencemanual/ReferenceManual/MovementTrail.adoc
@@ -47,8 +47,10 @@ This erases any existing trails, but leaves the trail's _showing_ or _hidden_ st
 
 *Trails start visible:*::  If checked, the piece will begin the game displaying movement trails.
 
-*Trails visibility synchronized for all players:*::  If selected, then toggling the visibility of the trail will affect all players' views and will be saved along with the game.
+*Trails visibility synchronized for all players:*::  If checked, then toggling the visibility of the trail will affect all players' views and will be saved along with the game.
 Otherwise, each player controls the visibility of trails on that player's view.
+
+*Ignore moves which don’t change either Location Name or Mat:*:: If checked then only a single point is recorded within each area traversed. The final position within the previous location is added to the movement trail when a piece leaves that location. In area movement games, this can be used to disregard inconsequential movement.
 
 *Circle radius:*:: The radius in pixels of the circle representing each location in the trail.
 


### PR DESCRIPTION
This is an alternate implementation to pull request #14231 which addresses and closes #12051

Add an option to keep the last movement trail position only when location name or mat change.
All off-board movement is always appended to the movement trail.
Check for mat to mat movement within a location.
Add unit tests for movement trails.
Update movement trails documentation adding the new option.

Closes #12051