### PR TITLE
Escape key should cancel Load Continuation

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/module/GameState.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/GameState.java
@@ -762,7 +762,8 @@ public class GameState implements CommandEncoder {
           options,
           options[0]
         );
-        if (result == JOptionPane.NO_OPTION) { // Note - this is actually the "Cancel" option.
+        if (result == JOptionPane.NO_OPTION || // Note - this is actually the "Cancel" option.
+            result == JOptionPane.CLOSED_OPTION) {
           return;
         }
         else if (result == JOptionPane.CANCEL_OPTION) { // "Don't Prompt Again" option.


### PR DESCRIPTION
Pressing Esc or clicking the top-right 'X' should cancel Load Continuation, whereas the current release treats these inputs as Ok, proceed.