### PR TITLE
14237 Fix Symbolic Dice Button atomic undo

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/module/DoActionButton.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/DoActionButton.java
@@ -137,8 +137,7 @@ public class DoActionButton extends AbstractToolbarItem
     launch = getLaunchButton(); // for compatibility
   }
 
-  // This only exists so SpecialDiceButton can avoid calling the other constructor
-  @SuppressWarnings("PMD.UnusedFormalParameter")
+  @Deprecated(since = "2025-12-04", forRemoval = true)
   protected DoActionButton(boolean dummy) { 
 
   }
@@ -532,8 +531,20 @@ public class DoActionButton extends AbstractToolbarItem
     loopIndexProperty.setPropertyValue(String.valueOf(indexValue));
   }
 
+  /**
+   * Invoked prior to executing doActions(). It can be overridden to preconfigure
+   * a Command and/or for some other initialization.
+   * @return A Command to which doAcions() can append. Return null to cancel doActions().
+   */
+  protected Command prepareActionsCommand() {
+    return new NullCommand();
+  }
+
   protected void doActions() throws RecursionLimitException {
-    final Command c = new NullCommand();
+    final Command c = prepareActionsCommand();
+    if (c == null) {
+      return;
+    }
     final GameModule mod = GameModule.getGameModule();
     final PropertySource ps;
 

--- a/vassal-app/src/main/java/VASSAL/build/module/SpecialDiceButton.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/SpecialDiceButton.java
@@ -41,6 +41,8 @@ import VASSAL.search.HTMLImageFinder;
 import VASSAL.tools.FormattedString;
 import VASSAL.tools.KeyStrokeListener;
 import VASSAL.tools.LaunchButton;
+import VASSAL.tools.RecursionLimitException;
+import VASSAL.tools.RecursionLimiter;
 import VASSAL.tools.SequenceEncoder;
 import VASSAL.tools.UniqueIdManager;
 import VASSAL.tools.imageop.ImageOp;
@@ -157,8 +159,18 @@ public class SpecialDiceButton extends DoActionButton implements CommandEncoder,
     return " *** " + getConfigureName() + " = "; //$NON-NLS-1$ //$NON-NLS-2$
   }
 
+  /**
+   * Forwards the result of the roll to the {@link Chatter#send} method of the {@link Chatter} of the {@link GameModule}.
+   * Format is prefix+[comma-separated roll list]+suffix additionally a command for every die is generated
+   */
   @Deprecated(since = "2025-12-04", forRemoval = true)
   protected void DR() {
+    try {
+      doActions();
+    }
+    catch (RecursionLimitException ex) {
+      RecursionLimiter.infiniteLoop(ex);
+    }
   }
 
   /**


### PR DESCRIPTION
Expanded ShowResults command to include the previous roll(s) using the ChangePropertyCommand as an example. Despite the addition, ShowResults remains backward compatible. Including the previous roll(s) in the command allows remote undo during online play. The parameter list and member variables of the ShowResults command follow the ChangePropertyCommand convention.

Made the construction of SpecialDiceButton class a litle bit more object oriented no longer requiring a special constructor to by-pass base class initialization. Added the prepareActionsCommand() function as a precursor to doActions() permitting child classes to perform custom setup. Deprecated the DR() function at the same time making it an empty function.

Tested pre/post commands with looping for online, standalone and log playback.

For proper update of dice properties during online play, PR #14382 is required.

Closes #14237
