### PR TITLE
14906 Fix Truncated text label on hidden pieces

### DIFF
--- a/vassal-app/src/main/java/VASSAL/counters/Hideable.java
+++ b/vassal-app/src/main/java/VASSAL/counters/Hideable.java
@@ -68,11 +68,6 @@ public class Hideable extends Decorator implements TranslatablePiece {
   protected KeyCommand hideCommand;
   protected String description = "";
 
-  // Cache the Hidden image that is shown to the owner. Only re-generate when Zoom or piece state changes.
-  protected BufferedImage cachedImage;
-  protected double cachedZoom = -1d;
-  protected String cachedState = "";
-
   @Override
   public void setProperty(Object key, Object val) {
     if (HIDDEN_BY.equals(key)) {
@@ -208,51 +203,58 @@ public class Hideable extends Decorator implements TranslatablePiece {
     }
 
     if (invisibleToOthers()) {
-      final Graphics2D g2d = (Graphics2D) g;
-
-      if (bgColor != null) {
-        g.setColor(bgColor);
-        final AffineTransform t = AffineTransform.getScaleInstance(zoom, zoom);
-        t.translate(x / zoom, y / zoom);
-        g2d.fill(t.createTransformedShape(piece.getShape()));
-      }
 
       // Determine piece bounds at current zoom
-      final Rectangle bounds = piece.getShape().getBounds();
-      final int w = (int) Math.ceil(bounds.width * zoom);
-      final int h = (int) Math.ceil(bounds.height * zoom);
+      Rectangle bounds = piece.getShape().getBounds();
+      final int w = (int) Math.round(bounds.width * zoom);
+      final int h = (int) Math.round(bounds.height * zoom);
 
       // If there's nothing visible at this zoom, skip
       if (w <= 0 || h <= 0) {
         return;
       }
 
-      final String visibleState = (String) piece.getProperty(Properties.VISIBLE_STATE);
-      if (cachedImage == null || zoom != cachedZoom || ! cachedState.equals(visibleState)) {
+      // Create an in-memory cached image and draw piece fully opaque
+      BufferedImage cachedImage = ImageUtils.createCompatibleTranslucentImage(w, h);
 
-        // Create an in-memory cached image and draw piece fully opaque
-        cachedImage = ImageUtils.createCompatibleTranslucentImage(w, h);
-        cachedZoom = zoom;
-        cachedState = visibleState;
+      Graphics2D cg = cachedImage.createGraphics();
+      try {
+        cg.translate((int)(-bounds.x * zoom), (int)(-bounds.y * zoom));
+        piece.draw(cg, 0, 0, obs, zoom); // Fully opaque
 
-        final Graphics2D cg = cachedImage.createGraphics();
-        try {
-          cg.scale(zoom, zoom);
-          cg.translate(-bounds.x, -bounds.y);
-
-          piece.draw(cg, 0, 0, obs, 1.0); // Fully opaque
-        }
-        finally {
+        final Rectangle boundsCheck = piece.getShape().getBounds();
+        final int wc = (int) Math.round(boundsCheck.width * zoom);
+        final int hc = (int) Math.round(boundsCheck.height * zoom);
+        if (wc > w || hc > h) {
+          // After drawing, the in-memory image buffer is too small.
+          // Resize the buffer and redraw.
+          // This can happen when a label's length increases.
+          bounds = boundsCheck;
+          cachedImage = ImageUtils.createCompatibleTranslucentImage(wc, hc);
           cg.dispose();
+          cg = cachedImage.createGraphics();
+          cg.translate((int)(-bounds.x * zoom), (int)(-bounds.y * zoom));
+          piece.draw(cg, 0, 0, obs, zoom); // Fully opaque
         }
+      }
+      finally {
+        cg.dispose();
       }
 
       // Apply the appropriate transparency to the overall image
+      final Graphics2D g2d = (Graphics2D) g;
       final Composite oldComp = g2d.getComposite();
       g2d.setComposite(AlphaComposite.getInstance(AlphaComposite.SRC_OVER, transparency));
 
-      final int drawX = x + (int) Math.round(bounds.x * zoom);
-      final int drawY = y + (int) Math.round(bounds.y * zoom);
+      if (bgColor != null) {
+        g2d.setColor(bgColor);
+        final AffineTransform t = AffineTransform.getTranslateInstance(x, y);
+        t.scale(zoom, zoom);
+        g2d.fill(t.createTransformedShape(piece.getShape()));
+      }
+
+      final int drawX = x + (int) (bounds.x * zoom);
+      final int drawY = y + (int) (bounds.y * zoom);
       g2d.drawImage(cachedImage, drawX, drawY, obs);
 
       g2d.setComposite(oldComp);

--- a/vassal-app/src/main/java/VASSAL/counters/Hideable.java
+++ b/vassal-app/src/main/java/VASSAL/counters/Hideable.java
@@ -68,6 +68,12 @@ public class Hideable extends Decorator implements TranslatablePiece {
   protected KeyCommand hideCommand;
   protected String description = "";
 
+  // Cache the Hidden image that is shown to the owner. Only re-generate when Zoom or piece state changes.
+  protected BufferedImage cachedImage;
+  protected double cachedZoom = -1d;
+  protected String cachedState = "";
+  protected Rectangle cachedBounds = new Rectangle();
+
   @Override
   public void setProperty(Object key, Object val) {
     if (HIDDEN_BY.equals(key)) {
@@ -205,7 +211,7 @@ public class Hideable extends Decorator implements TranslatablePiece {
     if (invisibleToOthers()) {
 
       // Determine piece bounds at current zoom
-      Rectangle bounds = piece.getShape().getBounds();
+      final Rectangle bounds = piece.getShape().getBounds();
       final int w = (int) Math.round(bounds.width * zoom);
       final int h = (int) Math.round(bounds.height * zoom);
 
@@ -214,31 +220,24 @@ public class Hideable extends Decorator implements TranslatablePiece {
         return;
       }
 
-      // Create an in-memory cached image and draw piece fully opaque
-      BufferedImage cachedImage = ImageUtils.createCompatibleTranslucentImage(w, h);
+      final String visibleState = (String) piece.getProperty(Properties.VISIBLE_STATE);
+      if (cachedImage == null || zoom != cachedZoom || ! cachedState.equals(visibleState)
+              || ! bounds.equals(cachedBounds)) {
 
-      Graphics2D cg = cachedImage.createGraphics();
-      try {
-        cg.translate((int)(-bounds.x * zoom), (int)(-bounds.y * zoom));
-        piece.draw(cg, 0, 0, obs, zoom); // Fully opaque
+        // Create an in-memory cached image and draw piece fully opaque
+        cachedImage = ImageUtils.createCompatibleTranslucentImage(w, h);
+        cachedZoom = zoom;
+        cachedState = visibleState;
+        cachedBounds = bounds;
 
-        final Rectangle boundsCheck = piece.getShape().getBounds();
-        final int wc = (int) Math.round(boundsCheck.width * zoom);
-        final int hc = (int) Math.round(boundsCheck.height * zoom);
-        if (wc > w || hc > h) {
-          // After drawing, the in-memory image buffer is too small.
-          // Resize the buffer and redraw.
-          // This can happen when a label's length increases.
-          bounds = boundsCheck;
-          cachedImage = ImageUtils.createCompatibleTranslucentImage(wc, hc);
-          cg.dispose();
-          cg = cachedImage.createGraphics();
+        final Graphics2D cg = cachedImage.createGraphics();
+        try {
           cg.translate((int)(-bounds.x * zoom), (int)(-bounds.y * zoom));
           piece.draw(cg, 0, 0, obs, zoom); // Fully opaque
         }
-      }
-      finally {
-        cg.dispose();
+        finally {
+          cg.dispose();
+        }
       }
 
       // Apply the appropriate transparency to the overall image


### PR DESCRIPTION
This is somewhat of a chicken and egg problem. The label size is computed in the `draw()` function. Since the size of the `BufferedImage` is based on the previous rendering, it can be too small for the new image. The proposal here is to recheck the image bounds, and resize the buffer and redraw if the bounds exceed the buffer size.

By moving where the background is rendered, the background now honors the opacity setting.

The adjustments to the translation and scaling remove the pixel shift when zoom is anything other than 100%.

Closes #14906