### PR TITLE
Check random numbers for consistency

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/GameModule.java
+++ b/vassal-app/src/main/java/VASSAL/build/GameModule.java
@@ -157,7 +157,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.NoSuchFileException;
-import java.security.SecureRandom;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -439,7 +438,7 @@ public class GameModule extends AbstractConfigurable
   /**
    * Random number generator
    */
-  private final Random RNG = new SecureRandom();
+  private final VASSAL.build.Random RNG = new VASSAL.build.Random();
 
   /**
    * Server object for online games
@@ -682,6 +681,7 @@ public class GameModule extends AbstractConfigurable
       .append(new RecursiveSingleChildInstance());
 
     addCommandEncoder(new ChangePropertyCommandEncoder(propsContainer));
+    addCommandEncoder(RNG);
   }
 
   /**
@@ -911,6 +911,7 @@ public class GameModule extends AbstractConfigurable
     theState = new GameState();
     theState.addTo(this);
     addCommandEncoder(theState);
+    theState.addGameComponent(RNG);
   }
 
   /**

--- a/vassal-app/src/main/java/VASSAL/build/Random.java
+++ b/vassal-app/src/main/java/VASSAL/build/Random.java
@@ -1,0 +1,503 @@
+/*
+ *
+ * Copyright (c) 2026 Christian Holm Christensen
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License (LGPL) as published by the Free Software Foundation.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public
+ * License along with this library; if not, copies are available
+ * at http://www.opensource.org.
+ */
+package VASSAL.build;
+import VASSAL.command.Command;
+import VASSAL.command.CommandEncoder;
+import VASSAL.tools.SequenceEncoder;
+import VASSAL.build.module.BasicLogger;
+import VASSAL.build.module.GameComponent;
+import VASSAL.tools.ErrorDialog;
+
+public class Random extends java.util.Random
+  implements CommandEncoder, GameComponent {
+  protected static final String COMMAND_PREFIX = "RNG\t";
+  
+  protected boolean seedSeen = false;
+  protected long storedSeed = 0;
+
+  static final long serialVersionUID = 0L;
+
+  /**
+   * Get the next random value.  This registers the random value and
+   * puts it to the current log file or clients listening.
+   */
+  @Override
+  public int nextInt() {
+    final int ret = super.nextInt();
+    logRandom("I", Integer.valueOf(ret));
+    return ret;
+  }
+  /**
+   * Get the next random value.  This registers the random value and
+   * puts it to the current log file or clients listening.
+   */
+  @Override
+  public int nextInt(int bound) {
+    final int ret = super.nextInt(bound);
+    logRandom("M", Integer.valueOf(ret), Integer.valueOf(bound));
+    return ret;
+  }
+  /**
+   * Get the next random value.  This registers the random value and
+   * puts it to the current log file or clients listening.
+   */
+  @Override
+  public long nextLong() {
+    final long ret = super.nextLong();
+    logRandom("L", Long.valueOf(ret));
+    return ret;
+  }
+  /**
+   * Get the next random value.  This registers the random value and
+   * puts it to the current log file or clients listening.
+   */
+  @Override
+  public double nextDouble() {
+    final double ret = super.nextDouble();
+    logRandom("D", Double.valueOf(ret));
+    return ret;
+  }
+  /**
+   * Get the next random value.  This registers the random value and
+   * puts it to the current log file or clients listening.
+   */
+  @Override
+  public float nextFloat() {
+    final float ret = super.nextFloat();
+    logRandom("F", Float.valueOf(ret));
+    return ret;
+  }
+  /**
+   * Get the next random value.  This registers the random value and
+   * puts it to the current log file or clients listening.
+   */
+  @Override
+  public boolean nextBoolean() {
+    final boolean ret = super.nextBoolean();
+    logRandom("B", Boolean.valueOf(ret));
+    return ret;
+  }
+  /**
+   * Get the next random value.  This registers the random value and
+   * puts it to the current log file or clients listening.
+   */
+  @Override
+  public double nextGaussian() {
+    final double ret = super.nextGaussian();
+    logRandom("G", Double.valueOf(ret));
+    return ret;
+  }
+  /**
+   * Set the seed on this random number generator.
+   *
+   * This also registeres that the seed was set.  That means, as a
+   * client, we will now check if the passed random values (via
+   * commands) actually match the next random variable in the
+   * sequence.  It also means, that if we're reading older log files,
+   * where the seed isn't set, that we will not do those checks.
+   */ 
+  @Override
+  public void setSeed(long seed) {
+    super.setSeed(seed);
+    storedSeed = seed;
+  }
+  public void restoreSeed(long seed) {
+    setSeed(seed);
+    seedSeen = true;
+    // System.out.println("Restoring seed " + seed);
+  }
+  public long getSeed() {
+    return storedSeed;
+  }
+    
+  /**
+   * This writes a command to the log.  The command is prefixed by our
+   * prefix, and then followed by the random value.
+   *
+   * @param type  The kind of random variable
+   * @param value  The value of the random value
+   * @param bound  Possible bound
+   */
+  protected Command logRandom(String type, Object value, Object bound) {
+    final RandomCommand c = new RandomCommand(type, value, bound);
+    GameModule.getGameModule().sendAndLog(c);
+    return c;
+  }
+  protected Command logRandom(String type, Object value) {
+    return logRandom(type, value, null);
+  }
+  
+  /*
+   * Checks that the seen value is the next one in the random number
+   * sequence. If not, an exception is thrown.
+   */
+  /**
+   * Check that the passed value is the next value of the generator's sequence.
+   * If not, then an exception is thrown.
+   *
+   * @param value Value to check
+   */
+  protected void checkInt(int value) {
+    if (!seedSeen) {
+      return;
+    }
+    
+    final int here = super.nextInt();
+    // System.out.println("Read=" + value + " here=" + here +
+    //                    " seed=" + storedSeed);
+    if (here != value) {
+      ErrorDialog.showDetails("Read random integer value " + value +
+                              " does not match next the expected value " +
+                              here,
+                              "Random.InconsistentNumber",
+                              "integer", value, here);
+    }
+  }
+  /**
+   * Check that the passed value is the next value of the generator's
+   * sequence.  If not, then an exception is thrown.
+   *
+   * @param value Value to check
+   */
+  protected void checkInt(int value, int bound) {
+    if (!seedSeen) {
+      return;
+    }
+    
+    final int here = super.nextInt(bound);
+    // System.out.println("Read=" + value + " here=" + here +
+    //                    " seed=" + storedSeed);
+    if (here != value) {
+      ErrorDialog.showDetails("Read random bound integer value " + value +
+                              " does not match the expected value " + here,
+                              "Random.InconsistentNumber",
+                              "bound integer", value, here);
+    }
+  }
+  /**
+   * Check that the passed value is the next value of the generator's
+   * sequence.  If not, then an exception is thrown.
+   *
+   * @param value Value to check
+   */
+  protected void checkLong(long value) {
+    if (!seedSeen) {
+      return;
+    }
+    
+    final long here = super.nextLong();
+    // System.out.println("Read=" + value + " here=" + here +
+    //                    " seed=" + storedSeed);
+    if (here != value) {
+      ErrorDialog.showDetails("Read random  long " + value +
+                              " does not match expected value " + here,
+                              "Random.InconsistentNumber",
+                              "long", value, here);
+    }
+  }
+  /**
+   * Check that the passed value is the next value of the generator's
+   * sequence.  If not, then an exception is thrown.
+   *
+   * @param value Value to check
+   */
+  protected void checkDouble(double value) {
+    if (!seedSeen) {
+      return;
+    }
+    
+    final double here = super.nextDouble();
+    // System.out.println("Read=" + value + " here=" + here +
+    //                    " seed=" + storedSeed);
+    if (here != value) {
+      ErrorDialog.showDetails("Read random  double " + value +
+                              " does not match expected value " + here,
+                              "Random.InconsistentNumber",
+                              "double", value, here);
+    }
+  }
+  /**
+   * Check that the passed value is the next value of the generator's
+   * sequence.  If not, then an exception is thrown.
+   *
+   * @param value Value to check
+   */
+  protected void checkFloat(float value) {
+    if (!seedSeen) {
+      return;
+    }
+    
+    final float here = super.nextFloat();
+    // System.out.println("Read=" + value + " here=" + here +
+    //                    " seed=" + storedSeed);
+    if (here != value) {
+      ErrorDialog.showDetails("Read random  float " + value +
+                              " does not match expected value " + here,
+                              "Random.InconsistentNumber",
+                              "float", value, here);
+    }
+  }
+  /**
+   * Check that the passed value is the next value of the generator's sequence.
+   * If not, then an exception is thrown.
+   *
+   * @param value Value to check
+   */
+  protected void checkBoolean(boolean value) {
+    if (!seedSeen) {
+      return;
+    }
+    
+    final boolean here = super.nextBoolean();
+    // System.out.println("Read=" + value + " here=" + here +
+    //                    " seed=" + storedSeed);
+    if (here != value) {
+      ErrorDialog.showDetails("Read random  boolean " + value +
+                              " does not match expected value " + here,
+                              "Random.InconsistentNumber",
+                              "boolean", value, here);
+    }
+  }
+  /**
+   * Check that the passed value is the next value of the generator's
+   * sequence.  If not, then an exception is thrown.
+   *
+   * @param value Value to check
+   */
+  protected void checkGaussian(double value) {
+    if (!seedSeen) {
+      return;
+    }
+    
+    final double here = super.nextGaussian();
+    // System.out.println("Read=" + value + " here=" + here +
+    //                    " seed=" + storedSeed);
+    if (here != value) {
+      ErrorDialog.showDetails("Read random  Gaussian " + value +
+                              " does not match next random value " + here,
+                              "Random.InconsistentNumber",
+                              "Gaussian", value, here);
+    }
+  }
+
+  /**
+   * Component interface
+   */
+  @Override
+  public void setup(boolean starting) {}
+
+  /**
+   * Command to add to save or log file to restore the random number
+   * seed.  This command will be read and executed when a log file is
+   * played-back.
+   */
+  @Override
+  public Command getRestoreCommand() {
+    // If we are not _actually_ recording a log, do nothing.
+    final GameModule  module = GameModule.getGameModule();
+    final BasicLogger logger = module != null ? module.getBasicLogger() : null;
+    if (!(logger != null && logger.isLogging() /* && !logger.isReplaying() */)) {
+      return null;
+    }
+    
+    // Generate a random number with the previous seed - possibly one
+    // read from a log file or from other client - so that we can
+    // check that this log is indeed a continuation of a previous log.
+    final long          val = (logger.isReplaying() ? storedSeed :
+                               super.nextLong());
+    final RandomCommand ret = new RandomCommand("L", Long.valueOf(val));
+    ret.append(new RandomCommand("Z", Long.valueOf(val)));
+
+    // We will use the above random number as the new seed.  In that
+    // way, we have a predicatable seed (and hence sequence of random
+    // numbers) which depends on that previous seed.  Thus, if the
+    // user loaded a save or log, and then starts a new log, then the
+    // seed will depend on that previous log.  If the user loaded the
+    // save or log, and then filled around with the numbers, then the
+    // new seed won't match, and we'll detect that.
+    //
+    // If no previous seed was seen, we make a new one. 
+    // System.out.println("Set new seed " + val);
+    setSeed(val);
+    
+    return ret;
+  }
+  /*
+   * Command interface
+   */
+  /**
+   * Decode a command.  We do this when, either
+   * - we are reading from a log file (PBEM)
+   * - or we are getting commands over network 
+   *
+   */
+  @Override
+  public Command decode(String command) {
+    final SequenceEncoder.Decoder sd =
+      new SequenceEncoder.Decoder(command, ';');
+    final String prefix = sd.nextToken("");
+    if (!prefix.equals(COMMAND_PREFIX)) {
+      return null; // Not for us 
+    }
+    final String        type = sd.nextToken("");
+    final RandomCommand cmd  = new RandomCommand(type);
+    
+    if (type.equals("Z")) {
+      // Got a seed value 
+      final long value = sd.nextLong(0);
+      cmd.setValue(Long.valueOf(value));
+      return cmd;
+    }
+
+    // We've not seen a seed, so we do nothing when we see a random
+    // number log.  This is the case when a user is simply playing a
+    // turn or similar, or if we're reading older log files without
+    // this random number generator wrapper.
+    if (type.equals("I")) {
+      cmd.setValue(Integer.valueOf(sd.nextInt(0)));
+    }
+    else if (type.equals("M")) {
+      cmd.setValue(Integer.valueOf(sd.nextInt(0)));
+      cmd.setBound(Integer.valueOf(sd.nextInt(0)));
+    }
+    else if (type.equals("L")) {
+      cmd.setValue(Long.valueOf(sd.nextLong(0)));
+    }
+    else if (type.equals("D")) {
+      cmd.setValue(Double.valueOf(sd.nextDouble(0.)));
+    }
+    else if (type.equals("F")) {
+      cmd.setValue(Float.valueOf((float)sd.nextDouble(0.)));
+    }
+    else if (type.equals("B")) {
+      cmd.setValue(Boolean.valueOf(sd.nextBoolean(false)));
+    }
+    else if (type.equals("G")) {
+      cmd.setValue(Double.valueOf(sd.nextDouble(0.)));
+    }
+    return cmd;
+  }
+  @Override
+  public String encode(Command command) {
+    if (!(command instanceof RandomCommand)) {
+      return null;
+    }
+
+    final RandomCommand rc    = (RandomCommand)command;
+    final String        type  = rc.getType();
+    final Object        value = rc.getValue();
+    final Object        bound = rc.getBound();
+
+    final SequenceEncoder se = new SequenceEncoder(COMMAND_PREFIX, ';');
+    se.append(type)
+      .append(value.toString())
+      .append(bound != null ? bound.toString() : "");
+    
+    return se.getValue() + "\\";
+  }
+
+  /**
+   * Command to keep track of random numbers generated
+   */
+  public static class RandomCommand extends Command {
+    protected String type;
+    protected Object value;
+    protected Object bound = null;
+
+    public RandomCommand(String t) {
+      this(t, null, 0);
+    }
+    public RandomCommand(String t, Object v) {
+      this(t, v, 0);
+    }
+    public RandomCommand(String t, Object v, Object b) {
+      type  = t;
+      value = v;
+      bound = b;
+    }
+
+    public void setValue(Object v) {
+      value = v;
+    }
+    public void setBound(Object b) {
+      bound = b;
+    }
+    public String getType() {
+      return type;
+    }
+    public Object getValue() {
+      return value;
+    }
+    public Object getBound() {
+      return bound;
+    }
+
+    /**
+     * Get our random number generator.  Note, it is cast to our type,
+     * as we will always use an object of that type.  This allows us
+     * to delegate checks to that type - particularly as we need to
+     * check if we've seen a seed has been set.
+     */
+    protected Random getRNG() {
+      return (Random)GameModule.getGameModule().getRNG();
+    }
+      
+
+    /**
+     * This checks that the random number we got is indeed the next
+     * value in the sequence of random numbers.  This throws an
+     * exception if it is not.
+     */
+    @Override   
+    public void executeCommand() {
+      if (type.equals("Z")) {
+        getRNG().restoreSeed(((Long)value).longValue());
+      }
+      else if (type.equals("I")) {
+        getRNG().checkInt(((Integer)value).intValue());
+      }
+      else if (type.equals("M")) {
+        getRNG().checkInt(((Integer)value).intValue(),
+                          ((Integer)bound).intValue());
+      }
+      else if (type.equals("L")) {
+        getRNG().checkLong(((Long)value).longValue());
+      }
+      else if (type.equals("D")) {
+        getRNG().checkDouble(((Double)value).doubleValue());
+      }
+      else if (type.equals("F")) {
+        getRNG().checkFloat(((Float)value).floatValue());
+      }
+      else if (type.equals("B")) {
+        getRNG().checkBoolean(((Boolean)value).booleanValue());
+      }
+      else if (type.equals("G")) {
+        getRNG().checkGaussian(((Double)value).doubleValue());
+      }
+    }
+    /**
+     * This returns null, because we cannot undo random numbers
+     */
+    @Override
+    protected Command myUndoCommand() {
+      return null;
+    }
+  }
+}
+

