### PR TITLE
Locale Configurer displays dropdown with names of both current and native locales

### DIFF
--- a/vassal-app/src/main/java/VASSAL/i18n/Resources.java
+++ b/vassal-app/src/main/java/VASSAL/i18n/Resources.java
@@ -113,7 +113,7 @@ public class Resources {
 
     final List<String> languages = new ArrayList<>();
     for (final Locale l : supportedLocales) {
-      languages.add(l.getLanguage());
+      languages.add(l.toLanguageTag());
     }
 
     final Prefs p = Prefs.getGlobalPrefs();
@@ -142,7 +142,9 @@ public class Resources {
             @Override
             public Component getListCellRendererComponent(JList list, Object value, int index, boolean isSelected, boolean cellHasFocus) {
               final JLabel l = (JLabel) super.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus);
-              l.setText(new Locale((String) value).getDisplayLanguage());
+              final Locale current = new Locale(getValueString());
+              final Locale locale = new Locale((String)value);
+              l.setText((locale.getDisplayLanguage(current)) + " (" + locale.getDisplayLanguage(locale) + ")"); //NON-NLS
               return l;
             }
           });

--- a/vassal-app/src/main/java/VASSAL/i18n/Resources.java
+++ b/vassal-app/src/main/java/VASSAL/i18n/Resources.java
@@ -132,6 +132,8 @@ public class Resources {
         LOCALE_PREF_KEY,
         getInstanceString("Prefs.language"),
         languages.toArray(new String[0])) {
+      Locale current = null;
+
       @Override
       public Component getControls() {
         if (getBox() == null) {
@@ -142,7 +144,9 @@ public class Resources {
             @Override
             public Component getListCellRendererComponent(JList list, Object value, int index, boolean isSelected, boolean cellHasFocus) {
               final JLabel l = (JLabel) super.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus);
-              final Locale current = new Locale(getValueString());
+              if (current == null) {
+                current = new Locale(getValueString());
+              }
               final Locale locale = new Locale((String)value);
               l.setText((locale.getDisplayLanguage(current)) + " (" + locale.getDisplayLanguage(locale) + ")"); //NON-NLS
               return l;


### PR DESCRIPTION
Show locale names in both the current and native locales, whereas the existing locale configurer displays only the English names. The image shows the dropdown from the perspective of the French locale.

Closes #9300 

<img width="258" height="182" alt="locale" src="https://github.com/user-attachments/assets/943c0602-3fba-4144-9437-b9091f6f481f" />
