### PR TITLE
Fix to VASSAL.sh script and add server option

### DIFF
--- a/dist/linux/VASSAL.sh
+++ b/dist/linux/VASSAL.sh
@@ -23,8 +23,10 @@ mod_entry=VASSAL.launch.ModuleManager
 ply_entry=VASSAL.launch.Player
 edt_entry=VASSAL.launch.Editor
 trl_entry=VASSAL.i18n.TranslateVassalWindow
+srv_entry=VASSAL.chat.node.Server
 entry=$mod_entry
 jar="$path/lib/Vengine.jar"
+srv_url=null
 
 # --- Some modus operandi --------------------------------------------
 # Do we do direct execution?, i.e., by-pass the module manager. Are we
@@ -117,13 +119,16 @@ while test $# -gt 0 ; do
             if test $drt -gt 0 ; then
                 entry=$edt_entry
             fi
-                        ;;
+            ;;
+        x--server)
+            entry=$srv_entry
+            ;;
         *)
             # If argument is a file ... 
-            if test -f $1 ; then
+            if test -f "$1" ; then
                 # ... then store full path name since VASSAL changes
                 # the current directory before opening target files.
-                f=$(realpath $1)
+                f=$(realpath "$1")
                 args+=("$f")
             else
                 args+=("$1")
@@ -136,6 +141,11 @@ done
 # --- Set source path ------------------------------------------------
 if test "x$cmd" == "x$jdb" ; then
     defs+=("-sourcepath" "$src")
+fi
+
+# --- Check server ---------------------------------------------------
+if test "x$entry" == "x$srv_entry" ; then
+    args+=("-URL" "$srv_url")
 fi
 
 # --- Run java with defines, entry point, and other arguments --------

--- a/dist/linux/vassal.6
+++ b/dist/linux/vassal.6
@@ -113,6 +113,16 @@ Create a new module.
 .BI \-\-new\-extension \ module
 Create a new module extension to \fImodule\fP. 
 .TP
+.B \-\-server
+Start a local Vassal server.
+.TP
+.BI \-URL \ URL
+Set the server reporting URL.  Statistics on games will be sent to the
+URL give.
+.TP
+.BI \-port \ PORT
+Set the port number (default 5050) for the server to listen on.
+.TP
 .B \-\-version
 Report the version of Vassal to standard output and exit.
 .PP


### PR DESCRIPTION
This patches makes sure we quite possible file names, so that we correctly parse that out.  Also add the command line option `--server` to start a local Vassal server.

For local Vassal servers, then the option `-URL` will set the URL to report games to.  Also for local servers, the option `-port` sets the port that the localhost server will listen to.