### PR TITLE
Fix to package workflow for Debian builds

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -260,7 +260,7 @@ jobs:
           eml="${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com"
           ver=$(make version-print 2>/dev/null | tr '_' '-')
           echo "Setting non-release Debian version to ${ver}-1"
-          EMAIL="${eml}" dch --release-heuristic log -v ${ver}-1 "Snapshot build"
+          EMAIL="${eml}" dch --release-heuristic log --force-bad-version -v ${ver}-1 "Snapshot build"
       - name: Store DEB variables
         id: deb_vars
         run: |


### PR DESCRIPTION
Add the option `--force-bad-version` to allow a version number that is seemingly in the past.  This is needed when the current repo is in the beta stage before a full release.  This will then allow `dch` to make a version that is apparently in the past relative to the latest release.