--- a/vassal-app/src/main/resources/VASSAL/i18n/VASSAL.properties
+++ b/vassal-app/src/main/resources/VASSAL/i18n/VASSAL.properties
@@ -1283,3 +1283,8 @@ Zoomer.ZoomMenu.fit_visible=Fit Visible
 Zoomer.ZoomDialog.title=Select Zoom Ratio
 Zoomer.ZoomDialog.zoom_ratio=Zoom Ratio
 Zoomer.ZoomDialog.zoom_percent=Zoom
+
+# Random
+Random.InconsistentNumber_title=Inconsistent random number read
+Random.InconsistentNumber_heading=Inconsistent random number read
+Random.InconsistentNumber_message=The random number read from log file is inconsistent with the current state of the random number generator.  This could indicate tampering with the log file by a user.  You should make the author of the log file aware of the problem and ask for a new log file.  If the problem persist, it may indicate your opponent is tampering with the random number generator.


### PR DESCRIPTION
This patch will place markers in a log file, so that an opponent may check that the log has not been doctored in a way to get better outcomes.

The strategy is best illustrated by a sequence of events.

1. Player **A** starts a game
2. **A** starts a log file - say `A1.vlog`
   - This will put the currently used seed - say `sA1` - into the log file
3. **A** generates random numbers
   - _Each_ random number is written to the log file, irrespective of whether it corresponds to a die roll or some other random thing.  In this way, the sequence of random numbers is documented in the log file.
