### PR TITLE
Remove explicit Java API version from flatpak skeleton

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -364,7 +364,7 @@ jobs:
       - name: Make recipe
         run: |
           mkdir -p flatpak
-          sed -e "s,@REPOSITORY@,${{ github.repository }}," -e "s,@RELEASE@,${{ github.ref_name }}," -e "s,@COMMIT@,${{ github.sha }}," -e "s,@JDK@,${{ env.JDK_API }}," < dist/linux/org.vassalengine.vassal.yml.in > flatpak/org.vassalengine.vassal.yml
+          sed -e "s,@REPOSITORY@,${{ github.repository }}," -e "s,@RELEASE@,${{ github.ref_name }}," -e "s,@COMMIT@,${{ github.sha }},"  < dist/linux/org.vassalengine.vassal.yml.in > flatpak/org.vassalengine.vassal.yml
           cat flatpak/org.vassalengine.vassal.yml
           
       - name: Make Maven dependencies

--- a/dist/linux/org.vassalengine.vassal.yml.in
+++ b/dist/linux/org.vassalengine.vassal.yml.in
@@ -3,7 +3,7 @@ runtime: org.freedesktop.Platform
 runtime-version: '25.08'
 sdk: org.freedesktop.Sdk
 sdk-extensions:
-  - org.freedesktop.Sdk.Extension.openjdk@JDK@
+  - org.freedesktop.Sdk.Extension.openjdk
 command: vassal
 
 finish-args:
@@ -19,12 +19,12 @@ modules:
   - name: openjdk
     buildsystem: simple
     build-commands:
-      - /usr/lib/sdk/openjdk@JDK@/install.sh
+      - /usr/lib/sdk/openjdk/install.sh
 
   - name: vassal
     buildsystem: simple
     build-options:
-      append-path: /usr/lib/sdk/openjdk@JDK@/bin
+      append-path: /usr/lib/sdk/openjdk/bin
       env:
         MAVEN_OPTS: -Dmaven.repo.local=.m2/repository
     build-commands:


### PR DESCRIPTION
According to
[org.freedesktop.sdk.extension.openjdk](https://github.com/flathub/org.freedesktop.Sdk.Extension.openjdk) we do not need to be explicit about the API used.

This means we shouldn't need to touch this again.

Note, we still set an explicit
```
runtime: org.freedesktop.Platform
runtime-version: '25.08'
```
I don't know if there's a way to specify - say - `latest` for `runtime-version`.