### PR TITLE
14562 Fix null pointer exception when searching in the editor

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/module/PredefinedSetup.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/PredefinedSetup.java
@@ -380,7 +380,6 @@ public class PredefinedSetup extends AbstractConfigurable implements GameCompone
    */
   @Override
   public List<String> getExpressionList() {
-    return List.of(name);
+    return name != null ? List.of(name) : List.of();
   }
 }
-  


### PR DESCRIPTION
When a Predefined Setup folder is not assigned a name, the name property is null. Attempting to create a list from a null throws the exception. In the case of a null name return an empty list.

Closes #14562 
