### PR TITLE
Use maximum compression for saves and logs

### DIFF
--- a/vassal-app/src/main/java/VASSAL/tools/io/ZipWriter.java
+++ b/vassal-app/src/main/java/VASSAL/tools/io/ZipWriter.java
@@ -30,6 +30,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.util.Objects;
+import java.util.zip.Deflater;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
@@ -60,6 +61,7 @@ public class ZipWriter implements Closeable {
 
     lock = fc.lock();
     zout = new ZipOutputStream(new BufferedOutputStream(Channels.newOutputStream(fc)));
+    zout.setLevel(Deflater.BEST_COMPRESSION);
   }
 
   public void write(File src, String dst) throws IOException {


### PR DESCRIPTION
**Problem.** Two different ZIP writers are used, at different compression levels:

- Interactive **Save** uses `ZipWriter`, which never calls `setLevel()`, so entries use `Deflater.DEFAULT_COMPRESSION` = **level 6** (`ZipWriter.java:62`, `makeEntry` `:120‑124`).
- The editor **refresh** save uses `ZipArchive`, which sets **level 9** (`ZipArchive.java:466`).

**Change.** Set the `ZipWriter` `ZipOutputStream` to level 9 to match. On our large sample vsav file this saved ~3 % on the obfuscated stream (33.1 vs 34.1 MB) — small, but free and consistent.
