### PR TITLE
Upgraded bundled Java to 26+35 (Windows x86_64, MacOS), 26+37 (Windows aarch64)

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ master, release-3.7 ]
 
+env:
+  JDK_API: 26
+  
 jobs:
   package:
     name: Test & Package
@@ -17,7 +20,7 @@ jobs:
           fetch-depth: 1
 
       - name: Set branch
-        if: github.ref != 'refs/heads/master' && github.ref != 'refs/heads/release-3.7' 
+        if: github.ref != 'refs/heads/master' && github.ref != 'refs/heads/release-3.7'
         # Checking out a detached head for PR means we have to set the branch
         # name for it to show up later; shallow checkout means the branch
         # won't exist yet so there's no conflict.
@@ -35,9 +38,10 @@ jobs:
 
       - name: Install Java
         uses: actions/setup-java@v5
+        id: setup-java
         with:
           distribution: 'temurin'
-          java-version: 25
+          java-version: ${{ env.JDK_API }}
           java-package: jdk
 
       - name: Cache Maven packages
@@ -61,7 +65,7 @@ jobs:
 
       - name: Install packaging dependencies
         if: steps.cache-bootstrap.outputs.cache-hit != 'true'
-        run: ./bootstrap.sh
+        run: ./bootstrap.sh -j ${{ steps.setup-java.outputs.version }} windows-x86_64 macos-x86_64 macos-aarch64
 
       - name: Build packages
         run: make release
@@ -90,14 +94,8 @@ jobs:
           name: VASSAL-${{ steps.version.outputs.VERSION }}-windows-x86_64.exe
           path: tmp/VASSAL-${{ steps.version.outputs.VERSION }}-windows-x86_64.exe
 
-      - name: Archive Windows aarch64
-        uses: actions/upload-artifact@v7
-        with:
-          name: VASSAL-${{ steps.version.outputs.VERSION }}-windows-aarch64.exe
-          path: tmp/VASSAL-${{ steps.version.outputs.VERSION }}-windows-aarch64.exe
-
-  package_win_x86_32:
-    name: Test & Package Windows x86_32
+  package_win_aarch64:
+    name: Test & Package Windows aarch64
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout repo
@@ -105,11 +103,8 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Get tags
-        run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
-
       - name: Set branch
-        if: github.ref != 'refs/heads/master' && github.ref != 'refs/heads/release-3.7' 
+        if: github.ref != 'refs/heads/master' && github.ref != 'refs/heads/release-3.7'
         # Checking out a detached head for PR means we have to set the branch
         # name for it to show up later; shallow checkout means the branch
         # won't exist yet so there's no conflict.
@@ -127,8 +122,78 @@ jobs:
 
       - name: Install Java
         uses: actions/setup-java@v5
+        id: setup-java
         with:
-          distribution: 'temurin'
+          distribution: 'liberica'
+          java-version: ${{ env.JDK_API }}
+          java-package: jdk
+
+      - name: Cache Maven packages
+        uses: actions/cache@v5
+        id: cache-maven
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-maven-
+
+      - name: Cache packaging dependencies
+        id: cache-bootstrap
+        uses: actions/cache@v5
+        with:
+          path: |
+            ./dist/dmg
+            ./dist/jdks
+            ./dist/launch4j
+            ./dist/lipo
+          key: ${{ runner.os }}-bootstrap-${{ hashFiles('bootstrap.sh') }}
+
+      - name: Install packaging dependencies
+        if: steps.cache-bootstrap.outputs.cache-hit != 'true'
+        run: ./bootstrap.sh -j ${{ steps.setup-java.outputs.version }} windows-aarch64
+
+      - name: Build Windows aarch64
+        run: make release-windows-aarch64
+
+      - name: Archive Windows aarch64
+        uses: actions/upload-artifact@v7
+        with:
+          name: VASSAL-${{ steps.version.outputs.VERSION }}-windows-aarch64.exe
+          path: tmp/VASSAL-${{ steps.version.outputs.VERSION }}-windows-aarch64.exe
+          
+  package_win_x86_32:
+    name: Test & Package Windows x86_32
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Get tags
+        run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
+
+      - name: Set branch
+        if: github.ref != 'refs/heads/master' && github.ref != 'refs/heads/release-3.7'
+        # Checking out a detached head for PR means we have to set the branch
+        # name for it to show up later; shallow checkout means the branch
+        # won't exist yet so there's no conflict.
+        run: git checkout -b ${GITHUB_HEAD_REF}
+
+      - name: Store version
+        id: version
+        run: echo "VERSION=$(make version-print)" >> $GITHUB_OUTPUT
+
+      - name: Update container
+        run: sudo apt update
+
+      - name: Install dependencies
+        run: sudo apt-get install dos2unix genisoimage ghostscript nsis
+
+      - name: Install Java
+        uses: actions/setup-java@v5
+        id: setup-java
+        with:
+          distribution: 'liberica'
           java-version: 21
           java-package: jdk
 
