### PR TITLE
14381 Update dice properties when replaying a log file

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/module/properties/ChangePropertyCommandEncoder.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/properties/ChangePropertyCommandEncoder.java
@@ -62,7 +62,14 @@ public class ChangePropertyCommandEncoder implements CommandEncoder {
       return null;
     }
 
-    final MutableProperty p = container.getMutableProperty(key);
+    MutableProperty p = container.getMutableProperty(key);
+    if (p == null) {
+      // If this is not an explicit global property
+      // then search for implicit module properties such as Special Dice properties.
+      if (container instanceof GlobalProperties) {
+        p = ((GlobalProperties) container).getParent().getMutableProperty(key);
+      }
+    }
     if (p == null) {
       return null;
     }


### PR DESCRIPTION
When replaying a log file or during online play, the `ChangePropertyCommand` (encoded as a MutableProperty message) communicates property changes. The associated `ChangePropertyCommandEncoder` searches a `GlobalProperties` object for the property and regenerates the `ChangePropertyCommand`. However it only finds explicit global properties which are of type `GlobalProperty`.

The Dice Action buttons create implicit global properties. These are of type `MutableProperty`. Since these are not `GlobalProperty` types, the encoder fails to find the dice properties returning null. This effectively filters out the  `ChangePropertyCommand` making it a no-op.

This pull request adds a secondary `MutableProperty` search for when the GlobalProperty search fails.

Closes #14381

Closes #13813

For Area of Effect I tested log files and undo. I did not test an online game. The log file must be written with a build that includes this commit. It's the writing, not the reading of the log file that matters.