### PR TITLE
Updates to `bootstrap.sh` to automate JDK downloads

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,13 +1,52 @@
 #!/bin/bash -e
 
+# --- Default release numbers ----------------------------------------
+#
+# Edit these for reasonable defaults
+#
 L4J_VERSION=3.50
 LIPO_VERSION=0.8.4
-JRE_API=26
-TEMURIN_BUILD=35
-BELLSOFT_BUILD=37
+TEMURIN_RELEASE=26+35
+LIBERICA_RELEASE=26.0.1+10
+
+# --- Variables used below -------------------------------------------
+#
+# Default values set here
+#
 ARCHS=
 NO_ACTION=0
 CLEAN=0
+WRAPPER=1
+BUILD_DMG=1
+VERBOSE=0
+CURL_SILENT=-s
+WGET_SILENT=-q
+UNZIP_SILENT=-q
+TAR_VERBOSE=
+MAKE_VERBOSE=
+CMAKE_QUIET="-DCMAKE_MESSAGE_LOG_LEVEL=WARNING"
+
+# --- Target directories ---------------------------------------------
+DMGDIR=dist/dmg
+L4JDIR=dist/launch4j
+JDKDIR=dist/jdks
+LIPODIR=dist/lipo
+
+
+# --- Message --------------------------------------------------------
+#
+# First argument is verbosity level
+# Rest are message arguments to echo
+#
+msg() {
+    lvl=$1 ; shift
+    if [ $VERBOSE -lt $lvl ] ; then
+        return
+    fi
+
+    echo "${@}"
+}
+
 
 # --- help -----------------------------------------------------------
 usage() {
@@ -15,13 +54,25 @@ usage() {
 	Usage: ${0} [OPTIONS] [ARCHITECTURES]
 
 	Options:
-	  -h,--help                    Show this help and exit
-	  -l,--l4j-version    VERSION  Set the Launch4J version to get
-	  -i,--lipo-version   VERSION  Set the Lipo version to get
-	  -j,--jre-version    VERSION  Set the API version of the JREs to get
-	  -t,--temurin-build  NUMBER   Temurin JRE build number
-	  -b,--bellsoft-build NUMBER   Bellsoft JRE build number
-          
+	  -h,--help                      Show this help and exit
+	  -l,--l4j-version      VERSION  Set the Launch4J version to get
+	  -i,--lipo-version     VERSION  Set the Lipo version to get
+	  -j,--jre-release      RELEASE  Set the API version of the JREs to get
+	  -t,--temurin-release  RELEASE  Temurin JRE release+build number
+	  -b,--bellsoft-release RELEASE  Bellsoft JRE release+build number
+	     --liberica-release RELEASE  Bellsoft JRE release+build number
+	  -v,--verbose                   Increase verbosity
+             --no-action                 Do nothing, show what to do
+             --clean                     Removes everyting
+             --no-wrapper                Do not update Maven wrapper
+             --no-dmg                    Do not build libdmg-hfplus
+
+        RELEASE is the full release number, including build number of one of
+        the builds of OpenJDK.  It defaults to
+	= Temurin: ${TEMURIN_RELEASE}
+	= Liberica: ${LIBERICA_RELEASE}
+        The option '--jre-release' sets both. 
+
 	ARCHITECTURES is one or more of
 	  windows-x86_64      Windows on Intel 64 bit
 	  windows-x86_32      Windows on Intel 32 bit(*)
@@ -43,11 +94,16 @@ while test $# -gt 0 ; do
         -h|--help) usage ; exit ;;
         -l|--l4j-version)    L4J_VERSION=$2 ; shift ;;
         -i|--lipo-version)   LIPO_VERSION=$2 ; shift ;;
-        -j|--jre-version)    JRE_API=$2 ; shift ;;
-        -t|--temurin-build)  TEMURIN_BUILD=$2 ; shift ;;
-        -b|--bellsoft-build) BELLSOFT_BUILD=$2 ; shift ;;
+        -j|--jre-release)      TEMURIN_RELEASE="$2"
+                               LIBERICA_RELEASE="$2"; shift ;;
+        -t|--temurin-release)  TEMURIN_RELEASE="$2" ; shift ;;
+        -b|--bellsoft-release) LIBERICA_RELEASE="$2" ; shift ;;
+        --liberica-release)    LIBERICA_RELEASE="$2" ; shift ;;
         --no-action)         NO_ACTION=1 ;;
         --clean)             CLEAN=1 ;;