@@ -153,7 +218,7 @@ jobs:
 
       - name: Install packaging dependencies
         if: steps.cache-bootstrap.outputs.cache-hit != 'true'
-        run: ./bootstrap.sh
+        run: ./bootstrap.sh -j ${{ steps.setup-java.outputs.version }} windows-x86_32
 
       - name: Build Windows x86_32
         run: make release-windows-x86_32
@@ -277,10 +342,3 @@ jobs:
         with:
           name: vassal_${{ steps.deb_vars.outputs.DEB_UPSTREAM }}.orig.tar.gz
           path: public/vassal_${{ steps.deb_vars.outputs.DEB_UPSTREAM }}.orig.tar.gz
-      # Alternative way to publish artefacts on tags.
-      # 
-      # - name: Publish DEB package
-      #   uses: softprops/action-gh-release@v2
-      #   if: github.ref_type == 'tag'
-      #   with:
-      #     files: public/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,9 @@ on:
   push:
     tags: '*'
 
+env:
+  JDK_API: 26
+    
 jobs:
   # Regular packages.  Note, we take the version number from the tag. 
   package:
@@ -23,11 +26,12 @@ jobs:
           sudo apt install -y dos2unix genisoimage ghostscript nsis
           sudo pip install jinja2-cli  --break-system-packages
 
-      - name: Setup Java
+      - name: Setup Java - Temurin
         uses: actions/setup-java@v5
+        id: setup-java
         with: 
           distribution: 'temurin'
-          java-version: 25
+          java-version: ${{ env.JDK_API }}
           java-package: jdk
 
       - name: Maven cache
@@ -49,7 +53,7 @@ jobs:
 
       - name: Bootstrap
         if: steps.cache-bootstrap.outputs.cache-hit != 'true'
-        run: ./bootstrap.sh
+        run: ./bootstrap.sh -j ${{ steps.setup-java.outputs.version }} windows-x86_64 macos-x86_64 macos-aarch64
           
       - name: Make release packages 
         run: |
@@ -82,8 +86,61 @@ jobs:
             tmp/VASSAL-${{ github.ref_name }}-macos-universal.dmg
             tmp/VASSAL-${{ github.ref_name }}-other.zip
             tmp/VASSAL-${{ github.ref_name }}-windows-x86_64.exe
