### PR TITLE
Create Flatpak recipe on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -267,6 +267,45 @@ jobs:
         with:
           files: public/vassal_${{ steps.deb_vars.outputs.DEB_VERSION }}_all.deb
 
+  package_flatpak:
+    name: Flatpak recipe 
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout 
+        uses: actions/checkout@v6
+        with: 
+          fetch-depth: 1
+          
+      - name: Update container 
+        run: |
+          sudo apt update -y
+          
+      - name: Setup Java
+        uses: actions/setup-java@v5
+        with: 
+          distribution: 'temurin'
+          java-version: 25
+          java-package: jdk
+          
+      - name: Make recipe
+        run: |
+          mkdir -p flatpak
+          sed -e "s,@REPOSITORY@,${{ github.repository }}," -e "s,@RELEASE@,${{ github.ref_name }}," -e "s,@COMMIT@,${{ github.sha }}," -e "s,@JDK@,25," < dist/linux/org.vassalengine.vassal.yml.in > flatpak/org.vassalengine.vassal.yml
+          cat flatpak/org.vassalengine.vassal.yml
+          
+      - name: Make Maven dependencies
+        run: |
+          java -version
+          ./dist/linux/fetch-maven-deps-for-flatpak.sh
+          
+      - name: Archive Flatpak files
+        uses: actions/upload-artifact@v7
+        with:
+          name: flatpak-recipe
+          path: |
+            flatpak/org.vassalengine.vassal.yml
+            flatpak/maven-dependencies.yml
+          
   package_digest:
     name: Sha256 digest of packages
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -296,7 +296,7 @@ jobs:
       - name: Make Maven dependencies
         run: |
           java -version
-          ./dist/linux/fetch-maven-deps-for-flatpak.sh
+          ./dist/linux/fetch-maven-deps-for-flatpak.sh 
           
       - name: Archive Flatpak files
         uses: actions/upload-artifact@v7

