### PR TITLE
Fix Linux VASSAL.sh in case of spaces in path

### DIFF
--- a/dist/linux/VASSAL.sh
+++ b/dist/linux/VASSAL.sh
@@ -48,7 +48,7 @@ if test ! -x "$java" ; then
 fi
 
 # --- Check for Java version -----------------------------------------
-if ! "$java" -cp $jar $ver_entry 2>/dev/null ; then
+if ! "$java" -cp "$jar" $ver_entry 2>/dev/null ; then
     cat <<-EOF
 	$0: Java installation too old to run VASSAL.  Please upgrade it
         with for example


### PR DESCRIPTION
This will fix the problem that the Java version check fails - even though an OK version is used - when the path to the `VASSAL.sh` script contains a space or similar.

The fix is to quote the path to `Vengine.jar`.