### PR TITLE
14525 Check and report over-sized image dimensions

### DIFF
--- a/vassal-app/src/main/java/VASSAL/tools/imageop/ScaleOpBitmapImpl.java
+++ b/vassal-app/src/main/java/VASSAL/tools/imageop/ScaleOpBitmapImpl.java
@@ -117,6 +117,13 @@ public class ScaleOpBitmapImpl extends AbstractTiledOpImpl
       // sum of the tiles widths and heights match the image width and height.
       final Dimension sd = sop.getSize();
       size = new Dimension((int)(sd.width * scale), (int)(sd.height * scale));
+
+      if ((long)size.width * size.height > Integer.MAX_VALUE) {
+        final String message = "Dimensions (width=" + size.width + " height=" + size.height + ") are too large. " +
+                "Image=" + (sop instanceof SourceOp ? ((SourceOp) sop).getName() : "") +
+                " (" + sd.width + " x " + sd.height + ") scale=" + scale;
+        throw new RuntimeException(message);
+      }
     }
   }
 


### PR DESCRIPTION
An exception reporting invalid (too large) dimensions occurs a bit too late to be of much use. This PR adds the same test earlier in the call stack to better understand the source of over dimensioning.

The `fixSize()` function does some scaling using floating point multiplication followed by an integer conversion. It is interesting that the exception reports both width and height as Integer.MAX_VALUE. Reviewing the Java specification on _Narrowing Conversions_, it notes that a overly large double converts to the maximum representable value, in this case Integer.MAX_VALUE. I did verify this with a quick test.

From: https://docs.oracle.com/javase/specs/jls/se25/html/jls-5.html

> 5.1.3. (1. bullet 3) b. The value must be too large (a positive value of large magnitude or positive infinity), and the result of the first step is the largest representable value of type int or long.

This PR doesn't fix the issue, but it should give more insight into the problem. This is something that occurs once every 6 months or so in different modules and varying versions of Vassal. This is a list of what appear to be duplicates of the same issue.

#14525
#14186
#13741
#14121
#14022 