4. **A** ends the log file
5. **A** sends the log file to player **B**

Now it is player **B**s turn

6. Player **B** opens the log file `A1.vlog`
   - Vassal will, as part of reading the log file, see the seed - `sA1` - written down in step 2 above.
   - The Random number generator is seeded with that seed `sA1`.
7.  **B** starts to step through the log file `A1.vlog`
    - When ever **A** made a random number, it is read in from the log file.   Vassal can now check, that given the above seed - `sA1`, that the random number read in is indeed the next random number in the sequence of random numbers - simply by drawing an equivalent random number from the random.
      - If the random number read from the log file matches the generated random number, then all is good.
      - If the random number read from the log file _does not_ match the generated random number, then something is a miss and the problem is reported (an exception is thrown).
8. Once **B** has stepped through the log file, **B** then _immediately_ opens up a new log file - say `B1.vlog`.
   - As above, that means that the current seed should be written to the log.
     - However, there's a bit of a caveat here, as we cannot reuse the old seed - `sA1` (otherwise we'd need to know the full sequence of random numbers, which will no be in the newly started log file).
     - So instead, we draw _one_ random number - say `iB1` (a `long`) using the current seed (the one read from the log file) and write that to the log file.
     - Furthermore, we use _that_ random number  as the new seed - `sB1` - from the random number generator, and we then write that seed to the log.
       - While we made a new seed - `sB1`, the seed we created is derived from the previous seed - `sA1`, and therefore we can check, later on, that that seed is as expected.
       - Had we simply generated a new seed, then we'd be back to the situation where a player may restart logs until favourable outcomes are achieved).
