### PR TITLE
14536 Don't re-prompt for save file after canceling the FileChooser dialog

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/module/GameState.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/GameState.java
@@ -480,17 +480,11 @@ public class GameState implements CommandEncoder {
       return NO_NEED_TO_SAVE;
     }
 
-    final int result = JOptionPane.showConfirmDialog(
+    return JOptionPane.showConfirmDialog(
       GameModule.getGameModule().getPlayerWindow(),
       Resources.getString("GameState.save_game_query"), //$NON-NLS-1$
       Resources.getString("GameState.game_modified"),   //$NON-NLS-1$
       JOptionPane.YES_NO_CANCEL_OPTION);
-
-    if (result == JOptionPane.YES_OPTION) {
-      saveGame();
-    }
-
-    return result;
   }
 
   /**
@@ -816,7 +810,10 @@ public class GameState implements CommandEncoder {
         int optionToSave = NO_NEED_TO_SAVE;
         if (gameStarted) {
           optionToSave = maybeSaveGame();
-          if (optionToSave == JOptionPane.CANCEL_OPTION) {
+          if (optionToSave == JOptionPane.YES_OPTION) {
+            saveGame();
+          }
+          else if (optionToSave == JOptionPane.CANCEL_OPTION) {
             return false;
           }
         }
@@ -952,7 +949,11 @@ public class GameState implements CommandEncoder {
           final URL url = new URL(text);
           final URLConnection uc = url.openConnection();
 
-          if (maybeSaveGame() != JOptionPane.CANCEL_OPTION) {
+          final int optionToSave = maybeSaveGame();
+          if (optionToSave == JOptionPane.YES_OPTION) {
+            saveGame();
+          }
+          if (optionToSave != JOptionPane.CANCEL_OPTION) {
 
             try (InputStream is = uc.getInputStream(); BufferedInputStream bis = new BufferedInputStream(is)) {
               if (gameStarted) {


### PR DESCRIPTION
To explain the solution, here is a brief description of the code causing the re-prompting for a filename. The `GameState.maybeSaveGame()` function prompts the user whether to save the game. If the user responds in the affirmative, then it calls `saveGame()`. The _FileChooser_ launches within the `saveGame()` function. If the user sets the filename and hits "save", the file is written and all is fine.

Whether the user saves or cancels _FileChooser_, `GameState.maybeSaveGame()` still returns `JOptionPane.YES_OPTION`. Within `GameState.setup()` we have:
```
      switch (maybeSaveGame()) {  // <- calls saveGame()
      case JOptionPane.YES_OPTION:
        saveGame();
```
This second call to `saveGame()` re-prompts the user for a filename since `lastSaveFile` is _null_ since the user canceled the first FileChooser.

The least disruptive fix removes the `saveGame()` call in `maybeSaveGame()` and invokes `saveGame()` after every `maybeSaveGame()` call site.

Closes #14536 
