### PR TITLE
Make Zone use full qualified path for property container

### DIFF
--- a/vassal-app/src/main/java/VASSAL/build/module/map/boardPicker/board/mapgrid/Zone.java
+++ b/vassal-app/src/main/java/VASSAL/build/module/map/boardPicker/board/mapgrid/Zone.java
@@ -621,7 +621,9 @@ public class Zone extends AbstractConfigurable implements GridContainer, Mutable
 
   @Override
   public String getMutablePropertiesContainerId() {
-    return (getMap() == null ? "" : getMap().getMapName()) + ":" + getConfigureName();
+    return ((getMap() == null ? "" : getMap().getMapName()) + ":" +
+            (getBoard() == null ? "" : getBoard().getName()) + ":" +
+            getConfigureName());
   }
 
   /*


### PR DESCRIPTION
The `getMutablePropertiesContainerId` method is updated to include the board name, so that the identifier for the container will be

    Map:Board:Zone

instead of the current

    Map:Zone

This addresses the case where a map may have multiple boards that contain zones with the same name and the same properties.  In that case, and without this fix, the property change - in a network game - may end up in the wrong board (the first board that contains the zone with the property).

The fix should _not_ affect saves and logs as they use a _different_ mechanism (not involving `VASSAL.build.module.properties.ChangePropertyCommandEncoder` and `VASSAL.build.module.properties.ChangePropertyCommand` - but rather uses the `VASSAL.build.module.properties.GlobalProperty.encode` and `VASSAL.build.module.properties.GlobalProperty.decode` interfaces).

See also [this thread](https://forum.vassalengine.org/t/highlighting-not-changing-during-online-game/90465), and in particular [this post](https://forum.vassalengine.org/t/highlighting-not-changing-during-online-game/90465/17) for more discussions.

If this fix should be accepted, it should go into 3.8.0 as soon as possible.