### PR TITLE
Module Manager Look and Feel

### DIFF
--- a/vassal-app/src/main/java/VASSAL/launch/AbstractLaunchAction.java
+++ b/vassal-app/src/main/java/VASSAL/launch/AbstractLaunchAction.java
@@ -39,6 +39,7 @@ import VASSAL.tools.io.ProcessLauncher;
 import VASSAL.tools.io.ProcessWrapper;
 import VASSAL.tools.lang.MemoryUtils;
 import org.apache.commons.codec.digest.DigestUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.SystemUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.slf4j.Logger;
@@ -47,6 +48,7 @@ import org.slf4j.LoggerFactory;
 import javax.swing.AbstractAction;
 import javax.swing.JOptionPane;
 import javax.swing.SwingWorker;
+import javax.swing.UIManager;
 import java.awt.Dimension;
 import java.awt.Window;
 import java.awt.event.ActionEvent;
@@ -571,6 +573,17 @@ public abstract class AbstractLaunchAction extends AbstractAction {
       // set the classpath
       result.add("-cp"); //NON-NLS
       result.add(System.getProperty("java.class.path"));
+
+      // Specify the look and feel.
+      String defaultLaf = System.getProperty("swing.defaultlaf");
+      if (defaultLaf == null) {
+        // On Windows the defaultlaf property is typically null.
+        // Get the current look and feel from the UIManager.
+        defaultLaf = UIManager.getLookAndFeel().getClass().getName();
+      }
+      if (!StringUtils.isBlank(defaultLaf)) {
+        result.add("-Dswing.defaultlaf=" + defaultLaf); //NON-NLS
+      }
 
       if (SystemUtils.IS_OS_MAC) {
         // set the MacOS dock parameters

--- a/vassal-app/src/main/java/VASSAL/launch/AbstractLaunchAction.java
+++ b/vassal-app/src/main/java/VASSAL/launch/AbstractLaunchAction.java
@@ -577,12 +577,17 @@ public abstract class AbstractLaunchAction extends AbstractAction {
       // Specify the look and feel.
       String defaultLaf = System.getProperty("swing.defaultlaf");
       if (defaultLaf == null) {
-        // On Windows the defaultlaf property is typically null.
+        // On Windows the defaultlaf property is typically null for jre provided LaF.
         // Get the current look and feel from the UIManager.
         defaultLaf = UIManager.getLookAndFeel().getClass().getName();
       }
       if (!StringUtils.isBlank(defaultLaf)) {
         result.add("-Dswing.defaultlaf=" + defaultLaf); //NON-NLS
+      }
+
+      final String lafFilePath = System.getProperty("look.feel");
+      if (!StringUtils.isBlank(lafFilePath)) {
+        result.add("-Dlook.feel=" + lafFilePath); //NON-NLS
       }
 
       if (SystemUtils.IS_OS_MAC) {

--- a/vassal-app/src/main/java/VASSAL/launch/AbstractLaunchAction.java
+++ b/vassal-app/src/main/java/VASSAL/launch/AbstractLaunchAction.java
@@ -566,12 +566,17 @@ public abstract class AbstractLaunchAction extends AbstractAction {
       // Specify the look and feel.
       String defaultLaf = System.getProperty("swing.defaultlaf");
       if (defaultLaf == null) {
-        // On Windows the defaultlaf property is typically null.
+        // On Windows the defaultlaf property is typically null for jre provided LaF.
         // Get the current look and feel from the UIManager.
         defaultLaf = UIManager.getLookAndFeel().getClass().getName();
       }
       if (!StringUtils.isBlank(defaultLaf)) {
         result.add("-Dswing.defaultlaf=" + defaultLaf); //NON-NLS
+      }
+
+      final String lafFilePath = System.getProperty("look.feel");
+      if (!StringUtils.isBlank(lafFilePath)) {
+        result.add("-Dlook.feel=" + lafFilePath); //NON-NLS
       }
 
       if (SystemUtils.IS_OS_MAC) {

--- a/vassal-app/src/main/java/VASSAL/launch/AbstractLaunchAction.java
+++ b/vassal-app/src/main/java/VASSAL/launch/AbstractLaunchAction.java
@@ -39,6 +39,7 @@ import VASSAL.tools.io.ProcessLauncher;
 import VASSAL.tools.io.ProcessWrapper;
 import VASSAL.tools.lang.MemoryUtils;
 import org.apache.commons.codec.digest.DigestUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.SystemUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.slf4j.Logger;
@@ -47,6 +48,7 @@ import org.slf4j.LoggerFactory;
 import javax.swing.AbstractAction;
 import javax.swing.JOptionPane;
 import javax.swing.SwingWorker;
+import javax.swing.UIManager;
 import java.awt.Dimension;
 import java.awt.Window;
 import java.awt.event.ActionEvent;
@@ -560,6 +562,17 @@ public abstract class AbstractLaunchAction extends AbstractAction {
       // set the classpath
       result.add("-cp"); //NON-NLS
       result.add(System.getProperty("java.class.path"));
+
+      // Specify the look and feel.
+      String defaultLaf = System.getProperty("swing.defaultlaf");
+      if (defaultLaf == null) {
+        // On Windows the defaultlaf property is typically null.
+        // Get the current look and feel from the UIManager.
+        defaultLaf = UIManager.getLookAndFeel().getClass().getName();
+      }
+      if (!StringUtils.isBlank(defaultLaf)) {
+        result.add("-Dswing.defaultlaf=" + defaultLaf); //NON-NLS
+      }
 
       if (SystemUtils.IS_OS_MAC) {
         // set the MacOS dock parameters

--- a/vassal-app/src/main/java/VASSAL/launch/ModuleManagerWindow.java
+++ b/vassal-app/src/main/java/VASSAL/launch/ModuleManagerWindow.java
@@ -90,6 +90,7 @@ import javax.swing.border.TitledBorder;
 import javax.swing.event.TreeExpansionEvent;
 import javax.swing.event.TreeWillExpandListener;
 import javax.swing.table.DefaultTableCellRenderer;
+import javax.swing.table.TableCellRenderer;
 import javax.swing.table.TableColumn;
 import javax.swing.table.TableColumnModel;
 import javax.swing.text.DefaultEditorKit;
@@ -1018,6 +1019,30 @@ public class ModuleManagerWindow extends JFrame {
       });
     }
 
+    /**
+     * Set the foreground color of all table cells in the row.
+     * @param renderer  the <code>TableCellRenderer</code> to prepare
+     * @param row       the row of the cell to render, where 0 is the first row
+     * @param column    the column of the cell to render,
+     *                  where 0 is the first column
+     */
+    @Override
+    public Component prepareRenderer(TableCellRenderer renderer, int row, int column) {
+      final Component component = super.prepareRenderer(renderer, row, column);
+
+      final MyTree tree = getInstance().tree;
+      final TreePath path = tree.getPathForRow(row);
+      if (path != null) {
+        final MyTreeNode node = (MyTreeNode) path.getLastPathComponent();
+        final AbstractInfo info = node.getNodeInfo();
+        final Color c = info.getTreeCellFgColor();
+        if (c != null) {
+          component.setForeground(c);
+        }
+      }
+      return component;
+    }
+
 // FIXME: Where's the rest of the comment???
     /**
      * There appears to be a bug/strange interaction between JXTreetable and the ComponentSplitter
@@ -1035,7 +1060,6 @@ public class ModuleManagerWindow extends JFrame {
    *   - Add file name as tooltip
    *   - Handle expanded display (some nodes use the same icon for expanded/unexpanded)
    *   - Gray out inactive extensions
-   *   - Gray out Save Games that belong to other modules
    */
   private static class MyTreeCellRenderer extends DefaultTreeCellRenderer {
     private static final long serialVersionUID = 1L;
@@ -1050,7 +1074,10 @@ public class ModuleManagerWindow extends JFrame {
       setText(info.toString());
       setToolTipText(info.getToolTipText());
       setIcon(info.getIcon(expanded));
-      setForeground(info.getTreeCellFgColor());
+      final Color c = info.getTreeCellFgColor();
+      if (c != null) {
+        setForeground(c);
+      }
       return this;
     }
   }
@@ -1324,7 +1351,7 @@ public class ModuleManagerWindow extends JFrame {
      *  @return cell text color
      */
     public Color getTreeCellFgColor() {
-      return Color.black;
+      return null;
     }
 
     /**
@@ -1695,7 +1722,10 @@ public class ModuleManagerWindow extends JFrame {
 
     @Override
     public Color getTreeCellFgColor() {
-      return Info.isModuleTooNew(getVassalVersion()) ? Color.GRAY : Color.BLACK;
+      if (Info.isModuleTooNew(getVassalVersion())) {
+        return UIManager.getColor("TextPane.inactiveForeground"); // Color.gray
+      }
+      return null;
     }
   }
 
@@ -1807,13 +1837,20 @@ public class ModuleManagerWindow extends JFrame {
 
     @Override
     public Color getTreeCellFgColor() {
-      // FIXME: should get colors from LAF
       if (isActive()) {
-        return metadata == null ? Color.red : Color.black;
+        if (metadata == null) {
+          return Color.red;
+        }
       }
       else {
-        return metadata == null ? Color.pink : Color.gray;
+        if (metadata == null) {
+          return Color.pink;
+        }
+        else {
+          return UIManager.getColor("TextPane.inactiveForeground"); // Color.gray
+        }
       }
+      return null; // default color
     }
 
     @Override
@@ -2051,8 +2088,12 @@ public class ModuleManagerWindow extends JFrame {
 
     @Override
     public Color getTreeCellFgColor() {
-      // FIXME: should get colors from LAF
-      return belongsToModule() ? Color.black : Color.gray;
+      if (!belongsToModule()) {
+        return UIManager.getColor("TextPane.inactiveForeground"); // Color.gray;
+      }
+      else {
+        return null;
+      }
     }
 
     @Override

--- a/vassal-app/src/main/java/VASSAL/launch/ModuleManagerWindow.java
+++ b/vassal-app/src/main/java/VASSAL/launch/ModuleManagerWindow.java
@@ -90,6 +90,7 @@ import javax.swing.border.TitledBorder;
 import javax.swing.event.TreeExpansionEvent;
 import javax.swing.event.TreeWillExpandListener;
 import javax.swing.table.DefaultTableCellRenderer;
+import javax.swing.table.TableCellRenderer;
 import javax.swing.table.TableColumn;
 import javax.swing.table.TableColumnModel;
 import javax.swing.text.DefaultEditorKit;
@@ -1137,6 +1138,30 @@ public class ModuleManagerWindow extends JFrame {
       });
     }
 
+    /**
+     * Set the foreground color of all table cells in the row.
+     * @param renderer  the <code>TableCellRenderer</code> to prepare
+     * @param row       the row of the cell to render, where 0 is the first row
+     * @param column    the column of the cell to render,
+     *                  where 0 is the first column
+     */
+    @Override
+    public Component prepareRenderer(TableCellRenderer renderer, int row, int column) {
+      final Component component = super.prepareRenderer(renderer, row, column);
+
+      final MyTree tree = getInstance().tree;
+      final TreePath path = tree.getPathForRow(row);
+      if (path != null) {
+        final MyTreeNode node = (MyTreeNode) path.getLastPathComponent();
+        final AbstractInfo info = node.getNodeInfo();
+        final Color c = info.getTreeCellFgColor();
+        if (c != null) {
+          component.setForeground(c);
+        }
+      }
+      return component;
+    }
+
 // FIXME: Where's the rest of the comment???
     /**
      * There appears to be a bug/strange interaction between JXTreetable and the ComponentSplitter
@@ -1154,7 +1179,6 @@ public class ModuleManagerWindow extends JFrame {
    *   - Add file name as tooltip
    *   - Handle expanded display (some nodes use the same icon for expanded/unexpanded)
    *   - Gray out inactive extensions
-   *   - Gray out Save Games that belong to other modules
    */
   private static class MyTreeCellRenderer extends DefaultTreeCellRenderer {
     private static final long serialVersionUID = 1L;
@@ -1169,7 +1193,10 @@ public class ModuleManagerWindow extends JFrame {
       setText(info.toString());
       setToolTipText(info.getToolTipText());
       setIcon(info.getIcon(expanded));
-      setForeground(info.getTreeCellFgColor());
+      final Color c = info.getTreeCellFgColor();
+      if (c != null) {
+        setForeground(c);
+      }
       return this;
     }
   }
@@ -1443,7 +1470,7 @@ public class ModuleManagerWindow extends JFrame {
      *  @return cell text color
      */
     public Color getTreeCellFgColor() {
-      return Color.black;
+      return null;
     }
 
     /**
@@ -1877,7 +1904,10 @@ public class ModuleManagerWindow extends JFrame {
 
     @Override
     public Color getTreeCellFgColor() {
-      return !isLaunchable() ? Color.GRAY : Color.BLACK;
+      if (Info.isModuleTooNew(getVassalVersion())) {
+        return UIManager.getColor("TextPane.inactiveForeground"); // Color.gray
+      }
+      return null;
     }
   }
 
@@ -1989,13 +2019,20 @@ public class ModuleManagerWindow extends JFrame {
 
     @Override
     public Color getTreeCellFgColor() {
-      // FIXME: should get colors from LAF
       if (isActive()) {
-        return metadata == null || !moduleInfo.isValid() ? Color.red : Color.black;
+        if (metadata == null) {
+          return Color.red;
+        }
       }
       else {
-        return metadata == null || !moduleInfo.isValid() ? Color.pink : Color.gray;
+        if (metadata == null) {
+          return Color.pink;
+        }
+        else {
+          return UIManager.getColor("TextPane.inactiveForeground"); // Color.gray
+        }
       }
+      return null; // default color
     }
 
     @Override
@@ -2233,8 +2270,12 @@ public class ModuleManagerWindow extends JFrame {
 
     @Override
     public Color getTreeCellFgColor() {
-      // FIXME: should get colors from LAF
-      return belongsToModule() && folderInfo.getModuleInfo().isValid() ? Color.black : Color.gray;
+      if (!belongsToModule()) {
+        return UIManager.getColor("TextPane.inactiveForeground"); // Color.gray;
+      }
+      else {
+        return null;
+      }
     }
 
     @Override

--- a/vassal-app/src/main/java/VASSAL/launch/StartUp.java
+++ b/vassal-app/src/main/java/VASSAL/launch/StartUp.java
@@ -116,18 +116,21 @@ public class StartUp {
         }
 
         if (!SystemUtils.IS_OS_WINDOWS) {
-          // use native LookAndFeel
-          // NB: This must be after Mac-specific properties
-          try {
-            UIManager.setLookAndFeel(
-              UIManager.getSystemLookAndFeelClassName()
-            );
+          // Check if Look and Feel is specified, otherwise default to system look and feel.
+          final String defaultLaf = System.getProperty("swing.defaultlaf");
+          if (defaultLaf == null) {
+            // use native LookAndFeel
+            // NB: This must be after Mac-specific properties
+            try {
+              UIManager.setLookAndFeel(
+                      UIManager.getSystemLookAndFeelClassName()
+              );
+            }
+            catch (ClassNotFoundException | UnsupportedLookAndFeelException
+                     | InstantiationException | IllegalAccessException e) {
+              ErrorDialog.bug(e);
+            }
           }
-          catch (ClassNotFoundException | UnsupportedLookAndFeelException
-            | InstantiationException | IllegalAccessException e) {
-            ErrorDialog.bug(e);
-          }
-
           // The GTK LaF has a color picker which lacks the ability to
           // select transparency. We can override that and it doesn't
           // look too goofy.

--- a/vassal-app/src/main/resources/VASSAL/i18n/VASSAL.properties
+++ b/vassal-app/src/main/resources/VASSAL/i18n/VASSAL.properties
@@ -1166,8 +1166,11 @@ ServerAddressBook.listening=Listen for Invites on Port %1$s
 ServerStatusView.4=html.disable
 
 # Startup Look and Feel
-Startup.laf_not_found=Cannot load the user specified Look and Feel:\n%1$s\nThe name is either misspelt or the file is not in the class path.
 Startup.laf_default=Loading the Default Look and Feel
+Startup.laf_malformed=Invalid look and feel filename or path.\nCheck the -Dlook.feel= option.\n%1$s
+Startup.laf_no_path=Cannot load the user specified Look and Feel.\nPossibly missing the -Dlook.feel option.\n%1$s
+Startup.laf_not_found=Look and Feel not found or unloadable.\n%1$s
+Startup.laf_unsupported=The selected Look and Feel is unsupported.\n%1$s
 
 # Tiling Handler
 TilingHandler.processing_image_tiles=Processing Image Tiles

--- a/vassal-app/src/main/resources/VASSAL/i18n/VASSAL.properties
+++ b/vassal-app/src/main/resources/VASSAL/i18n/VASSAL.properties
@@ -1165,6 +1165,10 @@ ServerAddressBook.listening=Listen for Invites on Port %1$s
 
 ServerStatusView.4=html.disable
 
+# Startup Look and Feel
+Startup.laf_not_found=Cannot load the user specified Look and Feel:\n%1$s\nThe name is either misspelt or the file is not in the class path.
+Startup.laf_default=Loading the Default Look and Feel
+
 # Tiling Handler
 TilingHandler.processing_image_tiles=Processing Image Tiles
 # Item 1 is an image filename being "tiled" (broken up into small squares for faster load & scrolling)

--- a/vassal-app/src/main/resources/VASSAL/i18n/VASSAL.properties
+++ b/vassal-app/src/main/resources/VASSAL/i18n/VASSAL.properties
@@ -1176,8 +1176,11 @@ ServerAddressBook.listening=Listen for Invites on Port %1$s
 ServerStatusView.4=html.disable
 
 # Startup Look and Feel
-Startup.laf_not_found=Cannot load the user specified Look and Feel:\n%1$s\nThe name is either misspelt or the file is not in the class path.
 Startup.laf_default=Loading the Default Look and Feel
+Startup.laf_malformed=Invalid look and feel filename or path.\nCheck the -Dlook.feel= option.\n%1$s
+Startup.laf_no_path=Cannot load the user specified Look and Feel.\nPossibly missing the -Dlook.feel option.\n%1$s
+Startup.laf_not_found=Look and Feel not found or unloadable.\n%1$s
+Startup.laf_unsupported=The selected Look and Feel is unsupported.\n%1$s
 
 # Tiling Handler
 TilingHandler.processing_image_tiles=Processing Image Tiles

--- a/vassal-app/src/main/resources/VASSAL/i18n/VASSAL.properties
+++ b/vassal-app/src/main/resources/VASSAL/i18n/VASSAL.properties
@@ -1175,6 +1175,10 @@ ServerAddressBook.listening=Listen for Invites on Port %1$s
 
 ServerStatusView.4=html.disable
 
+# Startup Look and Feel
+Startup.laf_not_found=Cannot load the user specified Look and Feel:\n%1$s\nThe name is either misspelt or the file is not in the class path.
+Startup.laf_default=Loading the Default Look and Feel
+
 # Tiling Handler
 TilingHandler.processing_image_tiles=Processing Image Tiles
 # Item 1 is an image filename being "tiled" (broken up into small squares for faster load & scrolling)


### PR DESCRIPTION
Module Manager honors the look and feel as set by the user on Windows/Mac/Linux systems. Select look and feel using the `swing.defaultlaf` system property.

- Module Manager gets the color from look and feel.
- Maintains the same look and feel for child processes (player and editor).
- Dynamically loads a custom Look and Feel.
- Supports loading of Intellij theme.json files using the FlatLaf extension.

For dark modes there are some downstream visibility issues. Some of the default buttons (server, camera, zoom) are hard to see in dark mode. Messages in the chat log are hard to read.

Custom Look and Feel can be set from the command line. Use the `swing.defaultlaf` system property to specify the class name. Define the `look.feel` property to specify a jar or json file. It can be a relative or absolute path. As a quick example of using Flatlaf on Windows, download and copy the jar to the Vassal.exe folder. Create or edit the vassal.l4j.ini file in the same folder, adding:
```
-Dswing.defaultlaf=com.formdev.flatlaf.FlatDarkLaf
-Dlook.feel=flatlaf-3.7.jar
```
Vassal should now start in dark mode. Other operating system have slightly different mechanisms for injecting command line parameters.

To load a json Look and Feel file, place the _theme.json_ file and the FlatLaf jar files in the Vassal installation folder. For example using the Salmon theme on Windows, add the following lines to the vassal.l4j.ini file. Loading a json file requires both FlatLaf jars.
```
-Dlook.feel=flatlaf-3.7.jar;flatlaf-intellij-themes-3.7.jar
-Dswing.defaultlaf=Salmon.theme.json
```
The _-Dlook.feel_ parameter follows the classpath syntax. The separator on Windows is the semicolon and colon for all other operating systems.

Closes #12821