### PR TITLE
Reduce NullCommand nesting on the pausedCommands deque

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/GameModule.java
+++ b/vassal-app/src/main/java/VASSAL/build/GameModule.java
@@ -1860,7 +1860,9 @@ public class GameModule extends AbstractConfigurable
     if (c != null && !c.isNull()) {
       synchronized (loggingLock) {
         if (loggingPaused) {
-          pausedCommands.getFirst().append(c);
+          Command topCmd = pausedCommands.pop();
+          topCmd = topCmd.append(c);
+          pausedCommands.push(topCmd);
         }
         else {
           getServer().sendToOthers(c);

--- a/vassal-app/src/test/java/VASSAL/build/module/DoActionButtonTest.java
+++ b/vassal-app/src/test/java/VASSAL/build/module/DoActionButtonTest.java
@@ -1,0 +1,81 @@
+package VASSAL.build.module;
+
+import VASSAL.build.GameModule;
+import VASSAL.command.Command;
+import VASSAL.command.Logger;
+import VASSAL.tools.RecursionLimitException;
+import org.codehaus.plexus.util.StringUtils;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import java.awt.*;
+import java.lang.reflect.Field;
+import java.util.ArrayDeque;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+
+public class DoActionButtonTest {
+
+  /**
+   * Test the enqueuing of commands onto the GameModule.pausedCommands deque
+   * during multi-command construction. The DoActionButton uses the deque to
+   * generate a sequence of commands which converts into a single composite
+   * command.
+   *
+   * @throws RecursionLimitException source DoActionButton.doActions
+   * @throws IllegalAccessException source Field.set
+   * @throws NoSuchFieldException source Class.getDeclaredField
+   */
+  @Test
+  public void deque_nullCommandDepth_expectOne() throws RecursionLimitException, IllegalAccessException, NoSuchFieldException {
+    try (MockedStatic<GameModule> staticGm = Mockito.mockStatic(GameModule.class)) {
+      final GameModule gm = mock(GameModule.class);
+
+      // The GameModule is mocked, but since some real member functions
+      // are invoked, GameModule requires some partial initialization.
+      // Get access to private members and initialize them.
+      Field field = gm.getClass().getDeclaredField("loggingLock");
+      field.setAccessible(true);
+      field.set(gm, new Object());
+      field = gm.getClass().getDeclaredField("pausedCommands");
+      field.setAccessible(true);
+      field.set(gm, new ArrayDeque<>());
+
+      // Mock the chatter, server and logger.
+      staticGm.when(GameModule::getGameModule).thenReturn(gm);
+      final Chatter chatter = mock(Chatter.class);
+      final ServerConnection server = mock(ServerConnection.class);
+      final Logger logger = mock(Logger.class);
+      when(gm.getChatter()).thenReturn(chatter);
+      when(gm.getServer()).thenReturn(server);
+      when(gm.getLogger()).thenReturn(logger);
+
+      // Indicate which of the "real" functions to call.
+      doCallRealMethod().when(gm).sendAndLog(any(Command.class));
+      when(gm.pauseLogging()).thenCallRealMethod();
+      when(gm.resumeLogging()).thenCallRealMethod();
+
+      // Setup a simple DoActionButton to generate a report.
+      DoActionButton button = new DoActionButton();
+      button.setAncestor(gm);
+      button.setAttribute(DoActionButton.DO_REPORT, true);
+      button.setAttribute(DoActionButton.REPORT_FORMAT, "Report format text");
+
+      button.doActions();
+
+      // Capture the output sent to others.
+      ArgumentCaptor<Command> commandCapture = ArgumentCaptor.forClass(Command.class);
+      verify(server).sendToOthers(commandCapture.capture());
+      Command command = commandCapture.getValue();
+
+      // The toString() method does a recursive descent concatenating the command
+      // names with a plus sign separator. Count the separators to get the total
+      // command count less one.
+      // Expecting a single null command and a display command.
+      assertEquals(1, StringUtils.countMatches(command.toString(), "+"));
+    }
+  }
+}


### PR DESCRIPTION
While debugging another issue I noticed nesting of NullCommands. This is inefficient. The nesting means there are recursive descents for various methods.

The idiom for appending sub-commands to a command that may be a NullCommand is:
```command = command.append(subcommand)```

The assignment turns the append into a replace when the command is a NullCommand. When the command is guaranteed not to be NullCommand, the assignment is not necessary. 

This pull request pops the top element from the deque, appends the sub-command with an assignment and then pushes it back on the deque.

On this before image note the 5 NullCommands.
![nullcommand_before](https://github.com/user-attachments/assets/3d4ccc57-0097-40d7-95ea-8ddab3d2456e)

After only 1 NullCommand remains.
![nullcommand_after](https://github.com/user-attachments/assets/7c2b5e28-4f91-4f0b-b491-56d94a7a9b2a)
