### PR TITLE
Don't compute the initial value of dynamic properties in the editor

### DIFF
--- a/vassal-app/src/main/java/VASSAL/counters/DynamicProperty.java
+++ b/vassal-app/src/main/java/VASSAL/counters/DynamicProperty.java
@@ -201,7 +201,10 @@ public class DynamicProperty extends Decorator implements TranslatablePiece, Pro
     final Stack parent = getParent();
     final Map map = getMap();
 
-    value = formatValue(value);
+    // Don't compute the initial value in the editor.
+    if (!GameModule.getGameModule().isEditorOpen()) {
+      value = formatValue(value);
+    }
 
     // If the property has changed the layer to which this piece belongs,
     // re-insert it into the map.


### PR DESCRIPTION
This prevents evaluation and replacement of expressions for the initial value of a dynamic property while in the editor. Expression evaluation is deferred to the player module.

I did some simple tests initializing from a global property with pieces in the Piece Palette and At-Start stacks. This change may make it harder to debug issues with expression evaluation being deferred to the player.

Closes #13609
