### PR TITLE
Deflate the saved-game command log before obfuscating it

### DIFF
--- a/vassal-app/src/main/java/VASSAL/tools/io/DeobfuscatingInputStream.java
+++ b/vassal-app/src/main/java/VASSAL/tools/io/DeobfuscatingInputStream.java
@@ -24,10 +24,13 @@ import java.io.PushbackInputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.zip.InflaterInputStream;
 
 /**
  * A {@link FilterInputStream} which converts a file created with
- * {@link ObfuscatingOutputStream} back into plain text.
+ * {@link ObfuscatingOutputStream} back into plain text. Both the deflated
+ * format ({@link ObfuscatingOutputStream#DEFLATED_HEADER}) and the older
+ * undeflated format ({@link ObfuscatingOutputStream#HEADER}) are read.
  * Additionally, plain text will be passed through unchanged.
  *
  * @author Joel Uckelman
@@ -44,8 +47,12 @@ public class DeobfuscatingInputStream extends FilterInputStream {
 
     final byte[] header = new byte[ObfuscatingOutputStream.HEADER.length()];
     readFully(in, header, header.length);
-    if (new String(header, StandardCharsets.UTF_8).equals(ObfuscatingOutputStream.HEADER)) {
+    final String headerStr = new String(header, StandardCharsets.UTF_8);
+    if (headerStr.equals(ObfuscatingOutputStream.HEADER)) {
       this.in = new DeobfuscatingInputStreamImpl(in);
+    }
+    else if (headerStr.equals(ObfuscatingOutputStream.DEFLATED_HEADER)) {
+      this.in = new InflaterInputStream(new DeobfuscatingInputStreamImpl(in));
     }
     else {
       final PushbackInputStream pin =

--- a/vassal-app/src/main/java/VASSAL/tools/io/ObfuscatingOutputStream.java
+++ b/vassal-app/src/main/java/VASSAL/tools/io/ObfuscatingOutputStream.java
@@ -26,20 +26,30 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Random;
+import java.util.zip.Deflater;
+import java.util.zip.DeflaterOutputStream;
 
 /**
  * A {@link FilterOutputStream} which handles simple obfuscation of a file's
  * contents, to prevent the casual cheat of hand-editing.
+ *
+ * The input is deflated before being obfuscated, so that obfuscation (which
+ * doubles the byte count and destroys the redundancy ZIP compression relies
+ * on) is applied to the small compressed form rather than the large plain
+ * text. Streams written by 3.7.x and earlier ({@link #HEADER}) contain
+ * obfuscated plain text; streams written by this version
+ * ({@link #DEFLATED_HEADER}) contain obfuscated deflated text.
+ * {@link DeobfuscatingInputStream} reads both.
  *
  * @author uckelman
  * @since 3.2.0
  */
 public class ObfuscatingOutputStream extends FilterOutputStream {
   public static final String HEADER = "!VCSK"; //NON-NLS
+  public static final String DEFLATED_HEADER = "!VCSZ"; //NON-NLS
   private static final Random rand = new Random();
 
-  private final byte key;
-  private final byte[] pair = new byte[2];
+  private final Deflater deflater;
 
   /**
    * @param out the stream to wrap
@@ -56,20 +66,26 @@ public class ObfuscatingOutputStream extends FilterOutputStream {
    */
   public ObfuscatingOutputStream(OutputStream out, byte key)
                                                           throws IOException {
-    super(out);
-    this.key = key;
-
-    out.write(HEADER.getBytes(StandardCharsets.UTF_8));
-
-    pair[0] = HEX[(key & 0xF0) >>> 4];
-    pair[1] = HEX[key & 0x0F];
-    out.write(pair);
+    super(null);
+    deflater = new Deflater(Deflater.BEST_COMPRESSION);
+    this.out = new DeflaterOutputStream(new XorHexOutputStream(out, key), deflater);
   }
 
   /** {@inheritDoc} */
   @Override
   public void write(byte[] bytes, int off, int len) throws IOException {
-    for (int i = 0; i < len; ++i) write(bytes[off + i]);
+    out.write(bytes, off, len);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void close() throws IOException {
+    try {
+      super.close();
+    }
+    finally {
+      deflater.end();
+    }
   }
 
   private static final byte[] HEX = {
@@ -77,14 +93,40 @@ public class ObfuscatingOutputStream extends FilterOutputStream {
     '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'
   };
 
-  /** {@inheritDoc} */
-  @Override
-  public void write(int b) throws IOException {
-    b ^= key;
+  /**
+   * XORs each byte with the key and writes it as two ASCII hex digits,
+   * preceded by the header and the key itself in hex.
+   */
+  private static class XorHexOutputStream extends FilterOutputStream {
+    private final byte key;
+    private final byte[] pair = new byte[2];
 
-    pair[0] = HEX[(b & 0xF0) >>> 4];
-    pair[1] = HEX[b & 0x0F];
-    out.write(pair);
+    public XorHexOutputStream(OutputStream out, byte key) throws IOException {
+      super(out);
+      this.key = key;
+
+      out.write(DEFLATED_HEADER.getBytes(StandardCharsets.UTF_8));
+
+      pair[0] = HEX[(key & 0xF0) >>> 4];
+      pair[1] = HEX[key & 0x0F];
+      out.write(pair);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void write(byte[] bytes, int off, int len) throws IOException {
+      for (int i = 0; i < len; ++i) write(bytes[off + i]);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void write(int b) throws IOException {
+      b ^= key;
+
+      pair[0] = HEX[(b & 0xF0) >>> 4];
+      pair[1] = HEX[b & 0x0F];
+      out.write(pair);
+    }
   }
 
   public static void main(String[] args) throws IOException {

--- a/vassal-app/src/test/java/VASSAL/tools/io/ObfuscatingOutputStreamTest.java
+++ b/vassal-app/src/test/java/VASSAL/tools/io/ObfuscatingOutputStreamTest.java
@@ -17,6 +17,7 @@
  */
 package VASSAL.tools.io;
 
+import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 
@@ -27,21 +28,41 @@ public class ObfuscatingOutputStreamTest {
   // A popular pangram.
   private final String plain = "All jackdaws love my great sphinx of quartz.";
 
-  // The same pangram, obfuscated.
-  private final String obfus = "!VCSK581934347832393b333c392f2b7834372e3d783521783f2a3d392c782b283031362078373e78292d392a2c2276";
-
   // The key used for the obfuscated text.
   private final byte key = (byte) 0x58;
 
   @Test
-  public void testObfuscatedOutput() throws IOException {
-    final byte[] expected = obfus.getBytes("UTF-8");
+  public void testObfuscatedOutputFormat() throws IOException {
     final ByteArrayOutputStream bout = new ByteArrayOutputStream();
 
     final ObfuscatingOutputStream out = new ObfuscatingOutputStream(bout, key);
     out.write(plain.getBytes("UTF-8"));
     out.close();
 
-    assertArrayEquals(expected, bout.toByteArray());
+    final String result = new String(bout.toByteArray(), "UTF-8");
+
+    // header, then the key in hex
+    assertTrue(result.startsWith(ObfuscatingOutputStream.DEFLATED_HEADER + "58"));
+
+    // everything after the header is lowercase hex
+    final String body = result.substring(ObfuscatingOutputStream.DEFLATED_HEADER.length());
+    assertTrue(body.matches("[0-9a-f]+"));
+  }
+
+  @Test
+  public void testRoundTrip() throws IOException {
+    final byte[] expected = plain.getBytes("UTF-8");
+    final ByteArrayOutputStream bout = new ByteArrayOutputStream();
+
+    final ObfuscatingOutputStream out = new ObfuscatingOutputStream(bout, key);
+    out.write(expected);
+    out.close();
+
+    final DeobfuscatingInputStream in = new DeobfuscatingInputStream(
+      new ByteArrayInputStream(bout.toByteArray()));
+    final byte[] result = in.readAllBytes();
+    in.close();
+
+    assertArrayEquals(expected, result);
   }
 }


### PR DESCRIPTION
ObfuscatingOutputStream hex-encodes two ASCII chars per byte, so the ZIP was asked to compress a 2x-inflated 16-symbol stream and could do little with it. Compressing first (Deflater.BEST_COMPRESSION) and obfuscating the small result cuts a 34 MB save to roughly 19 MB.

New-format streams are marked !VCSZ; DeobfuscatingInputStream reads both the new format and the old !VCSK (undeflated) format, and still passes plain text through unchanged. The .vsav remains an ordinary ZIP: the change is confined to the savedGame entry's payload.