9. **B** now generates random numbers and these are written to the log file, just like above.
10. **B** ends the log file - `B1.vlog` and sends it to **A**.

Now comes the part where we check that things are consistent

11. **A** Opens up its _own_ log file `A1.vlog` first - This reinitialises the Random number generator with the seed in that log file - `sA1`.
12. **A** then fast-forwards through the log file. - As above in 7, this will read in the random numbers and check if they are indeed in the sequence (and in order) of the Random number generator given the seed `sA1`
 13. Once **A** has stepped through the log file `A1.vlog`, the game is back to the state in step 4 above. - But _crucially_ the current random number seed is set to the read seed - `sA1`, _and_ we have replayed the sequence of random numbers to the same point as in step 4 above.
 14. **A** now opens the log sent by **B** - `B1.vlog`
      - This means that the random number generated in step 8 above - `iB1` - using the seed `sA1` is read in.   We can therefore check that that random number is the expected random number - as in step 7 above.
      - Opening the log _also_ means we read in the seed - `sB1` - set in step 8 above, and we seed the Random number generator with that seed.
15. **A** nows steps through the log file `B1.vlog`
      - As in step 7 above, every time we see a random number in the log file - generated from the seed `sB1`, which we are currently _also_ using, we check if that read random number matches the next random number in the current Random number generator sequence.
 16. Once **A** has stepped through all of the log file `B1.vlog`, then **A** _immediately_ starts a new log file - say `A2.vlog`
     - Again a new random number, given the seed `sB1` is generated and written to the log
     - That random number is set as the new seed - `sA2`, and written to the log
