### PR TITLE
Fixed NoClassDefFoundError from bug reporter dialog by switching to newer, maintained swingx library

### DIFF
--- a/vassal-app/pom.xml
+++ b/vassal-app/pom.xml
@@ -115,9 +115,9 @@
             <version>2.0.18</version>
         </dependency>
         <dependency>
-            <groupId>org.swinglabs.swingx</groupId>
+            <groupId>com.github.wumpz.swingx</groupId>
             <artifactId>swingx-all</artifactId>
-            <version>1.6.5-1</version>
+            <version>2.1</version>
         </dependency>
         <dependency>
             <groupId>net.java.dev.timingframework</groupId>


### PR DESCRIPTION
swingx 1.6.5 loads java.applet.Applet, which makes it incompatible with Java 26. Switch to a fork of swingx which is still maintained and has been updated to work with Java 26.