### PR TITLE
Fix null check for i18n applyTranslation

### DIFF
--- a/vassal-app/src/main/java/VASSAL/i18n/ComponentI18nData.java
+++ b/vassal-app/src/main/java/VASSAL/i18n/ComponentI18nData.java
@@ -288,7 +288,7 @@ public class ComponentI18nData {
    */
   public void applyTranslation(String attr, String value) {
     final Property p = translatableProperties.get(attr);
-    if (attr != null) {
+    if (p != null) {
       p.setUntranslatedValue(myComponent.getAttributeValueString(attr));
       myComponent.setAttribute(attr, value);
     }


### PR DESCRIPTION
Looks like this check is on the wrong variable. It should be checking `p` for not null indicating a valid lookup in the `TreeMap`. If `attr` is null it is too late as it would have already thrown a NPE on the `get()`.