### PR TITLE
Allow user to set Java Look and Feel

### DIFF
--- a/vassal-app/src/main/java/VASSAL/configure/LookAndFeelConfigurer.java
+++ b/vassal-app/src/main/java/VASSAL/configure/LookAndFeelConfigurer.java
@@ -1,0 +1,170 @@
+/*
+ *
+ * Copyright (c) 2026 by Christian Holm Christensen
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License (LGPL) as published by the Free Software Foundation.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public
+ * License along with this library; if not, copies are available
+ * at http://www.opensource.org.
+ */
+package VASSAL.configure;
+
+import VASSAL.tools.ErrorDialog;
+
+import java.awt.Dimension;
+import java.awt.Frame;
+import java.awt.Window;
+import java.awt.event.ItemListener;
+
+import javax.swing.BoxLayout;
+import javax.swing.JComboBox;
+import javax.swing.JFrame;
+import javax.swing.JPanel;
+import javax.swing.SwingUtilities;
+import javax.swing.UIManager;
+import javax.swing.UIManager.LookAndFeelInfo;
+
+
+/**
+ * A Configurer for {@link javax.swing.UIManager.LookAndFeel} values
+ */
+public class LookAndFeelConfigurer extends Configurer {
+  public static class Info extends LookAndFeelInfo {
+    public Info(String name, String clsName) {
+      super(name, clsName);
+    }
+    public Info(LookAndFeelInfo info) {
+      this(info.getName(), info.getClassName());
+    }
+    @Override
+    public String toString() {
+      return getName();
+    }
+  }
+        
+  private JPanel panel;
+  private JComboBox<Info> laf;
+
+  public LookAndFeelConfigurer(String key, String name) {
+    this(key, name,
+         new Info(UIManager.getLookAndFeel().getName(),
+                  UIManager.getLookAndFeel().getClass().getName()));
+  }
+
+  public LookAndFeelConfigurer(String key, String name, LookAndFeelInfo val) {
+    super(key, name, new Info(val));
+  }
+
+  protected Info getInfo() {
+    return (Info)value;
+  }
+  
+  @Override
+  public String getValueString() {
+    return encode((Info) value);
+  }
+
+  @Override
+  public void setValue(String s) {
+    setValue(decode(s));
+    updateLnF();
+  }
+
+  @Override
+  public java.awt.Component getControls() {
+    if (panel == null) {
+      panel = new ConfigurerPanel(getName(), "[]rel[]", "[]rel[]"); // NON-NLS
+      laf = new JComboBox<>();
+      final LookAndFeelInfo[] known = UIManager.getInstalledLookAndFeels();
+      final String sysClsName = UIManager.getSystemLookAndFeelClassName();
+      Info sysInfo    = null;
+      Info current    = null;
+      for (final LookAndFeelInfo info : known) {
+        final Info i = new Info(info);
+        laf.addItem(i);
+        if (value != null &&
+            getInfo().getClassName().equals(i.getClassName())) {
+          current = i;
+        }
+        if (i.getClassName().equals(sysClsName)) {
+          sysInfo = i;
+        }
+      }
+      laf.setSelectedItem(current == null ? sysInfo : current);
+      laf.setMaximumSize(new Dimension(laf.getMaximumSize().width,
+                                       laf.getPreferredSize().height));
+      panel.add(laf);
+
+      final ItemListener l = evt -> setValue(laf.getSelectedItem());
+      laf.addItemListener(l);
+    }
+    return panel;
+  }
+
+  public static Info decode(String s) {
+    final int i = s.indexOf(',');
+    return new Info(s.substring(0, i), s.substring(i + 1));
+  }
+
+  public static String encode(Info i) {
+    return i.getName() + "," + i.getClassName();
+  }
+
+  protected void updateLnF() {
+    // Check for change 
+    if (getInfo().getClassName().equals(UIManager.getLookAndFeel().getClass().getName()))
+      return;
+
+    try {
+      UIManager.setLookAndFeel(getInfo().getClassName());
+      for (final Frame frame : Frame.getFrames()) {
+        if (frame == null)
+          continue;
+        SwingUtilities.updateComponentTreeUI(frame);
+
+        for (final Window window : frame.getOwnedWindows()) 
+          SwingUtilities.updateComponentTreeUI(window);
+      }
+    }
+    catch (Exception e) {
+      ErrorDialog.bug(e);
+    }
+  }
+  @Override
+  public void fireUpdate() {
+    super.fireUpdate();
+    updateLnF();
+  }
+  
+  @Override
+  public void setLabelVisible(boolean visible) {
+    if (panel instanceof ConfigurerPanel) {
+      ((ConfigurerPanel) panel).setLabelVisibility(visible);
+    }
+  }
+
+  public static void main(String[] args) {
+    final JFrame frame = new JFrame();
+    frame.setLayout(new BoxLayout(frame.getContentPane(), BoxLayout.Y_AXIS));
+    final LookAndFeelConfigurer config = new LookAndFeelConfigurer("a", "LaF: "); //NON-NLS
+    frame.add(config.getControls());
+    config.addPropertyChangeListener(evt -> {
+      final Info info = (Info)evt.getNewValue();
+      final LookAndFeelConfigurer fconfig
+        = new LookAndFeelConfigurer(null, null, info);
+      fconfig.setValue(fconfig.getValueString());
+      fconfig.fireUpdate();
+      frame.pack();
+    });
+    frame.pack();
+    frame.setVisible(true);
+  }
+}