--- a/dist/linux/fetch-maven-deps-for-flatpak.sh
+++ b/dist/linux/fetch-maven-deps-for-flatpak.sh
@@ -1,0 +1,270 @@
+#!/bin/bash
+#
+# This script is a modified version of
+#
+# https://github.com/lenucksi/SieveEditor/blob/master/scripts/fetch-maven-deps-for-flatpak.sh
+#
+# Fetch Maven dependencies and generate Flatpak YAML
+# This script automates the entire process of fetching Maven dependencies
+# and generating the maven-dependencies.yaml file for Flatpak builds.
+
+set -euo pipefail  # Strict error handling
+
+# --- Configuration ---
+# Determine script directory and repo root
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(pwd)"
+
+# Output location (can be overridden by first argument)
+OUTPUT_DIR="${1:-${REPO_ROOT}/flatpak}"
+OUTPUT_YAML="${OUTPUT_DIR}/maven-dependencies.yml"
+BACKUP_YAML="${OUTPUT_YAML}.old"
+PYTHON_GENERATOR="${SCRIPT_DIR}/generate_flatpak_maven_sources.py"
+
+# Ensure output directory exists
+mkdir -p "${OUTPUT_DIR}"
+
+# Change to repo root for Maven execution
+cd "${REPO_ROOT}"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# --- Functions ---
+
+generate_random_id() {
+  # Generate 12-character alphanumeric ID
+  head -c 16 /dev/urandom | base64 | tr -dc 'a-z0-9' | head -c 12
+}
+
+cleanup_old_fetch_dirs() {
+  echo -e "${BLUE}Cleaning up old fetch directories...${NC}"
+
+  # Remove directories matching pattern
+  local count=0
+  rm -rf mvn-dep-fetch-* mvn-download-*.log*
+  for dir in mvn-dep-fetch-* mvn-download-*.log; do
+    if [ -e "$dir" ]; then
+      echo "  Removing: $dir"
+      rm -rf "$dir" || true
+      ((count++))
+    fi
+  done
+
+  # Also remove old test/ directory if it exists
+  if [ -d "test" ]; then
+    echo "  Removing: test/"
+    rm -rf test || true
+    ((count++))
+  fi
+
+  if [ $count -eq 0 ]; then
+    echo "  No old directories to clean"
+  else
+    echo -e "${GREEN}  Removed $count item(s)${NC}"
+  fi
+}
+
+run_maven_fetch() {
+  local temp_dir="$1"
+  local temp_log="$2"
+
+  echo ""
+  echo -e "${BLUE}Fetching Maven dependencies...${NC}"
+  echo "  Maven repo: ${temp_dir}"
+  echo "  Download log: ${temp_log}"
+  echo ""
+
+  # Run Maven and capture full output to a temp file
+  local maven_output="${temp_log}.full"
+
+  make jar MVN="mvn -B -Dmaven.repo.local=${temp_dir} -DskipTests" 2>/dev/stdout | tee ${maven_output}
+  ret1=$?
+  echo "  Make return: $ret1"
+
+  if test $ret1 -eq 0; then
+    # Maven succeeded, extract download lines
+    grep "Downloaded" "${maven_output}" > "${temp_log}" || true
+
+    local download_count
+    download_count=$(wc -l < "${temp_log}" 2>/dev/null || echo "0")
+    echo -e "${GREEN}  Maven build successful${NC}"
+    echo "  Downloaded: ${download_count} artifacts"
+
+    # Show last few lines of Maven output
+    echo ""
+    echo "Last 5 lines of Maven output:"
+    tail -5 "${maven_output}"
+
+    # Clean up full output
+    rm -f "${maven_output}"
+    return 0
+  else
+    echo -e "${RED}  ERROR: Maven build failed${NC}"
+    echo ""
+    echo "Last 20 lines of Maven output:"
+    tail -20 "${maven_output}"
+    echo ""
+    echo "Full Maven output saved to: ${maven_output}"
+    return 1
+  fi
+}
+
+generate_yaml() {
+  local temp_dir="$1"
+  local temp_log="$2"
+  local output="$3"
+
+  echo ""
+  echo -e "${BLUE}Generating Flatpak YAML...${NC}"
+
+  if [ ! -f "${PYTHON_GENERATOR}" ]; then
+    echo -e "${RED}ERROR: Python generator script not found: ${PYTHON_GENERATOR}${NC}"
+    return 1
+  fi
+
+  if python3 "${PYTHON_GENERATOR}" "${temp_log}" "${temp_dir}" "${output}"; then
+    echo -e "${GREEN}  YAML generated: ${output}${NC}"
+  else
+    echo -e "${RED}  ERROR: YAML generation failed${NC}"
+    echo "  Temporary files preserved for debugging:"
+    echo "    - ${temp_dir}"
+    echo "    - ${temp_log}"
+    return 1
+  fi
+}
+
+compare_and_backup() {
+  local output="$1"
+  local backup="$2"
+
+  echo ""
+  if [ ! -f "${backup}" ]; then
+    echo -e "${YELLOW}No previous YAML found${NC}"
+    echo "  This appears to be the first run"
+    return 0
+  fi
+
+  echo -e "${BLUE}Comparing with previous YAML...${NC}"
+
+  if diff -q "${output}" "${backup}" > /dev/null 2>&1; then
+    echo -e "${GREEN}  No changes detected${NC}"
+    echo "  Dependencies are up to date"
+  else
+    echo -e "${YELLOW}  Changes detected!${NC}"
+    echo ""
+    echo "--- Diff Summary (first 50 lines) ---"
+    diff -u "${backup}" "${output}" | head -50 || true
+    echo ""
+
+    local added
+    local removed
+    added=$(diff "${backup}" "${output}" | grep -c "^+" || echo "0")
+    removed=$(diff "${backup}" "${output}" | grep -c "^-" || echo "0")
+    echo "  Lines added: ${added}"
+    echo "  Lines removed: ${removed}"
+    echo ""
+    echo "  Full diff available: diff ${backup} ${output}"
+  fi
+}
+
+cleanup_temp_files() {
+  local temp_dir="$1"
+  local temp_log="$2"
+
+  echo ""
+  echo -e "${BLUE}Cleaning up temporary files...${NC}"
+
+  if [ -d "${temp_dir}" ]; then
+    rm -rf "${temp_dir}"
+    echo "  Removed: ${temp_dir}"
+  fi
+
+  if [ -f "${temp_log}" ]; then
+    rm -f "${temp_log}"
+    echo "  Removed: ${temp_log}"
+  fi
+
+  # Also remove .full file if it exists
+  if [ -f "${temp_log}.full" ]; then
+    rm -f "${temp_log}.full"
+    echo "  Removed: ${temp_log}.full"
+  fi
+
+  echo -e "${GREEN}  Cleanup complete${NC}"
+}
+
+# --- Main Execution ---
+
+main() {
+  echo "========================================================================"
+  echo "Maven Dependency Fetch for Flatpak"
+  echo "========================================================================"
+  echo ""
+  
+  # Generate random ID
+  local random_id
+  random_id=$(generate_random_id)
+  local temp_dir="mvn-dep-fetch-${random_id}"
+  local temp_log="mvn-download-${random_id}.log"
+
+  echo "Session ID: ${random_id}"
+
+  # Backup existing YAML if present
+  if [ -f "${OUTPUT_YAML}" ]; then
+    cp "${OUTPUT_YAML}" "${BACKUP_YAML}"
+    echo "Backed up existing YAML: ${BACKUP_YAML}"
+  fi
+
+  # Execute workflow
+  cleanup_old_fetch_dirs
+
+  if ! run_maven_fetch "${temp_dir}" "${temp_log}"; then
+    echo -e "${RED}Maven fetch failed. Temporary files preserved for debugging.${NC}"
+    exit 1
+  fi
+
+  if ! generate_yaml "${temp_dir}" "${temp_log}" "${OUTPUT_YAML}"; then
+    echo -e "${RED}YAML generation failed. Temporary files preserved for debugging.${NC}"
+    exit 1
+  fi
+
+  compare_and_backup "${OUTPUT_YAML}" "${BACKUP_YAML}"
+  cleanup_temp_files "${temp_dir}" "${temp_log}"
+
+  echo ""
+  echo "========================================================================"
+  echo -e "${GREEN}SUCCESS!${NC}"
+  echo "========================================================================"
+  echo "Output: ${OUTPUT_YAML}"
+  echo ""
+  echo "Next steps:"
+  echo "  1. Review the generated YAML file"
+  echo "  2. Copy to your Flatpak manifest directory"
+  echo "  3. Test with: flatpak-builder --sandbox builddir/ manifest.yaml"
+  echo ""
+}
+
+# Error handling
+trap_error() {
+  local exit_code=$?
+  if [ $exit_code -ne 0 ]; then
+    echo ""
+    echo -e "${RED}========================================================================"
+    echo "ERROR: Script failed with exit code ${exit_code}"
+    echo "========================================================================${NC}"
+    echo ""
+    echo "Temporary files may have been preserved for debugging."
+    echo "Check for directories matching: mvn-dep-fetch-*"
+    echo ""
+  fi
+}
+
+trap trap_error EXIT
+
+# Run main function
+main "$@"

