### PR TITLE
Default all of ListTurnTracker's items to the enabled state

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/module/turn/ListTurnLevel.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/turn/ListTurnLevel.java
@@ -133,6 +133,7 @@ public class ListTurnLevel extends TurnLevel implements ActionListener {
 
     final String[] s = sd.nextStringArray(0);
     active = new boolean[list.length];
+    Arrays.fill(active, true);
     final int l = Math.min(s.length, active.length);
     for (int i = 0; i < l; i++) {
       active[i] = s[i].equals("true"); //$NON-NLS-1$

--- a/vassal-app/src/test/java/VASSAL/build/module/turn/ListTurnTrackerTest.java
+++ b/vassal-app/src/test/java/VASSAL/build/module/turn/ListTurnTrackerTest.java
@@ -146,6 +146,32 @@ public class ListTurnTrackerTest {
     }
   }
 
+  // List Turn items remain active when the assigned state is invalid.
+  @Test
+  public void invalidStateLeavesListActive() {
+    try (MockedStatic<GameModule> staticGm = Mockito.mockStatic(GameModule.class)) {
+      final GameModule gm = mock(GameModule.class);
+      staticGm.when(GameModule::getGameModule).thenReturn(gm);
+      when(gm.getPrefs()).thenReturn(prefs);
+
+      final TurnTrackerAccessor tracker = new TurnTrackerAccessor();
+
+      final String turnNames = String.join(",", numbersList);
+      final ListTurnLevel level = new ListTurnLevel();
+      level.setAttribute("list", turnNames);
+      level.addTo(tracker);
+
+      // Setting invalid state (missing fields).
+      // There is sufficient state to set current index to zero.
+      tracker.setState("0|0");
+
+      // Step through the remainder of the list.
+      tracker.next(); // two
+      tracker.next(); // three
+      assertEquals("three", tracker.getTurnString());
+    }
+  }
+
   // Move forward on a turn tracker with two lists that are siblings.
   // First and last elements are not active.
   @Test


### PR DESCRIPTION
The ListTurnTracker has an 'active' flag array to store the state of each list item. In some modules, players can disable individual list items with that state stored in the active array.

When loading a saved game, the _setState()_ function initializes the ListTurnTracker. If the saved game is corrupt or possibly out of date, and since the _setState()_ function defaults the active array to false, all items in the ListTurnTracker can become disabled. This is problematic now that the active flag bug has been fixed because advancing the Turn Tracker will skip over the complete ListTurnTracker list.

- If the module has "Allow players to hide items" unchecked, there is no way for a player to re-enable the list items.
- Within the module editor there is no means to change the active flag state.
- For the average module designer it will be difficult if not impossible to edit a vsav file because of the encryption. This will likely result in recreation of the scenario from scratch.

Both _reset()_ and _setAttribute()_ default the active array to true. _setState()_ initializes to false making it inconsistent with these methods. In fact in debug you can see the active array with all true flags replaced with false flags. Setting the active array to true makes it consistent across all initialization methods.

A case in point is this forum thread [Turn Counter Mystery](https://forum.vassalengine.org/t/turn-counter-mystery/90024).

My suspicion is that a vsav from the prior version was loaded as the basis for an updated scenario. The old module had a slightly different TurnTracker configuration, the decoder was out of sync and thus all list items were disabled.