--- a/vassal-app/src/main/java/VASSAL/launch/AbstractLaunchAction.java
+++ b/vassal-app/src/main/java/VASSAL/launch/AbstractLaunchAction.java
@@ -39,6 +39,7 @@ import VASSAL.tools.io.ProcessLauncher;
 import VASSAL.tools.io.ProcessWrapper;
 import VASSAL.tools.lang.MemoryUtils;
 import org.apache.commons.codec.digest.DigestUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.SystemUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.slf4j.Logger;
@@ -47,6 +48,7 @@ import org.slf4j.LoggerFactory;
 import javax.swing.AbstractAction;
 import javax.swing.JOptionPane;
 import javax.swing.SwingWorker;
+import javax.swing.UIManager;
 import java.awt.Dimension;
 import java.awt.Window;
 import java.awt.event.ActionEvent;
@@ -557,6 +559,17 @@ public abstract class AbstractLaunchAction extends AbstractAction {
       final String vConf = System.getProperty("VASSAL.conf");
       if (vConf != null) result.add("-DVASSAL.conf=" + vConf); //NON-NLS
 
+      // pass on Swing look'n'feel
+      String laf = System.getProperty("swing.defaultlaf");
+      if (laf == null) {
+        // Get the current l'n'f name from the UIManager
+        laf = UIManager.getLookAndFeel().getClass().getName();
+      }
+      if (!StringUtils.isBlank(laf)) {
+        // Pass on the property to child process
+        result.add("-Dswing.defaultlaf=" + laf);
+      }
+      
       // set the classpath
       result.add("-cp"); //NON-NLS
       result.add(System.getProperty("java.class.path"));

--- a/vassal-app/src/main/java/VASSAL/launch/StartUp.java
+++ b/vassal-app/src/main/java/VASSAL/launch/StartUp.java
@@ -28,6 +28,7 @@ import javax.swing.UnsupportedLookAndFeelException;
 
 import VASSAL.preferences.Prefs;
 import VASSAL.preferences.ReadOnlyPrefs;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.SystemUtils;
 
 import org.slf4j.Logger;
@@ -115,29 +116,41 @@ public class StartUp {
           );
         }
 