+
+  # Regular packages.  Note, we take the version number from the tag. 
+  package_aarch64:
+    name: Release Windows ARM
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with: 
+          fetch-depth: 1
+
+      - name: Update container 
+        run: |
+          sudo apt update -y
+          sudo apt install -y dos2unix genisoimage ghostscript nsis
+
+      - name: Setup Java - liberica
+        uses: actions/setup-java@v5
+        id: setup-java
+        with: 
+          distribution: 'liberica'
+          java-version: ${{ env.JDK_API }}
+          java-package: jdk
+
+      - name: Maven cache
+        uses: actions/cache@v5
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-mavin-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-maven-
+
+      - name: Cache bootstrap 
+        uses: actions/cache@v5
+        with:
+          path: |
+            ./dist/dmg
+            ./dist/jdks
+            ./dist/launch4
+            ./dist/lipo
+          key: ${{ runner.os }}-bootstrap-${{ hashFiles('bootstrap.sh') }}
+
+      - name: Bootstrap Windows aarch64
+        if: steps.cache-bootstrap.outputs.cache-hit != 'true'
+        run: ./bootstrap.sh -j ${{ steps.setup-java.outputs.version }} windows-aarch64
+          
+      - name: Make Windows aarch64 release package
+        run: |
+          make release-windows-aarch64 MAVEN_VERSION=${{ github.ref_name }}
+
+      - name: Post Windows aarch64 artefact to release
+        uses: softprops/action-gh-release@v2
+        with: 
+          files:  |
             tmp/VASSAL-${{ github.ref_name }}-windows-aarch64.exe
-                
+            
   # Regular packages.  Note, we take the version number from the tag. 
   package_win32:
     name: Release Windows 32-bit
@@ -99,10 +156,11 @@ jobs:
           sudo apt update -y
           sudo apt install -y dos2unix genisoimage ghostscript nsis
 
-      - name: Setup Java
+      - name: Setup Java - liberica 21
         uses: actions/setup-java@v5
+        id: setup-java
         with: 
-          distribution: 'temurin'
+          distribution: 'liberica'
           java-version: 21
           java-package: jdk
 
@@ -123,15 +181,15 @@ jobs:
             ./dist/lipo
           key: ${{ runner.os }}-bootstrap-${{ hashFiles('bootstrap.sh') }}
 
-      - name: Bootstrap
+      - name: Bootstrap Windows x86_32
         if: steps.cache-bootstrap.outputs.cache-hit != 'true'
-        run: ./bootstrap.sh
+        run: ./bootstrap.sh -j ${{ steps.setup-java.outputs.version }} windows-x86_32
           
-      - name: Make release packages 
+      - name: Make Windows x86_32 release package
         run: |
           make release-windows-x86_32 MAVEN_VERSION=${{ github.ref_name }}
 
-      - name: Post artefacts to release
+      - name: Post Windows x86_32 artefact to release
         uses: softprops/action-gh-release@v2
         with: 
           files:  |
@@ -284,13 +342,13 @@ jobs:
         uses: actions/setup-java@v5
         with: 
           distribution: 'temurin'
-          java-version: 25
+          java-version: ${{ env.JDK_API }}
           java-package: jdk
           
       - name: Make recipe
         run: |
           mkdir -p flatpak
-          sed -e "s,@REPOSITORY@,${{ github.repository }}," -e "s,@RELEASE@,${{ github.ref_name }}," -e "s,@COMMIT@,${{ github.sha }}," -e "s,@JDK@,25," < dist/linux/org.vassalengine.vassal.yml.in > flatpak/org.vassalengine.vassal.yml
+          sed -e "s,@REPOSITORY@,${{ github.repository }}," -e "s,@RELEASE@,${{ github.ref_name }}," -e "s,@COMMIT@,${{ github.sha }}," -e "s,@JDK@,${{ env.JDK_API }}," < dist/linux/org.vassalengine.vassal.yml.in > flatpak/org.vassalengine.vassal.yml
           cat flatpak/org.vassalengine.vassal.yml
           
       - name: Make Maven dependencies
@@ -312,6 +370,7 @@ jobs:
     needs:
       - package
       - package_win32
+      - package_aarch64
       - package_debian
       - package_rpm
     steps:

--- a/Makefile
+++ b/Makefile
@@ -285,7 +285,7 @@ release-macos: release-macos-universal
 
 release-macos-universal: $(TMPDIR)/VASSAL-$(VERSION)-macos-universal.dmg
 
