### PR TITLE
Editor search matches Marker names as Property names

### DIFF
--- a/vassal-app/src/main/java/VASSAL/counters/Marker.java
+++ b/vassal-app/src/main/java/VASSAL/counters/Marker.java
@@ -267,6 +267,6 @@ public class Marker extends Decorator implements EditablePiece {
    */
   @Override
   public List<String> getPropertyList() {
-    return Arrays.asList(values);
+    return Arrays.asList(keys);
   }
 }

--- a/vassal-app/src/main/java/VASSAL/counters/Marker.java
+++ b/vassal-app/src/main/java/VASSAL/counters/Marker.java
@@ -263,6 +263,8 @@ public class Marker extends Decorator implements EditablePiece {
   }
 
   /**
+   * This implementation differs from the typical as the Marker's property names
+   * are the list of {@link #keys}.
    * @return a list of any Property Names referenced in the Decorator, if any (for search)
    */
   @Override


### PR DESCRIPTION
An Editor search advanced filters change. Changes the filter selection for searching for Marker properties to be consistent with other properties.

On the _Marker_ edit pane, the name field is labelled "Property name". It seems logical to search for a Marker in the Property name search category. With this change, _Marker_ search becomes consistent with searches on _Calculated Property_ and _Dynamic Property_.

Closes #13052