### PR TITLE
Update Preferences window on changes by SetGlobalProperty commands

### DIFF
--- a/vassal-app/src/main/java/VASSAL/counters/SetGlobalProperty.java
+++ b/vassal-app/src/main/java/VASSAL/counters/SetGlobalProperty.java
@@ -27,6 +27,7 @@ import VASSAL.build.module.properties.MutableProperty;
 import VASSAL.command.Command;
 import VASSAL.command.NullCommand;
 import VASSAL.configure.BooleanConfigurer;
+import VASSAL.configure.Configurer;
 import VASSAL.configure.DynamicKeyCommandListConfigurer;
 import VASSAL.configure.FormattedExpressionConfigurer;
 import VASSAL.configure.IntConfigurer;
@@ -237,7 +238,7 @@ public class SetGlobalProperty extends DynamicProperty {
         else {
           final String oldValue = prop.getPropertyValue();
           String newValue = keyCommand.propChanger.getNewValue(oldValue);
-          // Null indicates user cancelled a prompt dialog during chamnge
+          // Null indicates user cancelled a prompt dialog during change
           if (newValue != null) {
             // The PropertyChanger has already evaluated any Beanshell, only need to handle any remaining $$variables.
             if (newValue.indexOf('$') >= 0) {
@@ -245,6 +246,13 @@ public class SetGlobalProperty extends DynamicProperty {
               newValue = format.getText(getOutermost(this), this, "Editor.PropertyChangeConfigurer.new_value");
             }
             comm = comm.append(prop.setPropertyValue(newValue));
+
+            // If this is a Global Options custom preference then update the Preferences window.
+            final Configurer configurer = GameModule.getGameModule().getPrefs().getOption(propertyName);
+            if (configurer != null) {
+              configurer.setValue(newValue);
+              configurer.fireUpdate();
+            }
           }
         }
       }


### PR DESCRIPTION
Module designers can add custom preference settings to the global options. If so configured, these settings can appear in the Preferences window. Typically players open the Preferences window to customize the appearance and/or behaviour of a particular module. Since the preference settings are tied to global properties, any game piece with a "Set Global Property" trait can also modify any preference settings.

When a user changes a setting in the Preference window, that change is reflected in the module. However when the setting changes from a "Set Global Property" trait, the value in the Preference window is not updated. Since the contents of the Preferences window is saved to the prefs folder, any change initiated by a "Set Global Property" trait is not persisted.

This PR fires an event to notify the Preference window of a preference setting change.