+        --no-wrapper)        WRAPPER=0 ;;
+        --no-dmg)            BUILD_DMG=0 ;;
+        -v|--verbose)        VERBOSE=$(($VERBOSE + 1)) ;;
         *)                   ARCHS="${ARCHS} $1" ;;
     esac
     shift
@@ -55,86 +111,159 @@ done
 
 # --- Define prefix depending on action setting ----------------------
 act=
-if [ $NO_ACTION -gt 0 ] ; then
+if [ $NO_ACTION -gt 0 ] ; then 
     act=echo
 fi
 
-# --- See if we got a build number f.ex. from GitHub actions ---------
-BUILD=$(echo "$JRE_API" | sed -n 's/.*+\([0-9][0-9]*\)/\1/p')
-if [ "x$BUILD" != "x" ] ; then
-    TEMURIN_BUILD=$BUILD
-    BELLSOFT_BUILD=$BUILD
+# --- Verbosity ------------------------------------------------------
+if [ $VERBOSE -ge 3 ] ; then
+    CURL_SILENT=
+    UNZIP_SILENT=
+    WGET_SILENT=
+    TAR_VERBOSE=-v
+    MAKE_VERBOSE=1
+    CMAKE_QUIET=
 fi
 
-# --- Sanitise the JRE version we get in GitHub actions --------------
-JRE_API=$(echo "$JRE_API" | sed 's/\([0-9][0-9]*\)\..*/\1/')
+# --- Fix up a release number ----------------------------------------
+fix_release() {
+    release=$1 ; shift
+
+    build=$(echo "$release" | sed -n 's/.*+\([0-9][0-9]*\)/\1/p')
+    version=$(echo "$release" | sed 's/\([0-9][0-9.]*\).*/\1/')
+    case x$version in
+        x*.0.0) version=$(echo "$version" | sed 's/\..*//') ;; # 
+        x*) ;;
+    esac
+    echo "${version}+${build}"
+}
+    
+# --- See if we got a build number f.ex. from GitHub actions ---------
+TEMURIN_RELEASE=$(fix_release "$TEMURIN_RELEASE")
+LIBERICA_RELEASE=$(fix_release "$LIBERICA_RELEASE")
 
 # --- Default architectures ------------------------------------------
 if [ "x$ARCHS" = "x" ] ; then
-    echo "No architectures specified, getting them all"
+    msg 1 "No architectures specified, getting them all"
     ARCHS="windows-x86_64 windows-x86_32 windows-aarch64 macos-x86_64 macos-aarch64"
 fi
 
-# --- Target directories ---------------------------------------------
-#
-DMGDIR=dist/dmg
-L4JDIR=dist/launch4j
-JDKDIR=dist/jdks
-LIPODIR=dist/lipo
+# ---- Unpack downloaded archive -------------------------------------
+unpack_archive() {
+    filename=$1 ; shift
+    target=$1 ; shift
 
-# --- JRE (JDK) settings ---------------------------------------------
-TEMURIN_VERSION=jdk-${JRE_API}+${TEMURIN_BUILD}
-TEMURIN_FILENAME_VERSION=${JRE_API}_${TEMURIN_BUILD}
-TEMURIN_URL="https://github.com/adoptium/temurin${JRE_API}-binaries/releases/download/${TEMURIN_VERSION}"
-TEMURIN_FILENAME_BASE="OpenJDK${JRE_API}U-jmods"
+    if [ $CLEAN -gt 0 ] ; then
+        rm -rf "${target}"
+        return 0
+    fi
 
-BELLSOFT_VERSION=${JRE_API}+${BELLSOFT_BUILD}
-BELLSOFT_URL="https://download.bell-sw.com/java/${BELLSOFT_VERSION}"
-BELLSOFT_DIR=jdk-${JRE_API}
+    if [ -d "${target}" ] ; then
+        return 0
+    fi
 
-BELLSOFT_WIN32_API=21.0.10
-BELLSOFT_WIN32_BUILD=10
-BELLSOFT_WIN32_VERSION=${BELLSOFT_WIN32_API}+${BELLSOFT_WIN32_BUILD}
-BELLSOFT_WIN32_URL="https://download.bell-sw.com/java/${BELLSOFT_WIN32_VERSION}"
-BELLSOFT_WIN32_DIR=jdk-${BELLSOFT_WIN32_API}
-
-# ---- Download a JDK ------------------------------------------------
-get_jdk() {
-    filename="$1" ; shift
-    url="$1" ; shift
-    base="$1" ; shift 
-    target="$1" ; shift
+    case x$filename in
+        x*.zip)
+            parent=$(dirname "$target")
+            base=$(unzip -l "${filename}" | head -n4 | tail -n1 | sed -e 's/.* \([^ ][^ ]*\)/\1/' -e 's,/$,,')
+            msg 1 "Unpacking ${filename} (base=${base})"
+            $act mkdir -p "${parent}"
+            $act rm -rf "${target}"
+            $act unzip ${UNZIP_SILENT} "$filename"
+            msg 2 "Moving ${base} to ${target}"
+            $act mv "${base}" "${target}"
+            ;;
+        x*.tar.gz)
+            $act mkdir -p ${target}
+            msg 1 "Unpacking ${filename} to ${target}"
+            $act tar ${TAR_VERBOSE} -C "${target}" --strip-components=1 -xf "${filename}"
+            ;;
+        x*)
+            msg 0 "Unknown file type: $filenane" > dev/stderr
+            ;;
+    esac
     
