### PR TITLE
14537 Preserve the user directory preference after canceling from a file load or save dialog

### DIFF
--- a/vassal-app/src/main/java/VASSAL/tools/filechooser/FileChooser.java
+++ b/vassal-app/src/main/java/VASSAL/tools/filechooser/FileChooser.java
@@ -394,12 +394,11 @@ public abstract class FileChooser {
           value = ERROR_OPTION;
           cur = null;
         }
+        updateDirectoryPreference();
       }
       else {
         value = CANCEL_OPTION;
-        cur = null;
       }
-      updateDirectoryPreference();
       return value;
     }
 


### PR DESCRIPTION
In FileChooser, the _setCurrentDirectory()_ and _getCurrentDirectory()_ were not complementary functions. The _get_ should return the _set_ value. When _set_ was given a directory, the _get_ returned the parent. _getCurrentDirectory()_ now checks if the stored path is a directory and returns it.

Closes #14537 
