### PR TITLE
Set VASSAL.conf from the launch scripts so that logback.xml has access to it without needing conditionals

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -222,7 +222,7 @@ $(TMPDIR)/windows-%-$(VERSION)-build:
 
 JREOPTS:=
 
-$(TMPDIR)/windows-noinst-$(VERSION)-build/VASSAL.l4j.xml: JREOPTS:=<opt>-DVASSAL.conf="%EXEDIR%\\..\\VASSAL"</opt>
+$(TMPDIR)/windows-noinst-$(VERSION)-build/VASSAL.l4j.xml: JREOPTS:=<opt>-DVASSAL.conf="%APPDATA%\\VASSAL"</opt>
 
 $(TMPDIR)/windows-%-$(VERSION)-build/VASSAL.l4j.xml: $(DISTDIR)/windows/VASSAL.l4j.xml.in | $(TMPDIR)/windows-%-$(VERSION)-build
 	sed -e 's/%NUMVERSION%/$(VNUM)/g' \

--- a/dist/linux/VASSAL.sh
+++ b/dist/linux/VASSAL.sh
@@ -9,7 +9,7 @@ path=$(realpath "$0")
 path=$(dirname "$path")
 
 # Set default definitions and arguments 
-defs=("-Duser.home=$HOME" "-Duser.dir=$path")
+defs=("-Duser.home=$HOME" "-Duser.dir=$path" "-DVASSAL.conf=$HOME/.VASSAL")
 args=()
 
 # --- Find Java and debugger -----------------------------------------

--- a/dist/macos/VASSAL.sh
+++ b/dist/macos/VASSAL.sh
@@ -20,4 +20,4 @@ else
 fi
 
 # fire it up
-exec arch -$ARCH Contents/MacOS/jre/bin/java -classpath Contents/Resources/Java/Vengine.jar -Xdock:name=VASSAL -Xdock:icon=Contents/Resources/VASSAL.icns VASSAL.launch.ModuleManager "${ARGS[@]}"
+exec arch -$ARCH Contents/MacOS/jre/bin/java -classpath Contents/Resources/Java/Vengine.jar -Xdock:name=VASSAL -Xdock:icon=Contents/Resources/VASSAL.icns VASSAL.launch.ModuleManager -DVASSAL.conf="$HOME/Library/Application Support/VASSAL" "${ARGS[@]}"

--- a/vassal-app/src/main/resources/logback.xml
+++ b/vassal-app/src/main/resources/logback.xml
@@ -1,32 +1,9 @@
 <configuration>
   <property resource="git.properties" />
   <property name="LOG_FILE" value="errorLog-${git.version}" />
+  <property name="CONF_DIR" value="${VASSAL.conf}" />
 
-  <if condition='isDefined("VASSAL.conf")'>
-    <then>
-      <property name="CONF_DIR" value="${VASSAL.conf}" />
-    </then>
-    <else>
-      <if condition='property("os.name").toLowerCase().startsWith("windows")'>
-        <then>
-          <property name="CONF_DIR" value="${APPDATA}/VASSAL" />
-        </then>
-        <else>
-          <if condition='property("os.name").toLowerCase().startsWith("mac")'>
-            <then>
-              <property name="CONF_DIR" value="${user.home}/Library/Application Support/VASSAL" />
-            </then>
-            <else>
-              <property name="CONF_DIR" value="${user.home}/.VASSAL" />
-            </else>
-          </if>
-        </else>
-      </if>
-    </else>
-  </if>
-
-  <conversionRule conversionWord="pid"
-                  class="VASSAL.tools.logging.ProcessIDConverter" />
+  <conversionRule conversionWord="pid" class="VASSAL.tools.logging.ProcessIDConverter" />
 
   <appender name="FILE" class="ch.qos.logback.core.FileAppender">
     <file>${CONF_DIR}/${LOG_FILE}</file>

--- a/vassal-app/src/test/resources/logback.xml
+++ b/vassal-app/src/test/resources/logback.xml
@@ -1,43 +1,14 @@
 <configuration>
-  <conversionRule conversionWord="pid"
-                  converterClass="VASSAL.tools.logging.ProcessIDConverter" />
+  <conversionRule conversionWord="pid" converterClass="VASSAL.tools.logging.ProcessIDConverter" />
 
-  <if condition='property("os.name").toLowerCase().startsWith("windows")'>
-    <then>
-      <appender name="FILE" class="ch.qos.logback.core.FileAppender">
-        <file>${APPDATA}/VASSAL/vassal-test.log</file>
-        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
-          <charset>UTF-8</charset>
-          <pattern>%date [%pid-%thread] %-5level %logger - %msg%n</pattern>
-        </encoder>
-        <prudent>true</prudent>
-      </appender>
-    </then>
-    <else>
-      <if condition='property("os.name").toLowerCase().startsWith("mac")'>
-        <then>
-          <appender name="FILE" class="ch.qos.logback.core.FileAppender">
-            <file>${user.home}/Library/Application Support/VASSAL/vassal-test.log</file>
-            <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
-              <charset>UTF-8</charset>
-              <pattern>%date [%pid-%thread] %-5level %logger - %msg%n</pattern>
-            </encoder>
-            <prudent>true</prudent>
-          </appender>
-        </then>
-        <else>
-          <appender name="FILE" class="ch.qos.logback.core.FileAppender">
-            <file>${user.home}/.VASSAL/vassal-test.log</file>
-            <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
-              <charset>UTF-8</charset>
-              <pattern>%date [%pid-%thread] %-5level %logger - %msg%n</pattern>
-            </encoder>
-            <prudent>true</prudent>
-          </appender>
-        </else>
-      </if>
-    </else>
-  </if>
+  <appender name="FILE" class="ch.qos.logback.core.FileAppender">
+    <file>vassal-test.log</file>
+    <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+      <charset>UTF-8</charset>
+      <pattern>%date [%pid-%thread] %-5level %logger - %msg%n</pattern>
+    </encoder>
+    <prudent>true</prudent>
+  </appender>
 
   <root level="info">
     <appender-ref ref="FILE" />


### PR DESCRIPTION
This works around current logback having deprecated conditional attributes on if elements and Debian shipping an EOL version of logback that doesn't support conditional elements.