+    if [ ! -d "$target" ] && [ $NO_ACTION -lt 1 ]; then 
+        echo "Failed to unpack ${filename} to ${target}" > /dev/stderr 
+        exit 1
+    fi
+}
+    
+
+    
+# ---- Get Temurin URL and download ----------------------------------
+get_temurin_jdk() {
+    release=$1 ; shift
+    os=$1 ; shift
+    arch=$1 ; shift
+    target=$1 ; shift
+
+    req="https://api.adoptium.net/v3/binary/version/jdk-${release}/${os}/${arch}/jmods/hotspot/normal/eclipse?project=jdk"
+    msg 2 "Query for temurin download: ${req}"
+    url=$(curl ${CURL_SILENT} -i "$req" | sed -n 's/^location: *//p' | tr -d '\r\n')
+    msg 2 "Response: ${url}"
+    filename=$(basename "$url")
+
+    if [ "x$url" = "x" ] ; then
+        echo "Failed get to Temurin download URL for ${release}/${os}/${arch}" > /dev/stderr
+        exit 1
+    fi
+
     if [ $CLEAN -gt 0 ] ; then
         $act rm -rf ${target}
         $act rm -rf ${filename}
         return 0
     fi
-    
+       
     if [ ! -f "$filename" ] ; then
-        echo "Downloading ${url}/${filename}"
-        $act curl -O -L "${url}/${filename}"
+        msg 1 "Downloading ${url}"
+        $act curl ${CURL_SILENT} -O -L "${url}" -o "${filename}"
+        if [ ! -f "${filename}" ] ; then
+            echo "Failed to download ${url} to ${filename}" >/dev/stderr
+            exit 1
+        fi
+        $act rm -rf ${target}
     fi
 
-    if [ ! -d "$target" ] ; then 
-        case "x$filename" in 
-            x*.zip)
-                parent=$(dirname "$target")
-                $act mkdir -p $parent
-                $act unzip "$filename"
-                $act mv "$base" "$target"
-                ;;
-            x*.tar.gz)
-                $act mkdir -p "${target}"
-                $act tar -C "${target}" --strip-components=1 -xf "${filename}"
-                ;;
-            esac
+    unpack_archive "$filename" "$target"
+}
+            
+# ---- Get Temurin URL and download ----------------------------------
+get_liberica_jdk() {
+    release=$1 ; shift
+    os=$1 ; shift
+    arch=$1 ; shift
+    bits=$1 ; shift
+    target=$1 ; shift
+
+    req="https://api.bell-sw.com/v1/liberica/releases?version=${release}&bitness=${bits}&os=${os}&arch=${arch}&package-type=zip&bundle-type=jdk&output=text&fields=downloadUrl"
+    msg 2 "Query for liberica download: ${req}"
+    url=$(curl ${CURL_SILENT} "$req")
+    msg 2 "Response: ${url}"
+    case x$url in
+        x*errorDescription*|x)
+            echo "Failed to get Liberica download URL for ${release}/${os}/${arch}/${bits}" > /dev/stderr
+            ;;
+    esac
+    filename=$(basename "$url")
+
+    if [ $CLEAN -gt 0 ] ; then
+        $act rm -rf ${target}
+        $act rm -rf ${filename}
+        return 0
+    fi
+       
+    if [ ! -f "$filename" ] ; then
+        msg 1 "Downloading ${url}"
+        $act curl ${CURL_SILENT} -O -L "${url}" -o "${filename}"
+        if [ ! -f "${filename}" ] ; then
+            echo "Failed to download ${url} to ${filename}" >/dev/stderr
+            exit 1
+        fi
+        $act rm -rf ${target}
     fi
 
