### PR TITLE
Update MacOS launch script to allow more options

### DIFF
--- a/dist/macos/VASSAL.sh
+++ b/dist/macos/VASSAL.sh
@@ -1,23 +1,138 @@
-#!/usr/bin/env bash -e
+#!/bin/bash
+#
+# --- Find the path to the installation ------------------------------
+path="$(dirname "$0")/../.."
 
-# get the root directory of the bundle and go there
-APP_ROOT="$(dirname "$0")/../.."
-cd "$APP_ROOT"
+# --- Set default definitions and arguments --------------------------
+defs=("-Duser.home=$HOME"
+      "-Duser.dir=$path"
+      "-Xdock:name=VASSAL"
+      "-Xdock:icon=Contents/Resources/VASSAL.icns")
+args=()
 
-# filter out the -psn_* option added by Finder
-ARGS=()
-for ARG in "$@"; do
-  if [[ "$ARG" != -psn_* ]]; then
-    ARGS+=($(printf '%q' "$ARG"))
-  fi
-done
-
-# determine the correct CPU architecture
+# --- Architecture ---------------------------------------------------
 if sysctl machdep.cpu.brand_string | grep -q Intel ; then
-  ARCH=x86_64
+    arch=x86_64
 else
-  ARCH=arm64
+    arch=arm64
 fi
 
-# fire it up
-exec arch -$ARCH Contents/MacOS/jre/bin/java -classpath Contents/Resources/Java/Vengine.jar -Xdock:name=VASSAL -Xdock:icon=Contents/Resources/VASSAL.icns VASSAL.launch.ModuleManager "${ARGS[@]}"
+# --- Find Java and debugger -----------------------------------------
+java=Contents/MacOS/jre/bin/java
+cmd="$java"
+
+# --- The various entry points and the JAR ---------------------------
+ver_entry=VASSAL.launch.JavaVersionChecker
+mod_entry=VASSAL.launch.ModuleManager
+ply_entry=VASSAL.launch.Player
+edt_entry=VASSAL.launch.Editor
+trl_entry=VASSAL.i18n.TranslateVassalWindow
+srv_entry=VASSAL.chat.node.Server
+entry=$mod_entry
+jar="Contents/Resources/Java/Vengine.jar"
+srv_url=null
+
+# --- Some modus operandi --------------------------------------------
+# Do we do direct execution?, i.e., by-pass the module manager. Are we
+# debugging?  Possible source path for when debugging, e.g.,
+# ~/vassal/vassal-app/src/main/java if the VASSAL sources are cloned
+# to ~/vassal
+drt=0
+src=
+hlp=0
+
+# --- Parse command line ---------------------------------------------
+while test $# -gt 0 ; do
+    case x$1 in
+        x-h|x--help)
+            hlp=1
+            args+=("--help")
+            ;;
+        x-D*)
+            # Defines must come before JAR and entry point 
+            defs+=("$1")
+            ;;
+        x--direct)
+            # If passed, then we by-pass the module manager and
+            # execute the relevant entry point directly.
+            drt=1
+            ;;
+        x--translate)
+            entry=$trl_entry
+            ;;
+        x-l|x--load)
+            args+=("--load")
+            if test $drt -gt 0 ; then
+                entry=$ply_entry
+            fi
+            ;;
+        x-e|x--edit)
+            args+=("--edit")
+            if test $drt -gt 0 ; then
+                entry=$edt_entry
+            fi
+            ;;
+        x-n|x--new)
+            args+=("--new")
+            if test $drt -gt 0 ; then
+                entry=$edt_entry
+            fi
+            ;;
+        x--new-extension)
+            args+=("$1")
+            if test $drt -gt 0 ; then
+                entry=$edt_entry
+            fi
+            ;;
+        x--edit-extension)
+            args+=("$1")
+            if test $drt -gt 0 ; then
+                entry=$edt_entry
+            fi
+                        ;;
+        x--server)
+            entry=$srv_entry
+            ;;
+        *)
+            # If argument is a file ... 
+            if test -f "$1" ; then
+                # ... then store full path name since VASSAL changes
+                # the current directory before opening target files.
+                f=$(readlink -f "$1")
+                args+=("$f")
+            else
+                args+=("$1")
+            fi
+            ;;
+    esac
+    shift
+done
+
+# --- Go to application directory ------------------------------------
+cd $path
+
+# --- Check server ---------------------------------------------------
+if test "x$entry" == "x$srv_entry" ; then
+    args+=("-URL" "$srv_url")
+fi
+
+# --- Run java with defines, entry point, and other arguments --------
+arch -${arch} "${cmd}" "${defs[@]}" -classpath "${jar}" "$entry" "${args[@]}"
+
+# --- Extra help -----------------------------------------------------
+if test $hlp -gt 0 ; then
+    cat <<-EOF
+	In addition to the above options defined by VASSAL proper,
+	this wrapper script allows for a number of additional options.
+
+	Options:
+	  -Dvariable=value	  Set Java variable to value
+	  --direct		  By-pass the module manager and run
+	                          player, editor, ..., directly.
+	  --server                Start local Vassal server
+	EOF
+fi
+#
+# EOF
+#
+


### PR DESCRIPTION
- This patch brings the MacOS launch script into a closer match to the Linux launch script.
- It will allow one to pass JVM options via `-D<variable>=<value>`, e.g., to set the Swing Look'n'Feel.
- Allows for direct execution of `Editor`, `Player`, or as server.
- Explicit server option.
- Use full path name of any file passed on the command line.
- Run local server via the option `--server`, and possibly the options `-URL` and `-port`.

For example, one can do

    /Applications/VASSAL.app/Contents/MacOS/VASSAL.sh -l Foo.vmod

and Vassal will correctly find the `Foo.vmod` module, and similar for saves and log.  Also, one can do

    /Applications/VASSAL.app/Contents/MacOS/VASSAL.sh --server

to start a local server.