### PR TITLE
Fix for `DynamicPropertyTest`

### DIFF
--- a/vassal-app/src/main/java/VASSAL/counters/DynamicProperty.java
+++ b/vassal-app/src/main/java/VASSAL/counters/DynamicProperty.java
@@ -202,7 +202,7 @@ public class DynamicProperty extends Decorator implements TranslatablePiece, Pro
     final Map map = getMap();
 
     // Don't compute the initial value in the editor.
-    if (!GameModule.getGameModule().isEditorOpen()) {
+    if (GameModule.getGameModule() == null || !GameModule.getGameModule().isEditorOpen()) {
       value = formatValue(value);
     }
 


### PR DESCRIPTION
fix: Fix broken commit #ad9954d

The recent change to `VASSAL.counters.DynamicProperty` (see commit #ad9954d) breaks the test `VASSAL.counters.DynamicPropertyTest` because that commit _requires_ that a module is present, which is not the case for test.

Closes #14857