### PR TITLE
Accept HTTP 200 as a response for GitHub issue creation

### DIFF
--- a/vassal-app/src/main/java/VASSAL/tools/BugUtils.java
+++ b/vassal-app/src/main/java/VASSAL/tools/BugUtils.java
@@ -43,6 +43,9 @@ public class BugUtils {
     try (CloseableHttpClient client = HttpClients.createDefault()) {
       try (CloseableHttpResponse response = client.execute(httpPost)) {
         final responseCode = response.getCode();
+        // GitHub documents 201 as the expected success code, but starting
+        // in May 2026 we observed that 200 is sometimes returned, contra
+        // the documentation, so we check for both.
         if (responseCode != 200 && responseCode != 201) {
           final String msg = "Bug report failed: " + response.getCode();
 

--- a/vassal-app/src/main/java/VASSAL/tools/BugUtils.java
+++ b/vassal-app/src/main/java/VASSAL/tools/BugUtils.java
@@ -42,7 +42,8 @@ public class BugUtils {
     // send the POST
     try (CloseableHttpClient client = HttpClients.createDefault()) {
       try (CloseableHttpResponse response = client.execute(httpPost)) {
-        if (response.getCode() != 201) {
+        final responseCode = response.getCode();
+        if (responseCode != 200 && responseCode != 201) {
           final String msg = "Bug report failed: " + response.getCode();
 
           String responseText = null;

--- a/vassal-app/src/main/java/VASSAL/tools/BugUtils.java
+++ b/vassal-app/src/main/java/VASSAL/tools/BugUtils.java
@@ -42,7 +42,7 @@ public class BugUtils {
     // send the POST
     try (CloseableHttpClient client = HttpClients.createDefault()) {
       try (CloseableHttpResponse response = client.execute(httpPost)) {
-        final responseCode = response.getCode();
+        final int responseCode = response.getCode();
         // GitHub documents 201 as the expected success code, but starting
         // in May 2026 we observed that 200 is sometimes returned, contra
         // the documentation, so we check for both.


### PR DESCRIPTION
GitHub started returning 200 sometimes instead of 201 for issue creation, so check for 200 also.