### PR TITLE
Make button tooltips available on buttons in toolbar menus

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/module/ToolbarMenu.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/ToolbarMenu.java
@@ -241,6 +241,7 @@ public class ToolbarMenu extends AbstractToolbarItem
               new JMenuItem(otherItem.getText(), otherItem.getIcon());
             myItem.addActionListener(e -> otherItem.doClick());
             myItem.setEnabled(otherItem.isEnabled());
+            myItem.setToolTipText(otherItem.getToolTipText());
             subMenu.add(myItem);
             buttonsToMenuMap.put(otherItem, myItem);
           }
@@ -258,6 +259,7 @@ public class ToolbarMenu extends AbstractToolbarItem
           mi.setEnabled(b.isEnabled());
           mi.addActionListener(e -> GameModule.getGameModule().refreshVisibleMaps());
           mi.addActionListener(e -> b.doClick());
+          mi.setToolTipText(b.getToolTipText());
           buttonsToMenuMap.put(b, mi);
           menu.add(mi);
         }


### PR DESCRIPTION
fix: Show tool-tips on menu items in toolbar menu

This patch propagates tool-tips defined on buttons (e.g., `VASSAL.build.AbstractToolbarItem`), etc., to the menu items when those tool-bar buttons are put into a menu
(`VASSAL.module.build.ToolbarMenu`).

In that way, the tool-bar menu preserves the developer defined tool-tips.

Without this fix, the tool-tips are simply not shown.