-    if [ ! -d "$target" ] && [ $NO_ACTION -lt 1 ]; then 
-        echo "Failed to download ${url}/${filename} to ${target}" > /dev/stderr 
-        exit 1
-    fi
+    unpack_archive "$filename" "$target"
 }
 
 # --- Start downloading JREs -----------------------------------------
@@ -142,42 +271,44 @@ mkdir -p "$JDKDIR"
 pushd "$JDKDIR"
 
 for arch in $ARCHS ; do
-    # echo "Getting architecture $arch"
+    msg 3 "Getting architecture $arch"
     
     case $arch in
         windows-x86_32|win32)
-            get_jdk \
-                "bellsoft-jdk${BELLSOFT_WIN32_VERSION}-windows-i586.zip" \
-                "${BELLSOFT_WIN32_URL}" \
-                "${BELLSOFT_WIN32_DIR}" \
+            get_liberica_jdk 			\
+                "21.0.10+10" 			\
+                windows 			\
+                x86 				\
+                32 				\
                 "windows-x86_32"
             ;;
         windows-x86_64|win64)
-            get_jdk \
-                "${TEMURIN_FILENAME_BASE}_x64_windows_hotspot_${TEMURIN_FILENAME_VERSION}.zip" \
-                "${TEMURIN_URL}" \
-                "${TEMURIN_VERSION}-jmods" \
+            get_temurin_jdk 			\
+                "${TEMURIN_RELEASE}"	 	\
+                windows 			\
+                x64				\
                 "windows-x86_64/jmods"
             ;;
         windows-aarch64|winarm)
-            get_jdk \
-                "bellsoft-jdk${BELLSOFT_VERSION}-windows-aarch64.zip" \
-                "${BELLSOFT_URL}" \
-                "${BELLSOFT_DIR}" \
+            get_liberica_jdk 			\
+                "${LIBERICA_RELEASE}" 			\
+                windows 			\
+                arm				\
+                64 				\
                 "windows-aarch64"
             ;;
         macos-x86_64|macintel)
-            get_jdk \
-                "${TEMURIN_FILENAME_BASE}_x64_mac_hotspot_${TEMURIN_FILENAME_VERSION}.tar.gz" \
-                "${TEMURIN_URL}" \
-                "" \
+            get_temurin_jdk 			\
+                "${TEMURIN_RELEASE}" 		\
+                mac 				\
+                x64 				\
                 "macos-x86_64/Contents/Home/jmods"
             ;;
         macos-aarch64|mac)
-            get_jdk \
-                "${TEMURIN_FILENAME_BASE}_aarch64_mac_hotspot_${TEMURIN_FILENAME_VERSION}.tar.gz" \
-                "${TEMURIN_URL}" \
-                "" \
+            get_temurin_jdk 			\
+                "${TEMURIN_RELEASE}" 		\
+                mac 				\
+                aarch64 			\
                 "macos-aarch64/Contents/Home/jmods"
             ;;
         *)
@@ -189,56 +320,71 @@ done
 popd
 
 # --- Download lipo --------------------------------------------------
-mkdir -p "$LIPODIR"
-pushd "$LIPODIR"
-
-if [ $CLEAN -gt 0 ] ; then
-    rm -f lipo_linux_amd64
-else
-    $act wget https://github.com/konoui/lipo/releases/download/v${LIPO_VERSION}/lipo_linux_amd64
-    $act chmod a+x lipo_linux_amd64
+if [ "x$LIPO_VERSION" != "x" ] ; then 
+    mkdir -p "$LIPODIR"
+    pushd "$LIPODIR"
+    
+    if [ $CLEAN -gt 0 ] ; then
+        $act rm -f lipo_linux_amd64
+    else
+        msg 1 "Downloading https://github.com/konoui/lipo/releases/download/v${LIPO_VERSION}/lipo_linux_amd64"
+        $act wget ${WGET_SILENT} https://github.com/konoui/lipo/releases/download/v${LIPO_VERSION}/lipo_linux_amd64
+        $act chmod a+x lipo_linux_amd64
+    fi
+    
+    popd
 fi
-
-popd
 
 # --- Download and unpack launch4j -----------------------------------
