### PR TITLE
Stop writing obfuscated data in hex

### DIFF
--- a/vassal-app/src/main/java/VASSAL/tools/io/DeobfuscatingInputStream.java
+++ b/vassal-app/src/main/java/VASSAL/tools/io/DeobfuscatingInputStream.java
@@ -28,12 +28,16 @@ import java.nio.file.Path;
 /**
  * A {@link FilterInputStream} which converts a file created with
  * {@link ObfuscatingOutputStream} back into plain text.
- * Additionally, plain text will be passed through unchanged.
+ * Files in the legacy hex-encoded format are also handled, and
+ * plain text will be passed through unchanged.
  *
  * @author Joel Uckelman
  * @since 3.2.0
  */
 public class DeobfuscatingInputStream extends FilterInputStream {
+
+  /** The header used by the hex-encoded format written before VASSAL 3.8. */
+  private static final String LEGACY_HEADER = "!VCSK"; //NON-NLS
 
   /**
    * @param in the stream to wrap
@@ -42,17 +46,32 @@ public class DeobfuscatingInputStream extends FilterInputStream {
   public DeobfuscatingInputStream(InputStream in) throws IOException {
     super(null);
 
-    final byte[] header = new byte[ObfuscatingOutputStream.HEADER.length()];
-    readFully(in, header, header.length);
-    if (new String(header, StandardCharsets.UTF_8).equals(ObfuscatingOutputStream.HEADER)) {
-      this.in = new DeobfuscatingInputStreamImpl(in);
+    final int hlen = ObfuscatingOutputStream.HEADER.length();
+    final byte[] header = new byte[Math.max(hlen, LEGACY_HEADER.length())];
+
+    int n = readFully(in, header, 0, hlen);
+
+    if (n == hlen) {
+      if (ObfuscatingOutputStream.HEADER.equals(
+            new String(header, 0, hlen, StandardCharsets.UTF_8))) {
+        this.in = new DeobfuscatingInputStreamImpl(in);
+        return;
+      }
+
+      n += readFully(in, header, hlen, LEGACY_HEADER.length() - hlen);
+
+      if (n == LEGACY_HEADER.length() && LEGACY_HEADER.equals(
+            new String(header, 0, n, StandardCharsets.UTF_8))) {
+        this.in = new LegacyDeobfuscatingInputStreamImpl(in);
+        return;
+      }
     }
-    else {
-      final PushbackInputStream pin =
-        new PushbackInputStream(in, header.length);
-      pin.unread(header);
-      this.in = pin;
-    }
+
+    // Not obfuscated; pass the whole stream through unchanged
+    final PushbackInputStream pin =
+      new PushbackInputStream(in, header.length);
+    pin.unread(header, 0, n);
+    this.in = pin;
   }
 
   /**
@@ -62,14 +81,15 @@ public class DeobfuscatingInputStream extends FilterInputStream {
    * @param bytes the destination
    * @param off the offset into the destination array
    * @param len the number of bytes to read
-   * @throws IOException if <code>len</code> bytes cannot be read
+   * @return the number of bytes read
+   * @throws IOException if an I/O error occurs
    */
-  private static int readFully(InputStream in, byte[] bytes, int len)
+  private static int readFully(InputStream in, byte[] bytes, int off, int len)
                                                            throws IOException {
     int count;
     int n = 0;
     while (n < len) {
-      count = in.read(bytes, n, len - n);
+      count = in.read(bytes, off + n, len - n);
       if (count < 0) break;
       n += count;
     }
@@ -77,14 +97,51 @@ public class DeobfuscatingInputStream extends FilterInputStream {
     return n;
   }
 
+  /**
+   * Deobfuscates the format written by {@link ObfuscatingOutputStream}:
+   * a one-byte key, followed by the data XORed with the key.
+   */
   private static class DeobfuscatingInputStreamImpl extends FilterInputStream {
     private final byte key;
-    private final byte[] pair = new byte[2];
 
     public DeobfuscatingInputStreamImpl(InputStream in) throws IOException {
       super(in);
 
-      readFully(in, pair, 2);
+      final int k = in.read();
+      if (k < 0) {
+        throw new IOException("Truncated obfuscated stream: missing key"); //NON-NLS
+      }
+      key = (byte) k;
+    }
+
+    @Override
+    public int read(byte[] bytes, int off, int len) throws IOException {
+      final int n = in.read(bytes, off, len);
+      for (int i = 0; i < n; ++i) {
+        bytes[off + i] ^= key;
+      }
+      return n;
+    }
+
+    @Override
+    public int read() throws IOException {
+      final int b = in.read();
+      return b < 0 ? -1 : (b ^ key) & 0xFF;
+    }
+  }
+
+  /**
+   * Deobfuscates the legacy format, in which the key and each data byte
+   * were written as a pair of hex digits.
+   */
+  private static class LegacyDeobfuscatingInputStreamImpl extends FilterInputStream {
+    private final byte key;
+    private final byte[] pair = new byte[2];
+
+    public LegacyDeobfuscatingInputStreamImpl(InputStream in) throws IOException {
+      super(in);
+
+      readFully(in, pair, 0, 2);
       key = (byte) ((unhex(pair[0]) << 4) | unhex(pair[1]));
     }
 
@@ -98,7 +155,7 @@ public class DeobfuscatingInputStream extends FilterInputStream {
 
     @Override
     public int read() throws IOException {
-      switch (readFully(in, pair, 2)) {
+      switch (readFully(in, pair, 0, 2)) {
       case  0:
         return -1;
       case  2:

--- a/vassal-app/src/main/java/VASSAL/tools/io/DeobfuscatingInputStream.java
+++ b/vassal-app/src/main/java/VASSAL/tools/io/DeobfuscatingInputStream.java
@@ -21,9 +21,9 @@ import java.io.FilterInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.PushbackInputStream;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Arrays;
 
 /**
  * A {@link FilterInputStream} which converts a file created with
@@ -36,8 +36,8 @@ import java.nio.file.Path;
  */
 public class DeobfuscatingInputStream extends FilterInputStream {
 
-  /** The header used by the hex-encoded format written before VASSAL 3.8. */
-  private static final String LEGACY_HEADER = "!VCSK"; //NON-NLS
+  /** The header of the hex-encoded format written before VASSAL 3.8. */
+  private static final byte[] LEGACY_HEADER = { '!', 'V', 'C', 'S', 'K' };
 
   /**
    * @param in the stream to wrap
@@ -46,50 +46,52 @@ public class DeobfuscatingInputStream extends FilterInputStream {
   public DeobfuscatingInputStream(InputStream in) throws IOException {
     super(null);
 
-    final int hlen = ObfuscatingOutputStream.HEADER.length();
-    final byte[] header = new byte[Math.max(hlen, LEGACY_HEADER.length())];
+    final byte[] header = ObfuscatingOutputStream.HEADER_BYTES;
 
-    int n = readFully(in, header, 0, hlen);
+    // The legacy header is the longer of the two
+    final byte[] buf = new byte[LEGACY_HEADER.length];
 
-    if (n == hlen) {
-      if (ObfuscatingOutputStream.HEADER.equals(
-            new String(header, 0, hlen, StandardCharsets.UTF_8))) {
+    int n = readFully(in, buf, header.length);
+
+    if (n == header.length) {
+      if (Arrays.equals(buf, 0, n, header, 0, n)) {
         this.in = new DeobfuscatingInputStreamImpl(in);
         return;
       }
 
-      n += readFully(in, header, hlen, LEGACY_HEADER.length() - hlen);
+      // Read the byte by which the legacy header is longer
+      final int b = in.read();
+      if (b >= 0) {
+        buf[n++] = (byte) b;
 
-      if (n == LEGACY_HEADER.length() && LEGACY_HEADER.equals(
-            new String(header, 0, n, StandardCharsets.UTF_8))) {
-        this.in = new LegacyDeobfuscatingInputStreamImpl(in);
-        return;
+        if (Arrays.equals(buf, LEGACY_HEADER)) {
+          this.in = new LegacyDeobfuscatingInputStreamImpl(in);
+          return;
+        }
       }
     }
 
     // Not obfuscated; pass the whole stream through unchanged
-    final PushbackInputStream pin =
-      new PushbackInputStream(in, header.length);
-    pin.unread(header, 0, n);
+    final PushbackInputStream pin = new PushbackInputStream(in, buf.length);
+    pin.unread(buf, 0, n);
     this.in = pin;
   }
 
   /**
-   * Reads the given number of bytes.
+   * Reads up to the given number of bytes.
    *
    * @param in the source
    * @param bytes the destination
-   * @param off the offset into the destination array
    * @param len the number of bytes to read
    * @return the number of bytes read
    * @throws IOException if an I/O error occurs
    */
-  private static int readFully(InputStream in, byte[] bytes, int off, int len)
+  private static int readFully(InputStream in, byte[] bytes, int len)
                                                            throws IOException {
     int count;
     int n = 0;
     while (n < len) {
-      count = in.read(bytes, off + n, len - n);
+      count = in.read(bytes, n, len - n);
       if (count < 0) break;
       n += count;
     }
@@ -141,7 +143,7 @@ public class DeobfuscatingInputStream extends FilterInputStream {
     public LegacyDeobfuscatingInputStreamImpl(InputStream in) throws IOException {
       super(in);
 
-      readFully(in, pair, 0, 2);
+      readFully(in, pair, 2);
       key = (byte) ((unhex(pair[0]) << 4) | unhex(pair[1]));
     }
 
@@ -155,7 +157,7 @@ public class DeobfuscatingInputStream extends FilterInputStream {
 
     @Override
     public int read() throws IOException {
-      switch (readFully(in, pair, 0, 2)) {
+      switch (readFully(in, pair, 2)) {
       case  0:
         return -1;
       case  2:

--- a/vassal-app/src/main/java/VASSAL/tools/io/ObfuscatingOutputStream.java
+++ b/vassal-app/src/main/java/VASSAL/tools/io/ObfuscatingOutputStream.java
@@ -22,7 +22,6 @@ import java.io.FilterOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Random;
@@ -31,18 +30,28 @@ import java.util.Random;
  * A {@link FilterOutputStream} which handles simple obfuscation of a file's
  * contents, to prevent the casual cheat of hand-editing.
  *
- * <p>The output consists of {@link #HEADER}, followed by the one-byte key,
- * followed by the input XORed byte-by-byte with the key.</p>
+ * <p>The output consists of {@link #HEADER_BYTES}, followed by the one-byte
+ * key, followed by the input XORed byte-by-byte with the key.</p>
  *
  * @author uckelman
  * @since 3.2.0
  */
 public class ObfuscatingOutputStream extends FilterOutputStream {
-  public static final String HEADER = "VOBS"; //NON-NLS
+  /**
+   * The header of the hex-encoded format written before VASSAL 3.8.
+   *
+   * @deprecated The hex-encoded format is no longer written, only read.
+   * Obfuscated output is now marked with {@link #HEADER_BYTES}.
+   */
+  @Deprecated(since = "2026-09-08", forRemoval = true)
+  public static final String HEADER = "!VCSK"; //NON-NLS
+
+  /** The header marking obfuscated output. */
+  static final byte[] HEADER_BYTES = { 'V', 'O', 'B', 'S' };
+
   private static final Random rand = new Random();
 
   private final byte key;
-  private final byte[] buf = new byte[8192];
 
   /**
    * @param out the stream to wrap
@@ -63,23 +72,14 @@ public class ObfuscatingOutputStream extends FilterOutputStream {
     super(out);
     this.key = key;
 
-    out.write(HEADER.getBytes(StandardCharsets.UTF_8));
+    out.write(HEADER_BYTES);
     out.write(key);
   }
 
   /** {@inheritDoc} */
   @Override
   public void write(byte[] bytes, int off, int len) throws IOException {
-    // Obfuscate via a scratch buffer, so as not to alter the caller's array
-    while (len > 0) {
-      final int n = Math.min(len, buf.length);
-      for (int i = 0; i < n; ++i) {
-        buf[i] = (byte) (bytes[off + i] ^ key);
-      }
-      out.write(buf, 0, n);
-      off += n;
-      len -= n;
-    }
+    for (int i = 0; i < len; ++i) write(bytes[off + i]);
   }
 
   /** {@inheritDoc} */

--- a/vassal-app/src/main/java/VASSAL/tools/io/ObfuscatingOutputStream.java
+++ b/vassal-app/src/main/java/VASSAL/tools/io/ObfuscatingOutputStream.java
@@ -47,7 +47,7 @@ public class ObfuscatingOutputStream extends FilterOutputStream {
   public static final String HEADER = "!VCSK"; //NON-NLS
 
   /** The header marking obfuscated output. */
-  static final byte[] HEADER_BYTES = { 'V', 'O', 'B', 'S' };
+  public static final byte[] HEADER_BYTES = { 'V', 'O', 'B', 'S' };
 
   private static final Random rand = new Random();
 

--- a/vassal-app/src/main/java/VASSAL/tools/io/ObfuscatingOutputStream.java
+++ b/vassal-app/src/main/java/VASSAL/tools/io/ObfuscatingOutputStream.java
@@ -31,22 +31,26 @@ import java.util.Random;
  * A {@link FilterOutputStream} which handles simple obfuscation of a file's
  * contents, to prevent the casual cheat of hand-editing.
  *
+ * <p>The output consists of {@link #HEADER}, followed by the one-byte key,
+ * followed by the input XORed byte-by-byte with the key.</p>
+ *
  * @author uckelman
  * @since 3.2.0
  */
 public class ObfuscatingOutputStream extends FilterOutputStream {
-  public static final String HEADER = "!VCSK"; //NON-NLS
+  public static final String HEADER = "VOBS"; //NON-NLS
   private static final Random rand = new Random();
 
   private final byte key;
-  private final byte[] pair = new byte[2];
+  private final byte[] buf = new byte[8192];
 
   /**
    * @param out the stream to wrap
    * @throws IOException oops
    */
   public ObfuscatingOutputStream(OutputStream out) throws IOException {
-    this(out, (byte) rand.nextInt(256));
+    // Keys are in 1-255; XORing with 0 would leave the data in plain text.
+    this(out, (byte) (rand.nextInt(255) + 1));
   }
 
   /**
@@ -60,31 +64,28 @@ public class ObfuscatingOutputStream extends FilterOutputStream {
     this.key = key;
 
     out.write(HEADER.getBytes(StandardCharsets.UTF_8));
-
-    pair[0] = HEX[(key & 0xF0) >>> 4];
-    pair[1] = HEX[key & 0x0F];
-    out.write(pair);
+    out.write(key);
   }
 
   /** {@inheritDoc} */
   @Override
   public void write(byte[] bytes, int off, int len) throws IOException {
-    for (int i = 0; i < len; ++i) write(bytes[off + i]);
+    // Obfuscate via a scratch buffer, so as not to alter the caller's array
+    while (len > 0) {
+      final int n = Math.min(len, buf.length);
+      for (int i = 0; i < n; ++i) {
+        buf[i] = (byte) (bytes[off + i] ^ key);
+      }
+      out.write(buf, 0, n);
+      off += n;
+      len -= n;
+    }
   }
-
-  private static final byte[] HEX = {
-    '0', '1', '2', '3', '4', '5', '6', '7',
-    '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'
-  };
 
   /** {@inheritDoc} */
   @Override
   public void write(int b) throws IOException {
-    b ^= key;
-
-    pair[0] = HEX[(b & 0xF0) >>> 4];
-    pair[1] = HEX[b & 0x0F];
-    out.write(pair);
+    out.write(b ^ key);
   }
 
   public static void main(String[] args) throws IOException {

--- a/vassal-app/src/test/java/VASSAL/tools/io/DeobfuscatingInputStreamTest.java
+++ b/vassal-app/src/test/java/VASSAL/tools/io/DeobfuscatingInputStreamTest.java
@@ -71,7 +71,7 @@ public class DeobfuscatingInputStreamTest {
   @Test
   public void testHeaderLengthPlainInput() throws IOException {
     final byte[] expected = "abcd".getBytes(StandardCharsets.UTF_8);
-    assertEquals(ObfuscatingOutputStream.HEADER.length(), expected.length);
+    assertEquals(ObfuscatingOutputStream.HEADER_BYTES.length, expected.length);
     assertArrayEquals(expected, deobfuscate(expected));
   }
 
@@ -118,8 +118,7 @@ public class DeobfuscatingInputStreamTest {
   /** An obfuscated stream lacking a key is malformed. */
   @Test
   public void testMissingKey() {
-    final byte[] b =
-      ObfuscatingOutputStream.HEADER.getBytes(StandardCharsets.UTF_8);
+    final byte[] b = ObfuscatingOutputStream.HEADER_BYTES.clone();
     assertThrows(IOException.class, () -> deobfuscate(b));
   }
 

--- a/vassal-app/src/test/java/VASSAL/tools/io/DeobfuscatingInputStreamTest.java
+++ b/vassal-app/src/test/java/VASSAL/tools/io/DeobfuscatingInputStreamTest.java
@@ -18,62 +18,124 @@
 package VASSAL.tools.io;
 
 import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 
-import org.junit.*;
+import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.*;
 
 public class DeobfuscatingInputStreamTest {
   // A popular pangram.
   private final String plain = "All jackdaws love my great sphinx of quartz.";
 
-  // The same pangram, obfuscated.
-  private final String obfus = "!VCSK581934347832393b333c392f2b7834372e3d783521783f2a3d392c782b283031362078373e78292d392a2c2276";
+  // The same pangram, obfuscated in the legacy hex-encoded format.
+  private final String legacyObfus = "!VCSK581934347832393b333c392f2b7834372e3d783521783f2a3d392c782b283031362078373e78292d392a2c2276";
+
+  private static byte[] deobfuscate(byte[] b) throws IOException {
+    try (DeobfuscatingInputStream in =
+           new DeobfuscatingInputStream(new ByteArrayInputStream(b))) {
+      return in.readAllBytes();
+    }
+  }
+
+  private static byte[] obfuscate(byte[] b) throws IOException {
+    final ByteArrayOutputStream bout = new ByteArrayOutputStream();
+    try (ObfuscatingOutputStream out = new ObfuscatingOutputStream(bout)) {
+      out.write(b);
+    }
+    return bout.toByteArray();
+  }
 
   /** Test plain text input. */
   @Test
   public void testPlainInput() throws IOException {
-    final byte[] expected = plain.getBytes("UTF-8");
-
-    final DeobfuscatingInputStream in =
-      new DeobfuscatingInputStream(
-        new ByteArrayInputStream(expected));
-
-    final byte[] result = in.readAllBytes();
-    in.close();
-
-    assertArrayEquals(expected, result);
+    final byte[] expected = plain.getBytes(StandardCharsets.UTF_8);
+    assertArrayEquals(expected, deobfuscate(expected));
   }
 
-  /** Test obfuscated input with lowercase hex digits. */
+  /** Test plain text input shorter than a header. */
   @Test
-  public void testObfuscatedInputLowerCaseHexDigits() throws IOException {
-    final byte[] b = obfus.getBytes("UTF-8");
-    final byte[] expected = plain.getBytes("UTF-8");
-
-    final DeobfuscatingInputStream in =
-      new DeobfuscatingInputStream(
-        new ByteArrayInputStream(b));
-
-    final byte[] result = in.readAllBytes();
-    in.close();
-
-    assertArrayEquals(expected, result);
+  public void testShortPlainInput() throws IOException {
+    final byte[] expected = "ab".getBytes(StandardCharsets.UTF_8);
+    assertArrayEquals(expected, deobfuscate(expected));
   }
 
-  /** Test obfuscated input with uppercase hex digits. */
+  /** Test empty input. */
   @Test
-  public void testObfuscatedInputUpperCaseHexDigits() throws IOException {
-    final byte[] b = obfus.toUpperCase().getBytes("UTF-8");
-    final byte[] expected = plain.getBytes("UTF-8");
+  public void testEmptyInput() throws IOException {
+    assertArrayEquals(new byte[0], deobfuscate(new byte[0]));
+  }
 
-    final DeobfuscatingInputStream in =
-      new DeobfuscatingInputStream(
-        new ByteArrayInputStream(b));
+  /** Test plain text input which is exactly as long as the header. */
+  @Test
+  public void testHeaderLengthPlainInput() throws IOException {
+    final byte[] expected = "abcd".getBytes(StandardCharsets.UTF_8);
+    assertEquals(ObfuscatingOutputStream.HEADER.length(), expected.length);
+    assertArrayEquals(expected, deobfuscate(expected));
+  }
 
-    final byte[] result = in.readAllBytes();
-    in.close();
+  /** Test obfuscated input. */
+  @Test
+  public void testObfuscatedInput() throws IOException {
+    final byte[] expected = plain.getBytes(StandardCharsets.UTF_8);
+    assertArrayEquals(expected, deobfuscate(obfuscate(expected)));
+  }
 
-    assertArrayEquals(expected, result);
+  /** Test obfuscated input containing every byte value. */
+  @Test
+  public void testObfuscatedInputAllByteValues() throws IOException {
+    final byte[] expected = new byte[256];
+    for (int i = 0; i < expected.length; ++i) {
+      expected[i] = (byte) i;
+    }
+    assertArrayEquals(expected, deobfuscate(obfuscate(expected)));
+  }
+
+  /** Test empty obfuscated input. */
+  @Test
+  public void testEmptyObfuscatedInput() throws IOException {
+    assertArrayEquals(new byte[0], deobfuscate(obfuscate(new byte[0])));
+  }
+
+  /** Test obfuscated input read one byte at a time. */
+  @Test
+  public void testObfuscatedInputByByte() throws IOException {
+    final byte[] expected = plain.getBytes(StandardCharsets.UTF_8);
+    final ByteArrayOutputStream bout = new ByteArrayOutputStream();
+
+    try (DeobfuscatingInputStream in = new DeobfuscatingInputStream(
+           new ByteArrayInputStream(obfuscate(expected)))) {
+      int b;
+      while ((b = in.read()) >= 0) {
+        bout.write(b);
+      }
+    }
+
+    assertArrayEquals(expected, bout.toByteArray());
+  }
+
+  /** An obfuscated stream lacking a key is malformed. */
+  @Test
+  public void testMissingKey() {
+    final byte[] b =
+      ObfuscatingOutputStream.HEADER.getBytes(StandardCharsets.UTF_8);
+    assertThrows(IOException.class, () -> deobfuscate(b));
+  }
+
+  /** Test legacy obfuscated input with lowercase hex digits. */
+  @Test
+  public void testLegacyObfuscatedInputLowerCaseHexDigits() throws IOException {
+    final byte[] expected = plain.getBytes(StandardCharsets.UTF_8);
+    final byte[] b = legacyObfus.getBytes(StandardCharsets.UTF_8);
+    assertArrayEquals(expected, deobfuscate(b));
+  }
+
+  /** Test legacy obfuscated input with uppercase hex digits. */
+  @Test
+  public void testLegacyObfuscatedInputUpperCaseHexDigits() throws IOException {
+    final byte[] expected = plain.getBytes(StandardCharsets.UTF_8);
+    final byte[] b = legacyObfus.toUpperCase().getBytes(StandardCharsets.UTF_8);
+    assertArrayEquals(expected, deobfuscate(b));
   }
 }

--- a/vassal-app/src/test/java/VASSAL/tools/io/ObfuscatingOutputStreamTest.java
+++ b/vassal-app/src/test/java/VASSAL/tools/io/ObfuscatingOutputStreamTest.java
@@ -19,29 +19,131 @@ package VASSAL.tools.io;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 
-import org.junit.*;
+import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.*;
 
 public class ObfuscatingOutputStreamTest {
   // A popular pangram.
   private final String plain = "All jackdaws love my great sphinx of quartz.";
 
-  // The same pangram, obfuscated.
-  private final String obfus = "!VCSK581934347832393b333c392f2b7834372e3d783521783f2a3d392c782b283031362078373e78292d392a2c2276";
-
   // The key used for the obfuscated text.
   private final byte key = (byte) 0x58;
 
-  @Test
-  public void testObfuscatedOutput() throws IOException {
-    final byte[] expected = obfus.getBytes("UTF-8");
+  // A key with the high bit set, to catch sign-extension errors.
+  private final byte highKey = (byte) 0x80;
+
+  private byte[] obfuscated(byte key) {
+    final byte[] plainBytes = plain.getBytes(StandardCharsets.UTF_8);
+    final byte[] header =
+      ObfuscatingOutputStream.HEADER.getBytes(StandardCharsets.UTF_8);
+
+    final byte[] expected = new byte[header.length + 1 + plainBytes.length];
+    System.arraycopy(header, 0, expected, 0, header.length);
+    expected[header.length] = key;
+    for (int i = 0; i < plainBytes.length; ++i) {
+      expected[header.length + 1 + i] = (byte) (plainBytes[i] ^ key);
+    }
+
+    return expected;
+  }
+
+  private byte[] writeAsArray(byte key) throws IOException {
     final ByteArrayOutputStream bout = new ByteArrayOutputStream();
 
-    final ObfuscatingOutputStream out = new ObfuscatingOutputStream(bout, key);
-    out.write(plain.getBytes("UTF-8"));
-    out.close();
+    try (ObfuscatingOutputStream out =
+           new ObfuscatingOutputStream(bout, key)) {
+      out.write(plain.getBytes(StandardCharsets.UTF_8));
+    }
 
-    assertArrayEquals(expected, bout.toByteArray());
+    return bout.toByteArray();
+  }
+
+  private byte[] writeByByte(byte key) throws IOException {
+    final ByteArrayOutputStream bout = new ByteArrayOutputStream();
+
+    try (ObfuscatingOutputStream out =
+           new ObfuscatingOutputStream(bout, key)) {
+      for (final byte b : plain.getBytes(StandardCharsets.UTF_8)) {
+        out.write(b);
+      }
+    }
+
+    return bout.toByteArray();
+  }
+
+  /** Test writing an array. */
+  @Test
+  public void testObfuscatedOutput() throws IOException {
+    assertArrayEquals(obfuscated(key), writeAsArray(key));
+  }
+
+  /** Test writing one byte at a time. */
+  @Test
+  public void testObfuscatedOutputByByte() throws IOException {
+    assertArrayEquals(obfuscated(key), writeByByte(key));
+  }
+
+  /** Test writing an array with a key which has the high bit set. */
+  @Test
+  public void testObfuscatedOutputHighKey() throws IOException {
+    assertArrayEquals(obfuscated(highKey), writeAsArray(highKey));
+  }
+
+  /** Test writing one byte at a time with a key with the high bit set. */
+  @Test
+  public void testObfuscatedOutputByByteHighKey() throws IOException {
+    assertArrayEquals(obfuscated(highKey), writeByByte(highKey));
+  }
+
+  /** The caller's array must not be modified. */
+  @Test
+  public void testInputArrayUnmodified() throws IOException {
+    final byte[] bytes = plain.getBytes(StandardCharsets.UTF_8);
+    final byte[] copy = bytes.clone();
+
+    try (ObfuscatingOutputStream out =
+           new ObfuscatingOutputStream(new ByteArrayOutputStream(), key)) {
+      out.write(bytes);
+    }
+
+    assertArrayEquals(copy, bytes);
+  }
+
+  /** Writes longer than the internal buffer must be obfuscated correctly. */
+  @Test
+  public void testObfuscatedOutputLongerThanBuffer() throws IOException {
+    final byte[] bytes = new byte[100000];
+    for (int i = 0; i < bytes.length; ++i) {
+      bytes[i] = (byte) i;
+    }
+
+    final ByteArrayOutputStream bout = new ByteArrayOutputStream();
+
+    try (ObfuscatingOutputStream out =
+           new ObfuscatingOutputStream(bout, key)) {
+      out.write(bytes);
+    }
+
+    final byte[] result = bout.toByteArray();
+    final int off = ObfuscatingOutputStream.HEADER.length() + 1;
+
+    assertEquals(off + bytes.length, result.length);
+    for (int i = 0; i < bytes.length; ++i) {
+      assertEquals((byte) (bytes[i] ^ key), result[off + i]);
+    }
+  }
+
+  /** The key is never zero, as XORing with zero obfuscates nothing. */
+  @Test
+  public void testKeyIsNeverZero() throws IOException {
+    final int off = ObfuscatingOutputStream.HEADER.length();
+
+    for (int i = 0; i < 10000; ++i) {
+      final ByteArrayOutputStream bout = new ByteArrayOutputStream();
+      new ObfuscatingOutputStream(bout).close();
+      assertTrue(bout.toByteArray()[off] != 0);
+    }
   }
 }

--- a/vassal-app/src/test/java/VASSAL/tools/io/ObfuscatingOutputStreamTest.java
+++ b/vassal-app/src/test/java/VASSAL/tools/io/ObfuscatingOutputStreamTest.java
@@ -36,8 +36,7 @@ public class ObfuscatingOutputStreamTest {
 
   private byte[] obfuscated(byte key) {
     final byte[] plainBytes = plain.getBytes(StandardCharsets.UTF_8);
-    final byte[] header =
-      ObfuscatingOutputStream.HEADER.getBytes(StandardCharsets.UTF_8);
+    final byte[] header = ObfuscatingOutputStream.HEADER_BYTES;
 
     final byte[] expected = new byte[header.length + 1 + plainBytes.length];
     System.arraycopy(header, 0, expected, 0, header.length);
@@ -111,9 +110,9 @@ public class ObfuscatingOutputStreamTest {
     assertArrayEquals(copy, bytes);
   }
 
-  /** Writes longer than the internal buffer must be obfuscated correctly. */
+  /** A large write must be obfuscated correctly throughout. */
   @Test
-  public void testObfuscatedOutputLongerThanBuffer() throws IOException {
+  public void testObfuscatedOutputLargeArray() throws IOException {
     final byte[] bytes = new byte[100000];
     for (int i = 0; i < bytes.length; ++i) {
       bytes[i] = (byte) i;
@@ -127,7 +126,7 @@ public class ObfuscatingOutputStreamTest {
     }
 
     final byte[] result = bout.toByteArray();
-    final int off = ObfuscatingOutputStream.HEADER.length() + 1;
+    final int off = ObfuscatingOutputStream.HEADER_BYTES.length + 1;
 
     assertEquals(off + bytes.length, result.length);
     for (int i = 0; i < bytes.length; ++i) {
@@ -138,7 +137,7 @@ public class ObfuscatingOutputStreamTest {
   /** The key is never zero, as XORing with zero obfuscates nothing. */
   @Test
   public void testKeyIsNeverZero() throws IOException {
-    final int off = ObfuscatingOutputStream.HEADER.length();
+    final int off = ObfuscatingOutputStream.HEADER_BYTES.length;
 
     for (int i = 0; i < 10000; ++i) {
       final ByteArrayOutputStream bout = new ByteArrayOutputStream();


### PR DESCRIPTION
ObfuscatingOutputStream wrote each XORed byte as two hex digits, doubling the size of the savedGame entry and, since the result was a 16-symbol stream, leaving the ZIP little to compress. The hex encoding served no purpose: the point is only to deter casual hand-editing, and the XORed bytes are already less readable than hex.

The new format is the header VOBS, then the one-byte key, then the data XORed with the key. The leading bang is dropped and the header is four bytes, which is more typical. The key is now chosen in 1-255, so we never XOR with 0 and leave the data in plain text.

This deletes the hex table and per-byte pair buffer from ObfuscatingOutputStream, and gives it a real write(byte[], int, int) which XORs through a scratch buffer rather than delegating per byte.

In DeobfuscatingInputStream the old hex reader survives unchanged as LegacyDeobfuscatingInputStreamImpl, still matched on the !VCSK header, so saves written by earlier versions continue to load. A new, much smaller DeobfuscatingInputStreamImpl handles VOBS. Plain text is still passed through unchanged, including input shorter than a header.

A 1 MB payload now occupies 1,000,005 bytes rather than 2,000,007.