### PR TITLE
Limit scope of JMods cache to that actually built by sub-workflow

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -58,7 +58,9 @@ jobs:
         with:
           path: |
             ./dist/dmg
-            ./dist/jdks
+            ./dist/jdks/windows-x86_64
+            ./dist/jdks/macos-x86_64
+            ./dist/jdks/macos-aarch64
             ./dist/launch4j
             ./dist/lipo
           key: ${{ runner.os }}-bootstrap-${{ hashFiles('bootstrap.sh') }}
@@ -142,7 +144,7 @@ jobs:
         with:
           path: |
             ./dist/dmg
-            ./dist/jdks
+            ./dist/jdks/windows-aarch64
             ./dist/launch4j
             ./dist/lipo
           key: ${{ runner.os }}-bootstrap-${{ hashFiles('bootstrap.sh') }}
@@ -211,7 +213,7 @@ jobs:
         with:
           path: |
             ./dist/dmg
-            ./dist/jdks
+            ./dist/jdks/windows-x86_32
             ./dist/launch4j
             ./dist/lipo
           key: ${{ runner.os }}-bootstrap-${{ hashFiles('bootstrap.sh') }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,9 @@ jobs:
         with:
           path: |
             ./dist/dmg
-            ./dist/jdks
+            ./dist/jdks/windows-x86_64
+            ./dist/jdks/macos-x86_64
+            ./dist/jdks/macos-aarch64
             ./dist/launch4
             ./dist/lipo
           key: ${{ runner.os }}-bootstrap-${{ hashFiles('bootstrap.sh') }}
@@ -136,7 +138,7 @@ jobs:
         with:
           path: |
             ./dist/dmg
-            ./dist/jdks
+            ./dist/jdks/windows-aarch64
             ./dist/launch4
             ./dist/lipo
           key: ${{ runner.os }}-bootstrap-${{ hashFiles('bootstrap.sh') }}
@@ -190,7 +192,7 @@ jobs:
         with:
           path: |
             ./dist/dmg
-            ./dist/jdks
+            ./dist/jdks/windows-x86_32
             ./dist/launch4
             ./dist/lipo
           key: ${{ runner.os }}-bootstrap-${{ hashFiles('bootstrap.sh') }}


### PR DESCRIPTION
Part of upgrade to JDK 26 which does not allow JLink between different builds