### PR TITLE
Fix for change in `java.io.File` API in Java 25

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/GameModule.java
+++ b/vassal-app/src/main/java/VASSAL/build/GameModule.java
@@ -697,7 +697,7 @@ public class GameModule extends AbstractConfigurable
     final DataArchive darch = getDataArchive();
 
     final File f = new File(darch.getName());
-    if (!f.exists() || f.length() == 0) {
+    if (!f.isFile() || f.length() == 0) {
       // new module, no buildFile
       build(null);
     }

--- a/vassal-app/src/main/java/VASSAL/build/module/GameState.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/GameState.java
@@ -801,7 +801,7 @@ public class GameState implements CommandEncoder {
     final GameModule g = GameModule.getGameModule();
 
     try {
-      if (!f.exists()) throw new FileNotFoundException("Unable to locate " + f.getPath());
+      if (!f.isFile()) throw new FileNotFoundException("Unable to locate \"" + f.getAbsolutePath() + "\"");
 
       // Check the Save game for validity
       if (!isSaveMetaDataValid(f)) {
@@ -1016,7 +1016,7 @@ public class GameState implements CommandEncoder {
   }
 
   protected boolean checkForOldSaveFile(File f) {
-    if (f.exists()) {
+    if (f.isFile()) {
       // warn user if overwriting a save from an old version
       final AbstractMetaData md = MetaDataFactory.buildMetaData(f);
       if (md instanceof SaveMetaData) {

--- a/vassal-app/src/main/java/VASSAL/build/module/WizardSupport.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/WizardSupport.java
@@ -795,7 +795,7 @@ public class WizardSupport {
           @Override
           public void propertyChange(PropertyChangeEvent evt) {
             final File f = (File) evt.getNewValue();
-            if (f == null || !f.exists()) {
+            if (f == null || !f.isFile()) {
               controller.setProblem(Resources.getString("WizardSupport.NoSuchFile")); //$NON-NLS-1$
             }
             else if (f.isDirectory()) {

--- a/vassal-app/src/main/java/VASSAL/build/module/map/ImageSaver.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/ImageSaver.java
@@ -252,12 +252,9 @@ public class ImageSaver extends AbstractToolbarItem {
       files.add(f);
 
       // make sure that we can write the file before proceeding
-      if (f.exists()) {
-        if (!f.canWrite()) {
-          throw new IOException(
-            "Cannot write to the file \"" + f.getAbsolutePath() + "\""
-          );
-        }
+      if (f.exists() && (f.getPath().isEmpty() || !f.canWrite())) {
+        throw new IOException(
+          "Cannot write to the file \"" + f.getAbsolutePath() + "\"");
       }
       else {
         final File p = f.getParentFile();

--- a/vassal-app/src/main/java/VASSAL/build/module/metadata/MetaDataFactory.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/metadata/MetaDataFactory.java
@@ -54,7 +54,7 @@ public class MetaDataFactory {
   public static AbstractMetaData buildMetaData(File file) {
 
     // Check the file exists and is a file
-    if (file == null || !file.exists() || !file.isFile())
+    if (file == null || !file.isFile())
       return null;
 
     try (ZipFile zip = new ZipFile(file)) {

--- a/vassal-app/src/main/java/VASSAL/configure/FileConfigurer.java
+++ b/vassal-app/src/main/java/VASSAL/configure/FileConfigurer.java
@@ -93,7 +93,7 @@ public class FileConfigurer extends Configurer {
   public void setValue(Object o) {
 // FIXME: this creates a problem when the referenced file is in the JAR
     final File f = (File) o;
-    if (f != null && f.exists()) {
+    if (f != null && !f.getPath().isEmpty() && f.exists()) {
       if (archive != null) {
         addToArchive(f);
       }
@@ -110,7 +110,7 @@ public class FileConfigurer extends Configurer {
 
   @Override
   public void setValue(String s) {
-    if (s == null)
+    if (s == null || s.isEmpty())
       setValue((Object) null);
     else {
       setValue(new File(s));

--- a/vassal-app/src/main/java/VASSAL/configure/IconConfigurer.java
+++ b/vassal-app/src/main/java/VASSAL/configure/IconConfigurer.java
@@ -145,15 +145,12 @@ public class IconConfigurer extends Configurer {
     if (fc.showOpenDialog(getControls()) != FileChooser.APPROVE_OPTION) {
       setValue(null);
       setToolTipText(null);
+      return;
     }
-    else {
-      final File f = fc.getSelectedFile();
-      if (f != null && f.exists()) {
-        GameModule.getGameModule().getArchiveWriter()
-                                  .addImage(f.getPath(), f.getName());
-        setValue(f.getName());
-        setToolTipText(f.getPath());
-      }
-    }
+    final File f = fc.getSelectedFile();
+    GameModule.getGameModule().getArchiveWriter()
+        .addImage(f.getPath(), f.getName());
+    setValue(f.getName());
+    setToolTipText(f.getPath());
   }
 }

--- a/vassal-app/src/main/java/VASSAL/configure/ImageSelector.java
+++ b/vassal-app/src/main/java/VASSAL/configure/ImageSelector.java
@@ -191,7 +191,7 @@ public class ImageSelector extends Configurer implements ItemListener {
     final FileChooser fc = gm.getEditorImageChooser();
     fc.setFileFilter(new ImageFileFilter());
 
-    if (fc.showOpenDialog(gm.getPlayerWindow()) == FileChooser.APPROVE_OPTION && fc.getSelectedFile().exists()) {
+    if (fc.showOpenDialog(gm.getPlayerWindow()) == FileChooser.APPROVE_OPTION) {
       final String name = fc.getSelectedFile().getName();
       gm.getArchiveWriter().addImage(fc.getSelectedFile().getPath(), name);
       select.setModel(new DefaultComboBoxModel<>(ArrayUtils.addFirst(gm.getDataArchive().getImageNames(), NO_IMAGE)));

--- a/vassal-app/src/main/java/VASSAL/counters/ImagePicker.java
+++ b/vassal-app/src/main/java/VASSAL/counters/ImagePicker.java
@@ -167,8 +167,7 @@ public class ImagePicker extends JPanel
     final FileChooser fc = gm.getEditorImageChooser();
     fc.setFileFilter(new ImageFileFilter());
 
-    if (fc.showOpenDialog(this) == FileChooser.APPROVE_OPTION
-         && fc.getSelectedFile().exists()) {
+    if (fc.showOpenDialog(this) == FileChooser.APPROVE_OPTION) {
       final String name = fc.getSelectedFile().getName();
       gm.getArchiveWriter().addImage(fc.getSelectedFile().getPath(), name);
       select.setModel(new DefaultComboBoxModel<>(

--- a/vassal-app/src/main/java/VASSAL/launch/AbstractLaunchAction.java
+++ b/vassal-app/src/main/java/VASSAL/launch/AbstractLaunchAction.java
@@ -170,28 +170,17 @@ public abstract class AbstractLaunchAction extends AbstractAction {
     // loop until cancellation or we get an existing file
     if (fc.showOpenDialog() == FileChooser.APPROVE_OPTION) {
       lr.module = fc.getSelectedFile();
-      if (lr.module != null) {
-        if (lr.module.exists()) {
-          final AbstractMetaData metadata =
-            MetaDataFactory.buildMetaData(lr.module);
-          if (!(metadata instanceof ModuleMetaData)) {
-            ErrorDialog.show(
-              "Error.invalid_vassal_module", lr.module.getAbsolutePath()); //NON-NLS
-            logger.error(
-              "-- Load of {} failed: Not a Vassal module", //NON-NLS
-              lr.module.getAbsolutePath()
-            );
-            lr.module = null;
-          }
-        }
-        else {
-          lr.module = null;
-        }
-// FIXME: do something to warn about nonexistent file
-//        FileNotFoundDialog.warning(window, lr.module);
+      final AbstractMetaData metadata =
+        MetaDataFactory.buildMetaData(lr.module);
+      if (!(metadata instanceof ModuleMetaData)) {
+        ErrorDialog.show(
+          "Error.invalid_vassal_module", lr.module.getAbsolutePath()); //NON-NLS
+        logger.error(
+          "-- Load of {} failed: Not a Vassal module", //NON-NLS
+          lr.module.getAbsolutePath());
+        lr.module = null;
       }
     }
-
     return lr.module;
   }
 

--- a/vassal-app/src/main/java/VASSAL/launch/Editor.java
+++ b/vassal-app/src/main/java/VASSAL/launch/Editor.java
@@ -154,19 +154,12 @@ public class Editor extends Launcher {
       if (fc.showOpenDialog() == FileChooser.APPROVE_OPTION) {
         lr.importFile = fc.getSelectedFile();
 
-        if (lr.importFile != null) {
-          if (lr.importFile.exists()) {
-            final AbstractMetaData metadata =
-              MetaDataFactory.buildMetaData(lr.importFile);
-            if (!(metadata instanceof ImportMetaData)) {
-              ErrorDialog.show("Error.invalid_import_file", lr.importFile.getAbsolutePath());  //NON-NLS
-              logger.error("Import of " + lr.importFile.getAbsolutePath() + " failed: unrecognized import type");  //NON-NLS
-              lr.importFile = null;
-            }
-          }
-          else {
-            lr.importFile = null;
-          }
+        final AbstractMetaData metadata =
+          MetaDataFactory.buildMetaData(lr.importFile);
+        if (!(metadata instanceof ImportMetaData)) {
+          ErrorDialog.show("Error.invalid_import_file", lr.importFile.getAbsolutePath());  //NON-NLS
+          logger.error("Import of " + lr.importFile.getAbsolutePath() + " failed: unrecognized import type");  //NON-NLS
+          lr.importFile = null;
         }
       }
 

--- a/vassal-app/src/main/java/VASSAL/launch/LoadModuleAction.java
+++ b/vassal-app/src/main/java/VASSAL/launch/LoadModuleAction.java
@@ -64,10 +64,7 @@ public class LoadModuleAction extends GameModuleAction {
       }
 
       if (fc.showOpenDialog() == FileChooser.APPROVE_OPTION) {
-        final File f = fc.getSelectedFile();
-        if (f != null && f.exists()) {
-          target = f;
-        }
+        target = fc.getSelectedFile();
       }
 
       // bail out if still no target

--- a/vassal-app/src/main/java/VASSAL/launch/ModuleManagerWindow.java
+++ b/vassal-app/src/main/java/VASSAL/launch/ModuleManagerWindow.java
@@ -566,7 +566,7 @@ public class ModuleManagerWindow extends JFrame {
       Arrays.stream(moduleConfig.getStringArray())
     ).sorted().distinct().forEach(s -> {
       final ModuleInfo module = new ModuleInfo(s);
-      if (module.getFile().exists() && module.isValid()) {
+      if (module.getFile().isFile() && module.isValid()) {
         moduleList.add(module);
       }
       else {

--- a/vassal-app/src/main/java/VASSAL/tools/filechooser/FileChooser.java
+++ b/vassal-app/src/main/java/VASSAL/tools/filechooser/FileChooser.java
@@ -212,7 +212,15 @@ public abstract class FileChooser {
 
     @Override
     public int showOpenDialog(Component parent) {
-      final int value = fc.showOpenDialog(parent);
+      int value = fc.showOpenDialog(parent);
+      final int mode = fc.getFileSelectionMode();
+      final File selected = getSelectedFile();
+      if (value == APPROVE_OPTION &&
+          ((mode == DIRECTORIES_ONLY && !selected.isDirectory()) ||
+           (mode == FILES_ONLY       && !selected.isFile()))) {
+        value = ERROR_OPTION;
+        fc.setSelectedFile(null);
+      }
       updateDirectoryPreference();
       return value;
     }
@@ -356,7 +364,7 @@ public abstract class FileChooser {
 
       fd.setModal(true);
       fd.setFilenameFilter(filter);
-      if (cur != null) {
+      if (cur != null && !cur.getPath().isEmpty()) {
         if (cur.isDirectory())
           fd.setDirectory(cur.getPath());
         else {
@@ -376,10 +384,20 @@ public abstract class FileChooser {
       final int value;
       if (fd.getFile() != null) {
         cur = new File(fd.getDirectory(), fd.getFile());
-        value = APPROVE_OPTION;
+        if (cur.isFile() && mode == FILES_ONLY) {
+          value = APPROVE_OPTION;
+        }
+        else if (cur.isDirectory() && mode == DIRECTORIES_ONLY) {
+          value = APPROVE_OPTION;
+        }
+        else {
+          value = ERROR_OPTION;
+          cur = null;
+        }
       }
       else {
         value = CANCEL_OPTION;
+        cur = null;
       }
       updateDirectoryPreference();
       return value;

--- a/vassal-app/src/main/java/VASSAL/tools/icon/IconFamily.java
+++ b/vassal-app/src/main/java/VASSAL/tools/icon/IconFamily.java
@@ -644,34 +644,28 @@ public class IconFamily extends AbstractConfigurable {
       final FileChooser fc = GameModule.getGameModule().getEditorImageChooser();
       fc.setFileFilter(new FamilyImageFilter(family.getName()));
       fc.setSelectedFile(new File(family.getName() + ".*")); //$NON-NLS-1$
-      if (fc.showOpenDialog(getControls()) != FileChooser.APPROVE_OPTION) {
-        setWarning(""); //$NON-NLS-1$
-        setValue(null);
-      }
-      else {
+      if (fc.showOpenDialog(getControls()) == FileChooser.APPROVE_OPTION) {
         final File f = fc.getSelectedFile();
-        if (f != null && f.exists()) {
-          final String name = f.getName();
-          if (name.split("\\.").length != 2) { //$NON-NLS-1$
-            showError(Resources.getString("Editor.IconFamily.illegal_icon_name")); //$NON-NLS-1$
-          }
-          else if (!name.startsWith(family.getName())) {
-            showError(Resources.getString("Editor.IconFamily.bad_icon_name", family.getName())); //$NON-NLS-1$
-          }
-          else if (!ImageUtils.hasImageSuffix(name)) {
-            showError(Resources.getString("Editor.IconFamily.bad_icon_file")); //$NON-NLS-1$
-          }
-          else {
-            GameModule.getGameModule().getArchiveWriter().addImage(f.getPath(),
-                buildPath(f.getName()));
-            setWarning(""); //$NON-NLS-1$
-            setValue(name);
-          }
+        final String name = f.getName();
+        if (name.split("\\.").length != 2) { //$NON-NLS-1$
+          showError(Resources.getString("Editor.IconFamily.illegal_icon_name")); //$NON-NLS-1$
+        }
+        else if (!name.startsWith(family.getName())) {
+          showError(Resources.getString("Editor.IconFamily.bad_icon_name", family.getName())); //$NON-NLS-1$
+        }
+        else if (!ImageUtils.hasImageSuffix(name)) {
+          showError(Resources.getString("Editor.IconFamily.bad_icon_file")); //$NON-NLS-1$
         }
         else {
+          GameModule.getGameModule().getArchiveWriter().addImage(f.getPath(),
+              buildPath(f.getName()));
           setWarning(""); //$NON-NLS-1$
-          setValue(null);
+          setValue(name);
         }
+      }
+      else {
+        setWarning(""); //$NON-NLS-1$
+        setValue(null);
       }
     }
 

--- a/vassal-app/src/main/java/VASSAL/tools/image/tilecache/ImageTileDiskCache.java
+++ b/vassal-app/src/main/java/VASSAL/tools/image/tilecache/ImageTileDiskCache.java
@@ -96,7 +96,7 @@ public class ImageTileDiskCache implements ImageTileSource, FileStore {
     double scale) throws ImageIOException {
 
     final File f = new File(tileNameFor(name, tileX, tileY, scale));
-    return f.exists() && f.isFile();
+    return f.isFile();
   }
 
   /** {@inheritDoc} */

--- a/vassal-app/src/main/java/VASSAL/tools/imports/ImportAction.java
+++ b/vassal-app/src/main/java/VASSAL/tools/imports/ImportAction.java
@@ -149,10 +149,8 @@ public final class ImportAction extends EditModuleAction {
 
     if (fc.showOpenDialog() == FileChooser.APPROVE_OPTION) {
       final File f = fc.getSelectedFile();
-      if (f != null && f.exists()) {
-        loadModule(f);
-        actionCancelled = false;
-      }
+      loadModule(f);
+      actionCancelled = false;
     }
   }
 
@@ -263,8 +261,10 @@ public final class ImportAction extends EditModuleAction {
    */
   public File getCaseInsensitiveFile(File f, File base,
       boolean queryIfNotFound, FileFilter filter) {
+    if (f.getPath().isEmpty())
+      return null;
     // Easy case
-    if (f.exists())
+    if (f.isFile())
       return f;
 
     final String name = Importer.getFileName(f.getName());
@@ -307,8 +307,7 @@ public final class ImportAction extends EditModuleAction {
       fc.setSelectedFile(new File(f.getName()));
 
       if (fc.showOpenDialog() == FileChooser.APPROVE_OPTION) {
-        final File p = fc.getSelectedFile();
-        if (p.exists()) return p;
+        return fc.getSelectedFile();
       }
     }
 

--- a/vassal-app/src/main/java/VASSAL/tools/io/Tailer.java
+++ b/vassal-app/src/main/java/VASSAL/tools/io/Tailer.java
@@ -71,6 +71,7 @@ public class Tailer {
    */
   public Tailer(File file, long poll_interval) {
     if (file == null) throw new IllegalArgumentException("file == null");
+    if (file.getPath().isEmpty()) throw new IllegalArgumentException("Empty file name");
 
     this.file = file;
     this.poll_interval = poll_interval;


### PR DESCRIPTION
In particular the test if a file exists `new File("").exists()` now
returns `true` rather than false.  And `File("")` points to the run-time
default directory (`user.dir`) rather than to nothing. See also

    https://www.oracle.com/java/technologies/javase/25all-relnotes.html#JDK-8024695

The fix changes the `FileChooser` so that files that are opened for
reading are checked for existence (using `isFile`) before returning to
the caller.  If the file isn't found, then return `ERROR_OPTION`, so
that the client code can simply assume a return value of
`ACCCEPT_OPTION` means the chosen file is valid and can be used.

Some other similar fixes around in the code.

These all simplify the client code.