### PR TITLE
14732 Send back cargo with the mat when moving between maps

### DIFF
--- a/vassal-app/src/main/java/VASSAL/counters/SendToLocation.java
+++ b/vassal-app/src/main/java/VASSAL/counters/SendToLocation.java
@@ -552,9 +552,10 @@ public class SendToLocation extends Decorator implements TranslatablePiece {
       final ChangeTracker tracker = new ChangeTracker(this);
       setProperty(BACK_MAP, null);
       setProperty(BACK_POINT, null);
-      c = tracker.getChangeCommand();
 
       if (backMap != null && backPoint != null) {
+        c = tracker.getChangeCommand();
+
         // Prepare piece for move, setting "old location" properties. Mark moved and generate movement trail if global options setting is on
         c = prepareMove(c, GlobalOptions.getInstance().isSendToLocationMoveTrails());
 
@@ -568,6 +569,7 @@ public class SendToLocation extends Decorator implements TranslatablePiece {
           oldMap.repaint();
         }
         backMap.repaint();
+        map = backMap;
       }
     }
 
@@ -589,13 +591,6 @@ public class SendToLocation extends Decorator implements TranslatablePiece {
 
             // Prepare piece for move, setting "old location" properties. Mark moved and generate movement trail if global options setting is on
             c = piece.prepareMove(c, GlobalOptions.getInstance().isSendToLocationMoveTrails());
-
-            //BR// I sort of think cargo shouldn't snap when moving in lockstep with its mat.
-            //BR// This may lead to the eventual conclusion that cargo pieces shouldn't snap
-            //BR// even when dragged, IF they land on an eligible Mat.
-            //if (!Boolean.TRUE.equals(piece.getProperty(Properties.IGNORE_GRID))) {
-            //  dest = map.snapTo(dest);
-            //}
 
             c = c.append(map.placeOrMerge(piece, pt));
 


### PR DESCRIPTION
The _Send Back_ command of the _Send to Location_ trait did not initialize the map variable for cargo. This caused two issues.

1. When _Send to Location_ is across maps, the _Send Back_ would move the mat to the original map, while the cargo shifts position without changing maps.
2. Executing a _Send Back_ before a _Send To_ (possible in a saved game) causes a NPE.

Closes #14732
