### PR TITLE
MoveCameraButton now uses preferred center instead of viewport center

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/module/map/MoveCameraButton.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/MoveCameraButton.java
@@ -113,7 +113,7 @@ public class MoveCameraButton extends AbstractToolbarItem {
   }
 
   private Point getDestination() {
-    final SendToLocation.Destination dest = SendToLocation.getSendLocation(map, this, moveCameraMode, null, board, zone, region, gridLocation, x, y, propertyFilter, map, map.getCenter());
+    final SendToLocation.Destination dest = SendToLocation.getSendLocation(map, this, moveCameraMode, null, board, zone, region, gridLocation, x, y, propertyFilter, map, map.getPreferredCenter());
 
     if (dest.point != null) {
       offsetDest(dest.point);


### PR DESCRIPTION
Instead of using the map centre, which is limited by the view port, use the previously user requested map centre - i.e.,
`Map#getPreferredCenter`.  This will ensure that more pieces are seen when cycling through pieces.

Note that the algorithm is still broken in so far at it never will visit _all_ pieces selected by the selection criteria.

To make the algorithm visit _all_ pieces, it would have to keep some state information between invocations.

Closes #14303