### PR TITLE
Fix problem downloading Windows aarch64 from Liberica build of OpenJDK

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -67,6 +67,7 @@ if [ "x$BUILD" != "x" ] ; then
 fi
 
 # --- Sanitise the JRE version we get in GitHub actions --------------
+FULL_JRE=$(echo "$JRE_API" | sed 's/\([0-9][0-9.]*\).*/\1/')
 JRE_API=$(echo "$JRE_API" | sed 's/\([0-9][0-9]*\)\..*/\1/')
 
 # --- Default architectures ------------------------------------------
@@ -88,9 +89,9 @@ TEMURIN_FILENAME_VERSION=${JRE_API}_${TEMURIN_BUILD}
 TEMURIN_URL="https://github.com/adoptium/temurin${JRE_API}-binaries/releases/download/${TEMURIN_VERSION}"
 TEMURIN_FILENAME_BASE="OpenJDK${JRE_API}U-jmods"
 
-BELLSOFT_VERSION=${JRE_API}+${BELLSOFT_BUILD}
+BELLSOFT_VERSION=${FULL_JRE}+${BELLSOFT_BUILD}
 BELLSOFT_URL="https://download.bell-sw.com/java/${BELLSOFT_VERSION}"
-BELLSOFT_DIR=jdk-${JRE_API}
+BELLSOFT_DIR=jdk-${FULL_JRE}
 
 BELLSOFT_WIN32_API=21.0.10
 BELLSOFT_WIN32_BUILD=10


### PR DESCRIPTION
This will fix the problem https://github.com/vassalengine/vassal/pull/14612#issuecomment-4342687310 - hopefully :)

Problem is that Bellsoft changes their prefix on the download URL - kinda annoying, and no real good way to detect it automatically, except by using their [REST Api](https://api.bell-sw.com/#text) - e.g.: 

```
$ curl "https://api.bell-sw.com/v1/liberica/releases?version=26.0.1+10&bitness=64&os=windows&arch=arm&package-type=zip&bundle-type=jdk&output=text&fields=downloadUrl"
https://github.com/bell-sw/Liberica/releases/download/26.0.1+10/bellsoft-jdk26.0.1+10-windows-aarch64.zip
```

This could be put into the `bootstrap.sh` script instead - as  

```
BELLSORT_URL=$(curl https://api.bell-sw.com/v1/liberica/releases?version=${FULL_JDK}+${JDK_BUILD}&bitness=64&os=windows&arch=arm&package-type=zip&bundle-type=jdk&output=text&fields=downloadUrl)
```

(could also be done for Windows 32bit - although it will likely never change).  

A similar tactic could be used for the Temurin builds using their [REST Api](https://api.adoptium.net/q/swagger-ui/#/Binary/getBinary), though I didn't get it to work.

Yours,
_Christian_