17. **A** does its moves, including generating random numbers from seed `sA2`,  which are recorded in the log file.
18. **A** ends the log file `A2.vlog` and sends it to **B**

Now **B** follows the same logic:

19. **B** plays back its own log `B1.vlog`, so that the seed is set to `sB1`, and the sequence up to step 10 above is replayed.
20. **B** then opens the log file `A2.vlog`, which first checks the random number - `iA2` - based on seed `sB1` - written in the log, and then reads in the new seed `sA2`.
21. **B** then replayes the log and on each random number checks that it is the next random number in the sequence seeded in `sA2`.
22. **B** starts a new log - `B2.vlog`, generates a random number based on `sA2`, and sets that as the seed - `sB2`.
23. **B** makes random numbers, based on seed `sB2`
24. **B** Closes the log and sends it back to **A**

In this way, there's a consistency check on every step, that the sequence of random numbers is ultimate derived from the initial seed - `sA1` - possibly via intermittent seeds - `sB1`, `sA2`, `sB2`, `sA3`, ..., which them selves are derived - in a predictable fashion from the first seed `sA1`.   The "trick" is to use the fact that pseudo random number generators are just that - pseudo - and they will always produce the same sequence of random numbers given the same starting point (seed).

The benefit of this approach, in so far as it works and can be implemented in Vassal, is that it is entire self-contained and does not require external services or the like.  That also means that reading and writing log files does not require an internet connection.

