### PR TITLE
Only descend to Turn List sub-levels when the current list item is active

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/module/turn/ListTurnLevel.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/turn/ListTurnLevel.java
@@ -179,9 +179,17 @@ public class ListTurnLevel extends TurnLevel implements ActionListener {
    */
   @Override
   protected void advance() {
-    super.advance();
-
-    if (getTurnLevelCount() == 0 || (getTurnLevelCount() > 0 && hasSubLevelRolledOver())) {
+    final boolean isCurrentInactive = current < active.length && !active[current];
+    if (isCurrentInactive) {
+      final TurnLevel subLevel = getTurnLevel(currentSubLevel);
+      if (subLevel != null) {
+        subLevel.reset();
+      }
+    }
+    else {
+      super.advance();
+    }
+    if (getTurnLevelCount() == 0 || isCurrentInactive || hasSubLevelRolledOver()) {
       boolean done = false;
       for (int i = 0; i < list.length && !done; i++) {
         current++;
@@ -202,9 +210,18 @@ public class ListTurnLevel extends TurnLevel implements ActionListener {
 
   @Override
   protected void retreat() {
-    super.retreat();
+    final boolean isCurrentInactive = current < active.length && !active[current];
+    if (isCurrentInactive) {
+      final TurnLevel subLevel = getTurnLevel(currentSubLevel);
+      if (subLevel != null) {
+        subLevel.setHigh();
+      }
+    }
+    else {
+      super.retreat();
+    }
 
-    if (getTurnLevelCount() == 0 || (getTurnLevelCount() > 0 && hasSubLevelRolledOver())) {
+    if (getTurnLevelCount() == 0 || isCurrentInactive || hasSubLevelRolledOver()) {
       boolean done = false;
       for (int i = 0; i < list.length && !done; i++) {
         if (current == first) {
@@ -215,6 +232,9 @@ public class ListTurnLevel extends TurnLevel implements ActionListener {
           current = list.length - 1;
         }
         done = active[current];
+      }
+      if (! done) {
+        rolledOver = true;
       }
     }
     myValue.setPropertyValue(getValueString());

--- a/vassal-app/src/test/java/VASSAL/build/module/turn/ListTurnTrackerTest.java
+++ b/vassal-app/src/test/java/VASSAL/build/module/turn/ListTurnTrackerTest.java
@@ -366,6 +366,83 @@ public class ListTurnTrackerTest {
     }
   }
 
+  // Advance to the next element when the current one is inactive while its sub-levels are active.
+  // This turn tracker has two sub-levels to verify sub-level reset recurses to the lowest level.
+  @Test
+  public void turnTrackerSkipInactiveNodeWithNestedList() {
+    try (MockedStatic<GameModule> staticGm = Mockito.mockStatic(GameModule.class)) {
+      final GameModule gm = mock(GameModule.class);
+      staticGm.when(GameModule::getGameModule).thenReturn(gm);
+      when(gm.getPrefs()).thenReturn(prefs);
+
+      final TurnTrackerAccessor tracker = new TurnTrackerAccessor();
+
+      final String turnNames = String.join(",", turnList);
+      final ListTurnLevel level = new ListTurnLevel();
+      level.setAttribute("list", turnNames);
+      level.addTo(tracker);
+
+      final String numberNames = String.join(",", numbersList);
+      final ListTurnLevel level2 = new ListTurnLevel();
+      level2.setAttribute("list", numberNames);
+      level.addLevel(level2);
+
+      final String dayNames = String.join(",", dayList);
+      final ListTurnLevel level3 = new ListTurnLevel();
+      level3.setAttribute("list", dayNames);
+      level2.addLevel(level3);
+
+      // Set turn tracker initial conditions to: alpha two Tuesday
+      // alpha is inactive
+      tracker.setState("0|0;0;0;false,true,true;1\\;0\\;0\\;true,true,true\\;1\\\\;0\\\\;0\\\\;true,true,true");
+
+      tracker.next();
+
+      // Verify top level advances to the next active element and sub-levels reset.
+      assertEquals("beta", level.getTurnString());
+      assertEquals("one", level2.getTurnString());
+      assertEquals("Monday", level3.getTurnString());
+    }
+  }
+
+  // Backwards to the previous element when the current one is inactive while its sub-levels are active.
+  // This turn tracker has two sub-levels to verify sub-level set-high recurses to the lowest level.
+  @Test
+  public void turnTrackerSkipPrevInactiveNodeWithNestedList() {
+    try (MockedStatic<GameModule> staticGm = Mockito.mockStatic(GameModule.class)) {
+      final GameModule gm = mock(GameModule.class);
+      staticGm.when(GameModule::getGameModule).thenReturn(gm);
+      when(gm.getPrefs()).thenReturn(prefs);
+
+      final TurnTrackerAccessor tracker = new TurnTrackerAccessor();
+
+      final String turnNames = String.join(",", turnList);
+      final ListTurnLevel level = new ListTurnLevel();
+      level.setAttribute("list", turnNames);
+      level.addTo(tracker);
+
+      final String numberNames = String.join(",", numbersList);
+      final ListTurnLevel level2 = new ListTurnLevel();
+      level2.setAttribute("list", numberNames);
+      level.addLevel(level2);
+
+      final String dayNames = String.join(",", dayList);
+      final ListTurnLevel level3 = new ListTurnLevel();
+      level3.setAttribute("list", dayNames);
+      level2.addLevel(level3);
+
+      // Set turn tracker initial conditions to: gamma two Tuesday
+      // gamma is inactive
+      tracker.setState("0|2;0;0;true,true,false;1\\;0\\;0\\;true,true,true\\;1\\\\;0\\\\;0\\\\;true,true,true");
+
+      tracker.prev();
+
+      assertEquals("beta", level.getTurnString());
+      assertEquals("three", level2.getTurnString());
+      assertEquals("Wednesday", level3.getTurnString());
+    }
+  }
+
   @Test
   public void nestedListInactiveElement() {
     try (MockedStatic<GameModule> staticGm = Mockito.mockStatic(GameModule.class)) {


### PR DESCRIPTION
Players can deactivate Turn List items during game play. It is possible to deactivate the current list item. When the Turn Tracker subsequently advances, the Turn List should advance to the next active item **at the same level**. Deactivating a list item should disable it and all of its sub-levels. Descending to an active sub-level item when the parent is deactivated is incorrect behaviour. This PR first confirms that the current item is active before descending to a sub-level otherwise it advances to the next active item at the current level.

This issue was brought up in a forum post: [Turn Counter still having issues](https://forum.vassalengine.org/t/turn-counter-still-having-issues/90175)