### PR TITLE
Fixes for flatpak dependency generation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -364,6 +364,7 @@ jobs:
           distribution: 'temurin'
           java-version: ${{ env.TEMURIN_VERSION }}
           java-package: jdk
+          show-download-progress: true
           
       - name: Make recipe
         run: |
@@ -373,7 +374,6 @@ jobs:
           
       - name: Make Maven dependencies
         run: |
-          java -version
           ./dist/linux/fetch-maven-deps-for-flatpak.sh 
           
       - name: Archive Flatpak files

--- a/dist/linux/fetch-maven-deps-for-flatpak.sh
+++ b/dist/linux/fetch-maven-deps-for-flatpak.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+# SPDX-FileCopyrightText: 2025 Lenucksi
+# SPDX-License-Identifier: LGPL-3.0-or-later
 #
 # This script is a modified version of
 #
@@ -50,7 +52,7 @@ cleanup_old_fetch_dirs() {
   for dir in mvn-dep-fetch-* mvn-download-*.log; do
     if [ -e "$dir" ]; then
       echo "  Removing: $dir"
-      rm -rf "$dir" || true
+      rm -rf "$dir"
       ((count++))
     fi
   done
@@ -58,7 +60,7 @@ cleanup_old_fetch_dirs() {
   # Also remove old test/ directory if it exists
   if [ -d "test" ]; then
     echo "  Removing: test/"
-    rm -rf test || true
+    rm -rf test
     ((count++))
   fi
 
@@ -73,25 +75,41 @@ run_maven_fetch() {
   local temp_dir="$1"
   local temp_log="$2"
 
+  mvn=mvn
+  
   echo ""
   echo -e "${BLUE}Fetching Maven dependencies...${NC}"
   echo "  Maven repo: ${temp_dir}"
   echo "  Download log: ${temp_log}"
   echo ""
+  echo "  Maven version:"
+  ${mvn} --version 2>&1 | head -2 | sed 's/^/    /'
+  echo ""
 
   # Run Maven and capture full output to a temp file
   local maven_output="${temp_log}.full"
-
-  make jar MVN="mvn -B -Dmaven.repo.local=${temp_dir} -DskipTests" 2>/dev/stdout | tee ${maven_output}
+  local maven_opts="-U -B --color=never -Dmaven.repo.local=${temp_dir} -DskipTests -Dasciidoctor.attributes=optimize -Dasciidoctor.skip=true -Dspotbugs.skip=true -Dlicense.skipDownloadLicenses"
+  echo "  Options for Maven: ${maven_opts}"
+  echo "${BLUE}  Make maven (${mvn}) go offline ...${NC}"
+  ${mvn} ${maven_opts} clean dependency:go-offline 2>/dev/stdout | tee -a ${maven_output}
   ret1=$?
-  echo "  Make return: $ret1"
-
+  echo "  Offline return $ret1"
+  echo ""
   if test $ret1 -eq 0; then
+    # Resolve all dependencies to ensure complete download log
+    echo -e "  ${BLUE}Resolving all dependencies...${NC}"
+    if mvn ${maven_opts}  dependency:resolve 2>/dev/stdout | tee -a "${maven_output}" ; then
+      echo -e "  ${GREEN}  Dependency resolution complete${NC}"
+    else
+      echo -e "  ${YELLOW}  WARNING: dependency:resolve reported issues${NC}"
+    fi
+
     # Maven succeeded, extract download lines
     grep "Downloaded" "${maven_output}" > "${temp_log}" || true
 
     local download_count
     download_count=$(wc -l < "${temp_log}" 2>/dev/null || echo "0")
+    echo ""
     echo -e "${GREEN}  Maven build successful${NC}"
     echo "  Downloaded: ${download_count} artifacts"
 
@@ -101,7 +119,7 @@ run_maven_fetch() {
     tail -5 "${maven_output}"
 
     # Clean up full output
-    rm -f "${maven_output}"
+    # rm -f "${maven_output}"
     return 0
   else
     echo -e "${RED}  ERROR: Maven build failed${NC}"
@@ -134,6 +152,8 @@ generate_yaml() {
     echo "  Temporary files preserved for debugging:"
     echo "    - ${temp_dir}"
     echo "    - ${temp_log}"
+    echo "  Content of local repo"
+    find "${temp_dir}" -type f | sed 's/^/- /'
     return 1
   fi
 }
@@ -260,7 +280,6 @@ trap_error() {
     echo ""
     echo "Temporary files may have been preserved for debugging."
     echo "Check for directories matching: mvn-dep-fetch-*"
-    echo ""
   fi
 }
 

--- a/dist/linux/generate_flatpak_maven_sources.py
+++ b/dist/linux/generate_flatpak_maven_sources.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python3
+#
+# This script is a modified version of the script found at
+#
+# https://github.com/lenucksi/SieveEditor/blob/master/scripts/generate_flatpak_maven_sources.py
+# 
 """
 Generate Flatpak Maven sources YAML from Maven download log.
 
@@ -13,6 +18,8 @@ import sys
 import os
 import re
 import hashlib
+import argparse
+import xml.etree.ElementTree as ET
 from pathlib import Path
 from typing import Dict, Set, Optional, List
 
@@ -67,10 +74,6 @@ def parse_download_log(log_file: Path) -> Dict[str, str]:
     with open(log_file, 'r', encoding='utf-8') as f:
         for line in f:
             line_number += 1
-            
-            # print(f'{line_number:4d}: {line}')
-            # if 'vassal-maven' in line:
-            #     continue
             # Match lines like:
             # [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/...
             # [INFO] Downloaded from jitpack.io: https://jitpack.io/...
@@ -78,11 +81,10 @@ def parse_download_log(log_file: Path) -> Dict[str, str]:
             if not match:
                 continue
 
-
             url = match.group(1)
 
             # Only process .jar and .pom files
-            if not url.endswith(('.jar', '.pom', 'metadata.xml')):
+            if not url.endswith(('.jar', '.pom')):
                 continue
 
             # Extract relative path
@@ -99,10 +101,7 @@ def parse_download_log(log_file: Path) -> Dict[str, str]:
                 print(f"  Second: {url}")
                 print(f"  Using the first URL.")
             else:
-                rp = Path(relative_path)
-                if rp.name == 'maven-metadata.xml':
-                    rp = rp.parent / 'maven-metadata-central.xml' 
-                url_map[str(rp)] = url
+                url_map[relative_path] = url
 
     return url_map
 
@@ -172,35 +171,113 @@ def generate_yaml_entry(dest_path: str, url: str, sha256: str) -> str:
     Returns:
         Formatted YAML block
     """
-    destname = ''
-    if url.endswith('metadata.xml'):
-        destname = '\n  dest-filename: maven-metadata-central.xml'
-        
     return f"""- type: file
-  dest: .m2/repository/{dest_path}{destname}
+  dest: .m2/repository/{dest_path}
   url: {url}
   sha256: {sha256}"""
 
 
-def main():
-    """Main entry point."""
-    if len(sys.argv) != 4:
-        print(f"Usage: {sys.argv[0]} <download_log> <maven_repo_dir> <output_yaml>", file=sys.stderr)
-        print(file=sys.stderr)
-        print("Generate Flatpak Maven sources YAML from Maven download log.", file=sys.stderr)
-        print(file=sys.stderr)
-        print("Arguments:", file=sys.stderr)
-        print("  download_log    - Maven download log (e.g., dl2.txt)", file=sys.stderr)
-        print("  maven_repo_dir  - Maven repository directory (e.g., test/)", file=sys.stderr)
-        print("  output_yaml     - Output YAML file (e.g., maven-sources.yaml)", file=sys.stderr)
-        print(file=sys.stderr)
-        print("Example:", file=sys.stderr)
-        print(f"  {sys.argv[0]} dl2.txt test/ maven-sources.yaml", file=sys.stderr)
+def expected_artifact_dest(group_id: str, artifact_id: str, version: str) -> str:
+    """Generate the expected YAML dest path for a dependency GAV."""
+    group_path = group_id.replace('.', '/')
+    return f".m2/repository/{group_path}/{artifact_id}/{version}"
+
+
+def validate_against_pom(pom_path: Path, yaml_entries: List[str]) -> None:
+    """
+    Parse pom.xml and validate that all expected dependency artifacts
+    have corresponding entries in the generated YAML.
+
+    Non-test/provided scope missing → hard FAIL (exit 1).
+    Test scope missing → WARNING only.
+    """
+    ns = {'m': 'http://maven.apache.org/POM/4.0.0'}
+    tree = ET.parse(pom_path)
+    root = tree.getroot()
+
+    # Collect all dest paths from YAML entries
+    yaml_dests = set()
+    for entry in yaml_entries:
+        for line in entry.split('\n'):
+            line = line.strip()
+            if line.startswith('dest:'):
+                dest = line.split(':', 1)[1].strip()
+                yaml_dests.add(dest)
+
+    missing_compile = []
+    missing_test = []
+
+    for dep in root.findall('.//m:dependency', ns):
+        g_el = dep.find('m:groupId', ns)
+        a_el = dep.find('m:artifactId', ns)
+        v_el = dep.find('m:version', ns)
+        if g_el is None or a_el is None or v_el is None:
+            continue
+        g = g_el.text
+        a = a_el.text
+        v = v_el.text
+        if g is None or a is None or v is None:
+            continue
+
+        scope_el = dep.find('m:scope', ns)
+        scope = scope_el.text if scope_el is not None else 'compile'
+
+        # Resolve version property if applicable
+        if v.startswith('${'):
+            prop_name = v[2:-1]
+            prop_el = root.find(f'.//m:{prop_name}', ns)
+            if prop_el is not None and prop_el.text:
+                v = prop_el.text
+            else:
+                print(f"  WARNING: Cannot resolve version property '{v}' for {g}:{a}, skipping validation")
+                continue
+
+        expected = expected_artifact_dest(g, a, v)
+
+        if expected not in yaml_dests:
+            missing = [expected]
+        else:
+            missing = []
+
+        if missing:
+            if scope in ('compile', 'runtime'):
+                missing_compile.append((g, a, v, scope, missing))
+            elif scope == 'provided':
+                missing_compile.append((g, a, v, scope, missing))
+            else:
+                missing_test.append((g, a, v, scope, missing))
+
+    if missing_test:
+        print(f"\nWARNING: {len(missing_test)} test-scope dependencies missing from YAML (may be expected):")
+        for g, a, v, scope, paths in missing_test:
+            for p in paths:
+                print(f"  - {g}:{a}:{v} ({scope}) → {p}")
+
+    if missing_compile:
+        print(f"\nERROR: {len(missing_compile)} compile/runtime/provided dependencies missing from YAML:", file=sys.stderr)
+        for g, a, v, scope, paths in missing_compile:
+            for p in paths:
+                print(f"  - {g}:{a}:{v} ({scope}) → {p}", file=sys.stderr)
+        print("\nThis means the Flatpak build will fail at runtime.", file=sys.stderr)
         sys.exit(1)
 
-    log_file = Path(sys.argv[1])
-    maven_repo_dir = Path(sys.argv[2])
-    output_file = Path(sys.argv[3])
+    if not missing_test and not missing_compile:
+        print("  All pom.xml dependencies have corresponding YAML entries")
+
+
+def main():
+    """Main entry point."""
+    parser = argparse.ArgumentParser(description='Generate Flatpak Maven sources YAML from Maven download log.')
+    parser.add_argument('download_log', type=Path, help='Maven download log (e.g., dl2.txt)')
+    parser.add_argument('maven_repo_dir', type=Path, help='Maven repository directory (e.g., test/)')
+    parser.add_argument('output_yaml', type=Path, help='Output YAML file (e.g., maven-sources.yaml)')
+    parser.add_argument('--pom', type=Path, default=None, help='Path to pom.xml for GAV validation')
+    args = parser.parse_args()
+
+    log_file = args.download_log
+    maven_repo_dir = args.maven_repo_dir
+    output_file = args.output_yaml
+    pom_path = args.pom
 
     # Validate inputs
     if not log_file.exists():
@@ -284,14 +361,21 @@ def main():
         print(f"\nERROR: {len(orphaned_files)} files in {maven_repo_dir} were not in dl2.txt", file=sys.stderr)
         print("This indicates a problem with the download log or repository.", file=sys.stderr)
         print("\nOrphaned files:", file=sys.stderr)
-        for file_path in sorted(list(orphaned_files)[:20]):
+        maxl = 50
+        for file_path in sorted(list(orphaned_files)[:maxl]):
             print(f"  - {file_path}", file=sys.stderr)
-        if len(orphaned_files) > 20:
-            print(f"  ... and {len(orphaned_files) - 20} more", file=sys.stderr)
+        if len(orphaned_files) > maxl:
+            print(f"  ... and {len(orphaned_files) - maxl} more", file=sys.stderr)
         sys.exit(1)
 
     print("  Validation passed: All files accounted for")
     print()
+
+    # PHASE 4: Validate against pom.xml if requested
+    if pom_path is not None:
+        print("PHASE 4: Validating against pom.xml...")
+        validate_against_pom(pom_path, yaml_entries)
+        print()
 
     # Write output YAML
     print(f"Writing YAML to: {output_file}")
@@ -303,7 +387,7 @@ def main():
     print("=" * 70)
     print("SUCCESS!")
     print("=" * 70)
-    print(f"  Files in dl2.txt:        {len(url_map)}")
+    print(f"  Files in download log:   {len(url_map)}")
     print(f"  Files in repository:     {len(found_files)}")
     print(f"  YAML entries generated:  {len(yaml_entries)}")
     print(f"  Output file:             {output_file}")


### PR DESCRIPTION
- By default, `action/setup-java`, since [this commit](https://github.com/actions/setup-java/commit/6c4d4a5025dca6ad7cc86c839fadbcb66762ed3b) modifies the environment variable `MAVEN_ARGS` to contain `-ntp` to suppress download progress.  However, the flatpak Maven dependency generator depends on the download messages being written to standard output.  The `action/setup-java` option `shown-download-progress:true` renables the output.

- Rather than building the entire package, use `dependency:go-offline` instead, to extract the dependencies when making the dependency file for flatpak.

- Update script to generate maven source list for flatpak
  - The script `fetch-maven-deps-for-flatpak.sh` and `generate_flatpak_maven_sources.py` have been updated, with modifications, from the original repo at https://github.com/lenucksi/SieveEditor/tree/master/scripts
  - In particular, we pass the `-U` option to `mvn` when building
  - Also, the new script does resolution of source urls, which may help with the current problem.