### PR TITLE
Allow cannotMove to be set as a DynamicProperty

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/module/map/KeyBufferer.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/KeyBufferer.java
@@ -229,8 +229,11 @@ public class KeyBufferer extends MouseAdapter implements Buildable, MouseMotionL
 
         // Don't "eat" band-selects if the piece we start the mouse event on
         // is non-movable
-        if (SwingUtils.isMainMouseButtonDown(e) && Boolean.TRUE.equals(p.getProperty(Properties.NON_MOVABLE))) {
-          bandSelect = BandSelectType.SPECIAL;
+        if (SwingUtils.isMainMouseButtonDown(e)) {
+          final Object cannotMove = p.getProperty(Properties.NON_MOVABLE);
+          if (Boolean.TRUE.equals(cannotMove) || "true".equals(cannotMove)) {
+            bandSelect = BandSelectType.SPECIAL;
+          }
         }
       }
     }

--- a/vassal-app/src/main/java/VASSAL/build/module/map/PieceMover.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/PieceMover.java
@@ -1868,8 +1868,9 @@ public class PieceMover extends AbstractBuildable
       for (final PieceIterator i = db.getIterator();  // NOPMD
            i.hasMoreElements(); pieces.add(i.nextPiece()));
       for (final GamePiece piece : pieces) {
-        if (piece.getMap() != null &&
-            Boolean.TRUE.equals(piece.getProperty(Properties.NON_MOVABLE))) {
+        final Object cannotMove = piece.getProperty(Properties.NON_MOVABLE);
+        if (piece.getMap() != null && (Boolean.TRUE.equals(cannotMove) ||
+                                       "true".equals(cannotMove))) {
           db.remove(piece);
         }
       }


### PR DESCRIPTION
This patch will make Vassal react appropriately if a module developer some how sets the property `cannotMove`
(`VASSAL.counters.Properties.NON_MOVABLE`) via for example a `VASSAL.counters.DynamicProperty` trait or similar.

This will allow a module developer to define when certain pieces can
be moved and when they cannot.   For example, a module developer may
specify that Axis units may only move during the Axis movement phase,
or in the Allied combat phase to allow retreats.

Normally, the `cannotMove` property is defined by the `VASSAL.counters.Immobilized` trait.  That trait always defines the property to be of a value of `java.lang.Boolean`.

However, other traits, such as `VASSAL.counters.DynamicProperty` will define a property to be a value of `java.lang.String`.

So to achieve the above, the `VASSAL.build.module.map.PieceMover` and `VASSAL.build.module.map.KeyBufferer` will allow for the `cannotMove` property to be of type `java.lang.String` and use
`java.lang.Boolean.valueOf` to parse it.

The attached module ([PieceMoverPR.zip](https://github.com/user-attachments/files/30846005/PieceMoverPR.zip) - rename to `PieceMoverPR.vmod`) can be used to see what happens.   On the map of the module there are 5 counters:
- The white counter is a simple counter that does not define `cannotMove`. 
- The red counter is a simple counter that defines `cannotMove` to be `true` via a `VASSAL.counters.Marker` trait. 
- The green counter defines `cannotMove` to `false` via a `VASSAL.counters.Marker` trait. 
- The blue counter defines `cannotMove` via a  `VASSAL.counters.DynamicProperty` trait and provides two commands (`Ctrl+M` and `Ctrl+Shift+M`) to toggle the value of the `cannotMove`. 
- The gray counter is again a simple counter that has the `VASSAL.counters.Immobilized` with movement turned off (set to `java.lang.Boolean.FALSE`). 
[PieceMoverPR.zip](https://github.com/user-attachments/files/30846005/PieceMoverPR.zip)

One will see that one cannot move the red piece, and if movement is prohibited for the blue piece, one cannot move that either.   The gray piece cannot be moved.  The rest of the pieces can be moved at all times. 

Since the code introduced in both  `VASSAL.build.module.map.PieceMover` and `VASSAL.build.module.map.KeyBufferer` , is identical, it could make sense to put that into some tool.  E.g., 

```Java
    public static Boolean objectAsBoolean(Object o) { 
      if (o instanceof String) {
           return Boolean.valueOf((String) o);
       }
       if (o instanceof Boolean) {
          return o;
       }
       return Boolean.FALSE;
    }
```
However, I'm not sure where it would go best.

This could then also be used in a similar future change that would allow module developers to set the property `SELECTED` via for example a  `VASSAL.counters.DynamicProperty`.  In particular `VASSAL.counters.Immobilized` could benefit from that.  

Yours,
_Christian_
