### PR TITLE
12033 Log more info for the piece not on map exception

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/module/Map.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/Map.java
@@ -2573,8 +2573,10 @@ public class Map extends AbstractToolbarItem implements GameComponent, MouseList
    */
   public Point positionOf(GamePiece p) {
     if (p.getMap() != this) {
-      throw new IllegalArgumentException(
-        Resources.getString("Map.piece_not_on_map")); //$NON-NLS-1$
+      final String pieceMapName = p.getMap() != null ? p.getMap().mapName : "null"; //$NON-NLS-1$
+      final String message = Resources.getString("Map.piece_not_on_map") //$NON-NLS-1$
+        + String.format(": %s. Piece '%s' is on %s.", this.mapName, p.getName(), pieceMapName); //$NON-NLS-1$
+      throw new IllegalArgumentException(message);
     }
 
     final Point point = p.getPosition();


### PR DESCRIPTION
Report the piece name and the maps that cause the infrequent but chronic `IllegalArgumentException: Piece is not on this map`. Some additional information may help resolve the root cause of this exception. Sample output using a fabricated name and locations:

java.lang.IllegalArgumentException: Piece is not on this map: Main Map. Piece 'Superb Infantry Training' is on Player Mat.