### PR TITLE
Feature/window placement engine

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/GameModule.java
+++ b/vassal-app/src/main/java/VASSAL/build/GameModule.java
@@ -943,17 +943,17 @@ public class GameModule extends AbstractConfigurable
     if (GlobalOptions.getInstance().isUseSingleWindow()) {
       final Prefs p = Prefs.getGlobalPrefs();
 
-      // If we are not remembering the window size, reset preferences to force defaults
+      // If not "remembering" window size, nuke the pref
       if (Boolean.FALSE.equals(p.getOption(MAIN_WINDOW_REMEMBER).getValue())) {
         p.getOption(MAIN_WINDOW_WIDTH).setValue(-1);
         p.getOption(MAIN_WINDOW_HEIGHT).setValue(-1);
       }
 
-      // Read size preferences
+      // Read window size prefs
       final int ph = (Integer) p.getOption(MAIN_WINDOW_HEIGHT).getValue();
       final int pw = (Integer) p.getOption(MAIN_WINDOW_WIDTH).getValue();
 
-      // Use the preferences if valid; otherwise the current screen size
+      // Use pref if valid, otherwise screen dimensions
       final int h = (ph > 0) ? ph : screen.height;
       final int w = (pw > 0) ? pw : screen.width;
 

--- a/vassal-app/src/main/java/VASSAL/build/GameModule.java
+++ b/vassal-app/src/main/java/VASSAL/build/GameModule.java
@@ -941,26 +941,28 @@ public class GameModule extends AbstractConfigurable
     final Rectangle screen = SwingUtils.getScreenBounds(frame);
 
     if (GlobalOptions.getInstance().isUseSingleWindow()) {
-      frame.setLocation(screen.getLocation());
-
       final Prefs p = Prefs.getGlobalPrefs();
 
-      // If not "remembering" window size, nuke the pref
+      // If we are not remembering the window size, reset preferences to force defaults
       if (Boolean.FALSE.equals(p.getOption(MAIN_WINDOW_REMEMBER).getValue())) {
         p.getOption(MAIN_WINDOW_WIDTH).setValue(-1);
         p.getOption(MAIN_WINDOW_HEIGHT).setValue(-1);
       }
 
-      // Read window size prefs
+      // Read size preferences
       final int ph = (Integer) p.getOption(MAIN_WINDOW_HEIGHT).getValue();
       final int pw = (Integer) p.getOption(MAIN_WINDOW_WIDTH).getValue();
 
-      // Use pref if valid, otherwise screen dimensions
+      // Use the preferences if valid; otherwise the current screen size
       final int h = (ph > 0) ? ph : screen.height;
       final int w = (pw > 0) ? pw : screen.width;
 
-      // Before we have a map, we use 1/3 of height
-      frame.setSize(w, h / 3);
+      // Before a map exists, use 1/3 of the height as the default
+      final Rectangle r = new Rectangle(screen.x, screen.y, w, h / 3);
+
+      // Delegate restoring/saving of position and monitor clamping to PositionOption
+      final String key = "BoundsOfGameModule"; //$NON-NLS-1$
+      getPrefs().addOption(new PositionOption(key, frame, r));
     }
     else {
       final String key = "BoundsOfGameModule"; //$NON-NLS-1$

--- a/vassal-app/src/main/java/VASSAL/build/module/documentation/DialogHelpWindow.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/documentation/DialogHelpWindow.java
@@ -24,6 +24,8 @@ import javax.swing.JDialog;
 import javax.swing.event.HyperlinkEvent;
 import javax.swing.event.HyperlinkListener;
 
+import VASSAL.preferences.PositionOption;
+import VASSAL.preferences.Prefs;
 import VASSAL.tools.swing.HTMLWindowHelper;
 
 /**
@@ -39,7 +41,12 @@ public class DialogHelpWindow extends JDialog implements HyperlinkListener {
     setTitle(title);
     setDefaultCloseOperation(HIDE_ON_CLOSE);
 
+    // Persist and restore window bounds using the common layout engine
+    final PositionOption option = new PositionOption(PositionOption.key + "DialogHelpWindow", this);
+    Prefs.getGlobalPrefs().addOption(option);
+
     helper.setup(this, contents);
+
   }
 
   @Deprecated(since = "2021-12-01", forRemoval = true)

--- a/vassal-app/src/main/java/VASSAL/build/module/documentation/HelpWindow.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/documentation/HelpWindow.java
@@ -25,6 +25,8 @@ import javax.swing.event.HyperlinkListener;
 
 import VASSAL.tools.menu.MenuManager;
 import VASSAL.tools.swing.HTMLWindowHelper;
+import VASSAL.preferences.PositionOption;
+import VASSAL.preferences.Prefs;
 
 /**
  * A Window that displays HTML content, with navigation
@@ -39,6 +41,10 @@ public class HelpWindow extends JFrame implements HyperlinkListener {
     setDefaultCloseOperation(HIDE_ON_CLOSE);
     setJMenuBar(MenuManager.getInstance().getMenuBarFor(this));
     helper.setup(this, contents);
+
+    // Persist and restore window bounds using the common layout engine
+    final PositionOption option = new PositionOption(PositionOption.key + "HelpWindow", this); //NON-NLS
+    Prefs.getGlobalPrefs().addOption(option);
   }
 
   @Deprecated(since = "2021-12-01", forRemoval = true)

--- a/vassal-app/src/main/java/VASSAL/build/module/documentation/HelpWindow.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/documentation/HelpWindow.java
@@ -40,11 +40,13 @@ public class HelpWindow extends JFrame implements HyperlinkListener {
     super(title);
     setDefaultCloseOperation(HIDE_ON_CLOSE);
     setJMenuBar(MenuManager.getInstance().getMenuBarFor(this));
-    helper.setup(this, contents);
 
     // Persist and restore window bounds using the common layout engine
     final PositionOption option = new PositionOption(PositionOption.key + "HelpWindow", this); //NON-NLS
     Prefs.getGlobalPrefs().addOption(option);
+
+    helper.setup(this, contents);
+
   }
 
   @Deprecated(since = "2021-12-01", forRemoval = true)

--- a/vassal-app/src/main/java/VASSAL/chat/messageboard/MessageBoardControls.java
+++ b/vassal-app/src/main/java/VASSAL/chat/messageboard/MessageBoardControls.java
@@ -177,7 +177,8 @@ public class MessageBoardControls {
     }
 
     msgFrame.pack();
-    msgFrame.setLocation(java.awt.Toolkit.getDefaultToolkit().getScreenSize().width / 2 - msgFrame.getSize().width / 2, 0);
+    // Ensure the message board frame opens fully visible on the active/parent screen
+    SwingUtils.ensureOnScreen(msgFrame);
   }
 
   public Action getCheckMessagesAction() {
@@ -239,7 +240,8 @@ public class MessageBoardControls {
       SwingUtils.setDefaultButtons(getRootPane(), okButton, cancelButton);
 
       pack();
-      setLocation(java.awt.Toolkit.getDefaultToolkit().getScreenSize().width / 2 - getSize().width / 2, 0);
+      // Ensure the composer window is fully visible on the same screen as its owner/focused window
+      SwingUtils.ensureOnScreen(this);
     }
   }
 }

--- a/vassal-app/src/main/java/VASSAL/preferences/PositionOption.java
+++ b/vassal-app/src/main/java/VASSAL/preferences/PositionOption.java
@@ -19,6 +19,7 @@ package VASSAL.preferences;
 
 import java.awt.Dimension;
 import java.awt.Frame;
+import java.awt.GraphicsDevice;
 import java.awt.GraphicsEnvironment;
 import java.awt.Point;
 import java.awt.Rectangle;
@@ -109,16 +110,120 @@ public class PositionOption extends VASSAL.configure.Configurer
     }
   }
 
+  /**
+   * Returns the union of the bounds of all available screens (aka the virtual desktop bounds).
+   * This is used for validating and clamping window locations/sizes in multi-monitor setups.
+   */
+  private static Rectangle getVirtualDesktopBounds() {
+    final GraphicsEnvironment ge = GraphicsEnvironment.getLocalGraphicsEnvironment();
+    Rectangle virtual = null;
+    for (final GraphicsDevice gd : ge.getScreenDevices()) {
+      final Rectangle b = gd.getDefaultConfiguration().getBounds();
+      if (virtual == null) {
+        virtual = new Rectangle(b);
+      }
+      else {
+        virtual = virtual.union(b);
+      }
+    }
+    // Fallback (shouldn't happen) to primary screen size
+    if (virtual == null) {
+      final Dimension d = Toolkit.getDefaultToolkit().getScreenSize();
+      virtual = new Rectangle(0, 0, d.width, d.height);
+    }
+    return virtual;
+  }
+
+  /**
+   * Returns the bounds of all physical screens as reported by the GraphicsEnvironment.
+   * The rectangles are in the global (virtual desktop) coordinate space, so they may
+   * have non-zero x/y and can be vertically/horizontally offset and of different sizes.
+   */
+  private static Rectangle[] getAllScreenBounds() {
+    final GraphicsEnvironment ge = GraphicsEnvironment.getLocalGraphicsEnvironment();
+    final GraphicsDevice[] devices = ge.getScreenDevices();
+    final Rectangle[] result = new Rectangle[devices.length];
+    for (int i = 0; i < devices.length; i++) {
+      result[i] = new Rectangle(devices[i].getDefaultConfiguration().getBounds());
+    }
+    return result;
+  }
+
+  /** Returns true if r intersects any actual screen (not just the union bounding box). */
+  private static boolean intersectsAnyScreen(Rectangle r) {
+    for (final Rectangle s : getAllScreenBounds()) {
+      if (s.intersects(r) || s.contains(r)) return true;
+    }
+    return false;
+  }
+
+  /** Returns true if the given point lies on any actual screen. */
+  private static boolean pointOnAnyScreen(Point p) {
+    for (final Rectangle s : getAllScreenBounds()) {
+      if (s.contains(p)) return true;
+    }
+    return false;
+  }
+
+  /**
+   * Choose the best screen for the given rectangle. Preference order:
+   * 1) Screen with the largest intersection area with r
+   * 2) If no intersection, screen containing r's top-left point
+   * 3) Otherwise, nearest screen by distance from r's center to the screen's rectangle
+   */
+  private static Rectangle chooseBestScreen(Rectangle r) {
+    final Rectangle[] screens = getAllScreenBounds();
+    if (screens.length == 0) return getVirtualDesktopBounds();
+
+    // 1) Max intersection area
+    long bestArea = -1;
+    Rectangle best = null;
+    for (final Rectangle s : screens) {
+      final Rectangle inter = s.intersection(r);
+      final long area = (long) Math.max(0, inter.width) * Math.max(0, inter.height);
+      if (area > bestArea) {
+        bestArea = area;
+        best = s;
+      }
+    }
+    if (bestArea > 0) return new Rectangle(best);
+
+    // 2) Contains top-left
+    for (final Rectangle s : screens) {
+      if (s.contains(r.getLocation())) return new Rectangle(s);
+    }
+
+    // 3) Nearest by center distance
+    final double cx = r.getCenterX();
+    final double cy = r.getCenterY();
+    double bestDist = Double.MAX_VALUE;
+    best = screens[0];
+    for (final Rectangle s : screens) {
+      final double sx = clamp(cx, s.getMinX(), s.getMaxX());
+      final double sy = clamp(cy, s.getMinY(), s.getMaxY());
+      final double dx = cx - sx;
+      final double dy = cy - sy;
+      final double dist2 = dx * dx + dy * dy;
+      if (dist2 < bestDist) {
+        bestDist = dist2;
+        best = s;
+      }
+    }
+    return new Rectangle(best);
+  }
+
+  private static double clamp(double v, double lo, double hi) {
+    return Math.max(lo, Math.min(v, hi));
+  }
+
   @Override
   public String getValueString() {
-    return bounds.x + "," + bounds.y + "," +
-      bounds.width + "," + bounds.height;
+    return bounds.x + "," + bounds.y + "," + bounds.width + "," + bounds.height;
   }
 
   private boolean isOnScreen(Point p) {
-    return
-      p.x < Toolkit.getDefaultToolkit().getScreenSize().width &&
-      p.y < Toolkit.getDefaultToolkit().getScreenSize().height;
+    // Use real screens rather than the union to avoid accepting points in the gap between screens
+    return pointOnAnyScreen(p);
   }
 
   @Override
@@ -158,37 +263,65 @@ public class PositionOption extends VASSAL.configure.Configurer
   }
 
   protected void setFrameBounds() {
-    final Rectangle desktopBounds = GraphicsEnvironment.getLocalGraphicsEnvironment().getMaximumWindowBounds();
+    // Use the union of all screen bounds for general validation,
+    // but select a specific screen for clamping to handle different resolutions and offsets.
+    final Rectangle desktopBounds = getVirtualDesktopBounds();
+    final Rectangle requested = bounds == null ? null : new Rectangle(bounds);
 
     // Respect any existing bounds
-    if (bounds.width != 0 && bounds.height != 0) {
-      theFrame.setSize(new Dimension(Math.abs(bounds.width), Math.abs(bounds.height)));
+    if (bounds != null) {
+      if (bounds.width != 0 && bounds.height != 0) {
+        theFrame.setSize(new Dimension(Math.abs(bounds.width), Math.abs(bounds.height)));
+      }
+      theFrame.setLocation(bounds.getLocation());
     }
-    theFrame.setLocation(bounds.getLocation());
 
-    // Reduce size to fit on desktop
-    final int width = Math.min(theFrame.getSize().width, desktopBounds.width);
-    final int height = Math.min(theFrame.getSize().height, desktopBounds.height);
+    // Choose the screen we will clamp to
+    final Rectangle targetScreen = (requested != null) ? chooseBestScreen(requested) : chooseBestScreen(new Rectangle(desktopBounds));
+
+    // Reduce size to fit on chosen screen
+    final int width = Math.min(theFrame.getSize().width, targetScreen.width);
+    final int height = Math.min(theFrame.getSize().height, targetScreen.height);
     if (width != theFrame.getSize().width || height != theFrame.getSize().height) {
       theFrame.setSize(width, height);
     }
 
-    // Slide whole window onto desktop if any part off desktop
+    // Slide whole window onto the chosen screen if any part off that screen
     int x = theFrame.getLocation().x;
     int y = theFrame.getLocation().y;
-
-    if (x < desktopBounds.x) x = desktopBounds.x;
-    if (y < desktopBounds.y) y = desktopBounds.y;
-
-    if (x + theFrame.getSize().width > desktopBounds.x + desktopBounds.width) {
-      x = (desktopBounds.x + desktopBounds.width) - theFrame.getSize().width;
+    if (x < targetScreen.x) x = targetScreen.x;
+    if (y < targetScreen.y) y = targetScreen.y;
+    if (x + theFrame.getSize().width > targetScreen.x + targetScreen.width) {
+      x = (targetScreen.x + targetScreen.width) - theFrame.getSize().width;
     }
-    if (y + theFrame.getSize().height > desktopBounds.y + desktopBounds.height) {
-      y = (desktopBounds.y + desktopBounds.height) - theFrame.getSize().height;
+    if (y + theFrame.getSize().height > targetScreen.y + targetScreen.height) {
+      y = (targetScreen.y + targetScreen.height) - theFrame.getSize().height;
     }
-    if (x != theFrame.getLocation().x || y != theFrame.getLocation().y) {
+    final boolean willRelocate = (x != theFrame.getLocation().x || y != theFrame.getLocation().y);
+    if (willRelocate) theFrame.setLocation(x, y);
+
+    // Log final applied bounds and environment
+    Rectangle applied = new Rectangle(theFrame.getX(), theFrame.getY(), theFrame.getWidth(), theFrame.getHeight());
+    boolean appliedOnAnyScreen = intersectsAnyScreen(applied);
+
+    // Final safety: ensure never off-screen
+    if (!appliedOnAnyScreen) {
+      // Clamp again just in case and log a warning
+      // Choose best screen again based on the applied rect and clamp to it
+      final Rectangle safeScreen = chooseBestScreen(applied);
+      x = Math.max(safeScreen.x, Math.min(applied.x, safeScreen.x + safeScreen.width - applied.width));
+      y = Math.max(safeScreen.y, Math.min(applied.y, safeScreen.y + safeScreen.height - applied.height));
       theFrame.setLocation(x, y);
+      applied = new Rectangle(theFrame.getX(), theFrame.getY(), theFrame.getWidth(), theFrame.getHeight());
+      appliedOnAnyScreen = intersectsAnyScreen(applied);
+      if (!appliedOnAnyScreen) {
+        // As a last resort, move to desktop origin
+        theFrame.setLocation(desktopBounds.x, desktopBounds.y);
+      }
     }
+    // Update stored bounds so that persistence reflects the final applied rectangle even if
+    // no move/resize events occur before closing the window.
+    bounds = new Rectangle(theFrame.getX(), theFrame.getY(), theFrame.getWidth(), theFrame.getHeight());
   }
 
 }

--- a/vassal-app/src/main/java/VASSAL/preferences/PrefsEditor.java
+++ b/vassal-app/src/main/java/VASSAL/preferences/PrefsEditor.java
@@ -39,9 +39,7 @@ import javax.swing.JScrollPane;
 import javax.swing.JTabbedPane;
 import javax.swing.WindowConstants;
 import java.awt.BorderLayout;
-import java.awt.Dimension;
 import java.awt.Frame;
-import java.awt.Toolkit;
 import java.awt.event.ActionEvent;
 import java.awt.event.ComponentAdapter;
 import java.awt.event.ComponentEvent;
@@ -153,11 +151,8 @@ public class PrefsEditor {
       SwingUtils.setDefaultButtons(setupDialog.getRootPane(), okButton, okButton); // okButton for both
 
       setupDialog.pack();
-      final Dimension d = Toolkit.getDefaultToolkit().getScreenSize();
-      setupDialog.setLocation(
-        d.width / 2 - setupDialog.getSize().width / 2,
-        d.height / 2 - setupDialog.getSize().height / 2
-      );
+      // Center over owner (or screen) as preferred initial placement, then clamp
+      SwingUtils.applyInitialPlacement(setupDialog, SwingUtils.PreferredWindowPlacement.CENTER_OVER_OWNER);
       setupDialog.setVisible(true);
       setupDialog.removeAll();
     }
@@ -254,9 +249,8 @@ public class PrefsEditor {
           }
           storeValues();
           dialog.pack();
-          final Dimension d = SwingUtils.getScreenSize();
-          dialog.setLocation(d.width / 2 - dialog.getWidth() / 2, 0);
-          SwingUtils.ensureOnScreen(dialog);
+          // Center over owner (Preferences dialog) and clamp within screen bounds
+          SwingUtils.applyInitialPlacement(dialog, SwingUtils.PreferredWindowPlacement.CENTER_OVER_OWNER);
           dialog.setVisible(true);
         }
       };

--- a/vassal-app/src/main/java/VASSAL/tools/swing/AboutWindow.java
+++ b/vassal-app/src/main/java/VASSAL/tools/swing/AboutWindow.java
@@ -19,8 +19,6 @@
 package VASSAL.tools.swing;
 
 import java.awt.Color;
-import java.awt.Dimension;
-import java.awt.Toolkit;
 import java.awt.Window;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
@@ -56,10 +54,8 @@ public class AboutWindow extends JWindow {
     add(l2);
 
     pack();
-
-    final Dimension d = Toolkit.getDefaultToolkit().getScreenSize();
-    setLocation(d.width / 2 - getWidth() / 2,
-                d.height / 2 - getHeight() / 2);
+    // Center over owner (or on screen) then clamp within screen bounds
+    SwingUtils.applyInitialPlacement(this, SwingUtils.PreferredWindowPlacement.CENTER_OVER_OWNER);
 
     addMouseListener(new MouseAdapter() {
       @Override

--- a/vassal-app/src/main/java/VASSAL/tools/swing/HTMLWindowHelper.java
+++ b/vassal-app/src/main/java/VASSAL/tools/swing/HTMLWindowHelper.java
@@ -21,7 +21,6 @@ package VASSAL.tools.swing;
 import java.awt.Dimension;
 import java.awt.Font;
 import java.awt.FontMetrics;
-import java.awt.Toolkit;
 import java.awt.Window;
 import java.io.IOException;
 import java.net.URL;
@@ -82,12 +81,14 @@ public class HTMLWindowHelper implements HyperlinkListener {
     update(contents);
     w.pack();
 
-    final Dimension d = Toolkit.getDefaultToolkit().getScreenSize();
-    int width = Math.max(d.width / 2, w.getSize().width);
-    int height = Math.max(d.height / 2, w.getSize().height);
-    width = Math.min(width, d.width * 2 / 3);
-    height = Math.min(height, d.height * 2 / 3);
-    w.setSize(width, height);
-    w.setLocation(d.width / 2 - width / 2, 0);
+    // Suggest a reasonable initial size based on current screen bounds without forcing location.
+    // Let the common window layout engine (PositionOption) perform clamping and final placement.
+    final java.awt.Rectangle screen = SwingUtils.getScreenBounds(w);
+    int width = Math.max(screen.width / 2, w.getSize().width);
+    int height = Math.max(screen.height / 2, w.getSize().height);
+    width = Math.min(width, (screen.width * 2) / 3);
+    height = Math.min(height, (screen.height * 2) / 3);
+    w.setSize(new Dimension(width, height));
+    // Do not set explicit location here to avoid fighting with PositionOption
   }
 }

--- a/vassal-app/src/main/java/VASSAL/tools/swing/ProgressDialog.java
+++ b/vassal-app/src/main/java/VASSAL/tools/swing/ProgressDialog.java
@@ -116,6 +116,9 @@ public class ProgressDialog extends JDialog {
 
     // pack again to ensure that we respect the minimum size
     pack();
+
+    // Ensure the dialog opens fully visible on the same screen as its parent
+    SwingUtils.ensureOnScreen(this);
   }
 
   /**

--- a/vassal-app/src/main/java/VASSAL/tools/swing/SwingUtils.java
+++ b/vassal-app/src/main/java/VASSAL/tools/swing/SwingUtils.java
@@ -30,7 +30,10 @@ import javax.swing.undo.UndoManager;
 import java.awt.Component;
 import java.awt.Container;
 import java.awt.Dimension;
+import java.awt.GraphicsConfiguration;
+import java.awt.GraphicsDevice;
 import java.awt.GraphicsEnvironment;
+import java.awt.KeyboardFocusManager;
 import java.awt.Insets;
 import java.awt.Rectangle;
 import java.awt.Toolkit;
@@ -492,14 +495,14 @@ public class SwingUtils {
       }
       else {
         // If no explicit owner, try to use the currently focused window as a hint
-        final Window focused = java.awt.KeyboardFocusManager.getCurrentKeyboardFocusManager().getFocusedWindow();
+        final Window focused = KeyboardFocusManager.getCurrentKeyboardFocusManager().getFocusedWindow();
         if (focused != null && focused.getGraphicsConfiguration() != null) {
           c = focused;
         }
       }
     }
 
-    Rectangle screen;
+    final Rectangle screen;
     if (c != null && c.getGraphicsConfiguration() != null) {
       // Use the bounds of the physical screen which contains the component
       final Rectangle raw = new Rectangle(c.getGraphicsConfiguration().getBounds());
@@ -611,12 +614,12 @@ public class SwingUtils {
       return new Insets(0, 0, 0, 0);
     }
     else {
-      java.awt.GraphicsConfiguration gc = null;
+      GraphicsConfiguration gc = null;
       if (c != null) {
         gc = c.getGraphicsConfiguration();
       }
       if (gc == null) {
-        final java.awt.GraphicsDevice def = GraphicsEnvironment.getLocalGraphicsEnvironment().getDefaultScreenDevice();
+        final GraphicsDevice def = GraphicsEnvironment.getLocalGraphicsEnvironment().getDefaultScreenDevice();
         if (def != null) {
           gc = def.getDefaultConfiguration();
         }
@@ -645,22 +648,22 @@ public class SwingUtils {
     final Rectangle windowRect = new Rectangle(window.getX(), window.getY(), window.getWidth(), window.getHeight());
 
     Rectangle screenBounds = null;
-    java.awt.GraphicsConfiguration screenGC = null;
+    GraphicsConfiguration screenGC = null;
 
     try {
-      final java.awt.GraphicsEnvironment ge = java.awt.GraphicsEnvironment.getLocalGraphicsEnvironment();
-      final java.awt.GraphicsDevice[] devices = ge.getScreenDevices();
+      final GraphicsEnvironment ge = GraphicsEnvironment.getLocalGraphicsEnvironment();
+      final GraphicsDevice[] devices = ge.getScreenDevices();
       if (devices != null && devices.length > 0) {
         // Pick the screen with the largest intersection with the window rect; if none, the nearest by center.
         long bestArea = -1;
         double bestDist2 = Double.MAX_VALUE;
-        java.awt.GraphicsDevice bestDev = devices[0];
+        GraphicsDevice bestDev = devices[0];
         Rectangle bestBounds = new Rectangle(bestDev.getDefaultConfiguration().getBounds());
 
         final double cx = windowRect.getCenterX();
         final double cy = windowRect.getCenterY();
 
-        for (java.awt.GraphicsDevice gd : devices) {
+        for (final GraphicsDevice gd : devices) {
           final Rectangle b = new Rectangle(gd.getDefaultConfiguration().getBounds());
           final Rectangle inter = b.intersection(windowRect);
           final long area = (long) Math.max(0, inter.width) * Math.max(0, inter.height);

--- a/vassal-app/src/main/java/VASSAL/tools/swing/SwingUtils.java
+++ b/vassal-app/src/main/java/VASSAL/tools/swing/SwingUtils.java
@@ -670,7 +670,8 @@ public class SwingUtils {
             bestBounds = b;
             // Reset distance tracker when we find a better area
             bestDist2 = Double.MAX_VALUE;
-          } else if (area == 0 && bestArea <= 0) {
+          }
+          else if (area == 0 && bestArea <= 0) {
             // No overlap candidates yet: track nearest by center distance
             final double sx = Math.max(b.getMinX(), Math.min(cx, b.getMaxX()));
             final double sy = Math.max(b.getMinY(), Math.min(cy, b.getMaxY()));
@@ -696,7 +697,8 @@ public class SwingUtils {
         );
         screenBounds = bestBounds;
       }
-    } catch (Throwable t) {
+    }
+    catch (Throwable t) {
       // Fall back silently to previous behavior if anything goes wrong
     }
 

--- a/vassal-app/src/main/java/VASSAL/tools/swing/SwingUtils.java
+++ b/vassal-app/src/main/java/VASSAL/tools/swing/SwingUtils.java
@@ -738,7 +738,7 @@ public class SwingUtils {
       bounds.x = screenBounds.x;
     }
 
-    // Extends off right of visible screen? Slight left.
+    // Extends off right of visible screen? Slide left.
     if (bounds.x + bounds.width > screenBounds.x + screenBounds.width) {
       bounds.x = screenBounds.x + screenBounds.width - bounds.width;
     }

--- a/vassal-app/src/main/java/org/netbeans/api/wizard/displayer/WizardDisplayerImpl.java
+++ b/vassal-app/src/main/java/org/netbeans/api/wizard/displayer/WizardDisplayerImpl.java
@@ -16,7 +16,21 @@ package org.netbeans.api.wizard.displayer;
 
 import VASSAL.build.GameModule;
 
-import java.awt.*;
+import java.awt.BorderLayout;
+import java.awt.Color;
+import java.awt.ComponentOrientation;
+import java.awt.Container;
+import java.awt.Cursor;
+import java.awt.Dialog;
+import java.awt.Dimension;
+import java.awt.EventQueue;
+import java.awt.Font;
+import java.awt.Frame;
+import java.awt.IllegalComponentStateException;
+import java.awt.KeyboardFocusManager;
+import java.awt.Point;
+import java.awt.Rectangle;
+import java.awt.Window;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
 import java.lang.reflect.InvocationTargetException;


### PR DESCRIPTION
### Summary

This PR improves window and dialog placement in multi-monitor configurations, including setups with non-aligned desktop offsets. Windows and dialogs now open on the most appropriate monitor, remain fully visible, and no longer “snap back” to the primary display.

The issue was reproduced on Linux + KDE; the changes have been tested on Linux + KDE and Windows.

### What changes

* Window placement is now consistently **monitor-aware** across the application.
* The GameModule main window uses `PositionOption` in all modes, with bounds persisted under `"BoundsOfGameModule"` and sensible defaults.
* Dialogs prefer the module’s `PlayerWindow` (or another suitable owner) and are centered on the same monitor as their parent when no saved bounds exist.
* Target monitor selection works even when the owner window is not yet visible.
* `SwingUtils.ensureOnScreen` clamps windows to the screen with the largest intersection (or nearest one), preventing reassignment to the primary monitor.

### Result

* Main windows and dialogs restore previous bounds when available, otherwise use safe defaults.
* Windows never open off-screen and always stay within the usable area of the selected monitor.
* Behavior is robust across different resolutions, offsets, DPI/insets, and maximized state restoration.

### Adresses:
- #14371 