### PR TITLE
Fix regression leaking Global Option properties over network

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/module/properties/ChangePropertyCommandEncoder.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/properties/ChangePropertyCommandEncoder.java
@@ -58,21 +58,28 @@ public class ChangePropertyCommandEncoder implements CommandEncoder {
      * NB. If there is no containerID in the command, then it is a pre-bug fix command. Legacy
      * behaviour is to execute the change on the first matching property found in any container
      */
-    if (containerId.length() != 0 && !containerId.equals(container.getMutablePropertiesContainerId())) {
+    if (!containerId.isEmpty() && !containerId.equals(container.getMutablePropertiesContainerId())) {
       return null;
     }
 
-    MutableProperty p = container.getMutableProperty(key);
-    if (p == null) {
-      // If this is not an explicit global property
-      // then search for implicit module properties such as Special Dice properties.
-      if (container instanceof GlobalProperties) {
-        p = ((GlobalProperties) container).getParent().getMutableProperty(key);
+      MutableProperty p = container.getMutableProperty(key);
+      if (p == null) {
+          // If this is not an explicit global property
+          // then search for implicit module properties such as Special Dice properties.
+          if (container instanceof GlobalProperties) {
+              final MutableProperty implicitP = ((GlobalProperties) container).getParent().getMutableProperty(key);
+
+              // Filter out any property that is registered as a local user preference option
+              final boolean isPreference = VASSAL.build.GameModule.getGameModule().getPrefs().getOption(key) != null;
+
+              if (implicitP != null && !isPreference) {
+                  p = implicitP;
+              }
+          }
       }
-    }
-    if (p == null) {
-      return null;
-    }
+      if (p == null) {
+          return null;
+      }
 
     return new ChangePropertyCommand(p, key, oldValue, newValue);
   }

--- a/vassal-app/src/main/java/VASSAL/build/module/properties/ChangePropertyCommandEncoder.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/properties/ChangePropertyCommandEncoder.java
@@ -62,24 +62,24 @@ public class ChangePropertyCommandEncoder implements CommandEncoder {
       return null;
     }
 
-      MutableProperty p = container.getMutableProperty(key);
-      if (p == null) {
-          // If this is not an explicit global property
-          // then search for implicit module properties such as Special Dice properties.
-          if (container instanceof GlobalProperties) {
-              final MutableProperty implicitP = ((GlobalProperties) container).getParent().getMutableProperty(key);
+    MutableProperty p = container.getMutableProperty(key);
+    if (p == null) {
+        // If this is not an explicit global property
+        // then search for implicit module properties such as Special Dice properties.
+        if (container instanceof GlobalProperties) {
+            final MutableProperty implicitP = ((GlobalProperties) container).getParent().getMutableProperty(key);
 
-              // Filter out any property that is registered as a local user preference option
-              final boolean isPreference = VASSAL.build.GameModule.getGameModule().getPrefs().getOption(key) != null;
+            // Filter out any property that is registered as a local user preference option
+            final boolean isPreference = VASSAL.build.GameModule.getGameModule().getPrefs().getOption(key) != null;
 
-              if (implicitP != null && !isPreference) {
-                  p = implicitP;
-              }
-          }
-      }
-      if (p == null) {
-          return null;
-      }
+            if (implicitP != null && !isPreference) {
+                p = implicitP;
+            }
+        }
+    }
+    if (p == null) {
+        return null;
+    }
 
     return new ChangePropertyCommand(p, key, oldValue, newValue);
   }

--- a/vassal-app/src/main/java/VASSAL/build/module/properties/ChangePropertyCommandEncoder.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/properties/ChangePropertyCommandEncoder.java
@@ -78,7 +78,7 @@ public class ChangePropertyCommandEncoder implements CommandEncoder {
       }
     }
     if (p == null) {
-        return null;
+      return null;
     }
 
     return new ChangePropertyCommand(p, key, oldValue, newValue);

--- a/vassal-app/src/main/java/VASSAL/build/module/properties/ChangePropertyCommandEncoder.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/properties/ChangePropertyCommandEncoder.java
@@ -69,10 +69,8 @@ public class ChangePropertyCommandEncoder implements CommandEncoder {
       if (container instanceof GlobalProperties) {
         final MutableProperty implicitP = ((GlobalProperties) container).getParent().getMutableProperty(key);
 
-        // Filter out any property that is registered as a local user preference option
-        final boolean isPreference = VASSAL.build.GameModule.getGameModule().getPrefs().getOption(key) != null;
-
-        if (implicitP != null && !isPreference) {
+        // Additional conditional will filter out any property that is registered as a local user preference option
+        if (implicitP != null && VASSAL.build.GameModule.getGameModule().getPrefs().getOption(key) == null) {
           p = implicitP;
         }
       }

--- a/vassal-app/src/main/java/VASSAL/build/module/properties/ChangePropertyCommandEncoder.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/properties/ChangePropertyCommandEncoder.java
@@ -69,7 +69,7 @@ public class ChangePropertyCommandEncoder implements CommandEncoder {
       if (container instanceof GlobalProperties) {
         final MutableProperty implicitP = ((GlobalProperties) container).getParent().getMutableProperty(key);
 
-        // Additional conditional will filter out any property that is registered as a local user preference option
+        // Additional condition will filter out any property that is registered as a local user preference option
         if (implicitP != null && VASSAL.build.GameModule.getGameModule().getPrefs().getOption(key) == null) {
           p = implicitP;
         }

--- a/vassal-app/src/main/java/VASSAL/build/module/properties/ChangePropertyCommandEncoder.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/properties/ChangePropertyCommandEncoder.java
@@ -64,18 +64,18 @@ public class ChangePropertyCommandEncoder implements CommandEncoder {
 
     MutableProperty p = container.getMutableProperty(key);
     if (p == null) {
-        // If this is not an explicit global property
-        // then search for implicit module properties such as Special Dice properties.
-        if (container instanceof GlobalProperties) {
-            final MutableProperty implicitP = ((GlobalProperties) container).getParent().getMutableProperty(key);
+      // If this is not an explicit global property
+      // then search for implicit module properties such as Special Dice properties.
+      if (container instanceof GlobalProperties) {
+        final MutableProperty implicitP = ((GlobalProperties) container).getParent().getMutableProperty(key);
 
-            // Filter out any property that is registered as a local user preference option
-            final boolean isPreference = VASSAL.build.GameModule.getGameModule().getPrefs().getOption(key) != null;
+        // Filter out any property that is registered as a local user preference option
+        final boolean isPreference = VASSAL.build.GameModule.getGameModule().getPrefs().getOption(key) != null;
 
-            if (implicitP != null && !isPreference) {
-                p = implicitP;
-            }
+        if (implicitP != null && !isPreference) {
+          p = implicitP;
         }
+      }
     }
     if (p == null) {
         return null;


### PR DESCRIPTION
Checks if the Property is in the Global Options list before accepting a change into the local instance.