-release-windows: release-windows-x86_64 release-windows-aarch64
+release-windows: release-windows-x86_64 
 
 release-windows-x86_32: $(TMPDIR)/VASSAL-$(VERSION)-windows-x86_32.exe
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,135 +1,246 @@
 #!/bin/bash -e
 
-#
-# Configuration
+L4J_VERSION=3.50
+LIPO_VERSION=0.8.4
+JRE_API=26
+TEMURIN_BUILD=35
+BELLSOFT_BUILD=37
+ARCHS=
+NO_ACTION=0
+CLEAN=0
+
+# --- help -----------------------------------------------------------
+usage() {
+    cat <<-EOF
+	Usage: ${0} [OPTIONS] [ARCHITECTURES]
+
+	Options:
+	  -h,--help                    Show this help and exit
+	  -l,--l4j-version    VERSION  Set the Launch4J version to get
+	  -i,--lipo-version   VERSION  Set the Lipo version to get
+	  -j,--jre-version    VERSION  Set the API version of the JREs to get
+	  -t,--temurin-build  NUMBER   Temurin JRE build number
+	  -b,--bellsoft-build NUMBER   Bellsoft JRE build number
+          
+	ARCHITECTURES is one or more of
+	  windows-x86_64      Windows on Intel 64 bit
+	  windows-x86_32      Windows on Intel 32 bit(*)
+	  windows-aarch64     Windows on ARM 64 bit
+	  macos-x86_64        MacOS on intel 64 bit
+	  macos-aarch64       MacOS on ARM 64 bit
+
+	If no ARCHITCTURES are specified, then it will set to all
+	of the above. 
+
+	(*) The JRE API and Bellsoft build of Windows on Intel 32 bit
+	are fixed at 21.0.10 and 10, respectively.
+	EOF
+}
+
+# --- Parse command line ---------------------------------------------    
+while test $# -gt 0 ; do
+    case $1 in
+        -h|--help) usage ; exit ;;
+        -l|--l4j-version)    L4J_VERSION=$2 ; shift ;;
+        -i|--lipo-version)   LIPO_VERSION=$2 ; shift ;;
+        -j|--jre-version)    JRE_API=$2 ; shift ;;
+        -t|--temurin-build)  TEMURIN_BUILD=$2 ; shift ;;
+        -b|--bellsoft-build) BELLSOFT_BUILD=$2 ; shift ;;
+        --no-action)         NO_ACTION=1 ;;
+        --clean)             CLEAN=1 ;;
+        *)                   ARCHS="${ARCHS} $1" ;;
+    esac
+    shift
+done
+
+# --- Define prefix depending on action setting ----------------------
+act=
+if [ $NO_ACTION -gt 0 ] ; then
+    act=echo
+fi
+
+# --- See if we got a build number f.ex. from GitHub actions ---------
+BUILD=$(echo "$JRE_API" | sed -n 's/.*+\([0-9][0-9]*\)/\1/p')
+if [ "x$BUILD" != "x" ] ; then
+    TEMURIN_BUILD=$BUILD
+    BELLSOFT_BUILD=$BUILD
+fi
+
+# --- Sanitise the JRE version we get in GitHub actions --------------
+JRE_API=$(echo "$JRE_API" | sed 's/\([0-9][0-9]*\)\..*/\1/')
+
+# --- Default architectures ------------------------------------------
+if [ "x$ARCHS" = "x" ] ; then
+    echo "No architectures specified, getting them all"
+    ARCHS="windows-x86_64 windows-x86_32 windows-aarch64 macos-x86_64 macos-aarch64"
+fi
+
+# --- Target directories ---------------------------------------------
 #
 DMGDIR=dist/dmg
-
-L4JVER=3.50
 L4JDIR=dist/launch4j
-
 JDKDIR=dist/jdks
-
-LIPOVER=0.8.4
 LIPODIR=dist/lipo
 