Note, if no seed is seen in a log file, then no checks are performed. This would be to support older log files.  Also note, that the logic may carry over to on-line games, as an online game is really just a live replay of a log file.  In an online game, all players will use the same seed and they will all see the same sequence of random numbers so they can check for consistency.

Note that this patch changes the random number generator from a `java.security.SecureRandom` to a standard `java.util.Random`, because the former does not produce the same sequence of random numbers given the same starting seed, while the latter does. The use of a cryptography random number generator is, by all considerations, overkill, and the standard `java.util.Random` is surely safe and random enough for Vassal.

To try this out, pick any module you like and do the following. 

1. Open the module 
2. Start a log - say `A1.vlog`
3. Roll the dice a couple of times 
4. End the log
5. Quit Vassal 

Now for the "next" player 

1. Open the module
2. Fast-forward through the log `A1.vlog` (random numbers will be checked) 
3. Start a log - say `B1.vlog` 
4. Roll the dice a couple of times 
5. End the log
6. Quit Vassal

Back to the original player 

1. Open the module 
2. Fast-forward through the log `A1.vlog`  (random numbers will be checked)
3. Fast-forward through the log `B1.vlog`  (random numbers will be checked)
4. Quit Vassal 

Now, to do a case where inconsistencies are detected 

1. Open the module 
2. Start a log - say `A1.vlog`
3. Roll the dice a couple of times 
4. End the log
5. Quit Vassal 

Now for the "next" - cheating - player 

1. Open the module
2. Fast-forward through the log `A1.vlog` (random numbers will be checked) 
3. Roll the dice a couple of times (so as to get more favourable outcomes)
4. Start a log - say `B1.vlog` 
5. Roll the dice a couple of times 
6. End the log
7. Quit Vassal

Back to the original player who will detect the previous player's fraud

1. Open the module 
2. Fast-forward through the log `A1.vlog`  (random numbers will be checked)
3. Fast-forward through the log `B1.vlog`
    - This will result in an error dialog shown, warning that the random numbers read in the last log file - `B1.vlog` - are not consistent with the random numbers in the log file `A1.vlog`, and hence the previous player may have cheated. 

If, at any point, you'd like to see the content of a log file, use the `vsavdump.py` utility from [`pywargame`](https://gitlab.com/wargames_tex/pywargame). 

Yours,
_Christian_
