### PR TITLE
Add server options to Linux launch script

### DIFF
--- a/dist/linux/VASSAL.sh
+++ b/dist/linux/VASSAL.sh
@@ -23,8 +23,10 @@ mod_entry=VASSAL.launch.ModuleManager
 ply_entry=VASSAL.launch.Player
 edt_entry=VASSAL.launch.Editor
 trl_entry=VASSAL.i18n.TranslateVassalWindow
+srv_entry=VASSAL.chat.node.Server
 entry=$mod_entry
 jar="$path/lib/Vengine.jar"
+srv_url=null
 
 # --- Some modus operandi --------------------------------------------
 # Do we do direct execution?, i.e., by-pass the module manager. Are we
@@ -118,6 +120,9 @@ while test $# -gt 0 ; do
                 entry=$edt_entry
             fi
                         ;;
+        x--server)
+            entry=$srv_entry
+            ;;
         *)
             # If argument is a file ... 
             if test -f $1 ; then
@@ -137,6 +142,12 @@ done
 if test "x$cmd" == "x$jdb" ; then
     defs+=("-sourcepath" "$src")
 fi
+
+# --- Check server ---------------------------------------------------
+if test "x$entry" == "x$srv_entry" ; then
+    args+=("-URL" "$srv_url")
+fi
+
 
 # --- Run java with defines, entry point, and other arguments --------
 "${cmd}" "${defs[@]}" -classpath "${jar}" "$entry" "${args[@]}"

--- a/dist/linux/vassal.6
+++ b/dist/linux/vassal.6
@@ -113,6 +113,16 @@ Create a new module.
 .BI \-\-new\-extension \ module
 Create a new module extension to \fImodule\fP. 
 .TP
+.B \-\-server
+Start a local Vassal server.
+.TP
+.BI \-URL \ URL
+Set the server reporting URL.  Statistics on games will be sent to the
+URL given.
+.TP
+.BI \-port \ PORT
+Set the port number (default 5050) for the server to listen on.
+.TP
 .B \-\-version
 Report the version of Vassal to standard output and exit.
 .PP


### PR DESCRIPTION
This patch adds the command line option `--server` to start a local Vassal server.

For a local Vassal server, started with the option `--server`, the command line option `-URL` will set the URL to report games to. Likewise, the option `-port` will set the port that the server will listen on (defaults to 5050).

The man vassal(6) page has been updated to reflect these changes.