-#
-# Donwload and unpack JDKs
-#
+# --- JRE (JDK) settings ---------------------------------------------
+TEMURIN_VERSION=jdk-${JRE_API}+${TEMURIN_BUILD}
+TEMURIN_FILENAME_VERSION=${JRE_API}_${TEMURIN_BUILD}
+TEMURIN_URL="https://github.com/adoptium/temurin${JRE_API}-binaries/releases/download/${TEMURIN_VERSION}"
+TEMURIN_FILENAME_BASE="OpenJDK${JRE_API}U-jmods"
+
+BELLSOFT_VERSION=${JRE_API}+${BELLSOFT_BUILD}
+BELLSOFT_URL="https://download.bell-sw.com/java/${BELLSOFT_VERSION}"
+BELLSOFT_DIR=jdk-${JRE_API}
+
+BELLSOFT_WIN32_API=21.0.10
+BELLSOFT_WIN32_BUILD=10
+BELLSOFT_WIN32_VERSION=${BELLSOFT_WIN32_API}+${BELLSOFT_WIN32_BUILD}
+BELLSOFT_WIN32_URL="https://download.bell-sw.com/java/${BELLSOFT_WIN32_VERSION}"
+BELLSOFT_WIN32_DIR=jdk-${BELLSOFT_WIN32_API}
+
+# ---- Download a JDK ------------------------------------------------
+get_jdk() {
+    filename="$1" ; shift
+    url="$1" ; shift
+    base="$1" ; shift 
+    target="$1" ; shift
+    
+    if [ $CLEAN -gt 0 ] ; then
+        $act rm -rf ${target}
+        $act rm -rf ${filename}
+        return 0
+    fi
+    
+    if [ ! -f "$filename" ] ; then
+        echo "Downloading ${url}/${filename}"
+        $act curl -O -L "${url}/${filename}"
+    fi
+
+    if [ ! -d "$target" ] ; then 
+        case "x$filename" in 
+            x*.zip)
+                parent=$(dirname "$target")
+                $act mkdir -p $parent
+                $act unzip "$filename"
+                $act mv "$base" "$target"
+                ;;
+            x*.tar.gz)
+                $act mkdir -p "${target}"
+                $act tar -C "${target}" --strip-components=1 -xf "${filename}"
+                ;;
+            esac
+    fi
+
+    if [ ! -d "$target" ] && [ $NO_ACTION -lt 1 ]; then 
+        echo "Failed to download ${url}/${filename} to ${target}" > /dev/stderr 
+        exit 1
+    fi
+}
+
+# --- Start downloading JREs -----------------------------------------
 mkdir -p "$JDKDIR"
 pushd "$JDKDIR"
 
