### PR TITLE
Patch to fix deprecated logback XML elements

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -32,7 +32,6 @@ APP_I18N	:= $(shell find $(APP_SRCDIR)/resources/VASSAL/i18n/ \
 APP_BSH		:= $(shell find $(APP_SRCDIR)/resources/VASSAL/script/\
 			-name "*.bsh")
 APP_MISC	:= $(APP_SRCDIR)/resources/grayscale.icc	\
-		   $(APP_SRCDIR)/resources/logback.xml		\
 		   $(APP_SRCDIR)/resources/removed		\
 		   $(APP_SRCDIR)/resources/vassal.vmoptions
 APP_SPLASH	:= $(APP_JSRCDIR)/org/netbeans/modules/wizard/defaultWizard.png
@@ -132,6 +131,8 @@ deprecated: .compile
 	cp -a $(APP_ICON)                        $(OUT_DIR)/
 	cp -a $(APP_HELP)                        $(OUT_DIR)/
 	cp -a $(APP_MISC)			 $(OUT_DIR)/
+	cp -a $(APP_SRCDIR)/resources/logback-1.2.xml		\
+		   				 $(OUT_DIR)/logback.xml
 	cp -a git.properties                     $(OUT_DIR)/
 	cp -a deprecated			 $(OUT_DIR)/
 	cp -a $(APP_SPLASH)                      $(OUT_DIR)$(subst $(APP_JSRCDIR),,$(APP_SPLASH))

--- a/vassal-app/src/main/java/VASSAL/launch/Editor.java
+++ b/vassal-app/src/main/java/VASSAL/launch/Editor.java
@@ -50,10 +50,11 @@ import VASSAL.tools.version.VersionUtils;
 public class Editor extends Launcher {
   public static void main(String[] args) throws IOException {
     Info.setConfig(new StandardConfig());
+    logger = LoggerFactory.getLogger(Editor.class);
     new Editor(args);
   }
 
-  private static final Logger logger = LoggerFactory.getLogger(Editor.class);
+  private static Logger logger = null;
 
   protected Editor(String[] args) {
     // the ctor is protected to enforce that it's called via main()

--- a/vassal-app/src/main/java/VASSAL/launch/Launcher.java
+++ b/vassal-app/src/main/java/VASSAL/launch/Launcher.java
@@ -49,7 +49,7 @@ import java.util.concurrent.ExecutionException;
  * @since 3.1.0
  */
 public abstract class Launcher {
-  private static final Logger logger = LoggerFactory.getLogger(Launcher.class);
+  private static Logger logger = null;
 
   protected final LaunchRequest lr;
 
@@ -62,6 +62,8 @@ public abstract class Launcher {
   protected Launcher(String[] args) {
     if (instance != null) throw new IllegalStateException();
     instance = this;
+
+    if (logger == null) logger = LoggerFactory.getLogger(Launcher.class);
 
     LaunchRequest lreq = null;
     try {

--- a/vassal-app/src/main/java/VASSAL/launch/ModuleManager.java
+++ b/vassal-app/src/main/java/VASSAL/launch/ModuleManager.java
@@ -63,8 +63,7 @@ import VASSAL.tools.menu.MacOSXMenuManager;
  * @since 3.1.0
  */
 public class ModuleManager {
-  private static final Logger logger =
-    LoggerFactory.getLogger(ModuleManager.class);
+  private static Logger logger = null;
 
   private static final String NEXT_VERSION_CHECK = "nextVersionCheck"; //NON-NLS
   private static final String AUTO_VERSION_CHECK = "autoVersionCheck"; //NON-NLS
@@ -109,7 +108,9 @@ public class ModuleManager {
       e.printStackTrace();
       System.exit(1);
     }
-
+    // Initialize logger after standard configuration
+    logger = LoggerFactory.getLogger(ModuleManager.class);
+    
 // FIXME: We need to catch more exceptions in main() and then exit in
 // order to avoid situations where the main thread ends due to an uncaught
 // exception, but there are other threads still running, and so VASSAL

--- a/vassal-app/src/main/java/VASSAL/launch/StandardConfig.java
+++ b/vassal-app/src/main/java/VASSAL/launch/StandardConfig.java
@@ -39,11 +39,6 @@ public class StandardConfig implements Config {
   private final String reportableVersion;
 
   public StandardConfig() throws IOException {
-    // Set the version, reportable version
-    final GitProperties gitProperties = new GitProperties();
-    version = gitProperties.getVersion();
-    reportableVersion = version.contains("-") && !version.matches(".*-beta\\d+") ? version.substring(0, version.indexOf('-')) : version;
-
     baseDir = Path.of(System.getProperty("user.dir"));
 
     docDir = baseDir.resolve(
@@ -66,6 +61,7 @@ public class StandardConfig implements Config {
     else {
       confDir = Path.of(System.getProperty("user.home"), ".VASSAL"); //NON-NLS
     }
+    System.setProperty("VASSAL.conf", confDir.toString());
 
     final String cacheProp = System.getProperty("VASSAL.cache");
     if (cacheProp != null) {
@@ -79,6 +75,11 @@ public class StandardConfig implements Config {
     }
 
     Files.createDirectories(confDir);
+
+    // Set the version, reportable version
+    final GitProperties gitProperties = new GitProperties();
+    version = gitProperties.getVersion();
+    reportableVersion = version.contains("-") && !version.matches(".*-beta\\d+") ? version.substring(0, version.indexOf('-')) : version;
 
     prefsDir = confDir.resolve("prefs");
     errorLogPath = confDir.resolve("errorLog-" + getVersion());

--- a/vassal-app/src/main/resources/logback-1.2.xml
+++ b/vassal-app/src/main/resources/logback-1.2.xml
@@ -4,7 +4,7 @@
   <property name="CONF_DIR" value="${VASSAL.conf}" />
 
   <conversionRule conversionWord="pid"
-                  class="VASSAL.tools.logging.ProcessIDConverter" />
+                  converterClass="VASSAL.tools.logging.ProcessIDConverter" />
 
   <appender name="FILE" class="ch.qos.logback.core.FileAppender">
     <file>${CONF_DIR}/${LOG_FILE}</file>

--- a/vassal-app/src/test/resources/logback.xml
+++ b/vassal-app/src/test/resources/logback.xml
@@ -1,44 +1,16 @@
 <configuration>
   <conversionRule conversionWord="pid"
-                  converterClass="VASSAL.tools.logging.ProcessIDConverter" />
+                  class="VASSAL.tools.logging.ProcessIDConverter" />
 
-  <if condition='property("os.name").toLowerCase().startsWith("windows")'>
-    <then>
-      <appender name="FILE" class="ch.qos.logback.core.FileAppender">
-        <file>${APPDATA}/VASSAL/vassal-test.log</file>
-        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
-          <charset>UTF-8</charset>
-          <pattern>%date [%pid-%thread] %-5level %logger - %msg%n</pattern>
-        </encoder>
-        <prudent>true</prudent>
-      </appender>
-    </then>
-    <else>
-      <if condition='property("os.name").toLowerCase().startsWith("mac")'>
-        <then>
-          <appender name="FILE" class="ch.qos.logback.core.FileAppender">
-            <file>${user.home}/Library/Application Support/VASSAL/vassal-test.log</file>
-            <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
-              <charset>UTF-8</charset>
-              <pattern>%date [%pid-%thread] %-5level %logger - %msg%n</pattern>
-            </encoder>
-            <prudent>true</prudent>
-          </appender>
-        </then>
-        <else>
-          <appender name="FILE" class="ch.qos.logback.core.FileAppender">
-            <file>${user.home}/.VASSAL/vassal-test.log</file>
-            <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
-              <charset>UTF-8</charset>
-              <pattern>%date [%pid-%thread] %-5level %logger - %msg%n</pattern>
-            </encoder>
-            <prudent>true</prudent>
-          </appender>
-        </else>
-      </if>
-    </else>
-  </if>
-
+  <appender name="FILE" class="ch.qos.logback.core.FileAppender">
+    <file>vassal-test.log</file>
+    <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+      <charset>UTF-8</charset>
+      <pattern>%date [%pid-%thread] %-5level %logger - %msg%n</pattern>
+    </encoder>
+    <prudent>true</prudent>
+  </appender>
+  
   <root level="info">
     <appender-ref ref="FILE" />
   </root>


### PR DESCRIPTION
Patch to fix deprecated logback XML elements

This patch fixes the `logback.xml` configuration so as to not use deprecated elements.

This is done by slightly alterning the initialisation ordering of things. The code is changed so that `VASSAL.launch.StandardConfig` is  instantised before calls to `LoggerFactory.getLogger`, so that when the logger starts up, the system property `VASSAL.conf` is already set, and so we do not need to deduce it in `logback.xml`.

Ideally, `VASSAL.launch.StandardConfig` would propagate its data member `errorLogPath` as a system property - say `VASSAL.log`. However, to set that member, we need to read the Git version from `git.properties` first, which is done by `VASSAL.tools.version.GitProperties`.   That class instantised the log with `LoggerFactory.getLogger` to handle problems reading the `git.properties` file.  That means that we cannot set - say `VASSAL.log` - _before_ the first call to `LoggerFactory.getLogger`, and we have a race-condition problem. 

One _could_ argue, that if `VASSAL.tools.version.GitProperties` fails to read the `git.properties` file and therefore cannot set system property `git.version`, then any error reported will be put into `<confdir>/errorLog-git.version_IS_UNDEFINED` (where `<confdir>` is the configuration directory - say `~/.VASSAL`, and that therefore `VASSAL.tools.version.GitProperties` should _not_ use the `logback` logging facility, but rather throw a regular exception to be handled by the launched application. 

If that was the case, then we wouldn't have the chicken-egg problem outlined above.  In this patch, however, a more conservative approach is taken. 

This patch also adds the attribute `converterClass` to the `conversionRule` tag in `logback.xml` for handling the template `%pid`.  This is because older `logback` expects this attribute rather than the attribute `class`.   It should be OK to specify both `converterClass` and `class` because a: the XML parser will not fail on unknown attributes, and b: the `logback` code will only use the attribute that it expects. 

Alternative to #14599
