### PR TITLE
Fix `Requires` in RPM spec file, which prevents installation

### DIFF
--- a/dist/linux/vassal.spec.in
+++ b/dist/linux/vassal.spec.in
@@ -9,7 +9,7 @@ Release:	1
 Source0:	https://github.com/@REPOSITORY@/releases/download/@RELEASE@/VASSAL-@RELEASE@-linux.tar.bz2
 URL:		https://vassalengine.org/
 BuildArch:	noarch
-Requires:	java-17 OR java-18 OR java-19 OR java-20 OR java-21 OR java-22 OR java-23 OR java-24 OR java-25 OR java-26 OR java-27
+Requires:	(java-17 or java-18 or java-19 or java-20 or java-21 or java-22 or java-23 or java-24 or java-25 or java-26 or java-27)
 License:	LGPL-2.0+ AND Apache-2.0 AND BSD-3-Clause AND CPL-1.0 AND MIT AND EPL-1.0
 
 %description


### PR DESCRIPTION
- Currently installing the build RPM fails, as detailed in [this post](https://forum.vassalengine.org/t/vassal-3-7-25-released/90361/3).
- The problem is that the _or_ keyword should be lower case `or` - not `OR`, _and_ that the or'ed requirements need to bracketed in parenthesis.
- This fixes the RPM spec skeleton.

I did a local build of the RPM and tried to install the resulting RPM on
Fedora 42 (running as a virtual machine).   That worked.