-ZULU_URL='https://cdn.azul.com/zulu/bin'
-
-TEMURIN_URL='https://github.com/adoptium/temurin25-binaries/releases/download'
-TEMURIN_VERSION=jdk-25.0.2+10
-TEMURIN_FILENAME_VERSION=25.0.2_10
-
-BELLSOFT_URL='https://download.bell-sw.com/java/25.0.2%2B12'
-BELLSOFT_VERSION=25.0.2+12
-BELLSOFT_DIR=jdk-25.0.2
-
-BELLSOFT_WIN32_URL='https://download.bell-sw.com/java/21.0.10%2B10'
-BELLSOFT_WIN32_VERSION=21.0.10+10
-BELLSOFT_WIN32_DIR=jdk-21.0.10
-
-# TODO check for downloads
-
-# Windows x86_32
-filename="bellsoft-jdk$BELLSOFT_WIN32_VERSION-windows-i586.zip"
-if [ ! -f "$filename" ] ; then
-  curl -O "$BELLSOFT_WIN32_URL/$filename"
-fi
-if [ ! -d windows-x86_32 ] ; then
-  unzip $filename
-  mv $BELLSOFT_WIN32_DIR windows-x86_32
-fi
-
-# Windows x86_64
-filename="OpenJDK25U-jmods_x64_windows_hotspot_$TEMURIN_FILENAME_VERSION.zip"
-if [ ! -f "$filename" ] ; then
-  curl -L -O "$TEMURIN_URL/$TEMURIN_VERSION/$filename"
-fi
-if [ ! -d windows-x86_64 ] ; then
-  unzip $filename
-  mkdir -p windows-x86_64
-  mv $TEMURIN_VERSION-jmods windows-x86_64/jmods
-fi
-
-# Windows aarch64
-filename="bellsoft-jdk$BELLSOFT_VERSION-windows-aarch64.zip"
-if [ ! -f "$filename" ] ; then
-  curl -O "$BELLSOFT_URL/$filename"
-fi
-if [ ! -d windows-aarch64 ] ; then
-  unzip $filename
-  mv $BELLSOFT_DIR windows-aarch64
-fi
-
-# MacOS x86_64
-filename="OpenJDK25U-jmods_x64_mac_hotspot_$TEMURIN_FILENAME_VERSION.tar.gz"
-if [ ! -f "$filename" ] ; then
-  curl -L -O "$TEMURIN_URL/$TEMURIN_VERSION/$filename"
-fi
-if [ ! -d macos-x86_64 ] ; then
-  mkdir -p macos-x86_64/Contents/Home/jmods
-  tar -C macos-x86_64/Contents/Home/jmods --strip-components=1 -xvf $filename
-fi
-
-# MacOS aarch64
-filename="OpenJDK25U-jmods_aarch64_mac_hotspot_$TEMURIN_FILENAME_VERSION.tar.gz"
-if [ ! -f "$filename" ] ; then
-  curl -L -O "$TEMURIN_URL/$TEMURIN_VERSION/$filename"
-fi
-if [ ! -d macos-aarch64 ] ; then
-  mkdir -p macos-aarch64/Contents/Home/jmods
-  tar -C macos-aarch64/Contents/Home/jmods --strip-components=1 -xvf $filename
-fi
+for arch in $ARCHS ; do
+    # echo "Getting architecture $arch"
+    
+    case $arch in
+        windows-x86_32|win32)
+            get_jdk \
+                "bellsoft-jdk${BELLSOFT_WIN32_VERSION}-windows-i586.zip" \
+                "${BELLSOFT_WIN32_URL}" \
+                "${BELLSOFT_WIN32_DIR}" \
+                "windows-x86_32"
+            ;;
+        windows-x86_64|win64)
+            get_jdk \
+                "${TEMURIN_FILENAME_BASE}_x64_windows_hotspot_${TEMURIN_FILENAME_VERSION}.zip" \
+                "${TEMURIN_URL}" \
+                "${TEMURIN_VERSION}-jmods" \
+                "windows-x86_64/jmods"
+            ;;
+        windows-aarch64|winarm)
+            get_jdk \
+                "bellsoft-jdk${BELLSOFT_VERSION}-windows-aarch64.zip" \
+                "${BELLSOFT_URL}" \
+                "${BELLSOFT_DIR}" \
+                "windows-aarch64"
+            ;;
+        macos-x86_64|macintel)
+            get_jdk \
+                "${TEMURIN_FILENAME_BASE}_x64_mac_hotspot_${TEMURIN_FILENAME_VERSION}.tar.gz" \
+                "${TEMURIN_URL}" \
+                "" \
+                "macos-x86_64/Contents/Home/jmods"
+            ;;
+        macos-aarch64|mac)
+            get_jdk \
+                "${TEMURIN_FILENAME_BASE}_aarch64_mac_hotspot_${TEMURIN_FILENAME_VERSION}.tar.gz" \
+                "${TEMURIN_URL}" \
+                "" \
+                "macos-aarch64/Contents/Home/jmods"
+            ;;
+        *)
+            echo "Unknown architecture: ${arch} - ignored" > /dev/stderr
+            ;;
+    esac
+done 
 
 popd
 
-#
-# Download lipo
-#
+# --- Download lipo --------------------------------------------------
 mkdir -p "$LIPODIR"
 pushd "$LIPODIR"
 