--- a/dist/linux/generate_flatpak_maven_sources.py
+++ b/dist/linux/generate_flatpak_maven_sources.py
@@ -1,0 +1,316 @@
+#!/usr/bin/env python3
+"""
+Generate Flatpak Maven sources YAML from Maven download log.
+
+This script uses dl2.txt as the source of truth and generates YAML entries
+for all downloaded Maven artifacts (.jar and .pom files).
+
+Usage:
+    python3 generate_flatpak_maven_sources.py dl2.txt test/ maven-sources.yaml
+"""
+
+import sys
+import os
+import re
+import hashlib
+from pathlib import Path
+from typing import Dict, Set, Optional, List
+
+
+def extract_relative_path(url: str) -> Optional[str]:
+    """
+    Extract the relative Maven repository path from a URL.
+
+    Supports:
+    - Maven Central: https://repo.maven.apache.org/maven2/path/to/file.jar
+    - JitPack: https://jitpack.io/path/to/file.jar
+    - Other repositories with similar structure
+
+    Args:
+        url: The download URL
+
+    Returns:
+        Relative path (e.g., "com/example/artifact/1.0/artifact-1.0.jar") or None
+    """
+    # Try Maven Central pattern
+    match = re.search(r'/maven2/(.+)$', url)
+    if match:
+        return match.group(1)
+
+    # Try JitPack pattern
+    match = re.search(r'jitpack\.io/(.+)$', url)
+    if match:
+        return match.group(1)
+
+    # Try generic pattern: anything after repository name
+    # This handles other repository types
+    match = re.search(r'(?:repository|maven|repo)/(.+)$', url)
+    if match:
+        return match.group(1)
+
+    return None
+
+
+def parse_download_log(log_file: Path) -> Dict[str, str]:
+    """
+    Parse Maven download log and extract URL mappings.
+
+    Args:
+        log_file: Path to dl2.txt
+
+    Returns:
+        Dictionary mapping {relative_path: url} for all .jar and .pom files
+    """
+    url_map = {}
+    line_number = 0
+
+    with open(log_file, 'r', encoding='utf-8') as f:
+        for line in f:
+            line_number += 1
+            
+            # print(f'{line_number:4d}: {line}')
+            # if 'vassal-maven' in line:
+            #     continue
+            # Match lines like:
+            # [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/...
+            # [INFO] Downloaded from jitpack.io: https://jitpack.io/...
+            match = re.search(r'Downloaded from [\w.]+:\s+(https?://\S+)', line)
+            if not match:
+                continue
+
+
+            url = match.group(1)
+
+            # Only process .jar and .pom files
+            if not url.endswith(('.jar', '.pom', 'metadata.xml')):
+                continue
+
+            # Extract relative path
+            relative_path = extract_relative_path(url)
+            if not relative_path:
+                print(f"Warning: Could not extract path from URL at line {line_number}: {url}")
+                print(f"  This file will be skipped. Please report this if it's a valid Maven URL.")
+                continue
+
+            # Store mapping (dict automatically deduplicates)
+            if relative_path in url_map and url_map[relative_path] != url:
+                print(f"Warning: Duplicate entry for {relative_path} with different URLs:")
+                print(f"  First:  {url_map[relative_path]}")
+                print(f"  Second: {url}")
+                print(f"  Using the first URL.")
+            else:
+                rp = Path(relative_path)
+                if rp.name == 'maven-metadata.xml':
+                    rp = rp.parent / 'maven-metadata-central.xml' 
+                url_map[str(rp)] = url
+
+    return url_map
+
+
+def scan_maven_repo(repo_path: Path) -> Set[str]:
+    """
+    Scan Maven repository directory for all .jar and .pom files.
+
+    Args:
+        repo_path: Path to the Maven repository (e.g., test/)
+
+    Returns:
+        Set of relative paths for all .jar and .pom files
+    """
+    found_files = set()
+
+    for file_path in repo_path.rglob('*'):
+        if not file_path.is_file():
+            continue
+
+        # Skip metadata files
+        if file_path.name in ('_remote.repositories',) or \
+           file_path.name.endswith(('.sha1', '.sha256', '.md5', '.lastUpdated', '.repositories')):
+            continue
+
+        # Only include .jar and .pom files
+        if file_path.suffix in ('.jar', '.pom'):
+            # Get relative path from repo root
+            relative_path = str(file_path.relative_to(repo_path))
+            if 'vassal' in relative_path or 'wizard' in relative_path:
+                continue
+
+            found_files.add(relative_path)
+
+    return found_files
+
+
+def calculate_sha256(file_path: Path) -> str:
+    """
+    Calculate SHA256 checksum of a file.
+
+    Args:
+        file_path: Path to the file
+
+    Returns:
+        SHA256 hex digest
+    """
+    sha256_hash = hashlib.sha256()
+
+    with open(file_path, "rb") as f:
+        # Read file in chunks to handle large files
+        for byte_block in iter(lambda: f.read(65536), b""):
+            sha256_hash.update(byte_block)
+
+    return sha256_hash.hexdigest()
+
+
+def generate_yaml_entry(dest_path: str, url: str, sha256: str) -> str:
+    """
+    Generate a YAML entry for Flatpak Maven sources.
+
+    Args:
+        dest_path: Destination directory in .m2/repository
+        url: Download URL
+        sha256: SHA256 checksum
+
+    Returns:
+        Formatted YAML block
+    """
+    destname = ''
+    if url.endswith('metadata.xml'):
+        destname = '\n  dest-filename: maven-metadata-central.xml'
+        
+    return f"""- type: file
+  dest: .m2/repository/{dest_path}{destname}
+  url: {url}
+  sha256: {sha256}"""
+
+
+def main():
+    """Main entry point."""
+    if len(sys.argv) != 4:
+        print(f"Usage: {sys.argv[0]} <download_log> <maven_repo_dir> <output_yaml>", file=sys.stderr)
+        print(file=sys.stderr)
+        print("Generate Flatpak Maven sources YAML from Maven download log.", file=sys.stderr)
+        print(file=sys.stderr)
+        print("Arguments:", file=sys.stderr)
+        print("  download_log    - Maven download log (e.g., dl2.txt)", file=sys.stderr)
+        print("  maven_repo_dir  - Maven repository directory (e.g., test/)", file=sys.stderr)
+        print("  output_yaml     - Output YAML file (e.g., maven-sources.yaml)", file=sys.stderr)
+        print(file=sys.stderr)
+        print("Example:", file=sys.stderr)
+        print(f"  {sys.argv[0]} dl2.txt test/ maven-sources.yaml", file=sys.stderr)
+        sys.exit(1)
+
+    log_file = Path(sys.argv[1])
+    maven_repo_dir = Path(sys.argv[2])
+    output_file = Path(sys.argv[3])
+
+    # Validate inputs
+    if not log_file.exists():
+        print(f"ERROR: Download log file not found: {log_file}", file=sys.stderr)
+        sys.exit(1)
+
+    if not maven_repo_dir.exists() or not maven_repo_dir.is_dir():
+        print(f"ERROR: Maven repository directory not found: {maven_repo_dir}", file=sys.stderr)
+        sys.exit(1)
+
+    print("=" * 70)
+    print("Flatpak Maven Sources Generator")
+    print("=" * 70)
+    print()
+
+    # PHASE 1: Parse dl2.txt (source of truth)
+    print("PHASE 1: Parsing download log...")
+    print(f"  Reading: {log_file}")
+    url_map = parse_download_log(log_file)
+    print(f"  Found {len(url_map)} unique artifacts in download log")
+    print()
+
+    # PHASE 2: Process each entry from dl2.txt
+    print("PHASE 2: Processing artifacts and calculating checksums...")
+    yaml_entries = []
+    missing_files = []
+    processed_count = 0
+
+    for relative_path, url in sorted(url_map.items()):
+        # Construct expected file location
+        file_path = maven_repo_dir / relative_path
+
+        # Check if file exists
+        if not file_path.exists():
+            missing_files.append((relative_path, url))
+            print(f"  ERROR: File not found in repository: {relative_path}", file=sys.stderr)
+            continue
+
+        # Calculate SHA256
+        processed_count += 1
+        if processed_count % 50 == 0 or processed_count == 1:
+            print(f"  Processing {processed_count}/{len(url_map)}: {relative_path}")
+
+        try:
+            sha256 = calculate_sha256(file_path)
+        except Exception as e:
+            print(f"  ERROR: Failed to calculate SHA256 for {relative_path}: {e}", file=sys.stderr)
+            missing_files.append((relative_path, url))
+            continue
+
+        # Generate YAML entry
+        # dest_path is the parent directory of the file
+        dest_path = str(Path(relative_path).parent)
+        yaml_entry = generate_yaml_entry(dest_path, url, sha256)
+        yaml_entries.append(yaml_entry)
+
+    print(f"  Completed processing {processed_count}/{len(url_map)} artifacts")
+    print()
+
+    # Check for errors in Phase 2
+    if missing_files:
+        print(f"ERROR: {len(missing_files)} files from dl2.txt were not found in {maven_repo_dir}", file=sys.stderr)
+        print("This indicates a problem with the Maven download or repository.", file=sys.stderr)
+        print("\nMissing files:", file=sys.stderr)
+        for relative_path, url in missing_files[:20]:
+            print(f"  - {relative_path}", file=sys.stderr)
+        if len(missing_files) > 20:
+            print(f"  ... and {len(missing_files) - 20} more", file=sys.stderr)
+        sys.exit(1)
+
+    # PHASE 3: Validation - check for orphaned files
+    print("PHASE 3: Validating repository contents...")
+    print(f"  Scanning {maven_repo_dir} for .jar and .pom files...")
+    found_files = scan_maven_repo(maven_repo_dir)
+    print(f"  Found {len(found_files)} files in repository")
+
+    # Check for files in test/ that weren't in dl2.txt
+    orphaned_files = found_files - set(url_map.keys())
+
+    if orphaned_files:
+        print(f"\nERROR: {len(orphaned_files)} files in {maven_repo_dir} were not in dl2.txt", file=sys.stderr)
+        print("This indicates a problem with the download log or repository.", file=sys.stderr)
+        print("\nOrphaned files:", file=sys.stderr)
+        for file_path in sorted(list(orphaned_files)[:20]):
+            print(f"  - {file_path}", file=sys.stderr)
+        if len(orphaned_files) > 20:
+            print(f"  ... and {len(orphaned_files) - 20} more", file=sys.stderr)
+        sys.exit(1)
+
+    print("  Validation passed: All files accounted for")
+    print()
+
+    # Write output YAML
+    print(f"Writing YAML to: {output_file}")
+    with open(output_file, 'w', encoding='utf-8') as f:
+        f.write('\n'.join(yaml_entries))
+        f.write('\n')  # Trailing newline
+
+    print()
+    print("=" * 70)
+    print("SUCCESS!")
+    print("=" * 70)
+    print(f"  Files in dl2.txt:        {len(url_map)}")
+    print(f"  Files in repository:     {len(found_files)}")
+    print(f"  YAML entries generated:  {len(yaml_entries)}")
+    print(f"  Output file:             {output_file}")
+    print()
+    print("Next step: Test with flatpak-builder")
+    print("=" * 70)
+
+
+if __name__ == '__main__':
+    main()

