### PR TITLE
Report Internationalization setup inconsistencies as Bad Data

### DIFF
--- a/vassal-app/src/main/java/VASSAL/i18n/ComponentI18nData.java
+++ b/vassal-app/src/main/java/VASSAL/i18n/ComponentI18nData.java
@@ -28,11 +28,13 @@ import java.util.TreeMap;
 import VASSAL.build.AbstractConfigurable;
 import VASSAL.build.AbstractFolder;
 import VASSAL.build.AutoConfigurable;
+import VASSAL.build.BadDataReport;
 import VASSAL.build.Configurable;
 import VASSAL.counters.BasicPiece;
 import VASSAL.counters.Decorator;
 import VASSAL.counters.GamePiece;
 import VASSAL.counters.PlaceMarker;
+import VASSAL.tools.ErrorDialog;
 
 /**
  * Object encapsulating the internationalization information for a component.
@@ -106,11 +108,24 @@ public class ComponentI18nData {
     setPrefix(pfx);
     myComponent = c;
     children.addAll(Arrays.asList(myComponent.getConfigureComponents()));
-    for (int i = 0; i < translatable.length; i++) {
-      final Property p = new Property(names[i], descriptions[i]);
-      allProperties.put(names[i], p);
-      if (translatable[i]) {
-        translatableProperties.put(names[i], p);
+    try {
+      for (int i = 0; i < translatable.length; i++) {
+        final Property p = new Property(names[i], descriptions[i]);
+        allProperties.put(names[i], p);
+        if (translatable[i]) {
+          translatableProperties.put(names[i], p);
+        }
+      }
+    }
+    catch (IndexOutOfBoundsException ex) {
+      final String message = String.format(Resources.getString("Error.i18n_array_length_mismatch"), //NON-NLS
+              names.length, descriptions.length, translatable.length);
+      final String data = c.getClass().getName();
+      if (c instanceof AbstractConfigurable) {
+        ErrorDialog.dataWarning(new BadDataReport((AbstractConfigurable) c, message, data, ex));
+      }
+      else {
+        ErrorDialog.dataWarning(new BadDataReport(message, data, ex));
       }
     }
   }

--- a/vassal-app/src/main/resources/VASSAL/i18n/VASSAL.properties
+++ b/vassal-app/src/main/resources/VASSAL/i18n/VASSAL.properties
@@ -315,6 +315,7 @@ Error.build_piece_at_start_stack=Attempting to build Game Piece %1$s in At-Start
 Error.piece_slot_get_piece=Piece Slot failed to build piece
 Error.possible_infinite_string_loop=Possible infinite $ field loop
 Error.possible_infinite_expression_loop=Possible infinite loop evaluating expression
+Error.i18n_array_length_mismatch=Length mismatch of AttributeNames [%d], AttributeDescriptions [%d] and AttributeTypes [%d]. Array lengths should match.
 
 Error.tile_cache_error_message=Tile cache error: %1$s
 


### PR DESCRIPTION
The support of Internationalization in `AbstractConfigurable` types, requires three arrays ideally all of equal length. Since `AttributeNames`, `AttributeDescriptions`, and `AttributeTypes` are defined in different places it is quite possible for arrays to drift out of sync. The `@Override` declaration on the get methods can further exasperate the situation as the module designer/coder may inadvertently omit the proper chaining to super methods. In addition, enhancements and improvement to the Vassal executable can inadvertently break legacy modules.

A mismatch in array lengths is not a fatal error. A module can still be playable. When the name or description arrays are too short the modules currently terminate with the uncaught `IndexOutOfBoundsException`.

The intent of this PR is to allow modules with translation issues to run rather than terminally fail. This PR catches the exception and reports "Bad Data" allowing players to continue. The "Bad Data" message hopefully prompts the module designer to investigate and address the configuration error.

This is one of the issues preventing the module CEP_v1_0.vmod (#14559) from running using current versions of Vassal. There is an inherent issue with the module itself however it is not fatal and still playable (with mods to DiceButton) if the `IndexOutOfBoundsException` is caught.

A sample warning message looks like this:

Bad Data in Module: Source: Sombra.SombraDiceButton Error: Sistema Sombra - CEP[Sistema Sombra de Dados]: Length mismatch of AttributeNames [15], AttributeDescriptions [15] and AttributeTypes [24]. Array lengths should match.