-wget https://github.com/konoui/lipo/releases/download/v${LIPOVER}/lipo_linux_amd64
-chmod a+x lipo_linux_amd64
+if [ $CLEAN -gt 0 ] ; then
+    rm -f lipo_linux_amd64
+else
+    $act wget https://github.com/konoui/lipo/releases/download/v${LIPO_VERSION}/lipo_linux_amd64
+    $act chmod a+x lipo_linux_amd64
+fi
 
 popd
 
-#
-# Download and unpack launch4j
-#
+# --- Download and unpack launch4j -----------------------------------
 mkdir -p "$L4JDIR"
 pushd "$L4JDIR"
 
-wget https://downloads.sourceforge.net/project/launch4j/launch4j-3/${L4JVER}/launch4j-${L4JVER}-linux-x64.tgz
-tar -xvf launch4j-${L4JVER}-linux-x64.tgz
-# check if script is still broken in next release after 3.50
+if [ $CLEAN -gt 0 ] ; then
+    $act rm -f launch4j-${L4J_VERSION}-linux-x64.tgz
+    $act rm -rf launch4j
+else
+    $act wget https://downloads.sourceforge.net/project/launch4j/launch4j-3/${L4J_VERSION}/launch4j-${L4J_VERSION}-linux-x64.tgz
+    $act tar -xvf launch4j-${L4J_VERSION}-linux-x64.tgz
+    # check if script is still broken in next release after 3.50
 # see https://sourceforge.net/p/launch4j/bugs/227/
-dos2unix launch4j/launch4j
+    $act dos2unix launch4j/launch4j || true
+fi
+
 popd
 
-#
-# Compile dmg
-#
+# --- Compile dmg ----------------------------------------------------
 mkdir -p "$DMGDIR"
 pushd "$DMGDIR"
 
-if [ ! -d libdmg-hfsplus ]; then
-  git clone https://github.com/vassalengine/libdmg-hfsplus.git
+if [ $CLEAN -gt 0 ] ; then
+    $act rm -rf libdmg-hfsplus
+else
+    if [ ! -d libdmg-hfsplus ]; then
+        $act git clone https://github.com/vassalengine/libdmg-hfsplus.git
+    fi
+
+    $act pushd libdmg-hfsplus
+    $act cmake . -B build
+    $act make -C build/dmg VERBOSE=1
+    $act popd
 fi
 
-pushd libdmg-hfsplus
-cmake . -B build
-make -C build/dmg VERBOSE=1
 popd
 
-popd
+# --- Set up Maven Wrapper -------------------------------------------
+$act mvn wrapper:wrapper
 
 #
-# Set up Maven Wrapper
+# EOF
 #
-mvn wrapper:wrapper
+


### PR DESCRIPTION
This patch will
- Modify the `boostrap.sh` script to make it more flexible.  This is used in the workflows

  Note, when `bootstrap.sh` is invoked from the GitHub workflows, we pass in the select Java API version.  As the version we get also contains the build, the script will automatically extract that build too.  E.g., if the GitHub action `setup-java` figures out that the latest Temurin JDK with API=26 is `26.0.0+35`, then `bootstrap` will use API=26 and BUILD=35.  In that way, we can ensure that the JDK we are using to build the packages with is also the same we are shipping with the final installers.

- Split the Windows ARM package off from the main build of Windows 64, MacOS, Linux, and other packages, as it needs a different JDK. This is because in OpenJDK, `jlink` from one build of OpenJDK cannot link `jmods` from another build of OpenJDK.  Thus, we need to use the JDK - and therefore `jlink` - from the same build that we want to package into the installation package.

- Both the package and release workflows have been updated to use the new flexibility of the `bootstrap.sh` script.  Also, the JDK API version used (except for Windows 32 which is fixed at 21) is set at the top of the workflow file and then propagated to the jobs.  This makes it easier to change the API to use.
- In the `Makefile`, the `release` and `release-windows` targets do not build `release-windows-aarch64` target.