--- a/dist/linux/org.vassalengine.vassal.yml.in
+++ b/dist/linux/org.vassalengine.vassal.yml.in
@@ -1,0 +1,53 @@
+id: org.vassalengine.vassal
+runtime: org.freedesktop.Platform
+runtime-version: '25.08'
+sdk: org.freedesktop.Sdk
+sdk-extensions:
+  - org.freedesktop.Sdk.Extension.openjdk@JDK@
+command: vassal
+
+finish-args:
+  - --share=ipc
+  - --socket=x11
+  - --socket=pulseaudio
+  - --device=dri
+  - --share=network
+  - --filesystem=home
+  - --filesystem=/tmp
+  - --env=PATH=/app/jre/bin:/app/bin:/usr/bin
+
+modules:
+  - name: openjdk
+    buildsystem: simple
+    build-commands:
+      - /usr/lib/sdk/openjdk@JDK@/install.sh
+
+  - name: vassal
+    buildsystem: simple
+    build-options:
+      append-path: /usr/lib/sdk/openjdk@JDK@/bin
+      env:
+        MAVEN_OPTS: -Dmaven.repo.local=.m2/repository
+    build-commands:
+      - make jar SKIPS="-Dasciidoctor.skip=true -Dspotbugs.skip=true -Dlicense.skipDownloadLicenses -Dclirr.skip=true -Dmaven.javadoc.skip=true -Dpmd.skip=true -Dmaven.test.skip=true" MVN="mvn -Dmaven.repo.local=.m2/repository" MAVEN_VERSION=@RELEASE@ 
+      - mv release-prepare/target/lib ${FLATPAK_DEST}
+      - mv release-prepare/target/doc ${FLATPAK_DEST}
+      - install -Dm644 vassal-app/src/main/resources/icons/scalable/VASSAL.svg ${FLATPAK_DEST}/share/icons/hicolor/scalable/apps/${FLATPAK_ID}.svg
+      - install -Dm644 vassal-app/src/main/resources/icons/scalable/VASSAL.svg ${FLATPAK_DEST}/share/icons/hicolor/scalable/mimetypes/${FLATPAK_ID}.svg
+      - install -Dm755 dist/linux/VASSAL.sh ${FLATPAK_DEST}/VASSAL.sh
+      - install -Dm644 dist/linux/${FLATPAK_ID}.desktop ${FLATPAK_DEST}/share/applications/${FLATPAK_ID}.desktop 
+      - install -Dm644 dist/linux/${FLATPAK_ID}.metainfo.xml ${FLATPAK_DEST}/share/metainfo/${FLATPAK_ID}.metainfo.xml
+      - install -Dm644 dist/linux/${FLATPAK_ID}.mime.xml ${FLATPAK_DEST}/share/mime/packages/${FLATPAK_ID}.xml
+      - install -Dm644 dist/linux/vassal.6 ${FLATPAK_DEST}/share/man/man6/vassal.6
+      - install -d -Dm755 ${FLATPAK_DEST}/bin
+      - (cd ${FLATPAK_DEST}/bin && ln -s ../VASSAL.sh vassal)
+    sources:
+      - type: git
+        url: https://github.com/@REPOSITORY@.git
+        commit: @COMMIT@
+        tag: @RELEASE@
+        x-checker-data:
+          type: json
+          url: https://api.github.com/repos/@REPOSITORY@/releases/latest
+          tag-query: .tag_name
+      - maven-dependencies.yml


### PR DESCRIPTION
Create FlatPak files on release tag 

This PR will set-up the release workflow to generate the files 
- `org.vassalengine.vassal.yml` 
- `maven-dependencies.yml` 

These files are stored as artefacts of the job.

The files can then be pushed to `https://github.com/flathub/org.vassalengine.vassal`. 

This will ensure that the recipe at `https://github.com/flathub/org.vassalengine.vassal` is up-to-date with the most recent release, and remove the need to generate Maven dependencies elsewhere. 

Note that the patches at https://github.com/flathub/org.vassalengine.vassal are no longer needed. 

The point of this, is to make it easy to make a new release for FlatPak: 
- One downloads the `flatpak-recipe` artefacts from release job 
- One unpacks the files to a local clone of `https://github.com/flathub/org.vassalengine.vassal` 
- One commits the changes and push them upstream - Voila! New release of Vassal for FlatPak 

For an example of the release job, see 

- https://github.com/cholmcc/vassal/actions/runs/23870759315

The artefact `flatpak-recipe` contains the two above mentioned files. 

