### PR TITLE
Fix for showing obscured, rotated peek in mouse-over

### DIFF
--- a/vassal-app/src/main/java/VASSAL/counters/Obscurable.java
+++ b/vassal-app/src/main/java/VASSAL/counters/Obscurable.java
@@ -21,7 +21,6 @@ import VASSAL.build.GameModule;
 import VASSAL.build.module.ObscurableOptions;
 import VASSAL.build.module.PlayerRoster;
 import VASSAL.build.module.documentation.HelpFile;
-import VASSAL.build.module.map.CounterDetailViewer;
 import VASSAL.command.ChangeTracker;
 import VASSAL.command.Command;
 import VASSAL.configure.BooleanConfigurer;
@@ -221,7 +220,7 @@ public class Obscurable extends Decorator implements TranslatablePiece {
   }
 
   public boolean isAutoPeeking() {
-    return autoPeekRollover && CounterDetailViewer.isDrawingMouseOver() && obscuredToOthers() && !obscuredToMe();
+    return autoPeekRollover && (getMap() != null && getMap().isDrawingMouseOver()) && obscuredToOthers() && !obscuredToMe();
   }
 
   @Override
@@ -316,7 +315,7 @@ public class Obscurable extends Decorator implements TranslatablePiece {
       return obscuredBy;
     }
     else if (Properties.VISIBLE_STATE.equals(key)) {
-      return myGetState() + isPeeking() + getProperty(Properties.SELECTED) + obscuredToMe() + piece.getProperty(key);
+      return myGetState() + isPeeking() + isAutoPeeking() + getProperty(Properties.SELECTED) + obscuredToMe() + piece.getProperty(key);
     }
     // FIXME: Access to Obscured properties
     // If piece is obscured to me, then mask any properties returned by

--- a/vassal-app/src/main/java/VASSAL/counters/Obscurable.java
+++ b/vassal-app/src/main/java/VASSAL/counters/Obscurable.java
@@ -220,7 +220,7 @@ public class Obscurable extends Decorator implements TranslatablePiece {
   }
 
   public boolean isAutoPeeking() {
-    return autoPeekRollover && (getMap() != null && getMap().isDrawingMouseOver()) && obscuredToOthers() && !obscuredToMe();
+    return autoPeekRollover && getMap() != null && getMap().isDrawingMouseOver() && obscuredToOthers() && !obscuredToMe();
   }
 
   @Override


### PR DESCRIPTION
This patch fixes a problem where a rotated, masked, piece, with `autoPeeking` set to `true` is shown as the owner-obscured version when peeking at the piece via the `CounterDetailViewer`.

The problem is, that `FreeRotator` caches the images used, but does not update when the piece is shown in the `CounterDetailViewer`.  That means the `FreeRotator` will use the on-map image when drawing the piece in the `CounterDetailViewer`.

The fix is to add `isAutoPeeking` to the returned `VISIBLE_STATE` property to `Obscurable`, so that the `FreeRotater` will not necessarily use the same image for both the on-map piece and the piece shown in the `CounterDetailViewer`.

Fixes #14646

Also fixes a deprecation warning.