-mkdir -p "$L4JDIR"
-pushd "$L4JDIR"
+if [ x$L4J_VERSION != x ] ; then 
+    mkdir -p "$L4JDIR"
+    pushd "$L4JDIR"
 
-if [ $CLEAN -gt 0 ] ; then
-    $act rm -f launch4j-${L4J_VERSION}-linux-x64.tgz
-    $act rm -rf launch4j
-else
-    $act wget https://downloads.sourceforge.net/project/launch4j/launch4j-3/${L4J_VERSION}/launch4j-${L4J_VERSION}-linux-x64.tgz
-    $act tar -xvf launch4j-${L4J_VERSION}-linux-x64.tgz
-    # check if script is still broken in next release after 3.50
-# see https://sourceforge.net/p/launch4j/bugs/227/
-    $act dos2unix launch4j/launch4j || true
-fi
-
-popd
-
-# --- Compile dmg ----------------------------------------------------
-mkdir -p "$DMGDIR"
-pushd "$DMGDIR"
-
-if [ $CLEAN -gt 0 ] ; then
-    $act rm -rf libdmg-hfsplus
-else
-    if [ ! -d libdmg-hfsplus ]; then
-        $act git clone https://github.com/vassalengine/libdmg-hfsplus.git
+    if [ $CLEAN -gt 0 ] ; then
+        $act rm -f launch4j-${L4J_VERSION}-linux-x64.tgz
+        $act rm -rf launch4j
+    else
+        msg 1 "Downloading https://downloads.sourceforge.net/project/launch4j/launch4j-3/${L4J_VERSION}/launch4j-${L4J_VERSION}-linux-x64.tgz"
+        $act wget ${WGET_SILENT} https://downloads.sourceforge.net/project/launch4j/launch4j-3/${L4J_VERSION}/launch4j-${L4J_VERSION}-linux-x64.tgz
+        msg 2 "Extracting launch4j-${L4J_VERSION}-linux-x64.tgz"
+        $act tar ${TAR_VERBOSE} -xf launch4j-${L4J_VERSION}-linux-x64.tgz
+        # check if script is still broken in next release after 3.50
+        # see https://sourceforge.net/p/launch4j/bugs/227/
+        msg 3 "Fixing line-endings in launch4j"
+        $act dos2unix launch4j/launch4j || true
     fi
 
-    $act pushd libdmg-hfsplus
-    $act cmake . -B build
-    $act make -C build/dmg VERBOSE=1
-    $act popd
+    popd
 fi
 
-popd
+# --- Compile dmg ----------------------------------------------------
+if [ $BUILD_DMG -gt 0 ] ; then 
+    mkdir -p "$DMGDIR"
+    pushd "$DMGDIR"
+
+    if [ $CLEAN -gt 0 ] ; then
+        $act rm -rf libdmg-hfsplus
+    else
+        if [ ! -d libdmg-hfsplus ]; then
+            msg 1 "Cloning https://github.com/vassalengine/libdmg-hfsplus.git"
+            $act git clone https://github.com/vassalengine/libdmg-hfsplus.git
+        fi
+
+        msg 1 "Building libdmg-hfsplus"
+        $act pushd libdmg-hfsplus
+        $act cmake . -B build ${CMAKE_QUIET}
+        $act make -C build/dmg VERBOSE=${MAKE_VERBOSE}
+        $act popd
+    fi
+
+    popd
+fi
 
 # --- Set up Maven Wrapper -------------------------------------------
-$act mvn wrapper:wrapper
+if [ $WRAPPER -gt 0 ] ; then
+    msg 1 "Updating Maven wrapper"
+    $act mvn wrapper:wrapper
+fi
 
 #
 # EOF


### PR DESCRIPTION
This patch fixes up `boostrap.sh` so that it will query the Temurin and Bellsoft REST Apis for the appropriate download links given a release and build number.  In this way, one does not need to manually edit the file in case a new JDK is used - the release and build information is provided by the GitHub `setup/java` action in GitHub workflows, and for manual runs, one can specify the release and build numbers on the command line.

Of course, one may want to change the default numbers from time to time.

Note that one can still choose which Java API version to use - in GitHub workflows by providing an option to `setup/java` and manually by specifying the appropriate release and build number on the command line.

Several other changes have also been made to the `bootstrap.sh` script - for example options to turn on verbosity, leave out certain steps, only show what would be done, clean-up the downloads and so on.  These are there to allow a developer to check things out and so on.

This is an alternative PR to PR #14687.