-        if (!SystemUtils.IS_OS_WINDOWS) {
-          // use native LookAndFeel
-          // NB: This must be after Mac-specific properties
+        // Get the property that sets the look'n'feel
+        String laf = System.getProperty("swing.defaultlaf");
+        final String sysLaf = UIManager.getSystemLookAndFeelClassName();
+        if (laf == null || StringUtils.isBlank(laf)) {
+          // Default to system l'n'f
+          laf = sysLaf;
+        }
+        // NB: This must be after Mac-specific properties
+        try {
+          // System.out.println("Attempting to set LaF to " + laf);
+          UIManager.setLookAndFeel(laf);
+        }
+        catch (ClassNotFoundException |
+               UnsupportedLookAndFeelException |
+               InstantiationException |
+               IllegalAccessException e) {
+          // System.out.println("Failed installing LAF: " + e);
+          // Fall back to system LAF in case of errors
           try {
-            UIManager.setLookAndFeel(
-              UIManager.getSystemLookAndFeelClassName()
-            );
-          }
-          catch (ClassNotFoundException | UnsupportedLookAndFeelException
-            | InstantiationException | IllegalAccessException e) {
+            UIManager.setLookAndFeel(sysLaf);
             ErrorDialog.bug(e);
           }
-
-          // The GTK LaF has a color picker which lacks the ability to
-          // select transparency. We can override that and it doesn't
-          // look too goofy.
-          if ("com.sun.java.swing.plaf.gtk.GTKLookAndFeel".equals(//NON-NLS
-            UIManager.getLookAndFeel().getClass().getName())) {
-            UIManager.put(
-              "ColorChooserUI",
-              "javax.swing.plaf.basic.BasicColorChooserUI"
-            );
+          catch (ClassNotFoundException |
+                 UnsupportedLookAndFeelException |
+                 InstantiationException |
+                 IllegalAccessException ee) {
           }
+        }
+
+        // The GTK LaF has a color picker which lacks the ability to
+        // select transparency. We can override that and it doesn't
+        // look too goofy.
+        if ("com.sun.java.swing.plaf.gtk.GTKLookAndFeel".equals(laf)) { //NON-NLS
+          UIManager.put("ColorChooserUI",
+                        "javax.swing.plaf.basic.BasicColorChooserUI");
         }
 
         // Ensure consistent behavior in NOT consuming "mousePressed" events

--- a/vassal-app/src/main/java/VASSAL/preferences/Prefs.java
+++ b/vassal-app/src/main/java/VASSAL/preferences/Prefs.java
@@ -23,6 +23,7 @@ import VASSAL.configure.BooleanConfigurer;
 import VASSAL.configure.Configurer;
 import VASSAL.configure.DirectoryConfigurer;
 import VASSAL.configure.IntConfigurer;
+import VASSAL.configure.LookAndFeelConfigurer;
 import VASSAL.i18n.Resources;
 import VASSAL.tools.ReadErrorDialog;
 
@@ -66,7 +67,8 @@ public class Prefs implements Closeable {
   public static final String OVERRIDE_DEFAULT_FONT_SIZE = "overrideDefaultFontSize"; //NON-NLS
 
   public static final String TRANSLATABLE_SUPPORT = "translatableSupport"; //NON-NLS
-
+  public static final String LOOK_AND_FEEL = "lookAndFeel"; //NON-NLS
+  
   private static Prefs globalPrefs; // A Global Preferences object
 
   private final Map<String, Configurer> options = new HashMap<>();
@@ -343,6 +345,12 @@ public class Prefs implements Closeable {
     );
 
     globalPrefs.addOption(Resources.getString("Prefs.general_tab"), auditConf);
+
+    final LookAndFeelConfigurer laf =
+      new LookAndFeelConfigurer(LOOK_AND_FEEL,
+                                Resources.getString("General.lookAndFeel"));
+    globalPrefs.addOption(Resources.getString("Prefs.general_tab"), laf);
+
   }
 
   public static String sanitize(String str) {

--- a/vassal-app/src/main/resources/VASSAL/i18n/VASSAL.properties
+++ b/vassal-app/src/main/resources/VASSAL/i18n/VASSAL.properties
@@ -61,6 +61,7 @@ General.run=Run
 General.copy=Copy
 General.cut=Cut
 General.paste=Paste
+General.lookAndFeel=Look and Feel
 
 #
 # Dialogs


### PR DESCRIPTION


This will allow the user to set the Look and Feel (LnF) of the
graphical user interface.   The following changes are done

- The current value of `swing.defaultlaf` is propagated on to child processes. That means, when the `ModuleManager` spawns the `Player` or `Editor` (and other processes), that those child-processes will also get the current setting for the LnF.
- If no LnF is specified by the user, then the default is to use the system LnF.  Note, on Windows, the default was to switch to the system independent _Metal_ LnF, while for MacOS and Linux, the default LnF was always the system LnF.
- Adds a new configurer class `LookAndFeelConfigurer` which are added
  to the shared global preferences.   This allows a user to specify
  the LnF via _File_&rarr;_Preferences_&rarr;_General_&rarr;_Look and
  feel_, even at runtime.  The setting is of course stored in
  `V_Global`, and will therefore be used for subsequent launches.

This PR is somewhat at odds with the PR #14435 and they should not _both_ be applied.  Note that #14435 attempts to enable third-party provided LnFs, while this PR will only use those already provided (could in principle be third party too).

Screenshots of preferences: 

<img width="733" height="480" alt="ModuleManagerPrefs" src="https://github.com/user-attachments/assets/f20da0e9-18b7-4226-830f-fb9838528c73" />
<img width="785" height="879" alt="PlayerPrefs" src="https://github.com/user-attachments/assets/58935d2c-2436-40db-9167-266c4f077793" />