### PR TITLE
Correct Flatpak Maven dependency generation

### DIFF
--- a/dist/linux/fetch-maven-deps-for-flatpak.sh
+++ b/dist/linux/fetch-maven-deps-for-flatpak.sh
@@ -88,12 +88,12 @@ run_maven_fetch() {
 
   # Run Maven and capture full output to a temp file
   local maven_output="${temp_log}.full"
-  local maven_opts="-U -B --color=never -Dmaven.repo.local=${temp_dir} -DskipTests -Dasciidoctor.attributes=optimize -Dasciidoctor.skip=true -Dspotbugs.skip=true -Dlicense.skipDownloadLicenses"
+  local maven_opts="-U -B --color=never -Dmaven.repo.local=${temp_dir} -DskipTests"
   echo "  Options for Maven: ${maven_opts}"
   echo "${BLUE}  Make maven (${mvn}) go offline ...${NC}"
-  ${mvn} ${maven_opts} clean dependency:go-offline 2>/dev/stdout | tee -a ${maven_output}
+  make jar MVN="mvn ${maven_opts}" 2>/dev/stdout | tee ${maven_output}
   ret1=$?
-  echo "  Offline return $ret1"
+  echo "  Make return $ret1"
   echo ""
   if test $ret1 -eq 0; then
     # Resolve all dependencies to ensure complete download log

--- a/dist/linux/generate_flatpak_maven_sources.py
+++ b/dist/linux/generate_flatpak_maven_sources.py
@@ -84,7 +84,8 @@ def parse_download_log(log_file: Path) -> Dict[str, str]:
             url = match.group(1)
 
             # Only process .jar and .pom files
-            if not url.endswith(('.jar', '.pom')):
+            # Also needs metadata.xml from some repos
+            if not url.endswith(('.jar', '.pom', 'metadata.xml')):
                 continue
 
             # Extract relative path
@@ -101,7 +102,11 @@ def parse_download_log(log_file: Path) -> Dict[str, str]:
                 print(f"  Second: {url}")
                 print(f"  Using the first URL.")
             else:
-                url_map[relative_path] = url
+                # Change name from maven-metadata.xml to maven-metadata-central.xml
+                rp = Path(relative_path)
+                if rp.name == 'maven-metadata.xml':
+                    rp = rp.parent / 'maven-metadata-central.xml' 
+                url_map[str(rp)] = url
 
     return url_map
 
@@ -171,8 +176,13 @@ def generate_yaml_entry(dest_path: str, url: str, sha256: str) -> str:
     Returns:
         Formatted YAML block
     """
+    # If it's metadata, change the name 
+    destname = ''
+    if url.endswith('metadata.xml'):
+        destname = '\n  dest-filename: maven-metadata-central.xml'
+        
     return f"""- type: file
-  dest: .m2/repository/{dest_path}
+  dest: .m2/repository/{dest_path}{destname}
   url: {url}
   sha256: {sha256}"""
 


### PR DESCRIPTION
- Some of the latest changes to the Flatpak Maven dependency generation made the Flatpak package not build.
- It turns out that `mvn dependency:go-offline` does not do a complete enough job, so we revert to `make jar`.
- Also, it turns out that some of the `maven-metadata.xml` _are_ indeed needed, so we keep those in the dependency file too.

This was tested locally according to https://github.com/flathub/org.vassalengine.vassal#how-to-test-build-and-install-this-package